### PR TITLE
Use i64 instead of u64 for ID

### DIFF
--- a/rust/index/src/model/graph.rs
+++ b/rust/index/src/model/graph.rs
@@ -117,11 +117,11 @@ impl Graph {
     /// Any database errors will prevent the data from being loaded
     pub fn load_uri(&mut self, uri: String) -> Result<(), Box<dyn Error>> {
         let uri_id = self.add_uri(uri);
-        let loaded_data = self.db.load_uri(uri_id.to_string())?;
+        let loaded_data = self.db.load_uri(uri_id)?;
 
         for load_result in loaded_data {
-            let name_id = NameId::new(load_result.name_id);
-            let definition_id = DefinitionId::new(load_result.definition_id);
+            let name_id = load_result.name_id;
+            let definition_id = load_result.definition_id;
 
             self.declarations
                 .entry(name_id)

--- a/rust/index/tests/cli.rs
+++ b/rust/index/tests/cli.rs
@@ -50,7 +50,7 @@ fn prints_index_metrics() {
 }
 
 fn normalize_visualization_output(output: &str) -> String {
-    let def_re = Regex::new(r"def_[a-f0-9]+").unwrap();
+    let def_re = Regex::new(r"def_-?[a-f0-9]+").unwrap();
     let uri_re = Regex::new(r#"file://[^"]+/([^/"]+\.rb)"#).unwrap();
 
     let normalized = def_re.replace_all(output, "def_<ID>");


### PR DESCRIPTION
This is to fix the issue where the db Integer field expects an i64
value. We are currently trying to pass in a u64 value (as string) for
which a type mismatch error would be raised when we try to save the data.

So here we cast the u64 hash result into i64 to meet the db constraint.

