### PR TITLE
Revert use of archived actions-rs/toolchain action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,12 +10,11 @@ jobs:
         with:
           submodules: "recursive"
 
-      - name: Set up Rust
-        uses: actions-rs/toolchain@88dc2356392166efad76775c878094f4e83ff746 #v1.0.6
-        with:
-          toolchain: stable
-          components: rustfmt, clippy
-          override: true
+      - name: Install Rust tools
+        run: |
+          rustup update --no-self-update stable
+          rustup default stable
+          rustup component add --toolchain stable clippy rustfmt
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@a4effe49ee8ee5b8b5091268c473a4628afb5651 # v1.245.0
@@ -38,13 +37,6 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           submodules: "recursive"
-
-      - name: Set up Rust
-        uses: actions-rs/toolchain@88dc2356392166efad76775c878094f4e83ff746 #v1.0.6
-        with:
-          toolchain: stable
-          components: rustfmt, clippy
-          override: true
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@a4effe49ee8ee5b8b5091268c473a4628afb5651 # v1.245.0


### PR DESCRIPTION
The `actions-rs/toolchain` action was [archived in 2023](https://github.com/actions-rs/toolchain). My understanding is that we shouldn't need any custom actions as GH runners already have `rustup` and `rustc` installed.