### PR TITLE
Document i64 usage in Id struct

### DIFF
--- a/rust/index/src/model/id.rs
+++ b/rust/index/src/model/id.rs
@@ -9,6 +9,11 @@ use std::{
 };
 use xxhash_rust::xxh3::xxh3_64;
 
+/// A stable ID representation using i64.
+///
+/// We use i64 instead of u64 because SQLite doesn't support unsigned integers.
+/// IDs are generated from xxh3_64 hashes (u64) then cast to i64, preserving all bits.
+/// Negative values are expected and normal - not a sign of memory corruption.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Id<T> {
     value: i64,


### PR DESCRIPTION
## Summary
- Adds documentation to the `Id` struct explaining why we use `i64` instead of `u64`
- Addresses review feedback from PR #174

## Context
As discussed in [PR #174](https://github.com/Shopify/index/pull/174#discussion_r1998593923), the use of negative IDs could be confusing without proper documentation. This PR adds documentation explaining:

1. Why we use `i64` (SQLite doesn't support unsigned integers)
2. How the conversion works (xxh3_64 hash cast to i64)
3. That negative values are expected and not a sign of memory corruption
