### PR TITLE
Remove URI interning lock

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -178,6 +178,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -375,6 +400,7 @@ dependencies = [
 name = "index"
 version = "0.1.0"
 dependencies = [
+ "rayon",
  "ruby-prism",
  "tempfile",
  "url",
@@ -550,6 +576,26 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rayon"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "regex"

--- a/rust/index/Cargo.toml
+++ b/rust/index/Cargo.toml
@@ -13,6 +13,7 @@ crate-type = ["rlib"]
 [dependencies]
 ruby-prism = "1.4.0"
 url = "2.5.4"
+rayon = "1.10.0"
 
 [dev-dependencies]
 tempfile = "3.0"

--- a/rust/index/src/indexing.rs
+++ b/rust/index/src/indexing.rs
@@ -1,87 +1,100 @@
 use std::{
+    cmp, fs,
     sync::{Arc, Mutex},
-    thread,
 };
 
+use crate::{
+    indexing::{
+        errors::{IndexingError, MultipleErrors},
+        ruby_indexer::RubyIndexer,
+    },
+    model::index::Index,
+};
+use rayon::prelude::*;
 use url::Url;
-
-use crate::{indexing::ruby_indexer::RubyIndexer, model::index::Index};
-
+mod errors;
+pub mod indexed_data;
 pub mod ruby_indexer;
 
+// Represents a document to be indexed. If `source` is `Some(String)`, we're indexing a file state that's not committed
+// to disk yet and should then use the given `source` instead of reading from disk
 pub struct Document {
-    uri: String,
+    uri: Url,
     source: Option<String>,
 }
 
 impl Document {
+    /// # Errors
+    ///
+    /// Creating a new document fails on invalid URIs
+    pub fn new(uri: &str, source: Option<String>) -> Result<Self, url::ParseError> {
+        Ok(Self {
+            uri: Url::parse(uri)?,
+            source,
+        })
+    }
+
     #[must_use]
-    pub fn new(uri: String, source: Option<String>) -> Self {
-        Self { uri, source }
+    pub fn path(&self) -> &str {
+        self.uri.path()
     }
 }
 
 /// Indexes the given items, reading the content from disk and populating the given `Index` instance.
 ///
+/// # Errors
+///
+/// Returns Ok if indexing succeeded for all given documents or a vector of errors for all failures
+///
 /// # Panics
 /// This function will panic in the event of a thread dead lock, which indicates a bug in our implementation. There
 /// should not be any code that tries to lock the same mutex multiple times in the same thread
-pub fn index_in_parallel(index_arc: &Arc<Mutex<Index>>, documents: &Arc<Mutex<Vec<Document>>>) {
-    let num_threads = thread::available_parallelism().map(std::num::NonZero::get).unwrap_or(4);
-    let mut threads = Vec::with_capacity(num_threads);
+pub fn index_in_parallel(index_arc: &Arc<Mutex<Index>>, documents: &[Document]) -> Result<(), MultipleErrors> {
+    let chunk_size = cmp::max(10, documents.len() / rayon::current_num_threads());
 
-    for _ in 0..num_threads {
-        let queue_clone = Arc::clone(documents);
-        let index_clone = Arc::clone(index_arc);
-
-        // Each thread creates its own indexer instance, which they use to visit ASTs. The threads pop from a shared
-        // queue to avoid being idle. Definitions are collected for all of the files that got processed and then
-        // returned at the end
-        let handle = thread::spawn(move || {
+    let indexers: Vec<RubyIndexer> = documents
+        .par_chunks(chunk_size)
+        .map(|chunk| {
             let mut ruby_indexer = RubyIndexer::new();
 
-            loop {
-                // Pop a file path from the shared queue. This needs to happen in a small scope to avoid holding the
-                // lock for too long, which would cause other threads to slow down
-                let maybe_document = {
-                    let mut queue = queue_clone.lock().unwrap();
-                    queue.pop()
-                };
-
-                if let Some(document) = maybe_document {
-                    if let Ok(uri) = Url::parse(&document.uri) {
-                        let uri_id = index_clone.lock().unwrap().intern_uri(document.uri.to_string());
-
-                        if let Some(source) = document.source {
-                            ruby_indexer.index(uri_id, &source);
-                        } else if let Ok(source) = std::fs::read_to_string(uri.path()) {
-                            ruby_indexer.index(uri_id, &source);
-                        } else {
-                            panic!("Cannot index document at {}", uri.path());
+            for document in chunk {
+                // If the document includes the source, use it directly to index (especially since the content may not
+                // be committed to disk yet). Otherwise, read it from disk
+                if let Some(source) = &document.source {
+                    ruby_indexer.index(document.uri.to_string(), source);
+                } else {
+                    match fs::read_to_string(document.path()) {
+                        Ok(source) => {
+                            ruby_indexer.index(document.uri.to_string(), &source);
+                        }
+                        Err(e) => {
+                            ruby_indexer.add_error(IndexingError::FileReadError(format!(
+                                "Failed to read {}: {}",
+                                document.path(),
+                                e
+                            )));
                         }
                     }
-                } else {
-                    break;
                 }
             }
 
-            // Return the collected definitions when joining this thread
-            ruby_indexer.definitions
-        });
-
-        threads.push(handle);
-    }
-
-    let mut results = Vec::new();
-
-    for handle in threads {
-        let definitions = handle.join().expect("indexing thread panicked");
-        results.push(definitions);
-    }
+            ruby_indexer
+        })
+        .collect();
 
     // Insert all discovered definitions into the global index
+    let mut all_errors = Vec::new();
     let mut index = index_arc.lock().unwrap();
-    for definitions in results {
-        index.merge_definitions(definitions);
+
+    for indexer in indexers {
+        let (indexed_data, errors) = indexer.into();
+        index.merge_definitions(indexed_data);
+        all_errors.extend(errors);
+    }
+
+    if all_errors.is_empty() {
+        Ok(())
+    } else {
+        Err(MultipleErrors(all_errors))
     }
 }

--- a/rust/index/src/indexing/errors.rs
+++ b/rust/index/src/indexing/errors.rs
@@ -1,0 +1,28 @@
+use std::error::Error;
+
+#[derive(Debug)]
+pub struct MultipleErrors(pub Vec<IndexingError>);
+
+impl std::fmt::Display for MultipleErrors {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "Multiple errors: {:?}", self.0)
+    }
+}
+
+impl Error for MultipleErrors {}
+
+// Enum representing all types of indexing errors that may happen
+#[derive(Debug)]
+pub enum IndexingError {
+    FileReadError(String),
+}
+
+impl std::fmt::Display for IndexingError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            IndexingError::FileReadError(msg) => write!(f, "File read error: {msg}"),
+        }
+    }
+}
+
+impl Error for IndexingError {}

--- a/rust/index/src/indexing/indexed_data.rs
+++ b/rust/index/src/indexing/indexed_data.rs
@@ -1,0 +1,81 @@
+use std::collections::HashMap;
+
+use crate::model::{
+    definitions::Definition,
+    ids::{DeclarationId, UriId},
+};
+
+// A view of a declaration that may be incomplete since it is indexer specific and not global. This struct contains
+// everything we discovered about a given declaration inside a single indexing thread
+pub struct PartialDeclaration {
+    declaration_id: DeclarationId,
+    definitions: Vec<Definition>,
+}
+
+impl PartialDeclaration {
+    #[must_use]
+    pub fn new(declaration_id: DeclarationId) -> Self {
+        Self {
+            declaration_id,
+            definitions: Vec::new(),
+        }
+    }
+
+    #[must_use]
+    pub fn into(self) -> (DeclarationId, Vec<Definition>) {
+        (self.declaration_id, self.definitions)
+    }
+
+    pub fn add_definition(&mut self, definition: Definition) {
+        self.definitions.push(definition);
+    }
+}
+
+// A collection of declarations specific for this indexer. This is not the global representation of declarations, just a
+// list of all definitions discovered that will be merged into the global index. It helps us avoid having to hash fully
+// qualified names into DeclarationIds multiple times.
+//
+// This is similar to a temporary global index instance, but we prioritize performance since we will throw away this
+// state once it gets merged globally
+pub struct IndexingThreadData {
+    declarations: HashMap<String, PartialDeclaration>,
+    uris: HashMap<UriId, String>,
+}
+
+impl IndexingThreadData {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            declarations: HashMap::new(),
+            uris: HashMap::new(),
+        }
+    }
+
+    pub fn add_uri(&mut self, uri: String) -> UriId {
+        let uri_id = UriId::new(&uri);
+        self.uris.insert(uri_id, uri);
+        uri_id
+    }
+
+    pub fn add_definition(&mut self, name: String, definition: Definition) {
+        self.declarations
+            .entry(name)
+            .or_insert_with_key(|name| {
+                let id = DeclarationId::new(name);
+                PartialDeclaration::new(id)
+            })
+            .add_definition(definition);
+    }
+
+    // Returns all the owned data, so that we can merge it into the global index
+    #[must_use]
+    pub fn into_parts(self) -> (HashMap<String, PartialDeclaration>, HashMap<UriId, String>) {
+        (self.declarations, self.uris)
+    }
+}
+
+impl Default for IndexingThreadData {
+    fn default() -> Self {
+        Self::new()
+    }
+}


### PR DESCRIPTION
This PR removes the interning of URIs from the index, so that the threads don't have to compete on any locks and everything is merged at the end.

I also switched to using rayon for parallelism, which makes the implementation much simpler.