### PR TITLE
Move the CLI to the Ruby gem

### DIFF
--- a/exe/index
+++ b/exe/index
@@ -1,0 +1,47 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+$LOAD_PATH.unshift(File.expand_path("../lib", __dir__))
+require "optparse"
+
+OptionParser.new do |parser|
+  parser.banner = "Usage: [path1, path2]"
+
+  parser.on("--version", "Print the gem's version") do
+    require "index/version"
+    puts "v#{Index::VERSION}"
+    exit
+  end
+
+  parser.on("-h", "--help", "Prints this help") do
+    puts parser
+    exit
+  end
+end.parse!
+
+require "index"
+
+workspace_path = ARGV.first
+
+# If a workspace path is passed, we need to ensure that Bundler is setup in that context so that we find the
+# dependencies for that project
+if workspace_path
+  gemfile_path = File.join(workspace_path, "Gemfile")
+
+  if File.exist?(gemfile_path)
+    ENV["BUNDLE_GEMFILE"] = gemfile_path
+
+    begin
+      Bundler.setup
+    rescue Bundler::BundlerError => e
+      $stderr.puts(<<~MESSAGE)
+        Bundle setup failed for #{gemfile_path}. Indexing of dependencies may be partial
+        Error:
+          #{e.message}
+      MESSAGE
+    end
+  end
+end
+
+graph = Index::Graph.new(workspace_path: workspace_path)
+graph.index_workspace


### PR DESCRIPTION
Closes #75

This PR moves our CLI to the Ruby gem. This allow us to provide our CLI with full Bundler integrations, so that we can automatically index all dependencies.

I removed the Rust executable in hopes to centralize everything in a single one, but please let me know if you feel like we need the Rust executable still.