### PR TITLE
Split empty declaration check

### DIFF
--- a/rust/index/src/model/declaration.rs
+++ b/rust/index/src/model/declaration.rs
@@ -30,14 +30,19 @@ impl Declaration {
         &self.definition_ids
     }
 
-    // Deletes a definition from this declaration. Returns `true` if this declaration is now empty, which indicates that
-    // it must be removed from the graph
+    // Deletes a definition from this declaration
     pub fn remove_definition(&mut self, definition_id: &DefinitionId) -> bool {
         if let Some(pos) = self.definition_ids.iter().position(|id| id == definition_id) {
             self.definition_ids.swap_remove(pos);
             self.definition_ids.shrink_to_fit();
+            true
+        } else {
+            false
         }
+    }
 
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
         self.definition_ids.is_empty()
     }
 

--- a/rust/index/src/model/graph.rs
+++ b/rust/index/src/model/graph.rs
@@ -212,6 +212,7 @@ impl Graph {
                 if let Some(definition) = self.definitions.remove(def_id)
                     && let Some(declaration) = self.declarations.get_mut(definition.name_id())
                     && declaration.remove_definition(def_id)
+                    && declaration.is_empty()
                 {
                     self.declarations.remove(definition.name_id());
                 }
@@ -525,7 +526,7 @@ mod tests {
 
             # Module comment
             module CommentedModule; end
-            
+
             class NoCommentClass; end
             "
         });


### PR DESCRIPTION
Addresses https://github.com/Shopify/index/pull/156#discussion_r2398959831

I split the empty check separately. The code ends up needing a block of scope because `remove` returns `()` and can't be involved in a conditional.