### PR TITLE
Export ext and rust files in the Gemspec

### DIFF
--- a/index.gemspec
+++ b/index.gemspec
@@ -19,7 +19,10 @@ Gem::Specification.new do |spec|
   spec.metadata["source_code_uri"] = spec.homepage
   spec.metadata["changelog_uri"] = "#{spec.homepage}/releases"
 
-  spec.files = Dir.glob("lib/**/*.rb") + ["README.md", "LICENSE.txt"]
+  spec.files = Dir.glob("lib/**/*.rb") +
+    Dir.glob("ext/**/*.{c,h,rb}") +
+    Dir.glob("rust/**/*.{rs,toml}") +
+    ["README.md", "LICENSE.txt"]
   spec.bindir = "exe"
   spec.executables = Dir.glob("exe/*").map { |f| File.basename(f) }
   spec.require_paths = ["lib"]


### PR DESCRIPTION
I tihnk we need to expose these files since we build the extension at install time?