### PR TITLE
Use more accurate param distribution

### DIFF
--- a/utils/generate-corpus
+++ b/utils/generate-corpus
@@ -133,12 +133,15 @@ module Symbols
   class Method < NamedTree
     def write(buffer, indent:)
       write_comments(buffer, indent:)
-      params = rand(0..10).times.map { |i| "param#{i}" }
+
+      params = randomized_parameters
+
       if params.empty?
         buffer.puts "#{" " * indent}def #{@name}"
       else
         buffer.puts "#{" " * indent}def #{@name}(#{params.join(", ")})"
       end
+
       write_children(buffer, indent: indent)
 
       if children.any?
@@ -146,6 +149,63 @@ module Symbols
       end
 
       buffer.puts "#{" " * indent}end"
+    end
+
+    def randomized_parameters
+      required_roll = rand
+
+      params = if required_roll < 0.01
+        rand(4..10)
+      elsif required_roll < 0.05
+        3
+      elsif required_roll < 0.15
+        2
+      elsif required_roll < 0.30
+        0
+      else
+        1
+      end.times.map { |i| "pa#{randomize_parameter_name}#{i}" }
+
+      params << "op#{randomize_parameter_name} = 42" if rand < 0.05
+      params << "*rp#{randomize_parameter_name}" if rand < 0.02
+
+      # Posts parameters are used less than 1%, but they would appear at this point
+
+      keyword_roll = rand
+      params.concat(
+        if keyword_roll < 0.015
+          rand(5..10)
+        elsif keyword_roll < 0.03
+          3
+        elsif keyword_roll < 0.065
+          2
+        elsif keyword_roll < 0.085
+          1
+        else
+          0
+        end.times.map { |i| "kp#{randomize_parameter_name}#{i}:" },
+      )
+
+      optional_keyword_roll = rand
+      params.concat(
+        if optional_keyword_roll < 0.015
+          rand(3..8)
+        elsif optional_keyword_roll < 0.03
+          2
+        elsif optional_keyword_roll < 0.07
+          1
+        else
+          0
+        end.times.map { |i| "ok#{randomize_parameter_name}#{i}: 123" },
+      )
+
+      params << "**kr#{randomize_parameter_name}" if rand < 0.014
+      params << "&ba#{randomize_parameter_name}" if rand < 0.022
+      params
+    end
+
+    def randomize_parameter_name
+      (2...rand(5..10)).map { ("a".."z").to_a[rand(26)] }.join
     end
   end
 
@@ -195,7 +255,7 @@ class Generator
 
   def distribute(counts)
     files = counts[:files].times.map { |i| Symbols::File.new("file_#{i}.rb") }
-    puts "Instanciated #{counts[:files]} files"
+    puts "Instantiated #{counts[:files]} files"
 
     scopes = []
     classes = []
@@ -228,7 +288,7 @@ class Generator
       scopes << scope
     end
 
-    puts "Instanciated #{counts[:classes]} classes"
+    puts "Instantiated #{counts[:classes]} classes"
 
     counts[:constants].times do |i|
       const = Symbols::Constant.new("Constant#{i}")
@@ -241,7 +301,7 @@ class Generator
       end
     end
 
-    puts "Instanciated #{counts[:constants]} constants"
+    puts "Instantiated #{counts[:constants]} constants"
 
     methods = []
 
@@ -258,7 +318,7 @@ class Generator
       methods << method
     end
 
-    puts "Instanciated #{counts[:methods]} methods"
+    puts "Instantiated #{counts[:methods]} methods"
 
     counts[:variables].times do |i|
       variable = if rand < 0.0001
@@ -274,7 +334,7 @@ class Generator
       methods.sample.children << variable
     end
 
-    puts "Instanciated #{counts[:variables]} variables"
+    puts "Instantiated #{counts[:variables]} variables"
 
     files
   end


### PR DESCRIPTION
Step before #143

Right now, we're using a number of parameters for generating methods that doesn't really match the distribution we see in Core (just a random number between 0 and 10).

I created a simple visitor to gather the number of requireds, optionals, keywords and rest parameters, so that we can use percentages that are closer to what we see in our codebases.

Script used to gather data

<details>
<summary>Details</summary>

```
# frozen_string_literal: true

require "prism"

class Stats < Prism::Visitor
  def initialize
    @requireds = Hash.new(0)
    @posts = Hash.new(0)
    @optionals = Hash.new(0)
    @keywords = Hash.new(0)
    @optional_keywords = Hash.new(0)
    @rest = 0
    @keyword_rest = 0
    @forwarding = 0
    @block = 0
    @methods = 0
    super()
  end

  def print
    puts "Requireds"
    @requireds.sort.each { |k, v| puts "  #{k}: #{v} (#{v * 100.0 / @methods}%)" }
    puts "Optionals"
    @optionals.sort.each { |k, v| puts "  #{k}: #{v} (#{v * 100.0 / @methods}%)" }
    puts "Posts"
    @posts.sort.each { |k, v| puts "  #{k}: #{v} (#{v * 100.0 / @methods}%)" }
    puts "Keywords"
    @keywords.sort.each { |k, v| puts "  #{k}: #{v} (#{v * 100.0 / @methods}%)" }
    puts "Optional Keywords"
    @optional_keywords.sort.each { |k, v| puts "  #{k}: #{v} (#{v * 100.0 / @methods}%)" }
    puts "Rest: #{@rest} (#{@rest * 100.0 / @methods}%)"
    puts "Keyword Rest: #{@keyword_rest} (#{@keyword_rest * 100.0 / @methods}%)"
    puts "Forwarding: #{@forwarding} (#{@forwarding * 100.0 / @methods}%)"
    puts "Block: #{@block} (#{@block * 100.0 / @methods}%)"
    puts "Methods: #{@methods}"
  end

  def visit_def_node(node)
    parameters_node = node.parameters
    return super unless parameters_node

    @requireds[parameters_node.requireds.length] += 1
    @optionals[parameters_node.optionals.length] += 1
    @posts[parameters_node.posts.length] += 1

    keywords, optional_keywords = parameters_node.keywords.partition do |kw|
      kw.is_a?(Prism::RequiredKeywordParameterNode)
    end
    @keywords[keywords.length] += 1
    @optional_keywords[optional_keywords.length] += 1

    @rest += 1 if parameters_node.rest.is_a?(Prism::RestParameterNode)

    case parameters_node.keyword_rest
    when Prism::KeywordRestParameterNode
      @keyword_rest += 1
    when Prism::ForwardingParameterNode
      @forwarding += 1
    end

    @block += 1 if parameters_node.block&.name
    @methods += 1
    super
  end
end

visitor = Stats.new

RubyVM::YJIT.enable
Dir.glob("**/*.rb").each do |file|
  r = Prism.parse_file(file).value
  visitor.visit(r)
end

puts visitor.print
```

</details>

<details>
<summary>Data</summary>

```
Requireds
  0: 47533 (28.645036097819666%)
  1: 85928 (51.78319613349564%)
  2: 24459 (14.7398425918114%)
  3: 5890 (3.5495184948595258%)
  4: 1510 (0.9099784256770601%)
  5: 529 (0.3187937663464668%)
  6: 59 (0.0355554484204944%)
  7: 17 (0.010244790222854318%)
  8: 9 (0.005423712470922875%)
  9: 2 (0.001205269437982861%)
  12: 2 (0.001205269437982861%)
Optionals
  0: 155583 (93.75971748484373%)
  1: 9592 (5.780472224565802%)
  2: 652 (0.3929178367824127%)
  3: 101 (0.060866106618134484%)
  4: 7 (0.004218443032940014%)
  5: 3 (0.0018079041569742916%)
Posts
  0: 165928 (99.99397365281008%)
  1: 10 (0.006026347189914305%)
Keywords
  0: 131110 (79.01143800696646%)
  1: 14168 (8.538128698670588%)
  2: 10925 (6.5837843049813785%)
  3: 4898 (2.9517048536200265%)
  4: 2353 (1.417999493786836%)
  5: 1109 (0.6683219033614964%)
  6: 577 (0.3477202328580554%)
  7: 287 (0.17295616435054056%)
  8: 160 (0.09642155503862888%)
  9: 124 (0.07472670515493739%)
  10: 78 (0.04700550808133158%)
  11: 43 (0.02591329291663151%)
  12: 32 (0.019284311007725777%)
  13: 19 (0.01145005966083718%)
  14: 16 (0.009642155503862888%)
  15: 2 (0.001205269437982861%)
  16: 8 (0.004821077751931444%)
  17: 3 (0.0018079041569742916%)
  18: 3 (0.0018079041569742916%)
  19: 2 (0.001205269437982861%)
  20: 2 (0.001205269437982861%)
  21: 1 (0.0006026347189914305%)
  22: 4 (0.002410538875965722%)
  23: 4 (0.002410538875965722%)
  24: 3 (0.0018079041569742916%)
  25: 2 (0.001205269437982861%)
  27: 1 (0.0006026347189914305%)
  33: 1 (0.0006026347189914305%)
  35: 1 (0.0006026347189914305%)
  45: 1 (0.0006026347189914305%)
  87: 1 (0.0006026347189914305%)
Optional Keywords
  0: 141663 (85.37104219648302%)
  1: 12808 (7.718545480842242%)
  2: 5122 (3.086695030674107%)
  3: 2448 (1.475249792091022%)
  4: 1390 (0.8376622593980885%)
  5: 826 (0.49777627788692164%)
  6: 493 (0.29709891646277525%)
  7: 332 (0.20007472670515494%)
  8: 205 (0.12354011739324326%)
  9: 151 (0.09099784256770602%)
  10: 123 (0.07412407043594596%)
  11: 69 (0.04158179561040871%)
  12: 56 (0.03374754426352011%)
  13: 51 (0.03073437066856296%)
  14: 35 (0.021092215164700067%)
  15: 30 (0.018079041569742917%)
  16: 28 (0.016873772131760056%)
  17: 16 (0.009642155503862888%)
  18: 12 (0.007231616627897166%)
  19: 9 (0.005423712470922875%)
  20: 13 (0.007834251346888596%)
  21: 11 (0.006628981908905736%)
  22: 5 (0.0030131735949571526%)
  23: 5 (0.0030131735949571526%)
  24: 3 (0.0018079041569742916%)
  25: 2 (0.001205269437982861%)
  26: 3 (0.0018079041569742916%)
  27: 3 (0.0018079041569742916%)
  28: 2 (0.001205269437982861%)
  29: 3 (0.0018079041569742916%)
  31: 1 (0.0006026347189914305%)
  32: 2 (0.001205269437982861%)
  33: 2 (0.001205269437982861%)
  35: 1 (0.0006026347189914305%)
  37: 2 (0.001205269437982861%)
  38: 1 (0.0006026347189914305%)
  39: 1 (0.0006026347189914305%)
  40: 1 (0.0006026347189914305%)
  50: 1 (0.0006026347189914305%)
  57: 1 (0.0006026347189914305%)
  59: 1 (0.0006026347189914305%)
  68: 2 (0.001205269437982861%)
  69: 1 (0.0006026347189914305%)
  71: 1 (0.0006026347189914305%)
  78: 1 (0.0006026347189914305%)
  95: 1 (0.0006026347189914305%)
  118: 1 (0.0006026347189914305%)
Rest: 3285 (1.9796550518868492%)
Keyword Rest: 2321 (1.3987151827791102%)
Forwarding: 129 (0.07773987874989453%)
Block: 3636 (2.1911798382528413%)
Methods: 165938
```

</details>

With the data I gathered, I adapted the generation script, so that we can benchmark in a corpus that better matches what we see in Core.

Note: I did not consider for the corpus percentages that are too low and happen infrequently (e.g.: significantly smaller than 1%).