### PR TITLE
Rename `Index` to `Graph`

### DIFF
--- a/rust/index/src/indexing/ruby_indexer.rs
+++ b/rust/index/src/indexing/ruby_indexer.rs
@@ -2,8 +2,8 @@
 
 use crate::indexing::errors::IndexingError;
 use crate::model::definitions::{ClassDefinition, Definition, ModuleDefinition};
+use crate::model::graph::Graph;
 use crate::model::ids::UriId;
-use crate::model::index::Index;
 use crate::offset::Offset;
 
 use ruby_prism::Visit;
@@ -14,7 +14,7 @@ use ruby_prism::Visit;
 /// merged into the global state later.
 pub struct RubyIndexer {
     uri_id: UriId,
-    local_index: Index,
+    local_index: Graph,
     nesting_stacks: Vec<Vec<String>>,
     errors: Vec<IndexingError>,
 }
@@ -22,7 +22,7 @@ pub struct RubyIndexer {
 impl RubyIndexer {
     #[must_use]
     pub fn new(uri: String) -> Self {
-        let mut local_index = Index::new();
+        let mut local_index = Graph::new();
         let uri_id = local_index.add_uri(uri);
 
         Self {
@@ -34,7 +34,7 @@ impl RubyIndexer {
     }
 
     #[must_use]
-    pub fn into_parts(self) -> (Index, Vec<IndexingError>) {
+    pub fn into_parts(self) -> (Graph, Vec<IndexingError>) {
         (self.local_index, self.errors)
     }
 

--- a/rust/index/src/main.rs
+++ b/rust/index/src/main.rs
@@ -10,7 +10,7 @@ use clap::Parser;
 
 use index::{
     indexing::{Document, index_in_parallel},
-    model::index::Index,
+    model::graph::Graph,
 };
 
 #[derive(Parser, Debug)]
@@ -48,7 +48,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             .collect::<Vec<_>>()
     };
 
-    let index = Arc::new(Mutex::new(Index::new()));
+    let index = Arc::new(Mutex::new(Graph::new()));
     index_in_parallel(&index, &documents)?;
     Ok(())
 }

--- a/rust/index/src/model.rs
+++ b/rust/index/src/model.rs
@@ -1,3 +1,3 @@
 pub mod definitions;
+pub mod graph;
 pub mod ids;
-pub mod index;

--- a/rust/index/src/model/ids.rs
+++ b/rust/index/src/model/ids.rs
@@ -1,4 +1,4 @@
-//! This module contains stable ID representations that composed the `Index` graph
+//! This module contains stable ID representations that composed the `Graph` global representation
 
 use blake3::Hash;
 


### PR DESCRIPTION
Rename `Index` to `Graph` based on our vote. Since we keep talking about the global representation as graph, I believe it will avoid confusion.