### PR TITLE
Prevent adding duplicate definitions to documents or declarations

### DIFF
--- a/rust/index/src/indexing/ruby_indexer.rs
+++ b/rust/index/src/indexing/ruby_indexer.rs
@@ -267,7 +267,7 @@ impl<'a> RubyIndexer<'a> {
                     ruby_prism::Node::StringNode { .. } => {
                         let string = argument.as_string_node().unwrap();
                         let name = String::from_utf8_lossy(string.unescaped()).to_string();
-                        f(name, node.location());
+                        f(name, argument.location());
                     }
                     _ => {}
                 }

--- a/rust/index/src/model/declaration.rs
+++ b/rust/index/src/model/declaration.rs
@@ -47,6 +47,28 @@ impl Declaration {
     }
 
     pub fn add_definition(&mut self, definition_id: DefinitionId) {
+        debug_assert!(
+            !self.definition_ids.contains(&definition_id),
+            "Cannot add the same exact definition to a declaration twice. Duplicate definition IDs"
+        );
+
         self.definition_ids.push(definition_id);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[should_panic(expected = "Cannot add the same exact definition to a declaration twice. Duplicate definition IDs")]
+    fn inserting_duplicate_definitions() {
+        let mut decl = Declaration::new("MyDecl".to_string());
+        let def_id = DefinitionId::new(123);
+
+        decl.add_definition(def_id);
+        decl.add_definition(def_id);
+
+        assert_eq!(decl.definitions().len(), 1);
     }
 }

--- a/rust/index/src/model/document.rs
+++ b/rust/index/src/model/document.rs
@@ -28,6 +28,28 @@ impl Document {
     }
 
     pub fn add_definition(&mut self, definition_id: DefinitionId) {
+        debug_assert!(
+            !self.definition_ids.contains(&definition_id),
+            "Cannot add the same exact definition to a document twice. Duplicate definition IDs"
+        );
+
         self.definition_ids.push(definition_id);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[should_panic(expected = "Cannot add the same exact definition to a document twice. Duplicate definition IDs")]
+    fn inserting_duplicate_definitions() {
+        let mut document = Document::new("file:///foo.rb".to_string());
+        let def_id = DefinitionId::new(123);
+
+        document.add_definition(def_id);
+        document.add_definition(def_id);
+
+        assert_eq!(document.definitions().len(), 1);
     }
 }

--- a/rust/index/src/model/graph.rs
+++ b/rust/index/src/model/graph.rs
@@ -115,7 +115,7 @@ impl Graph {
     // Registers a definition into the `Graph`, automatically creating all relationships
     pub fn add_definition(&mut self, name: String, definition: Definition) {
         let uri_id = *definition.uri_id();
-        let definition_id = DefinitionId::from(&format!("{uri_id}{}", definition.start()));
+        let definition_id = DefinitionId::from(&format!("{uri_id}{}{}", definition.start(), &name));
         let name_id = *definition.name_id();
 
         self.declarations


### PR DESCRIPTION
Prevent duplicate definitions from being inserted into the vector of definitions inside documents and declarations - now that we no longer have the guarantees of a hashset.