### PR TITLE
Update extconf.rb to use dev build for Rust library when possible

### DIFF
--- a/ext/index/extconf.rb
+++ b/ext/index/extconf.rb
@@ -2,13 +2,18 @@ require "mkmf"
 
 # Get the absolute path to the target directory
 root_dir = File.expand_path("../..", __dir__)
-target_dir = File.join(root_dir, "target", "release")
+release = ENV["RELEASE"]
+if release
+  build_dir = File.join(root_dir, "target", "release")
+else
+  build_dir = File.join(root_dir, "target", "debug")
+end
 
 # Build Rust library before compiling C extension
 puts "Building Rust library..."
-system("cd #{root_dir} && cargo build --release") or abort("Rust build failed")
+system("cd #{root_dir} && cargo build #{release ? '--release' : ''}") or abort("Rust build failed")
 
 # Add the Rust target directory to the library search path
-$LOCAL_LIBS << " -L#{target_dir} -lindex"
+$LOCAL_LIBS << " -L#{build_dir} -lindex"
 
 create_makefile("index/index")


### PR DESCRIPTION
When building a Rust library, the command `cargo build --release` can be used to build an optimized version of the library. This however comes at a performance cost during compilation time. During development, these bits of time will add up significantly.

This PR enables the Ruby build script to call `cargo build` without the release flag. This will generate a dev build for the Rust lib whenever possible, saving us some time when developing.