### PR TITLE
Disallow manual-let-else

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -21,4 +21,3 @@ style = "forbid"
 pedantic = "warn"
 
 ptr-as-ptr = { level = "forbid", priority = 1 }
-manual-let-else = { level = "allow", priority = 1 }


### PR DESCRIPTION
There is a more elegant syntax for this: https://rust-lang.github.io/rust-clippy/rust-1.67.0/index.html#manual_let_else.