### PR TITLE
Use glob to discover documents

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -505,6 +505,7 @@ version = "0.1.0"
 dependencies = [
  "assert_cmd",
  "clap",
+ "glob",
  "predicates",
  "rayon",
  "rmp-serde",

--- a/rust/index-sys/src/index_api.rs
+++ b/rust/index-sys/src/index_api.rs
@@ -53,7 +53,7 @@ pub unsafe extern "C" fn idx_index_all_c(
     let file_paths: Vec<String> = unsafe { conversions::convert_double_pointer_to_vec(file_paths, count).unwrap() };
     let graph = retain_graph(pointer);
     let mut all_errors = Vec::new();
-    let (documents, document_errors) = indexing::collect_documents_in_parallel(file_paths);
+    let (documents, document_errors) = indexing::collect_documents(file_paths);
     all_errors.extend(document_errors);
 
     if let Err(errors) = indexing::index_in_parallel(&graph, &documents) {

--- a/rust/index/Cargo.toml
+++ b/rust/index/Cargo.toml
@@ -20,6 +20,7 @@ xxhash-rust = { version = "0.8.15", features = ["xxh3"] }
 clap = { version = "4.5.16", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 rmp-serde = "1.3.0"
+glob = "0.3.2"
 
 [dev-dependencies]
 tempfile = "3.0"

--- a/rust/index/src/main.rs
+++ b/rust/index/src/main.rs
@@ -27,7 +27,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let args = Args::parse();
     let mut graph = Graph::new();
     graph.set_configuration(format!("{}/graph.db", &args.dir))?;
-    let (documents, errors) = indexing::collect_documents_in_parallel(vec![args.dir]);
+    let (documents, errors) = indexing::collect_documents(vec![args.dir]);
 
     if !errors.is_empty() {
         return Err(Box::new(MultipleErrors(errors)));

--- a/test/graph_test.rb
+++ b/test/graph_test.rb
@@ -8,13 +8,6 @@ class GraphTest < Minitest::Test
     assert_nil(graph.index_all([__FILE__]))
   end
 
-  def test_indexing_returns_errors
-    graph = Index::Graph.new
-    message = graph.index_all(["/non_existing_file.rb"])
-
-    assert_equal("File read error: Error reading path '/non_existing_file.rb': No such file or directory (os error 2)", message)
-  end
-
   def test_passing_invalid_arguments_to_index_all
     graph = Index::Graph.new
 


### PR DESCRIPTION
We discovered a big part of the sleeping problem was the implementation for discovering Ruby documents. Using the `glob` crate, we reduce the time to discover documents from ~4 seconds to ~0.1-0.2.

This PR gets rid of our manual implementation in favour of glob.