### PR TITLE
Add dev.yml

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,15 +2,6 @@
     "rust-analyzer.check.command": "clippy",
     "rust-analyzer.check.allTargets": true,
     "rust-analyzer.diagnostics.enable": true,
-    "rust-analyzer.rustfmt.extraArgs": [
-        "--edition",
-        "2024"
-    ],
-    "rust-analyzer.rustfmt.overrideCommand": [
-        "rustfmt",
-        "--edition",
-        "2024"
-    ],
     "[rust]": {
         "editor.formatOnSave": true,
         "editor.defaultFormatter": "rust-lang.rust-analyzer"

--- a/dev.yml
+++ b/dev.yml
@@ -1,0 +1,4 @@
+up:
+  - ruby
+  - bundler
+  - rust


### PR DESCRIPTION
This morning dev seemed to have removed Rust from my machine. This PR adds a `dev.yml`, so that we can dev up and get the expected setup.

Also, formatting is failing for me with the `--edition` flag, but I'm not 100% sure that's actually necessary. Everything works without that flag.