### PR TITLE
Rename `start_offset` and `end_offset` to `start` and `end`

### DIFF
--- a/rust/index/src/indexing/ruby_indexer.rs
+++ b/rust/index/src/indexing/ruby_indexer.rs
@@ -199,18 +199,18 @@ mod tests {
 
         let definitions = context.graph.get("Foo").unwrap();
         assert_eq!(definitions.len(), 1);
-        assert_eq!(definitions[0].start_offset(), 0);
-        assert_eq!(definitions[0].end_offset(), 50);
+        assert_eq!(definitions[0].start(), 0);
+        assert_eq!(definitions[0].end(), 50);
 
         let definitions = context.graph.get("Foo::Bar").unwrap();
         assert_eq!(definitions.len(), 1);
-        assert_eq!(definitions[0].start_offset(), 12);
-        assert_eq!(definitions[0].end_offset(), 46);
+        assert_eq!(definitions[0].start(), 12);
+        assert_eq!(definitions[0].end(), 46);
 
         let definitions = context.graph.get("Foo::Bar::Baz").unwrap();
         assert_eq!(definitions.len(), 1);
-        assert_eq!(definitions[0].start_offset(), 26);
-        assert_eq!(definitions[0].end_offset(), 40);
+        assert_eq!(definitions[0].start(), 26);
+        assert_eq!(definitions[0].end(), 40);
 
         let not_found = context.graph.get("Foo::Bar::Baz::Qux");
         assert!(not_found.is_none());
@@ -251,18 +251,18 @@ mod tests {
 
         let definitions = context.graph.get("Foo").unwrap();
         assert_eq!(definitions.len(), 1);
-        assert_eq!(definitions[0].start_offset(), 0);
-        assert_eq!(definitions[0].end_offset(), 53);
+        assert_eq!(definitions[0].start(), 0);
+        assert_eq!(definitions[0].end(), 53);
 
         let definitions = context.graph.get("Foo::Bar").unwrap();
         assert_eq!(definitions.len(), 1);
-        assert_eq!(definitions[0].start_offset(), 13);
-        assert_eq!(definitions[0].end_offset(), 49);
+        assert_eq!(definitions[0].start(), 13);
+        assert_eq!(definitions[0].end(), 49);
 
         let definitions = context.graph.get("Foo::Bar::Baz").unwrap();
         assert_eq!(definitions.len(), 1);
-        assert_eq!(definitions[0].start_offset(), 28);
-        assert_eq!(definitions[0].end_offset(), 43);
+        assert_eq!(definitions[0].start(), 28);
+        assert_eq!(definitions[0].end(), 43);
 
         let not_found = context.graph.get("Foo::Bar::Baz::Qux");
         assert!(not_found.is_none());
@@ -303,13 +303,13 @@ mod tests {
 
         let definitions = context.graph.get("FOO").unwrap();
         assert_eq!(definitions.len(), 1);
-        assert_eq!(definitions[0].start_offset(), 0);
-        assert_eq!(definitions[0].end_offset(), 3);
+        assert_eq!(definitions[0].start(), 0);
+        assert_eq!(definitions[0].end(), 3);
 
         let definitions = context.graph.get("Foo::FOO").unwrap();
         assert_eq!(definitions.len(), 1);
-        assert_eq!(definitions[0].start_offset(), 21);
-        assert_eq!(definitions[0].end_offset(), 24);
+        assert_eq!(definitions[0].start(), 21);
+        assert_eq!(definitions[0].end(), 24);
     }
 
     #[test]
@@ -329,18 +329,18 @@ mod tests {
 
         let definitions = context.graph.get("FOO::BAR").unwrap();
         assert_eq!(definitions.len(), 1);
-        assert_eq!(definitions[0].start_offset(), 0);
-        assert_eq!(definitions[0].end_offset(), 8);
+        assert_eq!(definitions[0].start(), 0);
+        assert_eq!(definitions[0].end(), 8);
 
         let definitions = context.graph.get("Foo::FOO::BAR").unwrap();
         assert_eq!(definitions.len(), 1);
-        assert_eq!(definitions[0].start_offset(), 26);
-        assert_eq!(definitions[0].end_offset(), 34);
+        assert_eq!(definitions[0].start(), 26);
+        assert_eq!(definitions[0].end(), 34);
 
         let definitions = context.graph.get("BAZ").unwrap();
         assert_eq!(definitions.len(), 1);
-        assert_eq!(definitions[0].start_offset(), 41);
-        assert_eq!(definitions[0].end_offset(), 46);
+        assert_eq!(definitions[0].start(), 41);
+        assert_eq!(definitions[0].end(), 46);
     }
 
     #[test]
@@ -359,27 +359,27 @@ mod tests {
 
         let definitions = context.graph.get("FOO").unwrap();
         assert_eq!(definitions.len(), 1);
-        assert_eq!(definitions[0].start_offset(), 0);
-        assert_eq!(definitions[0].end_offset(), 3);
+        assert_eq!(definitions[0].start(), 0);
+        assert_eq!(definitions[0].end(), 3);
 
         let definitions = context.graph.get("BAR::BAZ").unwrap();
         assert_eq!(definitions.len(), 1);
-        assert_eq!(definitions[0].start_offset(), 5);
-        assert_eq!(definitions[0].end_offset(), 13);
+        assert_eq!(definitions[0].start(), 5);
+        assert_eq!(definitions[0].end(), 13);
 
         let definitions = context.graph.get("Foo::FOO").unwrap();
         assert_eq!(definitions.len(), 1);
-        assert_eq!(definitions[0].start_offset(), 34);
-        assert_eq!(definitions[0].end_offset(), 37);
+        assert_eq!(definitions[0].start(), 34);
+        assert_eq!(definitions[0].end(), 37);
 
         let definitions = context.graph.get("Foo::BAR::BAZ").unwrap();
         assert_eq!(definitions.len(), 1);
-        assert_eq!(definitions[0].start_offset(), 39);
-        assert_eq!(definitions[0].end_offset(), 47);
+        assert_eq!(definitions[0].start(), 39);
+        assert_eq!(definitions[0].end(), 47);
 
         let definitions = context.graph.get("BAZ").unwrap();
         assert_eq!(definitions.len(), 1);
-        assert_eq!(definitions[0].start_offset(), 49);
-        assert_eq!(definitions[0].end_offset(), 54);
+        assert_eq!(definitions[0].start(), 49);
+        assert_eq!(definitions[0].end(), 54);
     }
 }

--- a/rust/index/src/model/db.rs
+++ b/rust/index/src/model/db.rs
@@ -152,8 +152,8 @@ impl Db {
                 &name_id.to_string(),
                 &definition_type.to_string(),
                 &uri_id.to_string(),
-                &definition.start_offset().to_string(),
-                &definition.end_offset().to_string(),
+                &definition.start().to_string(),
+                &definition.end().to_string(),
             ])?;
         }
 
@@ -214,8 +214,8 @@ mod tests {
             definition_name_id,
             definition_type,
             definition_document_id,
-            start_offset,
-            end_offset,
+            start,
+            end,
             document_id,
             document_uri,
         ) = first.unwrap();
@@ -224,8 +224,8 @@ mod tests {
         assert_eq!(name_id, definition_name_id);
         assert_eq!(document_id, definition_document_id);
         assert_eq!(name, String::from("Foo"));
-        assert_eq!(0, start_offset);
-        assert_eq!(15, end_offset);
+        assert_eq!(0, start);
+        assert_eq!(15, end);
         assert_eq!(definition_type, 2);
         assert_eq!(document_uri, String::from("file:///foo.rb"));
         assert!(!definition_id.is_empty());

--- a/rust/index/src/model/definitions.rs
+++ b/rust/index/src/model/definitions.rs
@@ -34,20 +34,20 @@ pub enum Definition {
 
 impl Definition {
     #[must_use]
-    pub fn start_offset(&self) -> u32 {
+    pub fn start(&self) -> u32 {
         match self {
-            Definition::Class(it) => it.offset.start_offset(),
-            Definition::Module(it) => it.offset.start_offset(),
-            Definition::Constant(it) => it.offset.start_offset(),
+            Definition::Class(it) => it.offset.start(),
+            Definition::Module(it) => it.offset.start(),
+            Definition::Constant(it) => it.offset.start(),
         }
     }
 
     #[must_use]
-    pub fn end_offset(&self) -> u32 {
+    pub fn end(&self) -> u32 {
         match self {
-            Definition::Class(it) => it.offset.end_offset(),
-            Definition::Module(it) => it.offset.end_offset(),
-            Definition::Constant(it) => it.offset.end_offset(),
+            Definition::Class(it) => it.offset.end(),
+            Definition::Module(it) => it.offset.end(),
+            Definition::Constant(it) => it.offset.end(),
         }
     }
 

--- a/rust/index/src/model/graph.rs
+++ b/rust/index/src/model/graph.rs
@@ -125,7 +125,7 @@ impl Graph {
     // Registers a definition into the `Graph`, automatically creating all relationships
     pub fn add_definition(&mut self, uri_id: UriId, name: String, definition: Definition) {
         let name_id = NameId::new(&name);
-        let definition_id = DefinitionId::new(uri_id, definition.start_offset());
+        let definition_id = DefinitionId::new(uri_id, definition.start());
 
         self.names.insert(name_id, name);
         self.definitions.insert(definition_id, definition);
@@ -501,7 +501,7 @@ mod tests {
 
         let definitions = context.graph.get("Foo").unwrap();
         assert_eq!(definitions.len(), 1);
-        assert_eq!(definitions[0].start_offset(), 6);
+        assert_eq!(definitions[0].start(), 6);
 
         context.graph.assert_integrity();
     }
@@ -514,7 +514,7 @@ mod tests {
         context.index_uri("file:///foo2.rb", "\n\n\n\n\nmodule Foo; end");
 
         let definitions = context.graph.get("Foo").unwrap();
-        let mut offsets = definitions.iter().map(|d| d.start_offset()).collect::<Vec<_>>();
+        let mut offsets = definitions.iter().map(|d| d.start()).collect::<Vec<_>>();
         offsets.sort_unstable();
         assert_eq!(definitions.len(), 2);
         assert_eq!(vec![0, 5], offsets);
@@ -543,7 +543,7 @@ mod tests {
 
         let mut offsets = definitions
             .iter()
-            .map(|d| [d.start_offset(), d.end_offset()])
+            .map(|d| [d.start(), d.end()])
             .collect::<Vec<_>>();
         offsets.sort_unstable();
         assert_eq!([0, 15], offsets[0]);

--- a/rust/index/src/model/ids.rs
+++ b/rust/index/src/model/ids.rs
@@ -60,8 +60,8 @@ pub struct DefinitionId(Hash);
 impl DefinitionId {
     #[must_use]
     #[allow(clippy::cast_possible_truncation)]
-    pub fn new(uri_id: UriId, start_offset: u32) -> Self {
-        let id = format!("{uri_id}:{start_offset}");
+    pub fn new(uri_id: UriId, start: u32) -> Self {
+        let id = format!("{uri_id}:{start}");
         Self(create_hash(&id))
     }
 }

--- a/rust/index/src/offset.rs
+++ b/rust/index/src/offset.rs
@@ -6,14 +6,14 @@
 
 /// Represents a byte offset range within a specific file.
 ///
-/// An `Offset` tracks a contiguous span of bytes from `start_offset` to `end_offset` within a file. This is useful for
+/// An `Offset` tracks a contiguous span of bytes from `start` to `end` within a file. This is useful for
 /// representing the location of tokens, AST nodes, or other text spans in source code.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Offset {
     /// The starting byte offset (inclusive)
-    start_offset: u32,
+    start: u32,
     /// The ending byte offset (exclusive)
-    end_offset: u32,
+    end: u32,
 }
 
 impl Offset {
@@ -21,14 +21,11 @@ impl Offset {
     ///
     /// # Arguments
     ///
-    /// * `start_offset` - The starting byte position (inclusive)
-    /// * `end_offset` - The ending byte position (exclusive)
+    /// * `start` - The starting byte position (inclusive)
+    /// * `end` - The ending byte position (exclusive)
     #[must_use]
-    pub const fn new(start_offset: u32, end_offset: u32) -> Self {
-        Self {
-            start_offset,
-            end_offset,
-        }
+    pub const fn new(start: u32, end: u32) -> Self {
+        Self { start, end }
     }
 
     /// # Panics
@@ -40,21 +37,21 @@ impl Offset {
             location
                 .start_offset()
                 .try_into()
-                .expect("Expected usize `start_offset` to fit in `u32`"),
+                .expect("Expected usize `start` to fit in `u32`"),
             location
                 .end_offset()
                 .try_into()
-                .expect("Expected usize `end_offset` to fit in `u32`"),
+                .expect("Expected usize `end` to fit in `u32`"),
         )
     }
 
     #[must_use]
-    pub fn start_offset(&self) -> u32 {
-        self.start_offset
+    pub fn start(&self) -> u32 {
+        self.start
     }
 
     #[must_use]
-    pub fn end_offset(&self) -> u32 {
-        self.end_offset
+    pub fn end(&self) -> u32 {
+        self.end
     }
 }

--- a/rust/index/src/test_utils.rs
+++ b/rust/index/src/test_utils.rs
@@ -87,8 +87,8 @@ mod tests {
 
         let foo_defs = context.graph.get("Foo").unwrap();
         assert_eq!(foo_defs.len(), 1);
-        assert_eq!(foo_defs[0].start_offset(), 0);
-        assert_eq!(foo_defs[0].end_offset(), 14);
+        assert_eq!(foo_defs[0].start(), 0);
+        assert_eq!(foo_defs[0].end(), 14);
     }
 
     #[test]
@@ -105,13 +105,13 @@ mod tests {
 
         let foo_defs = context.graph.get("Foo").unwrap();
         assert_eq!(foo_defs.len(), 1);
-        assert_eq!(foo_defs[0].start_offset(), 0);
-        assert_eq!(foo_defs[0].end_offset(), 30);
+        assert_eq!(foo_defs[0].start(), 0);
+        assert_eq!(foo_defs[0].end(), 30);
 
         let bar_defs = context.graph.get("Foo::Bar").unwrap();
         assert_eq!(bar_defs.len(), 1);
-        assert_eq!(bar_defs[0].start_offset(), 12);
-        assert_eq!(bar_defs[0].end_offset(), 26);
+        assert_eq!(bar_defs[0].start(), 12);
+        assert_eq!(bar_defs[0].end(), 26);
     }
 
     #[test]
@@ -122,7 +122,7 @@ mod tests {
 
         let foo_defs = context.graph.get("Foo").unwrap();
         assert_eq!(foo_defs.len(), 1);
-        assert_eq!(foo_defs[0].start_offset(), 2);
-        assert_eq!(foo_defs[0].end_offset(), 16);
+        assert_eq!(foo_defs[0].start(), 2);
+        assert_eq!(foo_defs[0].end(), 16);
     }
 }


### PR DESCRIPTION
Let's not repeat ourselves. The name was suffixed because of Ruby's `end`, we don't need that in Rust.