### PR TITLE
Add content_hash to document struct

### DIFF
--- a/rust/saturn/src/indexing/ruby_indexer.rs
+++ b/rust/saturn/src/indexing/ruby_indexer.rs
@@ -48,9 +48,14 @@ pub struct RubyIndexer<'a> {
 
 impl<'a> RubyIndexer<'a> {
     #[must_use]
-    pub fn new(uri: String, location_converter: &'a dyn SourceLocationConverter, source: &'a str) -> Self {
+    pub fn new(
+        uri: String,
+        location_converter: &'a dyn SourceLocationConverter,
+        source: &'a str,
+        content_hash: u16,
+    ) -> Self {
         let mut local_index = Graph::new();
-        let uri_id = local_index.add_uri(uri);
+        let uri_id = local_index.add_uri(uri, content_hash);
 
         Self {
             uri_id,

--- a/rust/saturn/src/model/db.rs
+++ b/rust/saturn/src/model/db.rs
@@ -246,7 +246,7 @@ impl Db {
         ))?;
 
         for (uri_id, document) in graph.documents() {
-            stmt.execute(rusqlite::params![*uri_id, document.uri(), 123])?;
+            stmt.execute(rusqlite::params![*uri_id, document.uri(), document.content_hash()])?;
         }
 
         Ok(())

--- a/rust/saturn/src/model/document.rs
+++ b/rust/saturn/src/model/document.rs
@@ -6,13 +6,15 @@ use crate::model::ids::DefinitionId;
 pub struct Document {
     uri: String,
     definition_ids: Vec<DefinitionId>,
+    content_hash: u16,
 }
 
 impl Document {
     #[must_use]
-    pub fn new(uri: String) -> Self {
+    pub fn new(uri: String, content_hash: u16) -> Self {
         Self {
             uri,
+            content_hash,
             definition_ids: Vec::new(),
         }
     }
@@ -20,6 +22,11 @@ impl Document {
     #[must_use]
     pub fn uri(&self) -> &str {
         &self.uri
+    }
+
+    #[must_use]
+    pub fn content_hash(&self) -> u16 {
+        self.content_hash
     }
 
     #[must_use]
@@ -44,7 +51,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "Cannot add the same exact definition to a document twice. Duplicate definition IDs")]
     fn inserting_duplicate_definitions() {
-        let mut document = Document::new("file:///foo.rb".to_string());
+        let mut document = Document::new("file:///foo.rb".to_string(), 123u16);
         let def_id = DefinitionId::new(123);
 
         document.add_definition(def_id);

--- a/rust/saturn/src/model/integrity.rs
+++ b/rust/saturn/src/model/integrity.rs
@@ -121,7 +121,7 @@ mod tests {
         // Should pass since the index is empty
         checker.assert_integrity(&graph);
 
-        let uri_id = graph.add_uri("file:///foo.rb".to_string());
+        let uri_id = graph.add_uri("file:///foo.rb".to_string(), 123);
         let declaration_id = DeclarationId::from("Foo");
         let definition = Definition::Module(Box::new(ModuleDefinition::new(
             declaration_id,

--- a/rust/saturn/src/test_utils/graph_test.rs
+++ b/rust/saturn/src/test_utils/graph_test.rs
@@ -17,7 +17,8 @@ impl GraphTest {
     #[must_use]
     fn index_source(uri: &str, source: &str) -> Graph {
         let converter = UTF8SourceLocationConverter::new(source);
-        let mut indexer = RubyIndexer::new(uri.to_string(), &converter, source);
+        let content_hash = crate::indexing::Document::calculate_content_hash(source.as_bytes());
+        let mut indexer = RubyIndexer::new(uri.to_string(), &converter, source, content_hash);
         indexer.index();
         indexer.into_parts().0
     }


### PR DESCRIPTION
For https://github.com/Shopify/index/issues/88
Breaking up https://github.com/Shopify/index/pull/173 into smaller chunks.

Here we add content_hash to the Document model.

We are choosing to use `u16`​ here for the content_hash as the purpose of this field is for staleness check between two versions of a document, which is a different use case from the IDs that need the full 64 bits.

Collision risk comparison:

(how likely we would fail to detect a change in the document content for the number of files we have)

| Hash Size | Values | 100 Files Collision Risk |
| --- | --- | --- |
| u8 | 256 | 32\.4% |
| u16 | 65,536 | 0\.15% |
| u32 | 4\.3B | 0\.000002% |

For 100 file updates the collision risk is 0.15% which feels acceptable.