### PR TITLE
Recommend clangd extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,7 @@
 {
     "recommendations": [
         "rust-lang.rust-analyzer",
-        "shopify.ruby-extensions-pack"
+        "shopify.ruby-extensions-pack",
+        "llvm-vs-code-extensions.vscode-clangd"
     ]
 }


### PR DESCRIPTION
Add the clangd extension to our recommendations, so that people get LSP support on C files.