### PR TITLE
Add ability to load all data related to a URI

### DIFF
--- a/ext/index/graph.c
+++ b/ext/index/graph.c
@@ -86,7 +86,10 @@ static VALUE rb_graph_set_configuration(VALUE self, VALUE db_path) {
     void* graph;
     TypedData_Get_Struct(self, void*, &graph_type, graph);
 
-    idx_graph_set_configuration(graph, StringValueCStr(db_path));
+    if (!idx_graph_set_configuration(graph, StringValueCStr(db_path))) {
+        rb_raise(rb_eRuntimeError, "Failed to set the database configuration");
+    }
+
     return Qnil;
 }
 

--- a/rust/index-sys/src/index_api.rs
+++ b/rust/index-sys/src/index_api.rs
@@ -79,15 +79,14 @@ pub unsafe extern "C" fn idx_index_all_c(
 ///
 /// This function will panic in case of a dead lock on the graph mutex
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn idx_graph_set_configuration(pointer: GraphPointer, db_path: *const c_char) {
+pub unsafe extern "C" fn idx_graph_set_configuration(pointer: GraphPointer, db_path: *const c_char) -> bool {
     let graph = retain_graph(pointer);
 
     match unsafe { conversions::convert_char_ptr_to_string(db_path) } {
-        Ok(path) => {
-            graph.lock().unwrap().set_configuration(path);
-        }
+        Ok(path) => graph.lock().unwrap().set_configuration(path).is_ok(),
         Err(e) => {
             eprintln!("Failed to convert db_path to String: {e}");
+            false
         }
     }
 }

--- a/rust/index/src/db/load_document.sql
+++ b/rust/index/src/db/load_document.sql
@@ -1,0 +1,9 @@
+SELECT
+    names.id,
+    names.name,
+    definitions.id,
+    definitions.data
+FROM documents
+JOIN definitions ON documents.id = definitions.document_id
+JOIN names ON names.id = definitions.name_id
+WHERE documents.id = ?

--- a/rust/index/src/db/schema.sql
+++ b/rust/index/src/db/schema.sql
@@ -17,7 +17,6 @@ CREATE TABLE IF NOT EXISTS names (
 CREATE TABLE IF NOT EXISTS definitions (
     id TEXT PRIMARY KEY,  -- Blake3 hash converted to hex
     name_id TEXT NOT NULL REFERENCES names(id), -- References names.id
-    definition_type INTEGER NOT NULL CHECK(definition_type IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9)), -- 0=Class, 1=Module, 2=Constant, 3=GlobalVariable, 4=InstanceVariable, 5=ClassVariable, 6=AttrAccessor, 7=AttrReader, 8=AttrWriter, 9=Method
     document_id TEXT NOT NULL REFERENCES documents(id), -- References documents.id
     data BLOB NOT NULL, -- Serialized definition data
     FOREIGN KEY (name_id) REFERENCES names (id) ON DELETE CASCADE,

--- a/rust/index/src/main.rs
+++ b/rust/index/src/main.rs
@@ -26,7 +26,7 @@ struct Args {
 fn main() -> Result<(), Box<dyn Error>> {
     let args = Args::parse();
     let mut graph = Graph::new();
-    graph.set_configuration(format!("{}/graph.db", &args.dir));
+    graph.set_configuration(format!("{}/graph.db", &args.dir))?;
     let (documents, errors) = indexing::collect_documents_in_parallel(vec![args.dir]);
 
     if !errors.is_empty() {

--- a/rust/index/src/model/definitions.rs
+++ b/rust/index/src/model/definitions.rs
@@ -73,24 +73,6 @@ impl Definition {
             Definition::Method(it) => it.offset.end(),
         }
     }
-
-    // Mapping of a definition's type to the definition_type enum value in the DB.
-    #[must_use]
-    pub fn type_id(&self) -> u8 {
-        // NOTE: update the schema.sql file to match when adding new types
-        match self {
-            Definition::Class(_) => 0,
-            Definition::Module(_) => 1,
-            Definition::Constant(_) => 2,
-            Definition::GlobalVariable(_) => 3,
-            Definition::InstanceVariable(_) => 4,
-            Definition::ClassVariable(_) => 5,
-            Definition::AttrAccessor(_) => 6,
-            Definition::AttrReader(_) => 7,
-            Definition::AttrWriter(_) => 8,
-            Definition::Method(_) => 9,
-        }
-    }
 }
 
 /// A class definition

--- a/rust/index/src/model/ids.rs
+++ b/rust/index/src/model/ids.rs
@@ -1,5 +1,7 @@
 //! This module contains stable ID representations that composed the `Graph` global representation
 
+use std::str::FromStr;
+
 use blake3::Hash;
 
 /// Creates a Blake3 hash from a string input and returns it as a 32-byte array.
@@ -21,6 +23,17 @@ impl UriId {
     #[must_use]
     pub fn new(id: &str) -> Self {
         Self(create_hash(id))
+    }
+
+    /// # Panics
+    ///
+    /// This function will panic if invalid bytes were inserted directly into the database ID fields
+    #[must_use]
+    pub fn from_string(id: &str) -> Self {
+        Self(
+            Hash::from_str(id)
+                .expect("Hash data contains invalid bytes. This means we introduced invalid data into the database"),
+        )
     }
 }
 
@@ -46,6 +59,17 @@ impl NameId {
     pub fn new(id: &str) -> Self {
         Self(create_hash(id))
     }
+
+    /// # Panics
+    ///
+    /// This function will panic if invalid bytes were inserted directly into the database ID fields
+    #[must_use]
+    pub fn from_string(id: &str) -> Self {
+        Self(
+            Hash::from_str(id)
+                .expect("Hash data contains invalid bytes. This means we introduced invalid data into the database"),
+        )
+    }
 }
 
 impl std::fmt::Display for NameId {
@@ -59,10 +83,20 @@ pub struct DefinitionId(Hash);
 
 impl DefinitionId {
     #[must_use]
-    #[allow(clippy::cast_possible_truncation)]
     pub fn new(uri_id: UriId, start: u32) -> Self {
         let id = format!("{uri_id}:{start}");
         Self(create_hash(&id))
+    }
+
+    /// # Panics
+    ///
+    /// This function will panic if invalid bytes were inserted directly into the database ID fields
+    #[must_use]
+    pub fn from_string(id: &str) -> Self {
+        Self(
+            Hash::from_str(id)
+                .expect("Hash data contains invalid bytes. This means we introduced invalid data into the database"),
+        )
     }
 }
 

--- a/test/graph_test.rb
+++ b/test/graph_test.rb
@@ -34,7 +34,13 @@ class GraphTest < Minitest::Test
       graph.set_configuration(123)
     end
 
-    graph.set_configuration(".ruby-lsp/graph.db")
+    assert_raises(RuntimeError) do
+      graph.set_configuration(".non-existing-folder/graph.db")
+    end
+
+    graph.set_configuration("graph.db")
     pass
+  ensure
+    Dir.glob("graph.db*").each { |f| File.delete(f) }
   end
 end


### PR DESCRIPTION
Allow loading all graph data related to a URI from the database.

In addition to adding the loading logic, I also made the connection persistent. The previous approach was really annoying because in-memory databases are destroyed immediately if there are no connections, which meant that we would need to over-expose the API for testing.

I think this approach will also make it easier to handle failures, like the user deleting or corrupting the database file - which we can recover from.