### PR TITLE
Update Clippy settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,13 +1,6 @@
 {
     "rust-analyzer.check.command": "clippy",
     "rust-analyzer.check.allTargets": true,
-    "rust-analyzer.check.extraArgs": [
-        "--",
-        "-W",
-        "clippy::all",
-        "-W",
-        "clippy::nursery"
-    ],
     "rust-analyzer.diagnostics.enable": true,
     "rust-analyzer.rustfmt.extraArgs": [
         "--edition",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,18 @@ cbindgen = "0.29"
 lto = true
 opt-level = 3
 codegen-units = 1
+
+[workspace.lints.clippy]
+# See: https://doc.rust-lang.org/clippy/lints.html
+correctness = "forbid"
+suspicious = "forbid"
+perf = "forbid"
+complexity = "forbid"
+style = "forbid"
+pedantic = "warn"
+
+ptr-as-ptr = { level = "forbid", priority = 1 }
+manual-let-else = { level = "allow", priority = 1 }
+
+[lints]
+workspace = true

--- a/src/c_interface.rs
+++ b/src/c_interface.rs
@@ -8,7 +8,7 @@ pub type CEntry = std::ffi::c_void;
 #[unsafe(no_mangle)]
 pub extern "C" fn get_repository() -> *mut CRepository {
     let repository = Repository::new();
-    Box::into_raw(Box::new(repository)) as *mut CRepository
+    Box::into_raw(Box::new(repository)).cast::<CRepository>()
 }
 
 /// This will likely be removed
@@ -22,7 +22,7 @@ pub unsafe extern "C" fn repository_get_entry(repository: *const CRepository, na
         return std::ptr::null_mut();
     }
     unsafe {
-        let repository_ref = &*(repository as *const Repository);
+        let repository_ref = &*repository.cast::<Repository>();
         let c_str = std::ffi::CStr::from_ptr(name);
         let name_str = match c_str.to_str() {
             Ok(s) => s,
@@ -30,7 +30,7 @@ pub unsafe extern "C" fn repository_get_entry(repository: *const CRepository, na
         };
 
         match repository_ref.get_entry(name_str) {
-            Some(entry) => Box::into_raw(Box::new(entry.clone())) as *mut CEntry,
+            Some(entry) => Box::into_raw(Box::new(entry.clone())).cast::<CEntry>(),
             None => std::ptr::null_mut(),
         }
     }
@@ -47,7 +47,7 @@ pub unsafe extern "C" fn repository_add_entry(repository: *mut CRepository, name
         return;
     }
     unsafe {
-        let repository_ref = &mut *(repository as *mut Repository);
+        let repository_ref = &mut *repository.cast::<Repository>();
         let name_cstr = std::ffi::CStr::from_ptr(name);
         let value_cstr = std::ffi::CStr::from_ptr(value);
 
@@ -64,7 +64,7 @@ pub extern "C" fn entry_get_name(entry: *const CEntry) -> *const c_char {
         return std::ptr::null();
     }
     unsafe {
-        let entry_ref = &*(entry as *const Entry);
+        let entry_ref = &*entry.cast::<Entry>();
         match CString::new(entry_ref.name.clone()) {
             Ok(c_string) => c_string.into_raw(),
             Err(_) => std::ptr::null(),
@@ -78,7 +78,7 @@ pub extern "C" fn entry_get_value(entry: *const CEntry) -> *const c_char {
         return std::ptr::null();
     }
     unsafe {
-        let entry_ref = &*(entry as *const Entry);
+        let entry_ref = &*entry.cast::<Entry>();
         match CString::new(entry_ref.value.clone()) {
             Ok(c_string) => c_string.into_raw(),
             Err(_) => std::ptr::null(),
@@ -90,7 +90,7 @@ pub extern "C" fn entry_get_value(entry: *const CEntry) -> *const c_char {
 pub extern "C" fn delloc_entry(entry: *mut CEntry) {
     if !entry.is_null() {
         unsafe {
-            let _ = Box::from_raw(entry as *mut Entry);
+            let _ = Box::from_raw(entry.cast::<Entry>());
         }
     }
 }
@@ -99,7 +99,7 @@ pub extern "C" fn delloc_entry(entry: *mut CEntry) {
 pub extern "C" fn dealloc_repository(repository: *mut CRepository) {
     if !repository.is_null() {
         unsafe {
-            let _ = Box::from_raw(repository as *mut Repository);
+            let _ = Box::from_raw(repository.cast::<Repository>());
         }
     }
 }

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -11,6 +11,7 @@ impl Default for Repository {
 }
 
 impl Repository {
+    #[must_use]
     pub fn new() -> Self {
         Self {
             entries: HashMap::new(),
@@ -20,6 +21,7 @@ impl Repository {
         self.entries.insert(entry.name.clone(), entry);
     }
 
+    #[must_use]
     pub fn get_entry(&self, key: &str) -> Option<&Entry> {
         self.entries.get(key)
     }
@@ -32,6 +34,7 @@ pub struct Entry {
 }
 
 impl Entry {
+    #[must_use]
     pub fn new(name: String, value: String) -> Self {
         Self { name, value }
     }


### PR DESCRIPTION
Update Clippy settings
- setup workspace.lints.clippy
- forbid common lint issues
- warn on pedantic issues for learning
- disable linting settings in settings.json - use workspace settings consistently
- this has the effect of disabling nursery lints which is preferable due to instability

Change code to reflect Clippy settings
- use `cast` instead of `as` where appropriate
- add `must_use` where appropriate