### PR TITLE
Turn off the synchronous pragma

### DIFF
--- a/rust/index/src/model/db.rs
+++ b/rust/index/src/model/db.rs
@@ -63,7 +63,7 @@ impl Db {
         // Set default connection pragmas
         conn.execute_batch(
             "
-            PRAGMA synchronous = NORMAL;
+            PRAGMA synchronous = OFF;
             PRAGMA locking_mode = EXCLUSIVE;
             ",
         )?;


### PR DESCRIPTION
(WIP–Still waiting for the benchmark numbers)

For https://github.com/Shopify/team-ruby-dx/issues/1725

Turn it off so sqlite won't wait for disk syncs after each transaction.
This does mean we risk the corrupted data but it should be acceptable
because we are only using the db as a cache layer that can be rebuilt.

## Benchmark

Interestingly it doesn't help with the performance without any other changes. In fact it makes it slower (12 min -> 15 min on the huge corpus). But if adding it on top of other changes (removing unused index and removing foreign keys) It brings down the performance from 6.5 min to 4.9 min. 

### After - huge corpus - no other optimizations applied (on main)

```
PERFORMANCE BREAKDOWN

Initialization:    0.425s (  0.0%)
Indexing:          5.775s (  0.6%)
*Db operation:    902.400s ( 98.6%)*
Cleanup:           6.689s (  0.7%)
Total:           915.290s

----------------------------------------
Maximum Resident Set Size: 8809267200 bytes (8401.17 MB)
Peak Memory Footprint:     8694307392 bytes (8291.53 MB)
Execution Time:            915.65 seconds

```

### After - huge corpus - with the schema optimizations applied (https://github.com/Shopify/index/pull/184 and https://github.com/Shopify/index/pull/186)


```
PERFORMANCE BREAKDOWN

Initialization:    0.421s (  0.1%)
Indexing:          5.897s (  1.9%)
Db operation:    293.237s ( 95.7%)
Cleanup:           6.850s (  2.2%)
Total:           306.405s

----------------------------------------
Maximum Resident Set Size: 8800829440 bytes (8393.12 MB)
Peak Memory Footprint:     8660556352 bytes (8259.35 MB)
Execution Time:            306.73 seconds

```