### PR TITLE
Fix memleak script

### DIFF
--- a/.github/workflows/memleak.yml
+++ b/.github/workflows/memleak.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           bundler-cache: true
 
-      - run: sudo apt-get install -y valgrind
+      - run: sudo apt-get update && sudo apt-get install -y valgrind
 
       - name: Install Rust tools
         run: |


### PR DESCRIPTION
Currently it returns this error suggesting that it cannot find the
libc6-dbg package. Adding an `apt-get update`​ before trying

to install valgrind seems to fix the problem. 