### PR TITLE
Ensure deleting documents clear the database

### DIFF
--- a/rust/index/src/test_utils.rs
+++ b/rust/index/src/test_utils.rs
@@ -71,7 +71,7 @@ impl GraphTest {
     }
 
     pub fn delete_uri(&mut self, uri: &str) {
-        self.graph.delete_uri(uri);
+        self.graph.unload_uri(uri);
     }
 }
 


### PR DESCRIPTION
This PR is the second part of #130, adding the ability to unload a URI from memory. We actually already had that implemented, but for the `delete_uri` (which should handle a file being completely deleted).

I extracted the original implementation for only unloading from memory into `unload_uri` and made `delete_uri` handle the database portion of deletion as well.

With this, we are in a position where we can start benchmarking and testing what the memory usage looks like after we dump things to Sqlite and incrementally load/unload them.