### PR TITLE
Remove foreign keys

### DIFF
--- a/rust/index/src/db/schema.sql
+++ b/rust/index/src/db/schema.sql
@@ -16,11 +16,9 @@ CREATE TABLE IF NOT EXISTS names (
 -- Table for storing definitions that make up declarations
 CREATE TABLE IF NOT EXISTS definitions (
     id INTEGER PRIMARY KEY,  -- Blake3 hash converted to hex
-    name_id INTEGER NOT NULL REFERENCES names(id), -- References names.id
-    document_id INTEGER NOT NULL REFERENCES documents(id), -- References documents.id
-    data BLOB NOT NULL, -- Serialized definition data
-    FOREIGN KEY (name_id) REFERENCES names (id) ON DELETE CASCADE,
-    FOREIGN KEY (document_id) REFERENCES documents (id) ON DELETE CASCADE
+    name_id INTEGER NOT NULL, -- References names.id
+    document_id INTEGER NOT NULL, -- References documents.id
+    data BLOB NOT NULL -- Serialized definition data
 );
 
 -- Indexes for fast lookups

--- a/rust/index/src/model/graph.rs
+++ b/rust/index/src/model/graph.rs
@@ -109,6 +109,7 @@ impl Graph {
         // Delete the data from the database
         let uri_id = UriId::from(uri);
         self.db.delete_data_for_uri(uri_id)?;
+        self.db.remove_orphaned_entries()?;
         Ok(())
     }
 


### PR DESCRIPTION
Part of https://github.com/Shopify/team-ruby-dx/issues/1725

Remove the foreign key constraints so we don't spend unnecessary time
validating entries at inserting. Instead we will enforce data integrity
through a different app function call.

This brings down the db time of large_corpus from ~23 seconds (as of https://app.graphite.dev/github/pr/Shopify/index/184/Remove-unused-indexes) to ~18 seconds

### Before

```
PERFORMANCE BREAKDOWN

Initialization:    0.050s (  0.2%)
Indexing:          0.717s (  2.8%)
*Db operation:     23.873s ( 94.9%)*
Cleanup:           0.527s (  2.1%)
Total:            25.168s

----------------------------------------
Maximum Resident Set Size: 1050460160 bytes (1001.79 MB)
Peak Memory Footprint:     1048675432 bytes (1000.09 MB)
Execution Time:            25.37 seconds
```

### After 

```
PERFORMANCE BREAKDOWN

Initialization:    0.029s (  0.1%)
Indexing:          0.575s (  3.0%)
*Db operation:     18.128s ( 94.2%)*
Cleanup:           0.503s (  2.6%)
Total:            19.235s

----------------------------------------
Maximum Resident Set Size: 1054425088 bytes (1005.57 MB)
Peak Memory Footprint:     1052623952 bytes (1003.86 MB)
Execution Time:            19.45 seconds
```

This also brings down the db time for the huge corpus to 6.5 minutes (from 12 minutes)

```
PERFORMANCE BREAKDOWN

Initialization:    0.418s (  0.1%)
Indexing:          5.969s (  1.5%)
Db operation:    393.855s ( 96.9%)
Cleanup:           6.398s (  1.6%)
Total:           406.640s

----------------------------------------
Maximum Resident Set Size: 7834189824 bytes (7471.26 MB)
Peak Memory Footprint:     8819694120 bytes (8411.11 MB)
Execution Time:            406.95 seconds
```