### PR TITLE
Add script to print peak and MRSS memory usage

### DIFF
--- a/utils/mem-use
+++ b/utils/mem-use
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+if [ $# -eq 0 ]; then
+    echo "Usage: $0 <command> [args...]"
+    echo "Example: $0 cargo run"
+    exit 1
+fi
+
+temp_file=$(mktemp)
+
+echo "Running: $*"
+echo "----------------------------------------"
+
+/usr/bin/time -l "$@" 2> "$temp_file"
+exit_code=$?
+
+echo "----------------------------------------"
+
+if [ $exit_code -ne 0 ]; then
+    echo "Error: $exit_code"
+    cat "$temp_file"
+    rm "$temp_file"
+    exit $exit_code
+fi
+
+# Extract memory statistics
+mrss=$(grep "maximum resident set size" "$temp_file" | awk '{print $1}')
+peak=$(grep "peak memory footprint" "$temp_file" | awk '{print $1}')
+
+# Convert bytes to MB for readability
+if [ -n "$mrss" ]; then
+    mrss_mb=$(echo "scale=2; $mrss / 1024 / 1024" | bc -l 2>/dev/null || echo "$(($mrss / 1024 / 1024))")
+    echo "Maximum Resident Set Size: $mrss bytes (${mrss_mb} MB)"
+fi
+
+if [ -n "$peak" ]; then
+    peak_mb=$(echo "scale=2; $peak / 1024 / 1024" | bc -l 2>/dev/null || echo "$(($peak / 1024 / 1024))")
+    echo "Peak Memory Footprint:     $peak bytes (${peak_mb} MB)"
+fi
+
+# Also show execution time
+real_time=$(grep "real" "$temp_file" | awk '{print $1}')
+if [ -n "$real_time" ]; then
+    echo "Execution Time:            ${real_time} seconds"
+fi
+
+rm "$temp_file"
+exit $exit_code


### PR DESCRIPTION
For example:

```bash
$ utils/mem-use pwd

Running: pwd
----------------------------------------
/Users/user/src/github.com/Shopify/index
----------------------------------------
Maximum Resident Set Size: 1032192 bytes (.98 MB)
Peak Memory Footprint:     803328 bytes (.76 MB)
Execution Time:            0.02 seconds
```