### PR TITLE
Parse comments on demand

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -124,6 +124,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -479,6 +485,7 @@ name = "index"
 version = "0.1.0"
 dependencies = [
  "assert_cmd",
+ "bytecount",
  "clap",
  "glob",
  "predicates",

--- a/rust/index/Cargo.toml
+++ b/rust/index/Cargo.toml
@@ -20,6 +20,7 @@ clap = { version = "4.5.16", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 rmp-serde = "1.3.0"
 glob = "0.3.2"
+bytecount = "0.6.9"
 
 [dev-dependencies]
 tempfile = "3.0"

--- a/rust/index/src/bin/bench.rs
+++ b/rust/index/src/bin/bench.rs
@@ -55,6 +55,10 @@ fn main() -> Result<(), Box<dyn Error>> {
         indexing_duration = indexing_dur;
 
         let ((), querying_dur) = time_it(|| {
+            for declaration in graph.declarations().values() {
+                let _ = graph.get_documentation(declaration.name());
+            }
+
             println!("Found {} names", graph.declarations().len());
             println!("Found {} definitions", graph.definitions().len());
             println!("Found {} URIs", graph.documents().len());


### PR DESCRIPTION
Another approach to parse comments, as opposed to pre-computing at indexing time and storing the comments in db.

Compared to the pre-processing approach, this approach has the benefit of not requiring additional memory usage, with the disadvantage being that the querying time is 4.2x slower.

## Benchmark comparison

### Main

Initialization:    0.459s (  2.2%)  
Indexing:          9.428s ( 45.4%)  
Querying:          0.000s (  0.0%)  
Cleanup:          10.889s ( 52.4%)  
Total:            20.777s

Maximum Resident Set Size: 7508230144 bytes (7160.40 MB)  
Peak Memory Footprint:     7854135296 bytes (7490.28 MB)  
Execution Time:            21.07 seconds

### On-demand parsing

Initialization:    0.441s (  0.9%)  
Indexing:          9.816s ( 20.0%)  
Querying:         27.589s ( 56.3%)  
Cleanup:          11.121s ( 22.7%)  
Total:            48.967s

Maximum Resident Set Size: 6754041856 bytes (6441.15 MB)  
Peak Memory Footprint:     7835867136 bytes (7472.86 MB)  
Execution Time:            49.28 seconds

### Pre-process parsing

Initialization:    0.343s (  1.2%)  
Indexing:          9.733s ( 34.7%)  
Querying:          6.550s ( 23.4%)  
Cleanup:          11.384s ( 40.6%)  
Total:            28.010s

Maximum Resident Set Size: 7299235840 bytes (6961.09 MB)  
Peak Memory Footprint:     8322078848 bytes (7936.55 MB)  
Execution Time:            28.26 seconds