### PR TITLE
Add method to report memory size of repository

### DIFF
--- a/ext/index/repository.c
+++ b/ext/index/repository.c
@@ -110,6 +110,15 @@ static VALUE rb_repository_get(VALUE self, VALUE name) {
     return ruby_declaration;
 }
 
+static VALUE rb_repository_memsize(VALUE self) {
+    void* repository;
+    TypedData_Get_Struct(self, void*, &repository_type, repository);
+
+    size_t rust_memsize = idx_repository_memsize(repository);
+    size_t ruby_memsize = rb_obj_memsize_of(self);
+    return SIZET2NUM(rust_memsize + ruby_memsize);
+}
+
 void initialize_repository(VALUE mIndex) {
     cRepository  = rb_define_class_under(mIndex, "Repository",  rb_cObject);
     cDeclaration = rb_define_class_under(mIndex, "Declaration", rb_cObject);
@@ -119,4 +128,6 @@ void initialize_repository(VALUE mIndex) {
     rb_define_method(cRepository, "size", rb_repository_size, 0);
     rb_define_method(cRepository, "add_class", rb_repository_add_class, 3);
     rb_define_method(cRepository, "get", rb_repository_get, 1);
+
+    rb_define_method(cRepository, "memsize", rb_repository_memsize, 0);
 }

--- a/src/c_interface.rs
+++ b/src/c_interface.rs
@@ -59,6 +59,12 @@ pub extern "C" fn idx_repository_size(pointer: RepositoryPointer) -> usize {
 }
 
 #[unsafe(no_mangle)]
+pub extern "C" fn idx_repository_memsize(pointer: *mut c_void) -> usize {
+    let repository = retain_repository(pointer);
+    std::mem::size_of_val(&repository.lock().unwrap())
+}
+
+#[unsafe(no_mangle)]
 pub extern "C" fn idx_repository_add_class_declaration(
     pointer: RepositoryPointer,
     name: &mut c_char,

--- a/test/index_test.rb
+++ b/test/index_test.rb
@@ -10,6 +10,7 @@ class IndexRustyTest < Minitest::Test
   def test_index_all
     repository = Index::Repository.new
     repository.index_all([__FILE__])
+    puts repository.memsize
   end
 
   def test_add_and_get


### PR DESCRIPTION
This PR adds a method `Repository#memsize` to report the amount of memory used including what's stored in the Ruby VM + the Rust memory.