### PR TITLE
Avoid checking LD flags for Windows

### DIFF
--- a/ext/index/extconf.rb
+++ b/ext/index/extconf.rb
@@ -24,7 +24,7 @@ if Gem.win_platform?
   # These libraries are the ones informed by `cargo rustc -- --print native-static-libs`, which displays the
   # libraries necessary for statically linking the Rust code on the current platform
   ["kernel32", "ntdll", "userenv", "ws2_32", "dbghelp", "msvcrt"].each do |lib|
-    append_ldflags("-l#{lib}")
+    $LDFLAGS << " -l#{lib}"
   end
 else
   append_ldflags("-Wl,-rpath,#{target_dir}")


### PR DESCRIPTION
I think the dependencies were cached in #15 because Windows CI was passing, but in main it is failing. I think the reason is the LD flag checks.