### PR TITLE
Include phase breakdown in benchmark

### DIFF
--- a/rust/index/src/bin/bench.rs
+++ b/rust/index/src/bin/bench.rs
@@ -1,0 +1,89 @@
+use std::error::Error;
+use std::time::{Duration, Instant};
+
+use clap::Parser;
+
+use index::{
+    indexing::{self, errors::MultipleErrors},
+    model::graph::Graph,
+};
+
+#[derive(Parser, Debug)]
+#[command(name = "bench", about = "Benchmark the Ruby indexer", version)]
+struct Args {
+    #[arg(value_name = "CORPUS_PATH")]
+    corpus_path: String,
+}
+
+fn time_it<T, F>(f: F) -> (T, Duration)
+where
+    F: FnOnce() -> T,
+{
+    let start = Instant::now();
+    let result = f();
+    let duration = start.elapsed();
+    (result, duration)
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let args = Args::parse();
+    let corpus_path = std::path::Path::new(&args.corpus_path);
+
+    let total_start = Instant::now();
+    let setup_duration;
+    let indexing_duration;
+
+    {
+        let ((mut graph, documents, errors), setup_dur) = time_it(|| {
+            let mut graph = Graph::new();
+            graph
+                .set_configuration(format!("{}/graph.db", corpus_path.display()))
+                .unwrap();
+            let (documents, errors) = indexing::collect_documents(vec![corpus_path.to_string_lossy().to_string()]);
+            (graph, documents, errors)
+        });
+        setup_duration = setup_dur;
+
+        if !errors.is_empty() {
+            return Err(Box::new(MultipleErrors(errors)));
+        }
+
+        let ((), indexing_dur) = time_it(|| {
+            indexing::index_in_parallel(&mut graph, documents).unwrap();
+        });
+        indexing_duration = indexing_dur;
+    }
+
+    let total_duration = total_start.elapsed();
+    let cleanup_duration = total_duration - (setup_duration + indexing_duration);
+
+    println!();
+    println!("PERFORMANCE BREAKDOWN");
+    println!();
+
+    let total_time = total_duration.as_secs_f64();
+    let setup_time = setup_duration.as_secs_f64();
+    let indexing_time = indexing_duration.as_secs_f64();
+    let cleanup_time = cleanup_duration.as_secs_f64();
+
+    println!(
+        "Initialization: {:8.3}s ({:5.1}%)",
+        setup_time,
+        setup_time * 100.0 / total_time
+    );
+    println!(
+        "Indexing:       {:8.3}s ({:5.1}%)",
+        indexing_time,
+        indexing_time * 100.0 / total_time
+    );
+    println!(
+        "Cleanup:        {:8.3}s ({:5.1}%)",
+        cleanup_time,
+        cleanup_time * 100.0 / total_time
+    );
+    println!("Total:          {total_time:8.3}s");
+
+    println!();
+
+    Ok(())
+}

--- a/utils/bench
+++ b/utils/bench
@@ -18,6 +18,6 @@ if [ ! -d "$CORPUS_PATH" ]; then
     $SCRIPT_DIR/generate-corpus "$CORPUS_PATH" -s 1000
 fi
 
-cd "$PROJECT_ROOT/rust" && cargo build --release
+cd "$PROJECT_ROOT/rust" && cargo build --release --bin bench
 cd $PROJECT_ROOT
-utils/mem-use "$PROJECT_ROOT/rust/target/release/index_cli" "$CORPUS_PATH"
+utils/mem-use "$PROJECT_ROOT/rust/target/release/bench" "$CORPUS_PATH"


### PR DESCRIPTION
This allows us to benchmark on a finer level, with a breakdown among
the setting up, indexing, querying, and cleaning up phases

An example output after running `utils/bench`

```
PERFORMANCE BREAKDOWN
----------------------------------------
Initialization:    0.400s (  1.2%)
Indexing:         10.308s ( 29.7%)
Querying:         10.686s ( 30.8%)
Cleanup:          13.319s ( 38.4%)
Total:            34.713s

----------------------------------------
Maximum Resident Set Size: 7002750976 bytes (6678.34 MB)
Peak Memory Footprint:     8339200192 bytes (7952.88 MB)
Execution Time:            35.17 seconds

Maximum Resident Set Size: 7255179264 bytes (6919.07 MB)
Peak Memory Footprint:     8295700480 bytes (7911.39 MB)
Execution Time:            29.92 seconds
```