### PR TITLE
Move uri edges inside document

### DIFF
--- a/rust/index/src/main.rs
+++ b/rust/index/src/main.rs
@@ -58,7 +58,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         println!("Indexed {} files", documents.len());
         println!("Found {} names", graph.declarations().len());
         println!("Found {} definitions", graph.definitions().len());
-        println!("Found {} URIs", graph.uri_pool().len());
+        println!("Found {} URIs", graph.documents().len());
     }
 
     Ok(())

--- a/rust/index/src/model.rs
+++ b/rust/index/src/model.rs
@@ -1,6 +1,7 @@
 pub mod db;
 pub mod declaration;
 pub mod definitions;
+pub mod document;
 pub mod graph;
 pub mod id;
 pub mod identity_maps;

--- a/rust/index/src/model/db.rs
+++ b/rust/index/src/model/db.rs
@@ -177,8 +177,8 @@ impl Db {
     fn batch_insert_documents(conn: &rusqlite::Connection, graph: &Graph) -> Result<(), Box<dyn Error>> {
         let mut stmt = conn.prepare_cached("INSERT INTO documents (id, uri) VALUES (?, ?)")?;
 
-        for (uri_id, uri) in graph.uri_pool() {
-            stmt.execute([&uri_id.to_string(), uri])?;
+        for (uri_id, document) in graph.documents() {
+            stmt.execute([&uri_id.to_string(), document.uri()])?;
         }
 
         Ok(())

--- a/rust/index/src/model/document.rs
+++ b/rust/index/src/model/document.rs
@@ -1,0 +1,38 @@
+use std::collections::HashSet;
+
+use crate::model::{
+    identity_maps::{IdentityHashBuilder, IdentityHashSet},
+    ids::DefinitionId,
+};
+
+// Represents a document currently loaded into memory. Identified by its unique URI, it holds the edges to all
+// definitions discovered in it
+#[derive(Debug)]
+pub struct Document {
+    uri: String,
+    definition_ids: IdentityHashSet<DefinitionId>,
+}
+
+impl Document {
+    #[must_use]
+    pub fn new(uri: String) -> Self {
+        Self {
+            uri,
+            definition_ids: HashSet::with_hasher(IdentityHashBuilder),
+        }
+    }
+
+    #[must_use]
+    pub fn uri(&self) -> &str {
+        &self.uri
+    }
+
+    #[must_use]
+    pub fn definitions(&self) -> &IdentityHashSet<DefinitionId> {
+        &self.definition_ids
+    }
+
+    pub fn add_definition(&mut self, definition_id: DefinitionId) {
+        self.definition_ids.insert(definition_id);
+    }
+}

--- a/rust/index/tests/cli.rs
+++ b/rust/index/tests/cli.rs
@@ -75,13 +75,13 @@ fn visualize_simple_class() {
     rankdir=TB;
 
     "Name:SimpleClass" [label="SimpleClass",shape=hexagon];
+    "Name:SimpleClass" -> "def_<ID>" [dir=both];
 
     "def_<ID>" [label="Class(SimpleClass)",shape=ellipse];
 
     "file://<PATH>/simple.rb" [label="simple.rb",shape=box];
-
-    "Name:SimpleClass" -> "def_<ID>" [dir=both];
     "def_<ID>" -> "file://<PATH>/simple.rb";
+
 }
 
 "#;


### PR DESCRIPTION
Closes #139

This PR is the final step for moving edges inside the nodes they belong to for saving memory. This PR adds the concept of a `Document` and moves the URI related edges inside of it.