### PR TITLE
Sync with DB state during indexing

### DIFF
--- a/rakelib/index_top_gems.rake
+++ b/rakelib/index_top_gems.rake
@@ -51,6 +51,7 @@ task index_top_gems: :compile_release do
 
             # Index the gem's files and yield errors back to the main Ractor
             graph = Index::Graph.new
+            graph.set_configuration(File.join(@gems_dir, "#{gem}.db"))
             error = graph.index_all(Dir.glob("#{gem_dir}/**/*.rb"))
             next unless error
 

--- a/rust/index-sys/src/index_api.rs
+++ b/rust/index-sys/src/index_api.rs
@@ -56,7 +56,7 @@ pub unsafe extern "C" fn idx_index_all_c(
     all_errors.extend(document_errors);
 
     with_graph(pointer, |graph| {
-        if let Err(errors) = indexing::index_in_parallel(graph, documents) {
+        if let Err(errors) = indexing::index_and_sync(graph, documents) {
             all_errors.extend(errors.0);
         }
 

--- a/rust/index/src/db/schema.sql
+++ b/rust/index/src/db/schema.sql
@@ -4,7 +4,8 @@
 -- Table for storing documents
 CREATE TABLE IF NOT EXISTS documents (
     id INTEGER PRIMARY KEY,  -- Blake3 hash converted to hex
-    uri TEXT NOT NULL UNIQUE
+    uri TEXT NOT NULL UNIQUE,
+    content_hash INTEGER NOT NULL
 );
 
 -- Table for storing code declarations (classes, modules, methods, etc.)

--- a/rust/index/src/indexing/errors.rs
+++ b/rust/index/src/indexing/errors.rs
@@ -11,11 +11,24 @@ impl std::fmt::Display for MultipleErrors {
 
 impl Error for MultipleErrors {}
 
+impl From<Box<dyn Error>> for MultipleErrors {
+    fn from(error: Box<dyn Error>) -> Self {
+        MultipleErrors(vec![IndexingError::FailedDbOperation(error.to_string())])
+    }
+}
+
+impl From<IndexingError> for MultipleErrors {
+    fn from(error: IndexingError) -> Self {
+        MultipleErrors(vec![error])
+    }
+}
+
 // Enum representing all types of indexing errors that may happen
 #[derive(Debug)]
 pub enum IndexingError {
     FileReadError(String),
     InvalidUri(String),
+    FailedDbOperation(String),
 }
 
 impl std::fmt::Display for IndexingError {
@@ -23,6 +36,7 @@ impl std::fmt::Display for IndexingError {
         match self {
             IndexingError::FileReadError(msg) => write!(f, "File read error: {msg}"),
             IndexingError::InvalidUri(msg) => write!(f, "Invalid URI: {msg}"),
+            IndexingError::FailedDbOperation(msg) => write!(f, "Db operation failed: {msg}"),
         }
     }
 }

--- a/rust/index/src/indexing/ruby_indexer.rs
+++ b/rust/index/src/indexing/ruby_indexer.rs
@@ -47,9 +47,9 @@ pub struct RubyIndexer<'a> {
 
 impl<'a> RubyIndexer<'a> {
     #[must_use]
-    pub fn new(uri: String, location_converter: &'a dyn SourceLocationConverter, source: &'a str) -> Self {
+    pub fn new(document: &'a crate::indexing::Document, location_converter: &'a dyn SourceLocationConverter) -> Self {
         let mut local_index = Graph::new();
-        let uri_id = local_index.add_uri(uri);
+        let uri_id = local_index.add_document(document.uri.to_string(), Some(document.content_hash));
 
         Self {
             uri_id,
@@ -58,7 +58,7 @@ impl<'a> RubyIndexer<'a> {
             errors: Vec::new(),
             location_converter,
             comments: Vec::new(),
-            source,
+            source: &document.source,
         }
     }
 
@@ -247,7 +247,7 @@ impl<'a> RubyIndexer<'a> {
     // symbol arguments
     fn each_string_or_symbol_arg<F>(node: &ruby_prism::CallNode, mut f: F)
     where
-        F: FnMut(String, ruby_prism::Location),
+        F: FnMut(String, ruby_prism::Location<'_>),
     {
         let receiver = node.receiver();
 

--- a/rust/index/src/model/document.rs
+++ b/rust/index/src/model/document.rs
@@ -6,20 +6,27 @@ use crate::model::ids::DefinitionId;
 pub struct Document {
     uri: String,
     definition_ids: Vec<DefinitionId>,
+    content_hash: Option<i64>,
 }
 
 impl Document {
     #[must_use]
-    pub fn new(uri: String) -> Self {
+    pub fn new(uri: String, content_hash: Option<i64>) -> Self {
         Self {
             uri,
             definition_ids: Vec::new(),
+            content_hash,
         }
     }
 
     #[must_use]
     pub fn uri(&self) -> &str {
         &self.uri
+    }
+
+    #[must_use]
+    pub fn content_hash(&self) -> Option<i64> {
+        self.content_hash
     }
 
     #[must_use]

--- a/rust/index/src/model/integrity.rs
+++ b/rust/index/src/model/integrity.rs
@@ -121,7 +121,7 @@ mod tests {
         // Should pass since the index is empty
         checker.assert_integrity(&graph);
 
-        let uri_id = graph.add_uri("file:///foo.rb".to_string());
+        let uri_id = graph.add_document("file:///foo.rb".to_string(), None);
         let name_id = NameId::from("Foo");
         let definition = Definition::Module(Box::new(ModuleDefinition::new(
             name_id,

--- a/rust/index/src/test_utils.rs
+++ b/rust/index/src/test_utils.rs
@@ -16,7 +16,8 @@ impl GraphTest {
     #[must_use]
     fn index_source(uri: &str, source: &str) -> Graph {
         let converter = UTF8SourceLocationConverter::new(source);
-        let mut indexer = RubyIndexer::new(uri.to_string(), &converter, source);
+        let document = crate::indexing::Document::new(uri, Some(source.to_string())).unwrap();
+        let mut indexer = RubyIndexer::new(&document, &converter);
         indexer.index();
         indexer.into_parts().0
     }

--- a/test/graph_test.rb
+++ b/test/graph_test.rb
@@ -3,37 +3,40 @@
 require "test_helper"
 
 class GraphTest < Minitest::Test
+  def setup
+    @graph = Index::Graph.new
+  end
+
+  def teardown
+    # Clean up any database files created during tests
+    Dir.glob("graph.db*").each { |f| File.delete(f) }
+  end
+
   def test_indexing_a_list_of_file_paths
-    graph = Index::Graph.new
-    assert_nil(graph.index_all([__FILE__]))
+    @graph.set_configuration("graph.db")
+    assert_nil(@graph.index_all([__FILE__]))
   end
 
   def test_passing_invalid_arguments_to_index_all
-    graph = Index::Graph.new
-
     assert_raises(TypeError) do
-      graph.index_all("not an array")
+      @graph.index_all("not an array")
     end
 
     assert_raises(TypeError) do
-      graph.index_all([1, 2, 3])
+      @graph.index_all([1, 2, 3])
     end
   end
 
   def test_setting_the_graph_configuration
-    graph = Index::Graph.new
-
     assert_raises(TypeError) do
-      graph.set_configuration(123)
+      @graph.set_configuration(123)
     end
 
     assert_raises(RuntimeError) do
-      graph.set_configuration(".non-existing-folder/graph.db")
+      @graph.set_configuration(".non-existing-folder/graph.db")
     end
 
-    graph.set_configuration("graph.db")
+    @graph.set_configuration("graph.db")
     pass
-  ensure
-    Dir.glob("graph.db*").each { |f| File.delete(f) }
   end
 end


### PR DESCRIPTION
> Update this is now closed in favor of https://github.com/Shopify/saturn/compare/main.../jennyshih/save-updated-graph

For https://github.com/Shopify/index/issues/88

The current indexing flow, when we call the indexing entrypoint, does not interact with the db. We have the api ready but it's not hooked into the indexing flow yet.

Current flow:

```
indexing starts 
-> collect documents from workspace 
-> index 
-> build global graph in memory
```

Updated flow:

```
indexing starts 
-> collect documents from workspace 
-> *calculate diff against db state*
-> *delete stale entries from db* 
-> index
-> build global graph in memory 
-> *save graph to db*
```

To be able to know if the file has changed (and thus needs re-indexing) we will introduce a `content_hash` to the `documents` table in the db. Then during the diff checking stage we will categories them into the following categories

- new: incoming documents don't exist in the db yet
- deleted: db documents that are not present in the incoming documents
- existing: documents that exist in both the incoming and the db, and their content hashes are the same
- updated: documents that exist in both the incoming and the db, and their content hashes are not the same

From here we produce two sets:

- `new_uris`​: It's the union of (new + updated). We pass them on to be index and then save them to both memory and db
- `stale_uris`​: It's the union of (deleted + updated). We clean those up from the db as well as the memory

When we partially delete/create entries we shouldn't need to worry about cascading updates to entries from documents that remain unchanged, because we have not implemented more complex relationships in the graph yet (i.e., inheritance).