### PR TITLE
Use `let..else`

### DIFF
--- a/rust/index-sys/src/lib.rs
+++ b/rust/index-sys/src/lib.rs
@@ -24,9 +24,8 @@ pub unsafe extern "C" fn repository_get_entry(repository: *const CRepository, na
     unsafe {
         let repository_ref = &*repository.cast::<Repository>();
         let c_str = std::ffi::CStr::from_ptr(name);
-        let name_str = match c_str.to_str() {
-            Ok(s) => s,
-            Err(_) => return std::ptr::null_mut(),
+        let Ok(name_str) = c_str.to_str() else {
+            return std::ptr::null_mut();
         };
 
         match repository_ref.get_entry(name_str) {


### PR DESCRIPTION
See clippy:

```
warning: this could be rewritten as `let...else`
  --> index-sys/src/lib.rs:27:9
   |
27 | /         let name_str = match c_str.to_str() {
28 | |             Ok(s) => s,
29 | |             Err(_) => return std::ptr::null_mut(),
30 | |         };
   | |__________^ help: consider writing: `let Ok(name_str) = c_str.to_str() else { return std::ptr::null_mut() };`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_let_else
   = note: `-W clippy::manual-let-else` implied by `-W clippy::pedantic`
   = help: to override `-W clippy::pedantic` add `#[allow(clippy::manual_let_else)]`
```