### PR TITLE
Parse comments during indexing time

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -124,6 +124,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -479,6 +485,7 @@ name = "index"
 version = "0.1.0"
 dependencies = [
  "assert_cmd",
+ "bytecount",
  "clap",
  "glob",
  "predicates",

--- a/rust/index/Cargo.toml
+++ b/rust/index/Cargo.toml
@@ -20,6 +20,7 @@ clap = { version = "4.5.16", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 rmp-serde = "1.3.0"
 glob = "0.3.2"
+bytecount = "0.6.9"
 
 [dev-dependencies]
 tempfile = "3.0"

--- a/rust/index/src/indexing/ruby_indexer.rs
+++ b/rust/index/src/indexing/ruby_indexer.rs
@@ -11,9 +11,25 @@ use crate::model::ids::{NameId, UriId};
 use crate::offset::Offset;
 use crate::source_location::SourceLocationConverter;
 
-use ruby_prism::Visit;
+use ruby_prism::{ParseResult, Visit};
 
 pub type IndexerParts = (Graph, Vec<IndexingError>);
+
+const MAGIC_AND_RBS_COMMENT_PREFIX: &[&str] = &[
+    "frozen_string_literal:",
+    "typed:",
+    "compiled:",
+    "encoding:",
+    "shareable_constant_value:",
+    "warn_indent:",
+    "rubocop:",
+    "nodoc:",
+    "doc:",
+    "coding:",
+    "warn_past_scope:",
+    "#:",
+    "#|",
+];
 
 /// The indexer for the definitions found in the Ruby source code.
 ///
@@ -25,11 +41,13 @@ pub struct RubyIndexer<'a> {
     nesting_stacks: Vec<Vec<String>>,
     errors: Vec<IndexingError>,
     location_converter: &'a dyn SourceLocationConverter,
+    comments: Vec<CommentGroup>,
+    source: &'a str,
 }
 
 impl<'a> RubyIndexer<'a> {
     #[must_use]
-    pub fn new(uri: String, location_converter: &'a dyn SourceLocationConverter) -> Self {
+    pub fn new(uri: String, location_converter: &'a dyn SourceLocationConverter, source: &'a str) -> Self {
         let mut local_index = Graph::new();
         let uri_id = local_index.add_uri(uri);
 
@@ -39,6 +57,8 @@ impl<'a> RubyIndexer<'a> {
             local_index,
             errors: Vec::new(),
             location_converter,
+            comments: Vec::new(),
+            source,
         }
     }
 
@@ -51,13 +71,69 @@ impl<'a> RubyIndexer<'a> {
         self.errors.push(error);
     }
 
-    pub fn index(&mut self, source: &str) {
-        let result = ruby_prism::parse(source.as_ref());
+    pub fn index(&mut self) {
+        let result = ruby_prism::parse(self.source.as_bytes());
+        self.comments = self.parse_comments_into_groups(&result);
         self.visit(&result.node());
+    }
+
+    fn parse_comments_into_groups(&mut self, result: &ParseResult<'_>) -> Vec<CommentGroup> {
+        let mut iter = result.comments().peekable();
+        let mut groups = Vec::new();
+
+        while let Some(comment) = iter.next() {
+            let mut group = CommentGroup::new();
+            group.add_comment(&comment);
+            while let Some(next_comment) = iter.peek() {
+                if group.accepts(next_comment, self.source) {
+                    let next = iter.next().unwrap();
+                    group.add_comment(&next);
+                } else {
+                    break;
+                }
+            }
+            groups.push(group);
+        }
+        groups
     }
 
     fn location_to_string(location: &ruby_prism::Location) -> String {
         String::from_utf8_lossy(location.as_slice()).to_string()
+    }
+
+    fn find_comments_for(&self, offset: u32) -> Option<String> {
+        let offset_usize = offset as usize;
+        if self.comments.is_empty() {
+            return None;
+        }
+
+        let idx = match self.comments.binary_search_by_key(&offset_usize, |g| g.end_offset) {
+            Ok(_) => {
+                // This should never happen in valid Ruby syntax - a comment cannot end exactly
+                // where a definition begins (there must be at least a newline between them)
+                debug_assert!(false, "Comment ends exactly at definition start - this indicates a bug");
+                return None;
+            }
+            Err(i) if i > 0 => i - 1,
+            Err(_) => return None,
+        };
+
+        let group = &self.comments[idx];
+        let between = &self.source.as_bytes()[group.end_offset..offset_usize];
+        if !between.iter().all(|&b| b.is_ascii_whitespace()) {
+            return None;
+        }
+
+        // We allow at most one blank line between the comment and the definition
+        if bytecount::count(between, b'\n') > 2 {
+            return None;
+        }
+
+        if group.comments.is_empty() {
+            None
+        } else {
+            Some(group.comments.clone())
+        }
     }
 
     fn collect_parameters(node: &ruby_prism::DefNode) -> Vec<Parameter> {
@@ -235,13 +311,61 @@ impl<'a> RubyIndexer<'a> {
     }
 }
 
+struct CommentGroup {
+    end_offset: usize,
+    comments: String,
+}
+
+impl CommentGroup {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            end_offset: 0,
+            comments: String::new(),
+        }
+    }
+
+    // Accepts the next line if it is continuous
+    fn accepts(&self, next: &ruby_prism::Comment, source: &str) -> bool {
+        let current_end_offset = self.end_offset;
+        let next_line_start_offset = next.location().start_offset();
+
+        let between = &source.as_bytes()[current_end_offset..next_line_start_offset];
+        if !between.iter().all(|&b| b.is_ascii_whitespace()) {
+            return false;
+        }
+
+        // If there is at most one newline between the two texts,
+        // that means two texts are continuous
+        bytecount::count(between, b'\n') <= 1
+    }
+
+    // For the magic comments, what we want to do is the following:
+    // 1. still move the group end offset to the end of the magic comment
+    // 2. not add the comment to the comments array
+    fn add_comment(&mut self, comment: &ruby_prism::Comment) {
+        self.end_offset = comment.location().end_offset();
+        let text = String::from_utf8_lossy(comment.location().as_slice()).to_string();
+        if MAGIC_AND_RBS_COMMENT_PREFIX.iter().any(|&prefix| text.contains(prefix)) {
+            return;
+        }
+
+        let parsed_comment = text.trim().strip_prefix("# ").unwrap_or(text.trim());
+        if !self.comments.is_empty() {
+            self.comments.push('\n');
+        }
+        self.comments.push_str(parsed_comment);
+    }
+}
+
 impl Visit<'_> for RubyIndexer<'_> {
     fn visit_class_node(&mut self, node: &ruby_prism::ClassNode<'_>) {
         let name = Self::location_to_string(&node.constant_path().location());
-        
+
         self.with_updated_nesting(&name, |indexer, fully_qualified_name| {
             let name_id = NameId::from(&fully_qualified_name);
             let offset = Offset::from_prism_location(&node.location());
+            let comments = indexer.find_comments_for(offset.start()).unwrap_or_default();
             // Uses `location_converter` to evaluate the performance impact of the conversion
             self.location_converter.offset_to_position(&offset).unwrap();
 
@@ -249,6 +373,7 @@ impl Visit<'_> for RubyIndexer<'_> {
                 name_id,
                 indexer.uri_id,
                 offset,
+                comments,
             )));
 
             indexer.local_index.add_definition(fully_qualified_name, definition);
@@ -265,12 +390,14 @@ impl Visit<'_> for RubyIndexer<'_> {
         self.with_updated_nesting(&name, |indexer, fully_qualified_name| {
             let name_id = NameId::from(&fully_qualified_name);
             let offset = Offset::from_prism_location(&node.location());
+            let comments = indexer.find_comments_for(offset.start()).unwrap_or_default();
             // Uses `location_converter` to evaluate the performance impact of the conversion
             self.location_converter.offset_to_position(&offset).unwrap();
             let definition = Definition::Module(Box::new(ModuleDefinition::new(
                 name_id,
                 indexer.uri_id,
                 offset,
+                comments,
             )));
             indexer.local_index.add_definition(fully_qualified_name, definition);
 
@@ -287,12 +414,14 @@ impl Visit<'_> for RubyIndexer<'_> {
         self.with_updated_nesting(&name, |indexer, fully_qualified_name| {
             let name_id = NameId::from(&fully_qualified_name);
             let offset = Offset::from_prism_location(&name_loc);
+            let comments = indexer.find_comments_for(offset.start()).unwrap_or_default();
             // Uses `location_converter` to evaluate the performance impact of the conversion
             self.location_converter.offset_to_position(&offset).unwrap();
             let definition = Definition::Constant(Box::new(ConstantDefinition::new(
                 name_id,
                 indexer.uri_id,
                 offset,
+                comments,
             )));
 
             indexer.local_index.add_definition(fully_qualified_name, definition);
@@ -308,12 +437,14 @@ impl Visit<'_> for RubyIndexer<'_> {
         self.with_updated_nesting(&name, |indexer, fully_qualified_name| {
             let name_id = NameId::from(&fully_qualified_name);
             let offset = Offset::from_prism_location(&location);
+            let comments = indexer.find_comments_for(offset.start()).unwrap_or_default();
             // Uses `location_converter` to evaluate the performance impact of the conversion
             self.location_converter.offset_to_position(&offset).unwrap();
             let definition = Definition::Constant(Box::new(ConstantDefinition::new(
                 name_id,
                 indexer.uri_id,
                 offset,
+                comments,
             )));
 
             indexer.local_index.add_definition(fully_qualified_name, definition);
@@ -332,6 +463,7 @@ impl Visit<'_> for RubyIndexer<'_> {
                     self.with_updated_nesting(&name, |indexer, fully_qualified_name| {
                         let name_id = NameId::from(&fully_qualified_name);
                         let offset = Offset::from_prism_location(&location);
+                        let comments = indexer.find_comments_for(offset.start()).unwrap_or_default();
                         // Uses `location_converter` to evaluate the performance impact of the conversion
                         self.location_converter.offset_to_position(&offset).unwrap();
 
@@ -339,6 +471,7 @@ impl Visit<'_> for RubyIndexer<'_> {
                             name_id,
                             indexer.uri_id,
                             offset,
+                            comments,
                         )));
 
                         indexer.local_index.add_definition(fully_qualified_name, definition);
@@ -352,10 +485,12 @@ impl Visit<'_> for RubyIndexer<'_> {
                     // Uses `location_converter` to evaluate the performance impact of the conversion
                     self.location_converter.offset_to_position(&offset).unwrap();
 
+                    let comments = self.find_comments_for(offset.start()).unwrap_or_default();
                     let definition = Definition::GlobalVariable(Box::new(GlobalVariableDefinition::new(
                         name_id,
                         self.uri_id,
                         offset,
+                        comments,
                     )));
 
                     self.local_index.add_definition(name, definition);
@@ -367,6 +502,7 @@ impl Visit<'_> for RubyIndexer<'_> {
                     self.with_updated_nesting(&name, |indexer, fully_qualified_name| {
                         let name_id = NameId::from(&fully_qualified_name);
                         let offset = Offset::from_prism_location(&location);
+                        let comments = indexer.find_comments_for(offset.start()).unwrap_or_default();
                         // Uses `location_converter` to evaluate the performance impact of the conversion
                         self.location_converter.offset_to_position(&offset).unwrap();
 
@@ -374,6 +510,7 @@ impl Visit<'_> for RubyIndexer<'_> {
                             name_id,
                             indexer.uri_id,
                             offset,
+                            comments,
                         )));
 
                         indexer.local_index.add_definition(fully_qualified_name, definition);
@@ -386,6 +523,7 @@ impl Visit<'_> for RubyIndexer<'_> {
                     self.with_updated_nesting(&name, |indexer, fully_qualified_name| {
                         let name_id = NameId::from(&fully_qualified_name);
                         let offset = Offset::from_prism_location(&location);
+                        let comments = indexer.find_comments_for(offset.start()).unwrap_or_default();
                         // Uses `location_converter` to evaluate the performance impact of the conversion
                         self.location_converter.offset_to_position(&offset).unwrap();
 
@@ -393,6 +531,7 @@ impl Visit<'_> for RubyIndexer<'_> {
                             name_id,
                             indexer.uri_id,
                             offset,
+                            comments,
                         )));
 
                         indexer.local_index.add_definition(fully_qualified_name, definition);
@@ -411,6 +550,7 @@ impl Visit<'_> for RubyIndexer<'_> {
         self.with_updated_nesting(&name, |indexer, fully_qualified_name| {
             let name_id = NameId::from(&fully_qualified_name);
             let offset = Offset::from_prism_location(&node.location());
+            let comments = indexer.find_comments_for(offset.start()).unwrap_or_default();
             // Uses `location_converter` to evaluate the performance impact of the conversion
             self.location_converter.offset_to_position(&offset).unwrap();
 
@@ -421,6 +561,7 @@ impl Visit<'_> for RubyIndexer<'_> {
                 Self::collect_parameters(node),
                 node.receiver()
                     .is_some_and(|receiver| receiver.as_self_node().is_some()),
+                comments,
             );
 
             indexer
@@ -449,15 +590,16 @@ impl Visit<'_> for RubyIndexer<'_> {
                     self.with_updated_nesting(&name, |indexer, fully_qualified_name| {
                         let name_id = NameId::from(&fully_qualified_name);
                         let offset = Offset::from_prism_location(&location);
+                        let comments = indexer.find_comments_for(offset.start()).unwrap_or_default();
                         // Uses `location_converter` to evaluate the performance impact of the conversion
                         self.location_converter.offset_to_position(&offset).unwrap();
-
                         indexer.local_index.add_definition(
                             fully_qualified_name.clone(),
                             Definition::AttrAccessor(Box::new(AttrAccessorDefinition::new(
                                 name_id,
                                 indexer.uri_id,
                                 offset,
+                                comments.clone(),
                             ))),
                         );
 
@@ -469,6 +611,7 @@ impl Visit<'_> for RubyIndexer<'_> {
                                 writer_name_id,
                                 indexer.uri_id,
                                 Offset::from_prism_location(&location),
+                                comments.clone(),
                             ))),
                         );
                     });
@@ -479,6 +622,7 @@ impl Visit<'_> for RubyIndexer<'_> {
                     self.with_updated_nesting(&name, |indexer, fully_qualified_name| {
                         let name_id = NameId::from(&fully_qualified_name);
                         let offset = Offset::from_prism_location(&location);
+                        let comments = indexer.find_comments_for(offset.start()).unwrap_or_default();
                         // Uses `location_converter` to evaluate the performance impact of the conversion
                         self.location_converter.offset_to_position(&offset).unwrap();
 
@@ -488,6 +632,7 @@ impl Visit<'_> for RubyIndexer<'_> {
                                 name_id,
                                 indexer.uri_id,
                                 offset,
+                                comments,
                             ))),
                         );
                     });
@@ -499,6 +644,7 @@ impl Visit<'_> for RubyIndexer<'_> {
                         let writer_name = format!("{fully_qualified_name}=");
                         let name_id = NameId::from(&writer_name);
                         let offset = Offset::from_prism_location(&location);
+                        let comments = indexer.find_comments_for(offset.start()).unwrap_or_default();
                         // Uses `location_converter` to evaluate the performance impact of the conversion
                         self.location_converter.offset_to_position(&offset).unwrap();
 
@@ -508,6 +654,7 @@ impl Visit<'_> for RubyIndexer<'_> {
                                 name_id,
                                 indexer.uri_id,
                                 offset,
+                                comments,
                             ))),
                         );
                     });
@@ -535,11 +682,14 @@ impl Visit<'_> for RubyIndexer<'_> {
         let name_loc = node.name_loc();
         let name = Self::location_to_string(&name_loc);
         let name_id = NameId::from(&name);
+        let offset = Offset::from_prism_location(&name_loc);
 
+        let comments = self.find_comments_for(offset.start()).unwrap_or_default();
         let definition = Definition::GlobalVariable(Box::new(GlobalVariableDefinition::new(
             name_id,
             self.uri_id,
-            Offset::from_prism_location(&name_loc),
+            offset,
+            comments,
         )));
 
         self.local_index.add_definition(name, definition);
@@ -554,6 +704,7 @@ impl Visit<'_> for RubyIndexer<'_> {
         self.with_updated_nesting(&name, |indexer, fully_qualified_name| {
             let name_id = NameId::from(&fully_qualified_name);
             let offset = Offset::from_prism_location(&name_loc);
+            let comments = indexer.find_comments_for(offset.start()).unwrap_or_default();
             // Uses `location_converter` to evaluate the performance impact of the conversion
             self.location_converter.offset_to_position(&offset).unwrap();
 
@@ -561,6 +712,7 @@ impl Visit<'_> for RubyIndexer<'_> {
                 name_id,
                 indexer.uri_id,
                 offset,
+                comments,
             )));
 
             indexer.local_index.add_definition(fully_qualified_name, definition);
@@ -576,6 +728,7 @@ impl Visit<'_> for RubyIndexer<'_> {
         self.with_updated_nesting(&name, |indexer, fully_qualified_name| {
             let name_id = NameId::from(&fully_qualified_name);
             let offset = Offset::from_prism_location(&name_loc);
+            let comments = indexer.find_comments_for(offset.start()).unwrap_or_default();
             // Uses `location_converter` to evaluate the performance impact of the conversion
             self.location_converter.offset_to_position(&offset).unwrap();
 
@@ -583,6 +736,7 @@ impl Visit<'_> for RubyIndexer<'_> {
                 name_id,
                 indexer.uri_id,
                 offset,
+                comments,
             )));
 
             indexer.local_index.add_definition(fully_qualified_name, definition);
@@ -1013,6 +1167,230 @@ mod tests {
 
         assert!(context.graph.get("not_indexed").is_none());
         assert!(context.graph.get("not_indexed=").is_none());
+    }
+
+    #[test]
+    fn comment_basic_attachment() {
+        let mut context = GraphTest::new();
+
+        context.index_uri("file:///foo.rb", {
+            "
+            # Single comment
+            class Single; end
+
+            # Multi-line comment 1
+            # Multi-line comment 2
+            # Multi-line comment 3
+            class Multi; end
+
+            # Comment directly above (no gap)
+            class NoGap; end
+
+            # Comment with blank line
+
+            class BlankLine; end
+
+            class NoComment; end
+            "
+        });
+
+        let single = context.graph.get("Single").unwrap();
+        match &single[0] {
+            Definition::Class(_) => {
+                assert_eq!(single[0].comments(), "Single comment");
+            }
+            _ => panic!("Expected class"),
+        }
+
+        let multi = context.graph.get("Multi").unwrap();
+        match &multi[0] {
+            Definition::Class(_) => {
+                assert_eq!(
+                    multi[0].comments(),
+                    "Multi-line comment 1\nMulti-line comment 2\nMulti-line comment 3"
+                );
+            }
+            _ => panic!("Expected class"),
+        }
+
+        let no_gap = context.graph.get("NoGap").unwrap();
+        match &no_gap[0] {
+            Definition::Class(_) => {
+                assert_eq!(no_gap[0].comments(), "Comment directly above (no gap)");
+            }
+            _ => panic!("Expected class"),
+        }
+
+        let blank = context.graph.get("BlankLine").unwrap();
+        match &blank[0] {
+            Definition::Class(_) => {
+                assert_eq!(blank[0].comments(), "Comment with blank line");
+            }
+            _ => panic!("Expected class"),
+        }
+
+        let no_comment = context.graph.get("NoComment").unwrap();
+        match &no_comment[0] {
+            Definition::Class(_) => {
+                assert!(no_comment[0].comments().is_empty());
+            }
+            _ => panic!("Expected class"),
+        }
+    }
+
+    #[test]
+    fn comment_separation_rules() {
+        let mut context = GraphTest::new();
+
+        context.index_uri("file:///foo.rb", {
+            "
+            # Too far away
+
+
+            class TooFar; end
+
+            # Not attached due to code
+            x = 1
+            class CodeBetween; end
+
+            # Comment for Foo
+            class Foo; end
+            "
+        });
+
+        let too_far = context.graph.get("TooFar").unwrap();
+        match &too_far[0] {
+            Definition::Class(_) => {
+                assert!(too_far[0].comments().is_empty(), "Comment too far should not attach");
+            }
+            _ => panic!("Expected class"),
+        }
+
+        let code_between = context.graph.get("CodeBetween").unwrap();
+        match &code_between[0] {
+            Definition::Class(_) => {
+                assert!(
+                    code_between[0].comments().is_empty(),
+                    "Comment with code between should not attach"
+                );
+            }
+            _ => panic!("Expected class"),
+        }
+
+        let foo = context.graph.get("Foo").unwrap();
+        match &foo[0] {
+            Definition::Class(_) => {
+                assert_eq!(foo[0].comments(), "Comment for Foo");
+            }
+            _ => panic!("Expected class"),
+        }
+    }
+
+    #[test]
+    fn comment_indented_and_nested() {
+        let mut context = GraphTest::new();
+
+        context.index_uri("file:///foo.rb", {
+            "
+            # Outer class
+            class Outer
+              # Inner class at 2 spaces
+              class Inner
+                # Deep class at 4 spaces
+                class Deep; end
+              end
+
+              # Another inner class
+              # with multiple lines
+              class AnotherInner; end
+            end
+            "
+        });
+
+        let outer = context.graph.get("Outer").unwrap();
+        match &outer[0] {
+            Definition::Class(_) => {
+                assert_eq!(outer[0].comments(), "Outer class");
+            }
+            _ => panic!("Expected class"),
+        }
+
+        let inner = context.graph.get("Outer::Inner").unwrap();
+        match &inner[0] {
+            Definition::Class(_) => {
+                assert_eq!(inner[0].comments(), "Inner class at 2 spaces");
+            }
+            _ => panic!("Expected class"),
+        }
+
+        let deep = context.graph.get("Outer::Inner::Deep").unwrap();
+        match &deep[0] {
+            Definition::Class(_) => {
+                assert_eq!(deep[0].comments(), "Deep class at 4 spaces");
+            }
+            _ => panic!("Expected class"),
+        }
+
+        let another = context.graph.get("Outer::AnotherInner").unwrap();
+        match &another[0] {
+            Definition::Class(_) => {
+                assert_eq!(another[0].comments(), "Another inner class\nwith multiple lines");
+            }
+            _ => panic!("Expected class"),
+        }
+    }
+
+    #[test]
+    fn comment_modules_and_constants() {
+        let mut context = GraphTest::new();
+
+        context.index_uri("file:///foo.rb", {
+            "
+            # Module comment
+            module TestModule
+              # Constant comment
+              FOO = 42
+              
+              # Nested module
+              module Nested; end
+            end
+
+            # Multi-write constant
+            A, B = 1, 2
+            "
+        });
+
+        let module = context.graph.get("TestModule").unwrap();
+        match &module[0] {
+            Definition::Module(_) => {
+                assert_eq!(module[0].comments(), "Module comment");
+            }
+            _ => panic!("Expected module"),
+        }
+
+        let constant = context.graph.get("TestModule::FOO").unwrap();
+        match &constant[0] {
+            Definition::Constant(_) => {
+                assert_eq!(constant[0].comments(), "Constant comment");
+            }
+            _ => panic!("Expected constant"),
+        }
+
+        let nested = context.graph.get("TestModule::Nested").unwrap();
+        match &nested[0] {
+            Definition::Module(_) => {
+                assert_eq!(nested[0].comments(), "Nested module");
+            }
+            _ => panic!("Expected module"),
+        }
+
+        let multi_a = context.graph.get("A").unwrap();
+        match &multi_a[0] {
+            Definition::Constant(_) => {
+                assert_eq!(multi_a[0].comments(), "Multi-write constant");
+            }
+            _ => panic!("Expected constant"),
+        }
     }
 
     #[test]

--- a/rust/index/src/model/db.rs
+++ b/rust/index/src/model/db.rs
@@ -225,6 +225,8 @@ mod tests {
         context.index_uri("file:///complex.rb", {
             "
             module Outer
+              # Class comment
+              # Another class comment
               class Inner
                 def method_name
                   puts 'hello'
@@ -247,8 +249,8 @@ mod tests {
         assert!(load_results.len() == 4);
 
         // Verify we can find expected definitions
-        let outer_def = load_results.iter().find(|r| r.name == "Outer").unwrap();
-        let inner_def = load_results.iter().find(|r| r.name == "Outer::Inner").unwrap();
+        let module_def = load_results.iter().find(|r| r.name == "Outer").unwrap();
+        let class_def = load_results.iter().find(|r| r.name == "Outer::Inner").unwrap();
         let method_def = load_results
             .iter()
             .find(|r| r.name == "Outer::Inner::method_name")
@@ -258,10 +260,13 @@ mod tests {
             .find(|r| r.name == "Outer::Inner::CONSTANT")
             .unwrap();
 
-        assert!(matches!(outer_def.definition, Definition::Module(_)));
-        assert!(matches!(inner_def.definition, Definition::Class(_)));
+        assert!(matches!(module_def.definition, Definition::Module(_)));
+        assert!(matches!(class_def.definition, Definition::Class(_)));
         assert!(matches!(method_def.definition, Definition::Method(_)));
         assert!(matches!(constant_def.definition, Definition::Constant(_)));
+
+        let comments = class_def.definition.comments();
+        assert_eq!(comments, "Class comment\nAnother class comment");
     }
 
     #[test]

--- a/rust/index/src/model/definitions.rs
+++ b/rust/index/src/model/definitions.rs
@@ -124,6 +124,22 @@ impl Definition {
             Definition::Method(it) => &it.uri_id,
         }
     }
+
+    #[must_use]
+    pub fn comments(&self) -> &str {
+        match self {
+            Definition::Class(it) => &it.comments,
+            Definition::Module(it) => &it.comments,
+            Definition::Constant(it) => &it.comments,
+            Definition::Method(it) => &it.comments,
+            Definition::AttrAccessor(it) => &it.comments,
+            Definition::AttrReader(it) => &it.comments,
+            Definition::AttrWriter(it) => &it.comments,
+            Definition::GlobalVariable(it) => &it.comments,
+            Definition::InstanceVariable(it) => &it.comments,
+            Definition::ClassVariable(it) => &it.comments,
+        }
+    }
 }
 
 /// A class definition
@@ -138,15 +154,17 @@ pub struct ClassDefinition {
     name_id: NameId,
     uri_id: UriId,
     offset: Offset,
+    comments: String,
 }
 
 impl ClassDefinition {
     #[must_use]
-    pub const fn new(name_id: NameId, uri_id: UriId, offset: Offset) -> Self {
+    pub const fn new(name_id: NameId, uri_id: UriId, offset: Offset, comments: String) -> Self {
         Self {
             name_id,
             uri_id,
             offset,
+            comments,
         }
     }
 }
@@ -163,15 +181,17 @@ pub struct ModuleDefinition {
     name_id: NameId,
     uri_id: UriId,
     offset: Offset,
+    comments: String,
 }
 
 impl ModuleDefinition {
     #[must_use]
-    pub const fn new(name_id: NameId, uri_id: UriId, offset: Offset) -> Self {
+    pub const fn new(name_id: NameId, uri_id: UriId, offset: Offset, comments: String) -> Self {
         Self {
             name_id,
             uri_id,
             offset,
+            comments,
         }
     }
 }
@@ -187,15 +207,17 @@ pub struct ConstantDefinition {
     name_id: NameId,
     uri_id: UriId,
     offset: Offset,
+    comments: String,
 }
 
 impl ConstantDefinition {
     #[must_use]
-    pub const fn new(name_id: NameId, uri_id: UriId, offset: Offset) -> Self {
+    pub const fn new(name_id: NameId, uri_id: UriId, offset: Offset, comments: String) -> Self {
         Self {
             name_id,
             uri_id,
             offset,
+            comments,
         }
     }
 }
@@ -214,6 +236,7 @@ pub struct MethodDefinition {
     offset: Offset,
     parameters: Vec<Parameter>,
     is_singleton: bool,
+    comments: String,
 }
 
 impl MethodDefinition {
@@ -224,6 +247,7 @@ impl MethodDefinition {
         offset: Offset,
         parameters: Vec<Parameter>,
         is_singleton: bool,
+        comments: String,
     ) -> Self {
         Self {
             name_id,
@@ -231,6 +255,7 @@ impl MethodDefinition {
             offset,
             parameters,
             is_singleton,
+            comments,
         }
     }
 
@@ -292,15 +317,17 @@ pub struct AttrAccessorDefinition {
     name_id: NameId,
     uri_id: UriId,
     offset: Offset,
+    comments: String,
 }
 
 impl AttrAccessorDefinition {
     #[must_use]
-    pub const fn new(name_id: NameId, uri_id: UriId, offset: Offset) -> Self {
+    pub const fn new(name_id: NameId, uri_id: UriId, offset: Offset, comments: String) -> Self {
         Self {
             name_id,
             uri_id,
             offset,
+            comments,
         }
     }
 }
@@ -316,15 +343,17 @@ pub struct AttrReaderDefinition {
     name_id: NameId,
     uri_id: UriId,
     offset: Offset,
+    comments: String,
 }
 
 impl AttrReaderDefinition {
     #[must_use]
-    pub const fn new(name_id: NameId, uri_id: UriId, offset: Offset) -> Self {
+    pub const fn new(name_id: NameId, uri_id: UriId, offset: Offset, comments: String) -> Self {
         Self {
             name_id,
             uri_id,
             offset,
+            comments,
         }
     }
 }
@@ -340,15 +369,17 @@ pub struct AttrWriterDefinition {
     name_id: NameId,
     uri_id: UriId,
     offset: Offset,
+    comments: String,
 }
 
 impl AttrWriterDefinition {
     #[must_use]
-    pub const fn new(name_id: NameId, uri_id: UriId, offset: Offset) -> Self {
+    pub const fn new(name_id: NameId, uri_id: UriId, offset: Offset, comments: String) -> Self {
         Self {
             name_id,
             uri_id,
             offset,
+            comments,
         }
     }
 }
@@ -364,15 +395,17 @@ pub struct GlobalVariableDefinition {
     name_id: NameId,
     uri_id: UriId,
     pub offset: Offset,
+    comments: String,
 }
 
 impl GlobalVariableDefinition {
     #[must_use]
-    pub const fn new(name_id: NameId, uri_id: UriId, offset: Offset) -> Self {
+    pub const fn new(name_id: NameId, uri_id: UriId, offset: Offset, comments: String) -> Self {
         Self {
             name_id,
             uri_id,
             offset,
+            comments,
         }
     }
 }
@@ -388,15 +421,17 @@ pub struct InstanceVariableDefinition {
     name_id: NameId,
     uri_id: UriId,
     offset: Offset,
+    comments: String,
 }
 
 impl InstanceVariableDefinition {
     #[must_use]
-    pub const fn new(name_id: NameId, uri_id: UriId, offset: Offset) -> Self {
+    pub const fn new(name_id: NameId, uri_id: UriId, offset: Offset, comments: String) -> Self {
         Self {
             name_id,
             uri_id,
             offset,
+            comments,
         }
     }
 }
@@ -412,15 +447,17 @@ pub struct ClassVariableDefinition {
     name_id: NameId,
     uri_id: UriId,
     offset: Offset,
+    comments: String,
 }
 
 impl ClassVariableDefinition {
     #[must_use]
-    pub const fn new(name_id: NameId, uri_id: UriId, offset: Offset) -> Self {
+    pub const fn new(name_id: NameId, uri_id: UriId, offset: Offset, comments: String) -> Self {
         Self {
             name_id,
             uri_id,
             offset,
+            comments,
         }
     }
 }

--- a/rust/index/src/model/integrity.rs
+++ b/rust/index/src/model/integrity.rs
@@ -123,7 +123,12 @@ mod tests {
 
         let uri_id = graph.add_uri("file:///foo.rb".to_string());
         let name_id = NameId::from("Foo");
-        let definition = Definition::Module(Box::new(ModuleDefinition::new(name_id, uri_id, Offset::new(0, 15))));
+        let definition = Definition::Module(Box::new(ModuleDefinition::new(
+            name_id,
+            uri_id,
+            Offset::new(0, 15),
+            String::new(),
+        )));
         graph.add_definition("Foo".to_string(), definition);
 
         // Should fail since the index is not empty

--- a/rust/index/src/test_utils.rs
+++ b/rust/index/src/test_utils.rs
@@ -16,8 +16,8 @@ impl GraphTest {
     #[must_use]
     fn index_source(uri: &str, source: &str) -> Graph {
         let converter = UTF8SourceLocationConverter::new(source);
-        let mut indexer = RubyIndexer::new(uri.to_string(), &converter);
-        indexer.index(source);
+        let mut indexer = RubyIndexer::new(uri.to_string(), &converter, source);
+        indexer.index();
         indexer.into_parts().0
     }
 


### PR DESCRIPTION
For https://github.com/Shopify/index/issues/86

I've explored two approaches for comment parsing:

Approach 1 (this one) - Preprocessing: Parse and store comments in the database during indexing

- Trade-offs: +5% peak memory, +3% indexing time (compared to main)
- Benefit: Fast retrieval performance during queries

Approach 2 - On-demand (#169): Parse comments only when requested (e.g., hover requests)

- Trade-offs: No additional memory overhead
- Benefit: Zero indexing cost
- Drawback: 4.2x slower query performance compared to preprocessing

I am leaning towards the preprocessing approach for the following reasons:

- The memory/indexing overhead is minimal (5%/3% respectively)
- Query performance is critical for developer experience - 4.2x slower responses would be noticeable
- Comments are frequently accessed features (hover, documentation, etc.)
- The upfront cost during indexing pays dividends throughout the development workflow

The benchmark data suggests preprocessing offers the better user experience trade-off. Thoughts on this approach?

## Benchmark comparison

### Main

Initialization:    0.459s (  2.2%)
Indexing:          9.428s ( 45.4%)
Querying:          0.000s (  0.0%)
Cleanup:          10.889s ( 52.4%)
Total:            20.777s

Maximum Resident Set Size: 7508230144 bytes (7160.40 MB)
Peak Memory Footprint:     7854135296 bytes (7490.28 MB)
Execution Time:            21.07 seconds

### On-demand parsing

Initialization:    0.441s (  0.9%)
Indexing:          9.816s ( 20.0%)
Querying:         27.589s ( 56.3%)
Cleanup:          11.121s ( 22.7%)
Total:            48.967s

Maximum Resident Set Size: 6754041856 bytes (6441.15 MB)
Peak Memory Footprint:     7835867136 bytes (7472.86 MB)
Execution Time:            49.28 seconds

### Pre-process parsing

Initialization:    0.343s (  1.2%)
Indexing:          9.733s ( 34.7%)
Querying:          6.550s ( 23.4%)
Cleanup:          11.384s ( 40.6%)
Total:            28.010s

Maximum Resident Set Size: 7299235840 bytes (6961.09 MB)
Peak Memory Footprint:     8322078848 bytes (7936.55 MB)
Execution Time:            28.26 seconds