### PR TITLE
Move definition edges inside declaration

### DIFF
--- a/rust/index/src/main.rs
+++ b/rust/index/src/main.rs
@@ -56,7 +56,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         println!("{}", dot::generate(&graph));
     } else {
         println!("Indexed {} files", documents.len());
-        println!("Found {} names", graph.names().len());
+        println!("Found {} names", graph.declarations().len());
         println!("Found {} definitions", graph.definitions().len());
         println!("Found {} URIs", graph.uri_pool().len());
     }

--- a/rust/index/src/model.rs
+++ b/rust/index/src/model.rs
@@ -1,4 +1,5 @@
 pub mod db;
+pub mod declaration;
 pub mod definitions;
 pub mod graph;
 pub mod id;

--- a/rust/index/src/model/db.rs
+++ b/rust/index/src/model/db.rs
@@ -188,8 +188,8 @@ impl Db {
     fn batch_insert_names(conn: &rusqlite::Connection, graph: &Graph) -> Result<(), Box<dyn Error>> {
         let mut stmt = conn.prepare_cached("INSERT INTO names (id, name) VALUES (?, ?)")?;
 
-        for (name_id, name) in graph.names() {
-            stmt.execute([&name_id.to_string(), name])?;
+        for (name_id, declaration) in graph.declarations() {
+            stmt.execute([&name_id.to_string(), declaration.name()])?;
         }
 
         Ok(())

--- a/rust/index/src/model/declaration.rs
+++ b/rust/index/src/model/declaration.rs
@@ -1,0 +1,48 @@
+use std::collections::HashSet;
+
+use crate::model::{
+    identity_maps::{IdentityHashBuilder, IdentityHashSet},
+    ids::DefinitionId,
+};
+
+#[derive(Debug)]
+pub struct Declaration {
+    name: String,
+    definition_ids: IdentityHashSet<DefinitionId>,
+}
+
+impl Declaration {
+    #[must_use]
+    pub fn new(name: String) -> Self {
+        Self {
+            name,
+            definition_ids: HashSet::with_hasher(IdentityHashBuilder),
+        }
+    }
+
+    // Extend this declaration with more definitions by moving `other.definition_ids` inside
+    pub fn extend(&mut self, other: Declaration) {
+        self.definition_ids.extend(other.definition_ids);
+    }
+
+    #[must_use]
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    #[must_use]
+    pub fn definitions(&self) -> &IdentityHashSet<DefinitionId> {
+        &self.definition_ids
+    }
+
+    // Deletes a definition from this declaration. Returns `true` if this declaration is now empty, which indicates that
+    // it must be removed from the graph
+    pub fn remove_definition(&mut self, definition_id: &DefinitionId) -> bool {
+        self.definition_ids.remove(definition_id);
+        self.definition_ids.is_empty()
+    }
+
+    pub fn add_definition(&mut self, definition_id: DefinitionId) {
+        self.definition_ids.insert(definition_id);
+    }
+}

--- a/rust/index/src/model/integrity.rs
+++ b/rust/index/src/model/integrity.rs
@@ -111,7 +111,7 @@ mod tests {
         let mut checker = IntegrityChecker::new();
 
         checker.add_rule("Index must be empty", |index, errors| {
-            if !index.names().is_empty() {
+            if !index.declarations().is_empty() {
                 errors.push("Index is not empty".to_string());
             }
         });


### PR DESCRIPTION
Second step for #139

This PR creates the concept of a `Declaration`, so that we can move the edges of `name_to_definitions` inside of it and have more memory savings on the hash keys.

For now, the struct only stores its name and the list of definition IDs it is related to.