### PR TITLE
Add command to generate graph representation

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -539,6 +539,7 @@ dependencies = [
  "clap",
  "predicates",
  "rayon",
+ "regex",
  "rmp-serde",
  "ruby-prism",
  "rusqlite",

--- a/rust/index/Cargo.toml
+++ b/rust/index/Cargo.toml
@@ -25,6 +25,7 @@ rmp-serde = "1.3.0"
 tempfile = "3.0"
 assert_cmd = "2.0"
 predicates = "3.1"
+regex = "1.10"
 
 [lints]
 workspace = true

--- a/rust/index/src/lib.rs
+++ b/rust/index/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod indexing;
 pub mod model;
 pub mod offset;
+pub mod visualization;
 
 #[cfg(test)]
 pub mod test_utils;

--- a/rust/index/src/main.rs
+++ b/rust/index/src/main.rs
@@ -8,6 +8,7 @@ use clap::Parser;
 use index::{
     indexing::{self, errors::MultipleErrors},
     model::graph::Graph,
+    visualization::dot,
 };
 
 #[derive(Parser, Debug)]
@@ -21,6 +22,9 @@ struct Args {
         help = "Run integrity checks on the index after processing"
     )]
     check_integrity: bool,
+
+    #[arg(long = "visualize")]
+    visualize: bool,
 }
 
 fn main() -> Result<(), Box<dyn Error>> {
@@ -50,6 +54,17 @@ fn main() -> Result<(), Box<dyn Error>> {
             }
             std::process::exit(1);
         }
+    }
+
+    // Generate visualization or print statistics
+    let graph_lock = graph_arc.lock().unwrap();
+    if args.visualize {
+        println!("{}", dot::generate(&graph_lock));
+    } else {
+        println!("Indexed {} files", documents.len());
+        println!("Found {} names", graph_lock.names().len());
+        println!("Found {} definitions", graph_lock.definitions().len());
+        println!("Found {} URIs", graph_lock.uri_pool().len());
     }
 
     Ok(())

--- a/rust/index/src/model/definitions.rs
+++ b/rust/index/src/model/definitions.rs
@@ -73,6 +73,22 @@ impl Definition {
             Definition::Method(it) => it.offset.end(),
         }
     }
+
+    #[must_use]
+    pub fn kind(&self) -> &'static str {
+        match self {
+            Definition::Class(_) => "Class",
+            Definition::Module(_) => "Module",
+            Definition::Constant(_) => "Constant",
+            Definition::Method(_) => "Method",
+            Definition::AttrAccessor(_) => "AttrAccessor",
+            Definition::AttrReader(_) => "AttrReader",
+            Definition::AttrWriter(_) => "AttrWriter",
+            Definition::GlobalVariable(_) => "GlobalVariable",
+            Definition::InstanceVariable(_) => "InstanceVariable",
+            Definition::ClassVariable(_) => "ClassVariable",
+        }
+    }
 }
 
 /// A class definition

--- a/rust/index/src/visualization.rs
+++ b/rust/index/src/visualization.rs
@@ -1,0 +1,6 @@
+//! Graph visualization module for the Index structure.
+//!
+//! This module provides functionality to generate visual representations of the Index's
+//! internal graph structure, showing the relationships between Names, Definitions, and URIs.
+
+pub mod dot;

--- a/rust/index/src/visualization/dot.rs
+++ b/rust/index/src/visualization/dot.rs
@@ -1,0 +1,194 @@
+//! DOT format generator for Graphviz visualization of the graph structure.
+
+use std::fmt::Write;
+
+use crate::model::graph::Graph;
+
+const NAME_NODE_SHAPE: &str = "hexagon";
+const DEFINITION_NODE_SHAPE: &str = "ellipse";
+const URI_NODE_SHAPE: &str = "box";
+
+/// Escapes a string for use in DOT format labels and identifiers.
+fn escape_dot_string(s: &str) -> String {
+    if !s.contains('"') {
+        return s.to_string();
+    }
+
+    let mut result = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '"' => result.push_str("\\\""),
+            _ => result.push(c),
+        }
+    }
+    result
+}
+
+#[must_use]
+pub fn generate(graph: &Graph) -> String {
+    let mut output = String::new();
+    output.push_str("digraph {\n");
+    output.push_str("    rankdir=TB;\n\n");
+
+    write_name_nodes(&mut output, graph);
+    write_definition_nodes(&mut output, graph);
+    write_uri_nodes(&mut output, graph);
+    write_name_to_definition_edges(&mut output, graph);
+    write_definition_to_uri_edges(&mut output, graph);
+
+    output.push_str("}\n");
+    output
+}
+
+fn write_name_nodes(output: &mut String, graph: &Graph) {
+    let mut names: Vec<_> = graph.names().values().collect();
+    names.sort();
+
+    for name in names {
+        let escaped_name = escape_dot_string(name);
+        let node_id = format!("Name:{name}");
+        let _ = writeln!(
+            output,
+            "    \"{node_id}\" [label=\"{escaped_name}\",shape={NAME_NODE_SHAPE}];"
+        );
+    }
+    output.push('\n');
+}
+
+fn write_definition_nodes(output: &mut String, graph: &Graph) {
+    let mut definitions: Vec<_> = graph.definitions().iter().collect();
+    definitions.sort_by_key(|(def_id, _)| def_id.to_string());
+
+    for (def_id, definition) in definitions {
+        if let Some(name_id) = graph.definition_to_name().get(def_id)
+            && let Some(name) = graph.names().get(name_id)
+        {
+            let def_type = definition.kind();
+            let escaped_name = escape_dot_string(name);
+
+            let _ = writeln!(
+                output,
+                "    \"def_{def_id}\" [label=\"{def_type}({escaped_name})\",shape={DEFINITION_NODE_SHAPE}];"
+            );
+        }
+    }
+    output.push('\n');
+}
+
+fn write_uri_nodes(output: &mut String, graph: &Graph) {
+    let mut uris: Vec<_> = graph.uri_pool().values().collect();
+    uris.sort();
+
+    for uri in uris {
+        let label = uri.rsplit('/').next().unwrap_or(uri);
+        let escaped_uri = escape_dot_string(uri);
+        let escaped_label = escape_dot_string(label);
+        let _ = writeln!(
+            output,
+            "    \"{escaped_uri}\" [label=\"{escaped_label}\",shape={URI_NODE_SHAPE}];"
+        );
+    }
+    output.push('\n');
+}
+
+fn write_name_to_definition_edges(output: &mut String, graph: &Graph) {
+    let mut name_to_def_edges: Vec<_> = Vec::new();
+
+    for (name_id, definition_ids) in graph.name_to_definitions() {
+        if let Some(name) = graph.names().get(name_id) {
+            for def_id in definition_ids {
+                if graph.definitions().contains_key(def_id) {
+                    name_to_def_edges.push((name.clone(), def_id.to_string()));
+                }
+            }
+        }
+    }
+    name_to_def_edges.sort();
+
+    for (name, def_id) in name_to_def_edges {
+        let name_node = format!("Name:{}", escape_dot_string(&name));
+        let _ = writeln!(output, "    \"{name_node}\" -> \"def_{def_id}\" [dir=both];");
+    }
+}
+
+fn write_definition_to_uri_edges(output: &mut String, graph: &Graph) {
+    let mut uri_edges: Vec<_> = graph.uris_to_definitions().iter().collect();
+    uri_edges.sort_by_key(|(uri_id, _)| uri_id.to_string());
+
+    for (uri_id, definition_ids) in uri_edges {
+        if let Some(uri) = graph.uri_pool().get(uri_id) {
+            let escaped_uri = escape_dot_string(uri);
+            let mut sorted_def_ids: Vec<_> = definition_ids.iter().collect();
+            sorted_def_ids.sort_by_key(std::string::ToString::to_string);
+
+            for def_id in sorted_def_ids {
+                if graph.definitions().contains_key(def_id) {
+                    let _ = writeln!(output, "    \"def_{def_id}\" -> \"{escaped_uri}\";");
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_utils::GraphTest;
+
+    fn create_test_graph() -> Graph {
+        let mut graph_test = GraphTest::new();
+        graph_test.index_uri(
+            "file:///test.rb",
+            "
+                class TestClass
+                end
+
+                module TestModule
+                end
+            ",
+        );
+        graph_test.graph
+    }
+
+    #[test]
+    fn test_dot_generation() {
+        let graph = create_test_graph();
+        let dot_output = generate(&graph);
+
+        let class_def_id = graph
+            .definitions()
+            .iter()
+            .find(|(_, def)| matches!(def, crate::model::definitions::Definition::Class(_)))
+            .map(|(id, _)| id.to_string())
+            .unwrap();
+
+        let module_def_id = graph
+            .definitions()
+            .iter()
+            .find(|(_, def)| matches!(def, crate::model::definitions::Definition::Module(_)))
+            .map(|(id, _)| id.to_string())
+            .unwrap();
+
+        let expected = format!(
+            r#"digraph {{
+    rankdir=TB;
+
+    "Name:TestClass" [label="TestClass",shape=hexagon];
+    "Name:TestModule" [label="TestModule",shape=hexagon];
+
+    "def_{module_def_id}" [label="Module(TestModule)",shape=ellipse];
+    "def_{class_def_id}" [label="Class(TestClass)",shape=ellipse];
+
+    "file:///test.rb" [label="test.rb",shape=box];
+
+    "Name:TestClass" -> "def_{class_def_id}" [dir=both];
+    "Name:TestModule" -> "def_{module_def_id}" [dir=both];
+    "def_{module_def_id}" -> "file:///test.rb";
+    "def_{class_def_id}" -> "file:///test.rb";
+}}
+"#
+        );
+
+        assert_eq!(dot_output, expected);
+    }
+}

--- a/rust/index/tests/cli.rs
+++ b/rust/index/tests/cli.rs
@@ -1,5 +1,7 @@
 use assert_cmd::prelude::*;
 use predicates::prelude::*;
+use regex::Regex;
+use std::fs;
 use std::process::Command;
 
 #[test]
@@ -8,7 +10,9 @@ fn prints_help() {
     cmd.arg("--help");
     cmd.assert()
         .success()
-        .stdout(predicate::str::contains("A Ruby code indexer"));
+        .stdout(predicate::str::contains("A Ruby code indexer"))
+        .stdout(predicate::str::contains("Usage:"))
+        .stdout(predicate::str::contains("--visualize"));
 }
 
 #[test]
@@ -25,4 +29,62 @@ fn dir_argument_variants() {
     two.assert()
         .failure()
         .stderr(predicate::str::contains("unexpected argument").or(predicate::str::contains("error:")));
+}
+
+#[test]
+fn prints_index_metrics() {
+    let temp_dir = tempfile::tempdir().unwrap();
+
+    fs::write(temp_dir.path().join("file1.rb"), "class FirstClass\nend\n").unwrap();
+    fs::write(temp_dir.path().join("file2.rb"), "module SecondModule\nend\n").unwrap();
+
+    let mut cmd = Command::cargo_bin("index_cli").unwrap();
+    cmd.arg(temp_dir.path());
+
+    let output = cmd.output().unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Indexed 2 files"));
+    assert!(stdout.contains("Found 2 names"));
+    assert!(stdout.contains("Found 2 definitions"));
+}
+
+fn normalize_visualization_output(output: &str) -> String {
+    let def_re = Regex::new(r"def_[a-f0-9]+").unwrap();
+    let uri_re = Regex::new(r#"file://[^"]+/([^/"]+\.rb)"#).unwrap();
+
+    let normalized = def_re.replace_all(output, "def_<ID>");
+    uri_re.replace_all(&normalized, "file://<PATH>/$1").to_string()
+}
+
+#[test]
+fn visualize_simple_class() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    fs::write(temp_dir.path().join("simple.rb"), "class SimpleClass\nend\n").unwrap();
+
+    let mut cmd = Command::cargo_bin("index_cli").unwrap();
+    cmd.args([temp_dir.path().to_str().unwrap(), "--visualize"]);
+
+    let output = cmd.output().unwrap();
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let normalized = normalize_visualization_output(&stdout);
+
+    let expected = r#"digraph {
+    rankdir=TB;
+
+    "Name:SimpleClass" [label="SimpleClass",shape=hexagon];
+
+    "def_<ID>" [label="Class(SimpleClass)",shape=ellipse];
+
+    "file://<PATH>/simple.rb" [label="simple.rb",shape=box];
+
+    "Name:SimpleClass" -> "def_<ID>" [dir=both];
+    "def_<ID>" -> "file://<PATH>/simple.rb";
+}
+
+"#;
+
+    assert_eq!(normalized, expected);
 }


### PR DESCRIPTION
## Summary

Adds DOT format visualization to debug the indexer's graph structure. Useful for understanding how classes, modules, and their definitions are connected.

## Usage

```
# Visualize a directory
cargo run --bin index_cli -- ./src -o graph.dot

# view the generated dot file
dot -Tsvg graph.dot -o graph.svg
# or, interactively (but beware that it doesn't run on bigger input)
xdot graph.dot

```

### Example output for the server.rb file in ruby-lsp project

#### dot

```
digraph {
    rankdir=TB;

    "Name:RubyLsp" [label="RubyLsp",shape=hexagon];
    "Name:RubyLsp::Server" [label="RubyLsp::Server",shape=hexagon];

    "def_6659466995e20096b7beb50fc33de0d901655c992405d18ac937b94a87e53d9e" [label="Class(RubyLsp::Server)",shape=ellipse];
    "def_3d5da1207c50cb438f7788658a1b1ce83b8e98da779045b0d67aff460bc0f44d" [label="Module(RubyLsp)",shape=ellipse];

    "file:///Users/jennyshih/src/github.com/Shopify/ruby-lsp/lib/ruby_lsp/server.rb" [label="server.rb",shape=box];

    "Name:RubyLsp::Server" -> "def_6659466995e20096b7beb50fc33de0d901655c992405d18ac937b94a87e53d9e" [dir=both];
    "Name:RubyLsp" -> "def_3d5da1207c50cb438f7788658a1b1ce83b8e98da779045b0d67aff460bc0f44d" [dir=both];
    "def_6659466995e20096b7beb50fc33de0d901655c992405d18ac937b94a87e53d9e" -> "file:///Users/jennyshih/src/github.com/Shopify/ruby-lsp/lib/ruby_lsp/server.rb";
    "def_3d5da1207c50cb438f7788658a1b1ce83b8e98da779045b0d67aff460bc0f44d" -> "file:///Users/jennyshih/src/github.com/Shopify/ruby-lsp/lib/ruby_lsp/server.rb";
}

```

#### svg

![server_unfiltered](https://github.com/user-attachments/assets/a105b994-e851-4c5f-97ca-38783a7e5095)

## Future Iterations

Filtering capabilities will be added in a different pr

## Testing

```
cargo test --package index
```