### PR TITLE
Use vectors instead of hashsets for definition IDs

### DIFF
--- a/rust/index/src/model/declaration.rs
+++ b/rust/index/src/model/declaration.rs
@@ -1,14 +1,9 @@
-use std::collections::HashSet;
-
-use crate::model::{
-    identity_maps::{IdentityHashBuilder, IdentityHashSet},
-    ids::DefinitionId,
-};
+use crate::model::ids::DefinitionId;
 
 #[derive(Debug)]
 pub struct Declaration {
     name: String,
-    definition_ids: IdentityHashSet<DefinitionId>,
+    definition_ids: Vec<DefinitionId>,
 }
 
 impl Declaration {
@@ -16,7 +11,7 @@ impl Declaration {
     pub fn new(name: String) -> Self {
         Self {
             name,
-            definition_ids: HashSet::with_hasher(IdentityHashBuilder),
+            definition_ids: Vec::new(),
         }
     }
 
@@ -31,18 +26,22 @@ impl Declaration {
     }
 
     #[must_use]
-    pub fn definitions(&self) -> &IdentityHashSet<DefinitionId> {
+    pub fn definitions(&self) -> &[DefinitionId] {
         &self.definition_ids
     }
 
     // Deletes a definition from this declaration. Returns `true` if this declaration is now empty, which indicates that
     // it must be removed from the graph
     pub fn remove_definition(&mut self, definition_id: &DefinitionId) -> bool {
-        self.definition_ids.remove(definition_id);
+        if let Some(pos) = self.definition_ids.iter().position(|id| id == definition_id) {
+            self.definition_ids.swap_remove(pos);
+            self.definition_ids.shrink_to_fit();
+        }
+
         self.definition_ids.is_empty()
     }
 
     pub fn add_definition(&mut self, definition_id: DefinitionId) {
-        self.definition_ids.insert(definition_id);
+        self.definition_ids.push(definition_id);
     }
 }

--- a/rust/index/src/model/document.rs
+++ b/rust/index/src/model/document.rs
@@ -1,16 +1,11 @@
-use std::collections::HashSet;
-
-use crate::model::{
-    identity_maps::{IdentityHashBuilder, IdentityHashSet},
-    ids::DefinitionId,
-};
+use crate::model::ids::DefinitionId;
 
 // Represents a document currently loaded into memory. Identified by its unique URI, it holds the edges to all
 // definitions discovered in it
 #[derive(Debug)]
 pub struct Document {
     uri: String,
-    definition_ids: IdentityHashSet<DefinitionId>,
+    definition_ids: Vec<DefinitionId>,
 }
 
 impl Document {
@@ -18,7 +13,7 @@ impl Document {
     pub fn new(uri: String) -> Self {
         Self {
             uri,
-            definition_ids: HashSet::with_hasher(IdentityHashBuilder),
+            definition_ids: Vec::new(),
         }
     }
 
@@ -28,11 +23,11 @@ impl Document {
     }
 
     #[must_use]
-    pub fn definitions(&self) -> &IdentityHashSet<DefinitionId> {
+    pub fn definitions(&self) -> &[DefinitionId] {
         &self.definition_ids
     }
 
     pub fn add_definition(&mut self, definition_id: DefinitionId) {
-        self.definition_ids.insert(definition_id);
+        self.definition_ids.push(definition_id);
     }
 }

--- a/rust/index/src/visualization/dot.rs
+++ b/rust/index/src/visualization/dot.rs
@@ -155,8 +155,8 @@ mod tests {
     "def_{module_def_id}" [label="Module(TestModule)",shape=ellipse];
 
     "file:///test.rb" [label="test.rb",shape=box];
-    "def_{module_def_id}" -> "file:///test.rb";
     "def_{class_def_id}" -> "file:///test.rb";
+    "def_{module_def_id}" -> "file:///test.rb";
 
 }}
 "#


### PR DESCRIPTION
Vectors are actually more efficient for storing the list of edges inside of the nodes. We use less memory and building the graph is a bit faster.

For most cases, the list of edges is not too big so deletion performance is not so critical. Additionally, we don't care about order (at least in these specific edges), so we can use `swap_remove` which is O1 and does not preserve ordering.