### PR TITLE
Add missing definition_type to schema

### DIFF
--- a/rust/index/src/db/schema.sql
+++ b/rust/index/src/db/schema.sql
@@ -17,7 +17,7 @@ CREATE TABLE IF NOT EXISTS names (
 CREATE TABLE IF NOT EXISTS definitions (
     id TEXT PRIMARY KEY,  -- Blake3 hash converted to hex
     name_id TEXT NOT NULL REFERENCES names(id), -- References names.id
-    definition_type INTEGER NOT NULL CHECK(definition_type IN (1, 2)), -- 1=Class, 2=Module
+    definition_type INTEGER NOT NULL CHECK(definition_type IN (0, 1, 2)), -- 0=Class, 1=Module, 2=Constant
     document_id TEXT NOT NULL REFERENCES documents(id), -- References documents.id
     start_offset INTEGER NOT NULL,
     end_offset INTEGER NOT NULL,

--- a/rust/index/src/model/db.rs
+++ b/rust/index/src/model/db.rs
@@ -226,7 +226,7 @@ mod tests {
         assert_eq!(name, String::from("Foo"));
         assert_eq!(0, start);
         assert_eq!(15, end);
-        assert_eq!(definition_type, 2);
+        assert_eq!(definition_type, 1);
         assert_eq!(document_uri, String::from("file:///foo.rb"));
         assert!(!definition_id.is_empty());
     }

--- a/rust/index/src/model/definitions.rs
+++ b/rust/index/src/model/definitions.rs
@@ -54,10 +54,11 @@ impl Definition {
     // Mapping of a definition's type to the definition_type enum value in the DB.
     #[must_use]
     pub fn type_id(&self) -> u8 {
+        // NOTE: update the schema.sql file to match when adding new types
         match self {
-            Definition::Class(_) => 1,
-            Definition::Module(_) => 2,
-            Definition::Constant(_) => 3,
+            Definition::Class(_) => 0,
+            Definition::Module(_) => 1,
+            Definition::Constant(_) => 2,
         }
     }
 }


### PR DESCRIPTION
New definition types have to be added to the schema as well because there's database level validation.

I also changed so that our types begin at zero.