### PR TITLE
Use `include_str` to load schema at compile time

### DIFF
--- a/rust/index/src/model/db.rs
+++ b/rust/index/src/model/db.rs
@@ -16,6 +16,8 @@ pub struct Db {
 }
 
 impl Db {
+    const SCHEMA: &str = include_str!("../db/schema.sql");
+
     #[must_use]
     pub fn new(path: &str) -> Self {
         Self {
@@ -34,12 +36,7 @@ impl Db {
         ",
         )?;
 
-        let schema = std::fs::read_to_string(
-            std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
-                .join("src/db")
-                .join("schema.sql"),
-        )?;
-        tx.execute_batch(&schema)?;
+        tx.execute_batch(Self::SCHEMA)?;
         tx.execute(&format!("PRAGMA user_version = {SCHEMA_VERSION}"), [])?;
         tx.commit()?;
         Ok(())


### PR DESCRIPTION
We can't rely on the Cargo manifest path for the published version of the project because that doesn't exist on users' machines.

To be able to bundle the schema coming from a different file, we can use `include_str`, which includes the content of the file as a static string in a constant - that way we can still keep a separate SQL file, but it gets bundled in the compilation results.