### PR TITLE
Standardize gem setup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,3 @@ crate-type = ["cdylib"]
 
 [build-dependencies]
 cbindgen = "0.26"
-

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2025-present, Shopify Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/bin/setup
+++ b/bin/setup
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-IFS=$'\n\t'
-set -vx
-
-bundle install
-
-# Do any other automated setup that you need to do here

--- a/index.gemspec
+++ b/index.gemspec
@@ -5,34 +5,23 @@ require_relative "lib/index/version"
 Gem::Specification.new do |spec|
   spec.name = "index"
   spec.version = Index::VERSION
-  spec.authors = ["Siddarth Challa"]
-  spec.email = ["sid.challa@shopify.com"]
+  spec.authors = ["Shopify"]
+  spec.email = ["ruby@shopify.com"]
 
-  spec.summary = "TODO: Write a short summary, because RubyGems requires one."
-  spec.description = "TODO: Write a longer description or delete this line."
-  spec.homepage = "TODO: Put your gem's website or public repo URL here."
+  spec.summary = "A high performance static analysis suite for Ruby"
+  spec.description = "A high performance static analysis suite for Ruby, built in Rust with Ruby APIs"
+  spec.homepage = "https://github.com/Shopify/index"
   spec.required_ruby_version = ">= 3.1.0"
   spec.required_rubygems_version = ">= 3.3.11"
 
-  spec.metadata["allowed_push_host"] = "TODO: Set to your gem server 'https://example.com'"
+  spec.metadata["allowed_push_host"] = "https://rubygems.org"
   spec.metadata["homepage_uri"] = spec.homepage
-  spec.metadata["source_code_uri"] = "TODO: Put your gem's public repo URL here."
-  spec.metadata["changelog_uri"] = "TODO: Put your gem's CHANGELOG.md URL here."
+  spec.metadata["source_code_uri"] = spec.homepage
+  spec.metadata["changelog_uri"] = "#{spec.homepage}/releases"
 
-  # Specify which files should be added to the gem when it is released.
-  # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
-  gemspec = File.basename(__FILE__)
-  spec.files = IO.popen(["git", "ls-files", "-z"], chdir: __dir__, err: IO::NULL) do |ls|
-    ls.readlines("\x0", chomp: true).reject do |f|
-      (f == gemspec) ||
-        f.start_with?("bin/", "test/", "spec/", "features/", ".git", "appveyor", "Gemfile")
-    end
-  end
+  spec.files = Dir.glob("lib/**/*.rb") + ["README.md", "LICENSE.txt"]
   spec.bindir = "exe"
-  spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
+  spec.executables = Dir.glob("exe/*").map { |f| File.basename(f) }
   spec.require_paths = ["lib"]
   spec.extensions = ["ext/index/extconf.rb"]
-
-  # For more information and examples about making a new gem, check out our
-  # guide at: https://bundler.io/guides/creating_gem.html
 end

--- a/lib/index.rb
+++ b/lib/index.rb
@@ -1,10 +1,7 @@
 # frozen_string_literal: true
 
-require_relative "index/version"
-
+require "index/version"
 require "index/index"
 
 module Index
-  class Error < StandardError; end
-  # Your code goes here...
 end


### PR DESCRIPTION
This PR just makes a few changes to standardize the gem setup.

1. Added a license file
2. Updated the gemspec to match the setup we use for most projects
3. Removed `bin/setup` (we usually prefer rake tasks)