### PR TITLE
Add some parallel indexing logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -53,6 +62,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.66.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b84e06fc203107bfbad243f4aba2af864eb7db3b1cf46ea0a023b0b433d2a7"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "peeking_take_while",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn",
+ "which",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -78,10 +110,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "cc"
+version = "1.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d487aa071b5f64da6f19a3e848e3578944b726ee5a4854b82172f02aa876bfdc"
+dependencies = [
+ "shlex",
+]
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
 
 [[package]]
 name = "clap"
@@ -115,6 +176,12 @@ name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "equivalent"
@@ -151,6 +218,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
+
+[[package]]
 name = "hashbrown"
 version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -163,11 +236,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "home"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
 name = "index"
 version = "0.1.0"
 dependencies = [
  "cbindgen",
  "libc",
+ "ruby-prism",
 ]
 
 [[package]]
@@ -193,10 +276,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "libc"
 version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+
+[[package]]
+name = "libloading"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
+dependencies = [
+ "cfg-if",
+ "windows-targets",
+]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -217,6 +328,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -227,6 +354,22 @@ name = "once_cell_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+
+[[package]]
+name = "peeking_take_while"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
+
+[[package]]
+name = "prettyplease"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6837b9e10d61f45f987d50808f83d1ee3d206c66acf650c3e4ae2e1f6ddedf55"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -253,6 +396,75 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
+name = "regex"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+
+[[package]]
+name = "ruby-prism"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45a3a71142531d9dcb33cf162543a68c1d1e5567dd96ac5cc38b8b99b3166b8b"
+dependencies = [
+ "ruby-prism-sys",
+ "serde",
+ "serde_yaml",
+]
+
+[[package]]
+name = "ruby-prism-sys"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f77ce848645f060a1f3d60af962f481c58618863390184f96adf5d107e48954"
+dependencies = [
+ "bindgen",
+ "cc",
+]
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys",
+]
+
+[[package]]
 name = "rustix"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -261,7 +473,7 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.9.4",
  "windows-sys",
 ]
 
@@ -313,6 +525,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -338,7 +569,7 @@ dependencies = [
  "fastrand",
  "getrandom",
  "once_cell",
- "rustix",
+ "rustix 1.0.7",
  "windows-sys",
 ]
 
@@ -390,6 +621,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -402,6 +639,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
 dependencies = [
  "wit-bindgen-rt",
+]
+
+[[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix 0.38.44",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ cbindgen = "0.29"
 
 [dependencies]
 libc = "0.2.174"
+ruby-prism = "1.4.0"
 
 [profile.release]
 lto = true

--- a/bench.rb
+++ b/bench.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+$LOAD_PATH.unshift(File.expand_path("lib", __dir__))
+
+require "benchmark"
+require "index"
+
+all_core_files = Dir.glob("#{Dir.home}/world/trees/root/src/areas/core/shopify/**/*.rb")
+repo = Index::Repository.new
+
+rt = Benchmark.realtime do
+  repo.index_all(all_core_files)
+end
+
+puts "Took #{rt} to index #{repo.size} declarations"

--- a/ext/index/repository.c
+++ b/ext/index/repository.c
@@ -5,7 +5,7 @@ static VALUE cRepository;
 
 static void repository_free(void *ptr) {
     if (ptr) {
-        free(ptr);
+        free_repo(ptr);
     }
 }
 
@@ -53,9 +53,17 @@ static VALUE rb_repository_index_all(VALUE self, VALUE file_paths) {
     return Qnil;
 }
 
+static VALUE rb_repository_size(VALUE self) {
+    void* repository;
+    TypedData_Get_Struct(self, void*, &repository_type, repository);
+    size_t size = repo_size(repository);
+    return SIZET2NUM(size);
+}
+
 void initialize_repository(VALUE mIndex) {
     cRepository = rb_define_class_under(mIndex, "Repository", rb_cObject);
 
     rb_define_alloc_func(cRepository, rb_repository_alloc);
     rb_define_method(cRepository, "index_all", rb_repository_index_all, 1);
+    rb_define_method(cRepository, "size", rb_repository_size, 0);
 }

--- a/src/c_interface.rs
+++ b/src/c_interface.rs
@@ -1,16 +1,10 @@
-use crate::Repository;
+use crate::{Repository, index_in_parallel};
 use libc::{c_char, c_void, size_t};
 use std::ffi::CStr;
+use std::mem::forget;
 use std::slice::from_raw_parts;
 use std::str::Utf8Error;
-
-// Converts a void pointer from C into a mutable Rust reference without causing Rust to free the pointer once the object
-// goes out of scope. Always use this macro when reinstantiating a Rust object back from the void pointer
-macro_rules! pointer_to_ref {
-    ($pointer:expr, $type:ty) => {
-        unsafe { &mut *($pointer as *mut $type) }
-    };
-}
+use std::sync::{Arc, Mutex};
 
 unsafe fn convert_double_pointer_to_vec(data: &mut &mut c_char, len: size_t) -> Result<Vec<String>, Utf8Error> {
     unsafe {
@@ -22,13 +16,32 @@ unsafe fn convert_double_pointer_to_vec(data: &mut &mut c_char, len: size_t) -> 
 }
 
 #[unsafe(no_mangle)]
-pub extern "C" fn index_all_c(pointer: *mut c_void, file_paths: &mut &mut c_char, count: usize) {
-    let file_paths: Vec<String> = unsafe { convert_double_pointer_to_vec(file_paths, count).unwrap() };
-    let repository = pointer_to_ref!(pointer, Repository);
-    repository.index_all(file_paths);
+pub extern "C" fn new_repo() -> *mut c_void {
+    let repo_arc = Arc::new(Mutex::new(Repository::new()));
+    Arc::into_raw(repo_arc) as *mut c_void
 }
 
 #[unsafe(no_mangle)]
-pub extern "C" fn new_repo() -> *mut c_void {
-    Box::into_raw(Box::new(Repository::new())) as *mut c_void
+pub extern "C" fn free_repo(pointer: *mut c_void) {
+    unsafe {
+        let _ = Arc::from_raw(pointer as *mut Mutex<Repository>);
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn index_all_c(pointer: *mut c_void, file_paths: &mut &mut c_char, count: usize) {
+    let file_paths: Vec<String> = unsafe { convert_double_pointer_to_vec(file_paths, count).unwrap() };
+    let file_queue = Arc::new(Mutex::new(file_paths));
+
+    let repository = unsafe { Arc::from_raw(pointer as *mut Mutex<Repository>) };
+    index_in_parallel(&repository, &file_queue);
+    forget(repository);
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn repo_size(pointer: *mut c_void) -> usize {
+    let repository = unsafe { Arc::from_raw(pointer as *mut Mutex<Repository>) };
+    let size = repository.lock().unwrap().size();
+    forget(repository);
+    size
 }

--- a/src/declaration.rs
+++ b/src/declaration.rs
@@ -1,0 +1,68 @@
+#[derive(Debug)]
+pub enum Declaration {
+    Class(ClassDeclaration),
+    Module(ModuleDeclaration),
+}
+
+#[derive(Debug)]
+pub struct Location {
+    start_offset: usize,
+    end_offset: usize,
+}
+
+impl Location {
+    pub fn start_offset(&self) -> usize {
+        self.start_offset
+    }
+
+    pub fn end_offset(&self) -> usize {
+        self.end_offset
+    }
+}
+
+#[derive(Debug)]
+pub struct ClassDeclaration {
+    location: Location,
+}
+
+#[derive(Debug)]
+pub struct ModuleDeclaration {
+    location: Location,
+}
+
+impl ClassDeclaration {
+    pub fn new(location: ruby_prism::Location) -> Self {
+        ClassDeclaration {
+            location: Location {
+                start_offset: location.start_offset(),
+                end_offset: location.end_offset(),
+            },
+        }
+    }
+}
+
+impl ModuleDeclaration {
+    pub fn new(location: ruby_prism::Location) -> Self {
+        ModuleDeclaration {
+            location: Location {
+                start_offset: location.start_offset(),
+                end_offset: location.end_offset(),
+            },
+        }
+    }
+}
+
+impl std::fmt::Display for Declaration {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Declaration::Class(class_decl) => {
+                let location = &class_decl.location;
+                write!(f, "Class({}->{})", location.start_offset(), location.end_offset())
+            }
+            Declaration::Module(module_decl) => {
+                let location = &module_decl.location;
+                write!(f, "Module({}->{})", location.start_offset(), location.end_offset())
+            }
+        }
+    }
+}

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -1,0 +1,36 @@
+use std::collections::HashMap;
+
+use crate::declaration::{ClassDeclaration, Declaration, ModuleDeclaration};
+
+#[derive(Debug)]
+pub struct Repository {
+    entries: HashMap<String, Declaration>,
+}
+
+impl Repository {
+    pub fn new() -> Self {
+        Repository {
+            entries: HashMap::new(),
+        }
+    }
+
+    pub fn add_class(&mut self, name: String, location: ruby_prism::Location) {
+        let declaration = Declaration::Class(ClassDeclaration::new(location));
+        self.entries.insert(name, declaration);
+    }
+
+    pub fn add_module(&mut self, name: String, location: ruby_prism::Location) {
+        let declaration = Declaration::Module(ModuleDeclaration::new(location));
+        self.entries.insert(name, declaration);
+    }
+
+    pub fn size(&self) -> usize {
+        self.entries.len()
+    }
+}
+
+impl Default for Repository {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src/ruby_indexer.rs
+++ b/src/ruby_indexer.rs
@@ -1,0 +1,60 @@
+use ruby_prism::Visit;
+use std::sync::{Arc, Mutex};
+
+use crate::Repository;
+
+pub struct RubyIndexer<'a> {
+    nesting: Vec<String>,
+    repository: &'a Arc<Mutex<Repository>>,
+}
+
+impl<'a> RubyIndexer<'a> {
+    pub fn new(repository: &'a Arc<Mutex<Repository>>) -> Self {
+        RubyIndexer {
+            nesting: Vec::new(),
+            repository,
+        }
+    }
+
+    pub fn index(&mut self, file_path: String) {
+        let source = std::fs::read_to_string(&file_path).unwrap();
+        let result = ruby_prism::parse(source.as_ref());
+
+        self.visit(&result.node());
+        self.nesting.clear();
+    }
+}
+
+impl Visit<'_> for RubyIndexer<'_> {
+    fn visit_class_node(&mut self, node: &ruby_prism::ClassNode) {
+        match std::str::from_utf8(node.constant_path().location().as_slice()).map(str::to_string) {
+            Ok(name) => {
+                let mut repo_guard = self.repository.lock().unwrap();
+                repo_guard.add_class(name, node.location());
+            }
+            Err(_) => {
+                // Name is not a valid UTF-8 string
+            }
+        }
+
+        if let Some(body) = node.body() {
+            self.visit(&body);
+        }
+    }
+
+    fn visit_module_node(&mut self, node: &ruby_prism::ModuleNode) {
+        match std::str::from_utf8(node.constant_path().location().as_slice()).map(str::to_string) {
+            Ok(name) => {
+                let mut repo_guard = self.repository.lock().unwrap();
+                repo_guard.add_module(name, node.location());
+            }
+            Err(_) => {
+                // Name is not a valid UTF-8 string
+            }
+        }
+
+        if let Some(body) = node.body() {
+            self.visit(&body);
+        }
+    }
+}


### PR DESCRIPTION
This PR show cases the ability to index classes and modules in parallel using Rust. This implementation can index all files in Core (including all tests) in about 2 seconds.

Here's how to use it after running `bundle exec rake compile`:

```ruby
repository = Index::Repository.new
repository.index_all(Dir.glob("/path/to/shopify/**/*.rb"))
```