### PR TITLE
Switch files collection to use the `ignore` crate

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -236,6 +236,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -339,6 +364,19 @@ name = "glob"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
+
+[[package]]
+name = "globset"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54a1028dfc5f5df5da8a56a73e6c153c9a9708ec57232470703592a3f18e49f5"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
 
 [[package]]
 name = "hashbrown"
@@ -481,13 +519,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "ignore"
+version = "0.4.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d89fd380afde86567dfba715db065673989d6253f42b88179abd3eae47bda4b"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
+]
+
+[[package]]
 name = "index"
 version = "0.1.0"
 dependencies = [
  "assert_cmd",
  "bytecount",
  "clap",
- "glob",
+ "ignore",
  "predicates",
  "regex",
  "rmp-serde",
@@ -864,6 +918,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1084,6 +1147,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasi"
 version = "0.14.2+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1102,6 +1175,15 @@ dependencies = [
  "home",
  "once_cell",
  "rustix 0.38.44",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/rust/index-sys/src/index_api.rs
+++ b/rust/index-sys/src/index_api.rs
@@ -52,7 +52,7 @@ pub unsafe extern "C" fn idx_index_all_c(
     let file_paths: Vec<String> = unsafe { conversions::convert_double_pointer_to_vec(file_paths, count).unwrap() };
     let mut all_errors = Vec::new();
 
-    let (documents, document_errors) = indexing::collect_documents(file_paths);
+    let (documents, document_errors) = indexing::collect_documents(&file_paths);
     all_errors.extend(document_errors);
 
     with_graph(pointer, |graph| {

--- a/rust/index/Cargo.toml
+++ b/rust/index/Cargo.toml
@@ -19,8 +19,8 @@ xxhash-rust = { version = "0.8.15", features = ["xxh3"] }
 clap = { version = "4.5.16", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 rmp-serde = "1.3.0"
-glob = "0.3.2"
 bytecount = "0.6.9"
+ignore = "0.4.22"
 
 [dev-dependencies]
 tempfile = "3.0"

--- a/rust/index/src/main.rs
+++ b/rust/index/src/main.rs
@@ -42,7 +42,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     });
 
     let (documents, errors) = time_it!(listing, {
-        let (documents, errors) = indexing::collect_documents(vec![args.dir.clone()]);
+        let (documents, errors) = indexing::collect_documents(&[args.dir]);
         Ok::<_, Box<dyn Error>>((documents, errors))
     })?;
 


### PR DESCRIPTION
Proof of concept showing how we could reduce the time spent listing files using the [ignore](https://crates.io/crates/ignore). I'm sure we can do even better but this already gets us to a better state.

Comparison on shop/world:

```
Timing breakdown    before              after

Initialization      0.003s (  0.0%)    0.002s (  0.0%)
Listing             5.587s ( 51.5%)    1.755s ( 23.1%)
Indexing            4.970s ( 45.8%)    5.568s ( 73.3%)
Querying            0.293s (  2.7%)    0.272s (  3.6%)
Database            0.000s (  0.0%)    0.000s (  0.0%)
Cleanup             0.000s (  0.0%)    0.000s (  0.0%)
Total:             10.853s             7.597s         
```

Comparison on corpus/huge:

```
Timing breakdown    before              after

Initialization      0.004s (  0.0%)    0.002s (  0.0%)
Listing             0.167s (  0.9%)    0.099s (  0.6%)
Indexing           11.354s ( 64.1%)   10.541s ( 62.3%)
Querying            6.184s ( 34.9%)    6.287s ( 37.1%)
Database            0.000s (  0.0%)    0.000s (  0.0%)
Cleanup             0.000s (  0.0%)    0.000s (  0.0%)
Total:             17.709s            16.928s
```