### PR TITLE
Add `clear-db` option to drop the database before saving the graph

### DIFF
--- a/rust/index/src/main.rs
+++ b/rust/index/src/main.rs
@@ -11,6 +11,7 @@ use index::{
 
 #[derive(Parser, Debug)]
 #[command(name = "index_cli", about = "A Ruby code indexer", version)]
+#[allow(clippy::struct_excessive_bools)]
 struct Args {
     #[arg(value_name = "DIR", default_value = ".")]
     dir: String,
@@ -23,6 +24,9 @@ struct Args {
 
     #[arg(long = "visualize")]
     visualize: bool,
+
+    #[arg(long = "clear-db", help = "Clear the database before saving the graph")]
+    clear_db: bool,
 
     #[arg(long = "stats", help = "Show detailed performance statistics")]
     stats: bool,
@@ -64,6 +68,10 @@ fn main() -> Result<(), Box<dyn Error>> {
                 std::process::exit(1);
             }
         });
+    }
+
+    if args.clear_db {
+        graph.clear_database()?;
     }
 
     time_it!(database, { graph.save_to_database() })?;

--- a/rust/index/src/model/graph.rs
+++ b/rust/index/src/model/graph.rs
@@ -341,6 +341,15 @@ impl Graph {
         self.db.save_full_graph(self)
     }
 
+    /// Clears all data from the database
+    ///
+    /// # Errors
+    ///
+    /// This method will return an error if clearing the database fails.
+    pub fn clear_database(&self) -> Result<(), Box<dyn Error>> {
+        self.db.clear_database()
+    }
+
     // Clear graph data from memory
     pub fn clear_graph_data(&mut self) {
         self.declarations = IdentityHashMap::default();


### PR DESCRIPTION
When we repeatedly run the indexer on the same directory, the second run will fail because of unique constraint violations.

Currently, we need to manually drop the database before running the indexer, which is annoying. I think having an option to clear the database is useful.