### PR TITLE
Use TEXT column for ID fields

### DIFF
--- a/rust/index/src/db/schema.sql
+++ b/rust/index/src/db/schema.sql
@@ -3,21 +3,21 @@
 
 -- Table for storing documents
 CREATE TABLE IF NOT EXISTS documents (
-    id INTEGER PRIMARY KEY,  -- Blake3 hash converted to hex
+    id TEXT PRIMARY KEY,
     uri TEXT NOT NULL UNIQUE
 );
 
 -- Table for storing code declarations (classes, modules, methods, etc.)
 CREATE TABLE IF NOT EXISTS names (
-    id INTEGER PRIMARY KEY,  -- Blake3 hash converted to hex
+    id TEXT PRIMARY KEY,
     name TEXT NOT NULL
 );
 
 -- Table for storing definitions that make up declarations
 CREATE TABLE IF NOT EXISTS definitions (
-    id INTEGER PRIMARY KEY,  -- Blake3 hash converted to hex
-    name_id INTEGER NOT NULL REFERENCES names(id), -- References names.id
-    document_id INTEGER NOT NULL REFERENCES documents(id), -- References documents.id
+    id TEXT PRIMARY KEY,
+    name_id TEXT NOT NULL REFERENCES names(id), -- References names.id
+    document_id TEXT NOT NULL REFERENCES documents(id), -- References documents.id
     data BLOB NOT NULL, -- Serialized definition data
     FOREIGN KEY (name_id) REFERENCES names (id) ON DELETE CASCADE,
     FOREIGN KEY (document_id) REFERENCES documents (id) ON DELETE CASCADE


### PR DESCRIPTION
I discovered something a bit unfortunate. SQlite doesn't support `u64` integers only `i64`. If we happen to hash an ID that uses the sign bit in a way that exceeds the `i64` limit, then saving to database crashes.

Our tests didn't catch this earlier by pure randomness. Having a single `module Foo; end` definition didn't create an ID that exceeded the `i64` size and so we didn't hit the problem.

This PR switches the ID columns to be `TEXT` for now, so that we can keep using IDs of `u64` size. It's a bit of a trade off. Using numbers is generally faster, but since SQlite can't support `u64`, our only options would be:

1. Using `u32`, which greatly increases the collision risk
2. Truncating the `u64` into a `i64`, which also increases the collision risk

I think using `TEXT` for now is fair. Also, I improved our existing test so that it hits this scenario and properly fails.