### PR TITLE
Use a blob column to store definition specific data

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -149,6 +149,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "cbindgen"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -533,8 +539,10 @@ dependencies = [
  "clap",
  "predicates",
  "rayon",
+ "rmp-serde",
  "ruby-prism",
  "rusqlite",
+ "serde",
  "tempfile",
  "url",
 ]
@@ -683,6 +691,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
 name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -821,6 +835,28 @@ name = "regex-syntax"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+
+[[package]]
+name = "rmp"
+version = "0.8.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "228ed7c16fa39782c3b3468e974aec2795e9089153cd08ee2e9aefb3613334c4"
+dependencies = [
+ "byteorder",
+ "num-traits",
+ "paste",
+]
+
+[[package]]
+name = "rmp-serde"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52e599a477cf9840e92f2cde9a7189e67b42c57532749bf90aea6ec10facd4db"
+dependencies = [
+ "byteorder",
+ "rmp",
+ "serde",
+]
 
 [[package]]
 name = "ruby-prism"

--- a/rust/index/Cargo.toml
+++ b/rust/index/Cargo.toml
@@ -18,6 +18,8 @@ rusqlite = { version = "0.37.0", features = ["bundled"] }
 rayon = "1.10.0"
 blake3 = "1.8.2"
 clap = { version = "4.5.16", features = ["derive"] }
+serde = { version = "1.0", features = ["derive"] }
+rmp-serde = "1.3.0"
 
 [dev-dependencies]
 tempfile = "3.0"

--- a/rust/index/src/db/schema.sql
+++ b/rust/index/src/db/schema.sql
@@ -19,8 +19,7 @@ CREATE TABLE IF NOT EXISTS definitions (
     name_id TEXT NOT NULL REFERENCES names(id), -- References names.id
     definition_type INTEGER NOT NULL CHECK(definition_type IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9)), -- 0=Class, 1=Module, 2=Constant, 3=GlobalVariable, 4=InstanceVariable, 5=ClassVariable, 6=AttrAccessor, 7=AttrReader, 8=AttrWriter, 9=Method
     document_id TEXT NOT NULL REFERENCES documents(id), -- References documents.id
-    start_offset INTEGER NOT NULL,
-    end_offset INTEGER NOT NULL,
+    data BLOB NOT NULL, -- Serialized definition data
     FOREIGN KEY (name_id) REFERENCES names (id) ON DELETE CASCADE,
     FOREIGN KEY (document_id) REFERENCES documents (id) ON DELETE CASCADE
 );

--- a/rust/index/src/model/definitions.rs
+++ b/rust/index/src/model/definitions.rs
@@ -23,9 +23,11 @@
 //! 1. The declaration for the name `Foo`
 //! 2. The declaration for the name `Foo::Bar`
 
+use serde::{Deserialize, Serialize};
+
 use crate::offset::Offset;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize, Deserialize)]
 pub enum Definition {
     Class(Box<ClassDefinition>),
     Module(Box<ModuleDefinition>),
@@ -98,7 +100,7 @@ impl Definition {
 /// class Foo
 /// end
 /// ```
-#[derive(Debug)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct ClassDefinition {
     offset: Offset,
 }
@@ -117,7 +119,7 @@ impl ClassDefinition {
 /// module Foo
 /// end
 /// ```
-#[derive(Debug)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct ModuleDefinition {
     offset: Offset,
 }
@@ -135,7 +137,7 @@ impl ModuleDefinition {
 /// ```ruby
 /// FOO = 1
 /// ```
-#[derive(Debug)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct ConstantDefinition {
     offset: Offset,
 }
@@ -154,7 +156,7 @@ impl ConstantDefinition {
 /// def foo(bar, baz)
 /// end
 /// ```
-#[derive(Debug)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct MethodDefinition {
     offset: Offset,
     parameters: Vec<Parameter>,
@@ -182,7 +184,7 @@ impl MethodDefinition {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct Parameter {
     pub offset: Offset,
     pub name: String,
@@ -196,7 +198,7 @@ impl Parameter {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ParameterKind {
     RequiredPositional,
     OptionalPositional,
@@ -214,7 +216,7 @@ pub enum ParameterKind {
 /// ```ruby
 /// attr_accessor :foo
 /// ```
-#[derive(Debug)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct AttrAccessorDefinition {
     offset: Offset,
 }
@@ -232,7 +234,7 @@ impl AttrAccessorDefinition {
 /// ```ruby
 /// attr_reader :foo
 /// ```
-#[derive(Debug)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct AttrReaderDefinition {
     offset: Offset,
 }
@@ -250,7 +252,7 @@ impl AttrReaderDefinition {
 /// ```ruby
 /// attr_writer :foo
 /// ```
-#[derive(Debug)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct AttrWriterDefinition {
     offset: Offset,
 }
@@ -268,7 +270,7 @@ impl AttrWriterDefinition {
 /// ```ruby
 /// $foo = 1
 /// ```
-#[derive(Debug)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct GlobalVariableDefinition {
     pub offset: Offset,
 }
@@ -286,7 +288,7 @@ impl GlobalVariableDefinition {
 /// ```ruby
 /// @foo = 1
 /// ```
-#[derive(Debug)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct InstanceVariableDefinition {
     offset: Offset,
 }
@@ -304,7 +306,7 @@ impl InstanceVariableDefinition {
 /// ```ruby
 /// @@foo = 1
 /// ```
-#[derive(Debug)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct ClassVariableDefinition {
     offset: Offset,
 }

--- a/rust/index/src/offset.rs
+++ b/rust/index/src/offset.rs
@@ -4,11 +4,13 @@
 //! within a file. It can be used to track positions in source code and convert
 //! between byte offsets and line/column positions.
 
+use serde::{Deserialize, Serialize};
+
 /// Represents a byte offset range within a specific file.
 ///
 /// An `Offset` tracks a contiguous span of bytes from `start` to `end` within a file. This is useful for
 /// representing the location of tokens, AST nodes, or other text spans in source code.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct Offset {
     /// The starting byte offset (inclusive)
     start: u32,


### PR DESCRIPTION
Each definition may have its own specific fields that don't match other definitions. To account for this, what Pyre does is putting the definition specific data into a serialized blob column and only exposing columns it needs for querying.

I believe we should take the same approach. With the addition of #125, it's no longer possible to correctly dump the graph to the database because methods have extra fields other definitions do not have.

This PR changes the start and end offset columns to be a generic data blob column, which we store MessagePack serialized data for the definition in.

This is required to unblock #130.