### PR TITLE
Add a specific timer for files listing

### DIFF
--- a/rust/index/src/main.rs
+++ b/rust/index/src/main.rs
@@ -35,12 +35,15 @@ fn main() -> Result<(), Box<dyn Error>> {
         Timer::set_global_timer(Timer::new());
     }
 
-    let (mut graph, documents, document_count, errors) = time_it!(setup, {
+    let mut graph = time_it!(setup, {
         let mut graph = Graph::new();
         graph.set_configuration(format!("{}/graph.db", &args.dir))?;
+        graph
+    });
+
+    let (documents, errors) = time_it!(listing, {
         let (documents, errors) = indexing::collect_documents(vec![args.dir.clone()]);
-        let document_count = documents.len();
-        Ok::<_, Box<dyn Error>>((graph, documents, document_count, errors))
+        Ok::<_, Box<dyn Error>>((documents, errors))
     })?;
 
     if !errors.is_empty() {
@@ -82,7 +85,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     if args.visualize {
         println!("{}", dot::generate(&graph));
     } else {
-        println!("Indexed {document_count} files");
+        println!("Indexed {} files", graph.documents().len());
         println!("Found {} names", graph.declarations().len());
         println!("Found {} definitions", graph.definitions().len());
         println!("Found {} URIs", graph.documents().len());

--- a/rust/index/src/timer.rs
+++ b/rust/index/src/timer.rs
@@ -120,6 +120,7 @@ macro_rules! make_timer {
 
 make_timer! {
     setup, "Initialization";
+    listing, "Listing";
     indexing, "Indexing";
     querying, "Querying";
     integrity_check, "Integrity Check";


### PR DESCRIPTION
This shows we spend 50% of the time on shop/world listing files.

<img width="540" height="266" alt="image" src="https://github.com/user-attachments/assets/cd84cff0-d145-46a1-ba68-6541db17d245" />
