### PR TITLE
Add comments to synthetic corpus

### DIFF
--- a/utils/generate-corpus
+++ b/utils/generate-corpus
@@ -22,7 +22,35 @@ require "fileutils"
 require "stringio"
 
 module Symbols
+  module CommentUtils
+    CommentInput = Data.define(:probability, :line_count, :line_length)
+
+    # These numbers are based on Shopify core repo comment distribution
+    COMMENT_PARAMS = {
+      "Symbols::Class" => CommentInput.new(0.19, 2, 26),
+      "Symbols::Module" => CommentInput.new(0.41, 2, 27),
+      "Symbols::Method" => CommentInput.new(0.13, 1, 33),
+      "Symbols::SingletonClass" => CommentInput.new(0.16, 2, 20),
+      "Symbols::Constant" => CommentInput.new(0.09, 1, 36),
+    }
+
+    CHARACTERS = ("a".."z").to_a + [" "]
+
+    def write_comments(buffer, indent:)
+      comment_params = COMMENT_PARAMS.fetch(self.class.name)
+      return if rand > comment_params.probability
+
+      comments = comment_params.line_count.times.map do
+        "#{" " * indent}# " + CHARACTERS.sample(comment_params.line_length - 2).join
+      end.join("\n")
+
+      buffer.puts comments
+    end
+  end
+
   class Tree
+    include CommentUtils
+
     attr_reader :children
 
     def initialize
@@ -60,6 +88,7 @@ module Symbols
     attr_accessor :superclass
 
     def write(buffer, indent:)
+      write_comments(buffer, indent:)
       if @superclass
         buffer.puts "#{" " * indent}class #{@name} < #{@superclass.name}"
       else
@@ -72,6 +101,7 @@ module Symbols
 
   class Module < NamedTree
     def write(buffer, indent:)
+      write_comments(buffer, indent:)
       buffer.puts "#{" " * indent}module #{@name}"
       write_children(buffer, indent: indent)
       buffer.puts "#{" " * indent}end"
@@ -80,6 +110,7 @@ module Symbols
 
   class SingletonClass < Tree
     def write(buffer, indent:)
+      write_comments(buffer, indent:)
       buffer.puts "#{" " * indent}class << self"
       write_children(buffer, indent: indent)
       buffer.puts "#{" " * indent}end"
@@ -87,17 +118,21 @@ module Symbols
   end
 
   class Constant
+    include CommentUtils
+
     def initialize(name)
       @name = name
     end
 
     def write(buffer, indent:)
+      write_comments(buffer, indent:)
       buffer.puts "#{" " * indent}#{@name} = 42"
     end
   end
 
   class Method < NamedTree
     def write(buffer, indent:)
+      write_comments(buffer, indent:)
       params = rand(0..10).times.map { |i| "param#{i}" }
       if params.empty?
         buffer.puts "#{" " * indent}def #{@name}"


### PR DESCRIPTION
# 

Part of https://github.com/Shopify/index/issues/86

First step to benchmark the performance of parsing comments. The numbers were generated with the following script against core:

<details>
<summary>script to get comment distribution in core</summary>

```
require 'ruby_lsp/internal'
require 'benchmark'

start_time = Time.now

# Accept optional path argument
target_path = ARGV[0] || Dir.pwd
original_dir = Dir.pwd

puts "\nStarting comment metrics analysis..."
puts "Repository: #{target_path}"

NODES_TO_PARSE = [
  RubyIndexer::Entry::Module,
  RubyIndexer::Entry::Class,
  RubyIndexer::Entry::Method,
  RubyIndexer::Entry::Constant,
  RubyIndexer::Entry::SingletonClass,
]

# Change to target directory for indexing
indexing_time = 0
parsing_time = 0
entries = nil
tally = Hash.new { |h, k| h[k] = Array.new }
lengths = Hash.new { |h, k| h[k] = Array.new }

Dir.chdir(target_path) do
  index = RubyIndexer::Index.new
  indexing_time = Benchmark.realtime do
    index.index_all
  end

  entries = index.instance_variable_get(:@entries)

  parsing_time = Benchmark.realtime do
    entries.each do |_name, definitions|
      definitions.each do |definition|
        next unless NODES_TO_PARSE.include?(definition.class)

        comment_lines = definition.comments.lines.reject do |comment|
          comment.strip.start_with?('|', ':')
        end

        tally[definition.class] << comment_lines.count
        lengths[definition.class].concat(comment_lines.map(&:length))
      end
    end
  end
end

puts "\n" + "=" * 60
puts "COMMENT STATISTICS BY DEFINITION TYPE"
puts "=" * 60

tally.each do |type_class, comment_counts|
  type_name = type_class.name.split("::").last
  puts "=== #{type_name}"
  total = comment_counts.count
  with_comments = comment_counts.reject(&:zero?)
  percentage = total > 0 ? (with_comments.count * 100.0 / total).round(1) : 0
  median_line_count = with_comments.empty? ? 0 : with_comments.sort[with_comments.count / 2]  
  line_lengths = lengths.fetch(type_class)
  median_line_length = line_lengths.empty? ? 0 : line_lengths.sort[line_lengths.count / 2]
  puts "- Percentage of definitions with comments: #{percentage}% (#{with_comments.count}/#{total})"
  puts "- Median number of lines: #{median_line_count} lines"
  puts "- Median length per line: #{median_line_length} lines"
  puts
end

total_time = Time.now - start_time
puts "\n" + "=" * 60
puts "PERFORMANCE METRICS"
puts "=" * 60
puts "Indexing time: %.2f seconds" % indexing_time
puts "Parsing time: %.2f seconds" % parsing_time
puts "Total time: %.2f seconds" % total_time
puts "Entries processed: #{entries.count}"
```

</details>

<details>
<summary>result</summary>

```
Starting comment metrics analysis...
Repository: core

============================================================
COMMENT STATISTICS BY DEFINITION TYPE
============================================================

=== Class
- Percentage of definitions with comments: 18.8% (12554/66951)
- Median number of lines: 2 lines
- Median length per line: 26 lines

=== Method
- Percentage of definitions with comments: 12.6% (41762/332302)
- Median number of lines: 1 lines
- Median length per line: 33 lines

=== SingletonClass
- Percentage of definitions with comments: 15.6% (3956/25370)
- Median number of lines: 2 lines
- Median length per line: 20 lines

=== Module
- Percentage of definitions with comments: 41.1% (49519/120482)
- Median number of lines: 2 lines
- Median length per line: 27 lines

=== Constant
- Percentage of definitions with comments: 9.2% (5509/59993)
- Median number of lines: 1 lines
- Median length per line: 36 lines


============================================================
PERFORMANCE METRICS
============================================================
Indexing time: 61.09 seconds
Parsing time: 415.72 seconds
Total time: 477.11 seconds
Entries processed: 338654
```

</details>