### PR TITLE
Add content_hash to documents schema

### DIFF
--- a/rust/index/src/db/schema.sql
+++ b/rust/index/src/db/schema.sql
@@ -4,7 +4,8 @@
 -- Table for storing documents
 CREATE TABLE IF NOT EXISTS documents (
     id INTEGER PRIMARY KEY,  -- Blake3 hash converted to hex
-    uri TEXT NOT NULL UNIQUE
+    uri TEXT NOT NULL UNIQUE,
+    content_hash INTEGER NOT NULL
 );
 
 -- Table for storing code declarations (classes, modules, methods, etc.)

--- a/rust/index/src/model/db.rs
+++ b/rust/index/src/model/db.rs
@@ -219,10 +219,12 @@ impl Db {
 
     /// Performs batch insert of documents (URIs) to the database
     fn batch_insert_documents(conn: &rusqlite::Connection, graph: &Graph) -> Result<(), Box<dyn Error>> {
-        let mut stmt = conn.prepare_cached(&format!("INSERT INTO {TABLE_DOCUMENTS} (id, uri) VALUES (?, ?)"))?;
+        let mut stmt = conn.prepare_cached(&format!(
+            "INSERT INTO {TABLE_DOCUMENTS} (id, uri, content_hash) VALUES (?, ?, ?)"
+        ))?;
 
         for (uri_id, document) in graph.documents() {
-            stmt.execute(rusqlite::params![*uri_id, document.uri()])?;
+            stmt.execute(rusqlite::params![*uri_id, document.uri(), 123])?;
         }
 
         Ok(())


### PR DESCRIPTION
For https://github.com/Shopify/index/issues/88
Breaking up https://github.com/Shopify/index/pull/173 into smaller chunks. 

This change is to add the content_hash field into the documents table. We will use this for document staleness check. 