### PR TITLE
Start tracking unresolved constant references

### DIFF
--- a/rust/index/src/model.rs
+++ b/rust/index/src/model.rs
@@ -7,3 +7,4 @@ pub mod id;
 pub mod identity_maps;
 pub mod ids;
 pub mod integrity;
+pub mod references;

--- a/rust/index/src/model/references.rs
+++ b/rust/index/src/model/references.rs
@@ -1,0 +1,60 @@
+use crate::{
+    model::ids::{NameId, UriId},
+    offset::Offset,
+};
+
+#[derive(Debug)]
+pub enum UnresolvedReference {
+    Constant(Box<UnresolvedConstantRef>),
+}
+
+// An unresolved constant reference is a usage of a constant in a context where we can't immediately determine what it
+// refers to. For example:
+//
+// ```ruby
+// module Foo
+//   BAR
+// end
+// ```
+//
+// Here, we don't immediately know if `BAR` refers to `Foo::BAR` or top level `BAR`. Until we resolve it, it is
+// considered an unresolved constant
+#[derive(Debug)]
+pub struct UnresolvedConstantRef {
+    name: String,
+    nesting: Vec<NameId>,
+    uri_id: UriId,
+    offset: Offset,
+}
+
+impl UnresolvedConstantRef {
+    #[must_use]
+    pub fn new(name: String, nesting: Vec<NameId>, uri_id: UriId, offset: Offset) -> Self {
+        Self {
+            name,
+            nesting,
+            uri_id,
+            offset,
+        }
+    }
+
+    #[must_use]
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    #[must_use]
+    pub fn nesting(&self) -> &[NameId] {
+        &self.nesting
+    }
+
+    #[must_use]
+    pub fn uri_id(&self) -> UriId {
+        self.uri_id
+    }
+
+    #[must_use]
+    pub fn offset(&self) -> &Offset {
+        &self.offset
+    }
+}


### PR DESCRIPTION
First step for #85

This PR introduces a semi optimized implementation for tracking unresolved constant references. I say semi optimized because we still have to look into interning non fully qualified names, which will likely save a bit more memory.

However, I did use a stack of Name IDs to save memory in remembering the exact nesting where we found the reference. This is really important to make the incremental architecture work because an indirect change may alter what the constant refers to - and without the exact nesting we discovered it, we cannot properly resolve it. For example:

```ruby
# Initially here, CONST does not exist

module Foo
  class Compact::Style
    CONST
  end
end

# Then someone creates `CONST` inside the Compact class in another file

module Foo
  class Compact
    CONST = 123
  end
end

# CONST **still** doesn't exist here because the compact style means we're not inside
# the `Compact` namespace. The only way to properly resolve the `CONST` reference,
# is if we remember the exact nesting where we found  it.
#
# If we simply store `Foo::Compact::Style`, we could mistakenly resolve it to `Foo::Compact::CONST`,
# which is not correct. This code raises

module Foo
  class Compact::Style
    CONST
  end
end
```

I would really like us to ship 3 important things for the prototype:

1. Constant reference tracking (part of this PR)
2. Basic inheritance tracking (includes, prepends, parent classes)
3. Resolution + ancestor linearization

It's way too much to try to put in a single branch, so I want to ship small pieces and then optimize later. It's really hard to see the exact shape of all pieces before implementing the entire thing.

I did benchmark this on Core (while we haven't added constant references to the corpus) and the performance was not degraded much. Memory usage increased, but we can probably reduce it a bit with string interning later.

```
// Maximum Resident Set Size: 432488448 bytes (412.45 MB)
// Peak Memory Footprint:     403456720 bytes (384.76 MB)
// Execution Time:            3.49 seconds

// Maximum Resident Set Size: 698466304 bytes (666.10 MB)
// Peak Memory Footprint:     673645432 bytes (642.43 MB)
// Execution Time:            3.62 seconds
```