### PR TITLE
Store comments as optional array

### DIFF
--- a/rust/index/src/model/db.rs
+++ b/rust/index/src/model/db.rs
@@ -309,7 +309,10 @@ mod tests {
         assert!(matches!(constant_def.definition, Definition::Constant(_)));
 
         let comments = class_def.definition.comments();
-        assert_eq!(comments, "Class comment\nAnother class comment");
+        assert_eq!(
+            comments,
+            Some(&["Class comment".to_string(), "Another class comment".to_string()][..])
+        );
     }
 
     #[test]

--- a/rust/index/src/model/definitions.rs
+++ b/rust/index/src/model/definitions.rs
@@ -99,8 +99,8 @@ impl Definition {
     }
 
     #[must_use]
-    pub fn comments(&self) -> &str {
-        all_definitions!(self, it => &it.comments)
+    pub fn comments(&self) -> Option<&[String]> {
+        all_definitions!(self, it => it.comments.as_deref())
     }
 }
 
@@ -116,17 +116,17 @@ pub struct ClassDefinition {
     name_id: NameId,
     uri_id: UriId,
     offset: Offset,
-    comments: String,
+    comments: Option<Box<[String]>>,
 }
 
 impl ClassDefinition {
     #[must_use]
-    pub const fn new(name_id: NameId, uri_id: UriId, offset: Offset, comments: String) -> Self {
+    pub fn new(name_id: NameId, uri_id: UriId, offset: Offset, comments: Option<Vec<String>>) -> Self {
         Self {
             name_id,
             uri_id,
             offset,
-            comments,
+            comments: comments.map(|c| c.into_boxed_slice()),
         }
     }
 }
@@ -143,17 +143,17 @@ pub struct ModuleDefinition {
     name_id: NameId,
     uri_id: UriId,
     offset: Offset,
-    comments: String,
+    comments: Option<Box<[String]>>,
 }
 
 impl ModuleDefinition {
     #[must_use]
-    pub const fn new(name_id: NameId, uri_id: UriId, offset: Offset, comments: String) -> Self {
+    pub fn new(name_id: NameId, uri_id: UriId, offset: Offset, comments: Option<Vec<String>>) -> Self {
         Self {
             name_id,
             uri_id,
             offset,
-            comments,
+            comments: comments.map(|c| c.into_boxed_slice()),
         }
     }
 }
@@ -169,17 +169,17 @@ pub struct ConstantDefinition {
     name_id: NameId,
     uri_id: UriId,
     offset: Offset,
-    comments: String,
+    comments: Option<Box<[String]>>,
 }
 
 impl ConstantDefinition {
     #[must_use]
-    pub const fn new(name_id: NameId, uri_id: UriId, offset: Offset, comments: String) -> Self {
+    pub fn new(name_id: NameId, uri_id: UriId, offset: Offset, comments: Option<Vec<String>>) -> Self {
         Self {
             name_id,
             uri_id,
             offset,
-            comments,
+            comments: comments.map(|c| c.into_boxed_slice()),
         }
     }
 }
@@ -198,18 +198,18 @@ pub struct MethodDefinition {
     offset: Offset,
     parameters: Vec<Parameter>,
     is_singleton: bool,
-    comments: String,
+    comments: Option<Box<[String]>>,
 }
 
 impl MethodDefinition {
     #[must_use]
-    pub const fn new(
+    pub fn new(
         name_id: NameId,
         uri_id: UriId,
         offset: Offset,
         parameters: Vec<Parameter>,
         is_singleton: bool,
-        comments: String,
+        comments: Option<Vec<String>>,
     ) -> Self {
         Self {
             name_id,
@@ -217,7 +217,7 @@ impl MethodDefinition {
             offset,
             parameters,
             is_singleton,
-            comments,
+            comments: comments.map(|c| c.into_boxed_slice()),
         }
     }
 
@@ -279,17 +279,17 @@ pub struct AttrAccessorDefinition {
     name_id: NameId,
     uri_id: UriId,
     offset: Offset,
-    comments: String,
+    comments: Option<Box<[String]>>,
 }
 
 impl AttrAccessorDefinition {
     #[must_use]
-    pub const fn new(name_id: NameId, uri_id: UriId, offset: Offset, comments: String) -> Self {
+    pub fn new(name_id: NameId, uri_id: UriId, offset: Offset, comments: Option<Vec<String>>) -> Self {
         Self {
             name_id,
             uri_id,
             offset,
-            comments,
+            comments: comments.map(|c| c.into_boxed_slice()),
         }
     }
 }
@@ -305,17 +305,17 @@ pub struct AttrReaderDefinition {
     name_id: NameId,
     uri_id: UriId,
     offset: Offset,
-    comments: String,
+    comments: Option<Box<[String]>>,
 }
 
 impl AttrReaderDefinition {
     #[must_use]
-    pub const fn new(name_id: NameId, uri_id: UriId, offset: Offset, comments: String) -> Self {
+    pub fn new(name_id: NameId, uri_id: UriId, offset: Offset, comments: Option<Vec<String>>) -> Self {
         Self {
             name_id,
             uri_id,
             offset,
-            comments,
+            comments: comments.map(|c| c.into_boxed_slice()),
         }
     }
 }
@@ -331,17 +331,17 @@ pub struct AttrWriterDefinition {
     name_id: NameId,
     uri_id: UriId,
     offset: Offset,
-    comments: String,
+    comments: Option<Box<[String]>>,
 }
 
 impl AttrWriterDefinition {
     #[must_use]
-    pub const fn new(name_id: NameId, uri_id: UriId, offset: Offset, comments: String) -> Self {
+    pub fn new(name_id: NameId, uri_id: UriId, offset: Offset, comments: Option<Vec<String>>) -> Self {
         Self {
             name_id,
             uri_id,
             offset,
-            comments,
+            comments: comments.map(|c| c.into_boxed_slice()),
         }
     }
 }
@@ -357,17 +357,17 @@ pub struct GlobalVariableDefinition {
     name_id: NameId,
     uri_id: UriId,
     pub offset: Offset,
-    comments: String,
+    comments: Option<Box<[String]>>,
 }
 
 impl GlobalVariableDefinition {
     #[must_use]
-    pub const fn new(name_id: NameId, uri_id: UriId, offset: Offset, comments: String) -> Self {
+    pub fn new(name_id: NameId, uri_id: UriId, offset: Offset, comments: Option<Vec<String>>) -> Self {
         Self {
             name_id,
             uri_id,
             offset,
-            comments,
+            comments: comments.map(|c| c.into_boxed_slice()),
         }
     }
 }
@@ -383,17 +383,17 @@ pub struct InstanceVariableDefinition {
     name_id: NameId,
     uri_id: UriId,
     offset: Offset,
-    comments: String,
+    comments: Option<Box<[String]>>,
 }
 
 impl InstanceVariableDefinition {
     #[must_use]
-    pub const fn new(name_id: NameId, uri_id: UriId, offset: Offset, comments: String) -> Self {
+    pub fn new(name_id: NameId, uri_id: UriId, offset: Offset, comments: Option<Vec<String>>) -> Self {
         Self {
             name_id,
             uri_id,
             offset,
-            comments,
+            comments: comments.map(|c| c.into_boxed_slice()),
         }
     }
 }
@@ -409,17 +409,17 @@ pub struct ClassVariableDefinition {
     name_id: NameId,
     uri_id: UriId,
     offset: Offset,
-    comments: String,
+    comments: Option<Box<[String]>>,
 }
 
 impl ClassVariableDefinition {
     #[must_use]
-    pub const fn new(name_id: NameId, uri_id: UriId, offset: Offset, comments: String) -> Self {
+    pub fn new(name_id: NameId, uri_id: UriId, offset: Offset, comments: Option<Vec<String>>) -> Self {
         Self {
             name_id,
             uri_id,
             offset,
-            comments,
+            comments: comments.map(|c| c.into_boxed_slice()),
         }
     }
 }

--- a/rust/index/src/model/graph.rs
+++ b/rust/index/src/model/graph.rs
@@ -354,10 +354,10 @@ impl Graph {
         for declaration in self.declarations().values() {
             // Check documentation
             if let Some(definitions) = self.get(declaration.name()) {
-                let has_docs = definitions.iter().any(|def| !def.comments().is_empty());
+                let has_docs = definitions.iter().any(|def| def.comments().is_some_and(|c| !c.is_empty()));
                 if has_docs {
                     declarations_with_docs += 1;
-                    let doc_size: usize = definitions.iter().map(|def| def.comments().len()).sum();
+                    let doc_size: usize = definitions.iter().map(|def| def.comments().map_or(0, |c| c.len())).sum();
                     total_doc_size += doc_size;
                 }
             }
@@ -615,15 +615,18 @@ mod tests {
 
         let definitions = context.graph.get("CommentedClass").unwrap();
         let def = definitions.first().unwrap();
-        assert_eq!(def.comments(), "This is a class comment\nMulti-line comment");
+        assert_eq!(
+            def.comments(),
+            Some(&["This is a class comment".to_string(), "Multi-line comment".to_string()][..])
+        );
 
         let definitions = context.graph.get("CommentedModule").unwrap();
         let def = definitions.first().unwrap();
-        assert_eq!(def.comments(), "Module comment");
+        assert_eq!(def.comments(), Some(&["Module comment".to_string()][..]));
 
         let definitions = context.graph.get("NoCommentClass").unwrap();
         let def = definitions.first().unwrap();
-        assert!(def.comments().is_empty());
+        assert_eq!(def.comments(), None);
 
         assert!(context.graph.get("NonExistent").is_none());
     }

--- a/rust/index/src/model/integrity.rs
+++ b/rust/index/src/model/integrity.rs
@@ -127,7 +127,7 @@ mod tests {
             name_id,
             uri_id,
             Offset::new(0, 15),
-            String::new(),
+            None,
         )));
         graph.add_definition("Foo".to_string(), definition);
 


### PR DESCRIPTION
Instead of formatting the comments as strings, we now store and present them as an optional arrays of strings. Benchmarks return similar numbers. 

### Benchmark

Running with huge_corpus, commenting out the db operation (it still takes too long) 

#### Before

```
Found 13907063 names
Found 13907063 definitions
Found 99999 URIs

PERFORMANCE BREAKDOWN

Initialization:    0.172s (  1.4%)
Indexing:          5.401s ( 43.9%)
Db operation:      0.000s (  0.0%)
Cleanup:           6.718s ( 54.7%)
Total:            12.291s

----------------------------------------
Maximum Resident Set Size: 8844394496 bytes (8434.67 MB)
Peak Memory Footprint:     8709528176 bytes (8306.05 MB)
Execution Time:            12.62 seconds
```

#### After 

```
Found 13907063 names
Found 13907063 definitions
Found 99999 URIs

PERFORMANCE BREAKDOWN

Initialization:    0.151s (  1.2%)
Indexing:          5.640s ( 43.2%)
Db operation:      0.000s (  0.0%)
Cleanup:           7.279s ( 55.7%)
Total:            13.070s

----------------------------------------
Maximum Resident Set Size: 8915632128 bytes (8502.60 MB)
Peak Memory Footprint:     8778373792 bytes (8371.70 MB)
Execution Time:            13.51 seconds
```