### PR TITLE
Remove unused indexes

### DIFF
--- a/rust/index/src/db/schema.sql
+++ b/rust/index/src/db/schema.sql
@@ -25,5 +25,3 @@ CREATE TABLE IF NOT EXISTS definitions (
 
 -- Indexes for fast lookups
 CREATE INDEX IF NOT EXISTS names_name_index ON names (name);
-CREATE INDEX IF NOT EXISTS definitions_name_id_index ON definitions (name_id);
-CREATE INDEX IF NOT EXISTS definitions_document_id_index ON definitions (document_id);


### PR DESCRIPTION
For https://github.com/Shopify/team-ruby-dx/issues/1725

We don't actually need those indexes for the queries. Removing allows us
to have a better performance.

For our large corpus, it cuts down the db time from ~32 seconds to ~23 seconds

### Before

```
PERFORMANCE BREAKDOWN

Initialization:    0.043s (  0.1%)
Indexing:          0.677s (  2.0%)
Db operation:     31.939s ( 96.3%)
Cleanup:           0.508s (  1.5%)
Total:            33.167s
```

### After

```
PERFORMANCE BREAKDOWN

Initialization:    0.050s (  0.2%)
Indexing:          0.717s (  2.8%)
*Db operation:     23.873s ( 94.9%)*
Cleanup:           0.527s (  2.1%)
Total:            25.168s

----------------------------------------
Maximum Resident Set Size: 1050460160 bytes (1001.79 MB)
Peak Memory Footprint:     1048675432 bytes (1000.09 MB)
Execution Time:            25.37 seconds
```