### PR TITLE
Use channels to incrementally build global graph

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -230,31 +230,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
-name = "crossbeam-deque"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
-
-[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -507,7 +482,6 @@ dependencies = [
  "clap",
  "glob",
  "predicates",
- "rayon",
  "regex",
  "rmp-serde",
  "ruby-prism",
@@ -757,26 +731,6 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
-
-[[package]]
-name = "rayon"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
-dependencies = [
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
-dependencies = [
- "crossbeam-deque",
- "crossbeam-utils",
-]
 
 [[package]]
 name = "regex"

--- a/rust/index-sys/src/index_api.rs
+++ b/rust/index-sys/src/index_api.rs
@@ -56,7 +56,7 @@ pub unsafe extern "C" fn idx_index_all_c(
     all_errors.extend(document_errors);
 
     with_graph(pointer, |graph| {
-        if let Err(errors) = indexing::index_in_parallel(graph, &documents) {
+        if let Err(errors) = indexing::index_in_parallel(graph, documents) {
             all_errors.extend(errors.0);
         }
 

--- a/rust/index/Cargo.toml
+++ b/rust/index/Cargo.toml
@@ -15,7 +15,6 @@ crate-type = ["rlib"]
 ruby-prism = "1.4.0"
 url = "2.5.4"
 rusqlite = { version = "0.37.0", features = ["bundled"] }
-rayon = "1.10.0"
 xxhash-rust = { version = "0.8.15", features = ["xxh3"] }
 clap = { version = "4.5.16", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/rust/index/src/main.rs
+++ b/rust/index/src/main.rs
@@ -29,12 +29,13 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mut graph = Graph::new();
     graph.set_configuration(format!("{}/graph.db", &args.dir))?;
     let (documents, errors) = indexing::collect_documents(vec![args.dir]);
+    let document_count = documents.len();
 
     if !errors.is_empty() {
         return Err(Box::new(MultipleErrors(errors)));
     }
 
-    indexing::index_in_parallel(&mut graph, &documents)?;
+    indexing::index_in_parallel(&mut graph, documents)?;
 
     // Run integrity checks if requested
     if args.check_integrity {
@@ -55,7 +56,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     if args.visualize {
         println!("{}", dot::generate(&graph));
     } else {
-        println!("Indexed {} files", documents.len());
+        println!("Indexed {document_count} files");
         println!("Found {} names", graph.declarations().len());
         println!("Found {} definitions", graph.definitions().len());
         println!("Found {} URIs", graph.documents().len());


### PR DESCRIPTION
We're still spending quite a bit of time sleeping because the main thread doesn't do anything while the others are indexing. We can get some more speed up by using channels to communicate partial results back to the main thread as they are ready to be merged into the global graph.

This eliminates most of the sleeping and further reduces our initial indexing time.