### PR TITLE
Introduce `DeclarationId`

### DIFF
--- a/rust/index/src/db/load_document.sql
+++ b/rust/index/src/db/load_document.sql
@@ -1,9 +1,9 @@
 SELECT
-    names.id,
-    names.name,
+    declarations.id,
+    declarations.name,
     definitions.id,
     definitions.data
 FROM documents
 JOIN definitions ON documents.id = definitions.document_id
-JOIN names ON names.id = definitions.name_id
+JOIN declarations ON declarations.id = definitions.declaration_id
 WHERE documents.id = ?

--- a/rust/index/src/db/schema.sql
+++ b/rust/index/src/db/schema.sql
@@ -3,24 +3,24 @@
 
 -- Table for storing documents
 CREATE TABLE IF NOT EXISTS documents (
-    id INTEGER PRIMARY KEY,  -- Blake3 hash converted to hex
+    id INTEGER PRIMARY KEY,  -- Hashed document ID
     uri TEXT NOT NULL UNIQUE,
     content_hash INTEGER NOT NULL
 );
 
 -- Table for storing code declarations (classes, modules, methods, etc.)
-CREATE TABLE IF NOT EXISTS names (
-    id INTEGER PRIMARY KEY,  -- Blake3 hash converted to hex
+CREATE TABLE IF NOT EXISTS declarations (
+    id INTEGER PRIMARY KEY,  -- Hashed declaration ID
     name TEXT NOT NULL
 );
 
 -- Table for storing definitions that make up declarations
 CREATE TABLE IF NOT EXISTS definitions (
-    id INTEGER PRIMARY KEY,  -- Blake3 hash converted to hex
-    name_id INTEGER NOT NULL, -- References names.id
-    document_id INTEGER NOT NULL, -- References documents.id
+    id INTEGER PRIMARY KEY,  -- Hashed definition ID
+    declaration_id INTEGER NOT NULL,
+    document_id INTEGER NOT NULL,
     data BLOB NOT NULL -- Serialized definition data
 );
 
 -- Indexes for fast lookups
-CREATE INDEX IF NOT EXISTS names_name_index ON names (name);
+CREATE INDEX IF NOT EXISTS names_name_index ON declarations (name);

--- a/rust/index/src/indexing/ruby_indexer.rs
+++ b/rust/index/src/indexing/ruby_indexer.rs
@@ -7,7 +7,7 @@ use crate::model::definitions::{
     ModuleDefinition, Parameter, ParameterStruct,
 };
 use crate::model::graph::Graph;
-use crate::model::ids::{NameId, UriId};
+use crate::model::ids::{DeclarationId, UriId};
 use crate::model::references::{UnresolvedConstantRef, UnresolvedReference};
 use crate::offset::Offset;
 use crate::source_location::SourceLocationConverter;
@@ -319,7 +319,7 @@ impl<'a> RubyIndexer<'a> {
             .last()
             .expect("There should always be at least one stack. This is a bug")
             .clone();
-        let name_id_nesting: Vec<NameId> = nesting.iter().map(NameId::from).collect();
+        let name_id_nesting: Vec<DeclarationId> = nesting.iter().map(DeclarationId::from).collect();
 
         let reference = UnresolvedReference::Constant(Box::new(UnresolvedConstantRef::new(
             name,
@@ -383,14 +383,14 @@ impl Visit<'_> for RubyIndexer<'_> {
         let name = Self::location_to_string(&node.constant_path().location());
 
         self.with_updated_nesting(&name, |indexer, fully_qualified_name| {
-            let name_id = NameId::from(&fully_qualified_name);
+            let declaration_id = DeclarationId::from(&fully_qualified_name);
             let offset = Offset::from_prism_location(&node.location());
             let comments = indexer.find_comments_for(offset.start()).unwrap_or_default();
             // Uses `location_converter` to evaluate the performance impact of the conversion
             self.location_converter.offset_to_position(&offset).unwrap();
 
             let definition = Definition::Class(Box::new(ClassDefinition::new(
-                name_id,
+                declaration_id,
                 indexer.uri_id,
                 offset,
                 comments,
@@ -408,13 +408,13 @@ impl Visit<'_> for RubyIndexer<'_> {
         let name = Self::location_to_string(&node.constant_path().location());
 
         self.with_updated_nesting(&name, |indexer, fully_qualified_name| {
-            let name_id = NameId::from(&fully_qualified_name);
+            let declaration_id = DeclarationId::from(&fully_qualified_name);
             let offset = Offset::from_prism_location(&node.location());
             let comments = indexer.find_comments_for(offset.start()).unwrap_or_default();
             // Uses `location_converter` to evaluate the performance impact of the conversion
             self.location_converter.offset_to_position(&offset).unwrap();
             let definition = Definition::Module(Box::new(ModuleDefinition::new(
-                name_id,
+                declaration_id,
                 indexer.uri_id,
                 offset,
                 comments,
@@ -432,13 +432,13 @@ impl Visit<'_> for RubyIndexer<'_> {
         let name = Self::location_to_string(&name_loc);
 
         self.with_updated_nesting(&name, |indexer, fully_qualified_name| {
-            let name_id = NameId::from(&fully_qualified_name);
+            let declaration_id = DeclarationId::from(&fully_qualified_name);
             let offset = Offset::from_prism_location(&name_loc);
             let comments = indexer.find_comments_for(offset.start()).unwrap_or_default();
             // Uses `location_converter` to evaluate the performance impact of the conversion
             self.location_converter.offset_to_position(&offset).unwrap();
             let definition = Definition::Constant(Box::new(ConstantDefinition::new(
-                name_id,
+                declaration_id,
                 indexer.uri_id,
                 offset,
                 comments,
@@ -455,13 +455,13 @@ impl Visit<'_> for RubyIndexer<'_> {
         let name = Self::location_to_string(&location);
 
         self.with_updated_nesting(&name, |indexer, fully_qualified_name| {
-            let name_id = NameId::from(&fully_qualified_name);
+            let declaration_id = DeclarationId::from(&fully_qualified_name);
             let offset = Offset::from_prism_location(&location);
             let comments = indexer.find_comments_for(offset.start()).unwrap_or_default();
             // Uses `location_converter` to evaluate the performance impact of the conversion
             self.location_converter.offset_to_position(&offset).unwrap();
             let definition = Definition::Constant(Box::new(ConstantDefinition::new(
-                name_id,
+                declaration_id,
                 indexer.uri_id,
                 offset,
                 comments,
@@ -489,14 +489,14 @@ impl Visit<'_> for RubyIndexer<'_> {
                     let name = Self::location_to_string(&location);
 
                     self.with_updated_nesting(&name, |indexer, fully_qualified_name| {
-                        let name_id = NameId::from(&fully_qualified_name);
+                        let declaration_id = DeclarationId::from(&fully_qualified_name);
                         let offset = Offset::from_prism_location(&location);
                         let comments = indexer.find_comments_for(offset.start()).unwrap_or_default();
                         // Uses `location_converter` to evaluate the performance impact of the conversion
                         self.location_converter.offset_to_position(&offset).unwrap();
 
                         let definition = Definition::Constant(Box::new(ConstantDefinition::new(
-                            name_id,
+                            declaration_id,
                             indexer.uri_id,
                             offset,
                             comments,
@@ -508,14 +508,14 @@ impl Visit<'_> for RubyIndexer<'_> {
                 ruby_prism::Node::GlobalVariableTargetNode { .. } => {
                     let location = left.location();
                     let name = Self::location_to_string(&location);
-                    let name_id = NameId::from(&name);
+                    let declaration_id = DeclarationId::from(&name);
                     let offset = Offset::from_prism_location(&location);
                     // Uses `location_converter` to evaluate the performance impact of the conversion
                     self.location_converter.offset_to_position(&offset).unwrap();
 
                     let comments = self.find_comments_for(offset.start()).unwrap_or_default();
                     let definition = Definition::GlobalVariable(Box::new(GlobalVariableDefinition::new(
-                        name_id,
+                        declaration_id,
                         self.uri_id,
                         offset,
                         comments,
@@ -528,14 +528,14 @@ impl Visit<'_> for RubyIndexer<'_> {
                     let name = Self::location_to_string(&location);
 
                     self.with_updated_nesting(&name, |indexer, fully_qualified_name| {
-                        let name_id = NameId::from(&fully_qualified_name);
+                        let declaration_id = DeclarationId::from(&fully_qualified_name);
                         let offset = Offset::from_prism_location(&location);
                         let comments = indexer.find_comments_for(offset.start()).unwrap_or_default();
                         // Uses `location_converter` to evaluate the performance impact of the conversion
                         self.location_converter.offset_to_position(&offset).unwrap();
 
                         let definition = Definition::InstanceVariable(Box::new(InstanceVariableDefinition::new(
-                            name_id,
+                            declaration_id,
                             indexer.uri_id,
                             offset,
                             comments,
@@ -549,14 +549,14 @@ impl Visit<'_> for RubyIndexer<'_> {
                     let name = Self::location_to_string(&location);
 
                     self.with_updated_nesting(&name, |indexer, fully_qualified_name| {
-                        let name_id = NameId::from(&fully_qualified_name);
+                        let declaration_id = DeclarationId::from(&fully_qualified_name);
                         let offset = Offset::from_prism_location(&location);
                         let comments = indexer.find_comments_for(offset.start()).unwrap_or_default();
                         // Uses `location_converter` to evaluate the performance impact of the conversion
                         self.location_converter.offset_to_position(&offset).unwrap();
 
                         let definition = Definition::ClassVariable(Box::new(ClassVariableDefinition::new(
-                            name_id,
+                            declaration_id,
                             indexer.uri_id,
                             offset,
                             comments,
@@ -576,14 +576,14 @@ impl Visit<'_> for RubyIndexer<'_> {
         let name = Self::location_to_string(&node.name_loc());
 
         self.with_updated_nesting(&name, |indexer, fully_qualified_name| {
-            let name_id = NameId::from(&fully_qualified_name);
+            let declaration_id = DeclarationId::from(&fully_qualified_name);
             let offset = Offset::from_prism_location(&node.location());
             let comments = indexer.find_comments_for(offset.start()).unwrap_or_default();
             // Uses `location_converter` to evaluate the performance impact of the conversion
             self.location_converter.offset_to_position(&offset).unwrap();
 
             let method = MethodDefinition::new(
-                name_id,
+                declaration_id,
                 indexer.uri_id,
                 offset,
                 Self::collect_parameters(node),
@@ -607,9 +607,9 @@ impl Visit<'_> for RubyIndexer<'_> {
         fn create_attr_accessor(indexer: &mut RubyIndexer, node: &ruby_prism::CallNode) {
             RubyIndexer::each_string_or_symbol_arg(node, |name, location| {
                 indexer.with_updated_nesting(&name, |indexer, fully_qualified_name| {
-                    let name_id = NameId::from(&fully_qualified_name);
+                    let declaration_id = DeclarationId::from(&fully_qualified_name);
                     let writer_name = format!("{fully_qualified_name}=");
-                    let writer_name_id = NameId::from(&writer_name);
+                    let writer_declaration_id = DeclarationId::from(&writer_name);
                     let offset = Offset::from_prism_location(&location);
                     let comments = indexer.find_comments_for(offset.start()).unwrap_or_default();
                     // Uses `location_converter` to evaluate the performance impact of the conversion
@@ -617,7 +617,7 @@ impl Visit<'_> for RubyIndexer<'_> {
                     indexer.local_index.add_definition(
                         fully_qualified_name,
                         Definition::AttrAccessor(Box::new(AttrAccessorDefinition::new(
-                            name_id,
+                            declaration_id,
                             indexer.uri_id,
                             offset,
                             comments.clone(),
@@ -627,7 +627,7 @@ impl Visit<'_> for RubyIndexer<'_> {
                     indexer.local_index.add_definition(
                         writer_name,
                         Definition::AttrAccessor(Box::new(AttrAccessorDefinition::new(
-                            writer_name_id,
+                            writer_declaration_id,
                             indexer.uri_id,
                             Offset::from_prism_location(&location),
                             comments.clone(),
@@ -640,7 +640,7 @@ impl Visit<'_> for RubyIndexer<'_> {
         fn create_attr_reader(indexer: &mut RubyIndexer, node: &ruby_prism::CallNode) {
             RubyIndexer::each_string_or_symbol_arg(node, |name, location| {
                 indexer.with_updated_nesting(&name, |indexer, fully_qualified_name| {
-                    let name_id = NameId::from(&fully_qualified_name);
+                    let declaration_id = DeclarationId::from(&fully_qualified_name);
                     let offset = Offset::from_prism_location(&location);
                     let comments = indexer.find_comments_for(offset.start()).unwrap_or_default();
                     // Uses `location_converter` to evaluate the performance impact of the conversion
@@ -649,7 +649,7 @@ impl Visit<'_> for RubyIndexer<'_> {
                     indexer.local_index.add_definition(
                         fully_qualified_name,
                         Definition::AttrReader(Box::new(AttrReaderDefinition::new(
-                            name_id,
+                            declaration_id,
                             indexer.uri_id,
                             offset,
                             comments,
@@ -663,7 +663,7 @@ impl Visit<'_> for RubyIndexer<'_> {
             RubyIndexer::each_string_or_symbol_arg(node, |name, location| {
                 indexer.with_updated_nesting(&name, |indexer, fully_qualified_name| {
                     let writer_name = format!("{fully_qualified_name}=");
-                    let name_id = NameId::from(&writer_name);
+                    let declaration_id = DeclarationId::from(&writer_name);
                     let offset = Offset::from_prism_location(&location);
                     let comments = indexer.find_comments_for(offset.start()).unwrap_or_default();
                     // Uses `location_converter` to evaluate the performance impact of the conversion
@@ -672,7 +672,7 @@ impl Visit<'_> for RubyIndexer<'_> {
                     indexer.local_index.add_definition(
                         writer_name,
                         Definition::AttrWriter(Box::new(AttrWriterDefinition::new(
-                            name_id,
+                            declaration_id,
                             indexer.uri_id,
                             offset,
                             comments,
@@ -749,12 +749,12 @@ impl Visit<'_> for RubyIndexer<'_> {
     fn visit_global_variable_write_node(&mut self, node: &ruby_prism::GlobalVariableWriteNode) {
         let name_loc = node.name_loc();
         let name = Self::location_to_string(&name_loc);
-        let name_id = NameId::from(&name);
+        let declaration_id = DeclarationId::from(&name);
         let offset = Offset::from_prism_location(&name_loc);
 
         let comments = self.find_comments_for(offset.start()).unwrap_or_default();
         let definition = Definition::GlobalVariable(Box::new(GlobalVariableDefinition::new(
-            name_id,
+            declaration_id,
             self.uri_id,
             offset,
             comments,
@@ -770,14 +770,14 @@ impl Visit<'_> for RubyIndexer<'_> {
         let name = Self::location_to_string(&name_loc);
 
         self.with_updated_nesting(&name, |indexer, fully_qualified_name| {
-            let name_id = NameId::from(&fully_qualified_name);
+            let declaration_id = DeclarationId::from(&fully_qualified_name);
             let offset = Offset::from_prism_location(&name_loc);
             let comments = indexer.find_comments_for(offset.start()).unwrap_or_default();
             // Uses `location_converter` to evaluate the performance impact of the conversion
             self.location_converter.offset_to_position(&offset).unwrap();
 
             let definition = Definition::InstanceVariable(Box::new(InstanceVariableDefinition::new(
-                name_id,
+                declaration_id,
                 indexer.uri_id,
                 offset,
                 comments,
@@ -794,14 +794,14 @@ impl Visit<'_> for RubyIndexer<'_> {
         let name = Self::location_to_string(&name_loc);
 
         self.with_updated_nesting(&name, |indexer, fully_qualified_name| {
-            let name_id = NameId::from(&fully_qualified_name);
+            let declaration_id = DeclarationId::from(&fully_qualified_name);
             let offset = Offset::from_prism_location(&name_loc);
             let comments = indexer.find_comments_for(offset.start()).unwrap_or_default();
             // Uses `location_converter` to evaluate the performance impact of the conversion
             self.location_converter.offset_to_position(&offset).unwrap();
 
             let definition = Definition::ClassVariable(Box::new(ClassVariableDefinition::new(
-                name_id,
+                declaration_id,
                 indexer.uri_id,
                 offset,
                 comments,

--- a/rust/index/src/model/definitions.rs
+++ b/rust/index/src/model/definitions.rs
@@ -26,7 +26,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    model::ids::{NameId, UriId},
+    model::ids::{DeclarationId, UriId},
     offset::Offset,
 };
 
@@ -89,8 +89,8 @@ impl Definition {
     }
 
     #[must_use]
-    pub fn name_id(&self) -> &NameId {
-        all_definitions!(self, it => &it.name_id)
+    pub fn declaration_id(&self) -> &DeclarationId {
+        all_definitions!(self, it => &it.declaration_id)
     }
 
     #[must_use]
@@ -113,7 +113,7 @@ impl Definition {
 /// ```
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ClassDefinition {
-    name_id: NameId,
+    declaration_id: DeclarationId,
     uri_id: UriId,
     offset: Offset,
     comments: String,
@@ -121,9 +121,9 @@ pub struct ClassDefinition {
 
 impl ClassDefinition {
     #[must_use]
-    pub const fn new(name_id: NameId, uri_id: UriId, offset: Offset, comments: String) -> Self {
+    pub const fn new(declaration_id: DeclarationId, uri_id: UriId, offset: Offset, comments: String) -> Self {
         Self {
-            name_id,
+            declaration_id,
             uri_id,
             offset,
             comments,
@@ -140,7 +140,7 @@ impl ClassDefinition {
 /// ```
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ModuleDefinition {
-    name_id: NameId,
+    declaration_id: DeclarationId,
     uri_id: UriId,
     offset: Offset,
     comments: String,
@@ -148,9 +148,9 @@ pub struct ModuleDefinition {
 
 impl ModuleDefinition {
     #[must_use]
-    pub const fn new(name_id: NameId, uri_id: UriId, offset: Offset, comments: String) -> Self {
+    pub const fn new(declaration_id: DeclarationId, uri_id: UriId, offset: Offset, comments: String) -> Self {
         Self {
-            name_id,
+            declaration_id,
             uri_id,
             offset,
             comments,
@@ -166,7 +166,7 @@ impl ModuleDefinition {
 /// ```
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ConstantDefinition {
-    name_id: NameId,
+    declaration_id: DeclarationId,
     uri_id: UriId,
     offset: Offset,
     comments: String,
@@ -174,9 +174,9 @@ pub struct ConstantDefinition {
 
 impl ConstantDefinition {
     #[must_use]
-    pub const fn new(name_id: NameId, uri_id: UriId, offset: Offset, comments: String) -> Self {
+    pub const fn new(declaration_id: DeclarationId, uri_id: UriId, offset: Offset, comments: String) -> Self {
         Self {
-            name_id,
+            declaration_id,
             uri_id,
             offset,
             comments,
@@ -193,7 +193,7 @@ impl ConstantDefinition {
 /// ```
 #[derive(Debug, Serialize, Deserialize)]
 pub struct MethodDefinition {
-    name_id: NameId,
+    declaration_id: DeclarationId,
     uri_id: UriId,
     offset: Offset,
     parameters: Vec<Parameter>,
@@ -204,7 +204,7 @@ pub struct MethodDefinition {
 impl MethodDefinition {
     #[must_use]
     pub const fn new(
-        name_id: NameId,
+        declaration_id: DeclarationId,
         uri_id: UriId,
         offset: Offset,
         parameters: Vec<Parameter>,
@@ -212,7 +212,7 @@ impl MethodDefinition {
         comments: String,
     ) -> Self {
         Self {
-            name_id,
+            declaration_id,
             uri_id,
             offset,
             parameters,
@@ -276,7 +276,7 @@ impl ParameterStruct {
 /// ```
 #[derive(Debug, Serialize, Deserialize)]
 pub struct AttrAccessorDefinition {
-    name_id: NameId,
+    declaration_id: DeclarationId,
     uri_id: UriId,
     offset: Offset,
     comments: String,
@@ -284,9 +284,9 @@ pub struct AttrAccessorDefinition {
 
 impl AttrAccessorDefinition {
     #[must_use]
-    pub const fn new(name_id: NameId, uri_id: UriId, offset: Offset, comments: String) -> Self {
+    pub const fn new(declaration_id: DeclarationId, uri_id: UriId, offset: Offset, comments: String) -> Self {
         Self {
-            name_id,
+            declaration_id,
             uri_id,
             offset,
             comments,
@@ -302,7 +302,7 @@ impl AttrAccessorDefinition {
 /// ```
 #[derive(Debug, Serialize, Deserialize)]
 pub struct AttrReaderDefinition {
-    name_id: NameId,
+    declaration_id: DeclarationId,
     uri_id: UriId,
     offset: Offset,
     comments: String,
@@ -310,9 +310,9 @@ pub struct AttrReaderDefinition {
 
 impl AttrReaderDefinition {
     #[must_use]
-    pub const fn new(name_id: NameId, uri_id: UriId, offset: Offset, comments: String) -> Self {
+    pub const fn new(declaration_id: DeclarationId, uri_id: UriId, offset: Offset, comments: String) -> Self {
         Self {
-            name_id,
+            declaration_id,
             uri_id,
             offset,
             comments,
@@ -328,7 +328,7 @@ impl AttrReaderDefinition {
 /// ```
 #[derive(Debug, Serialize, Deserialize)]
 pub struct AttrWriterDefinition {
-    name_id: NameId,
+    declaration_id: DeclarationId,
     uri_id: UriId,
     offset: Offset,
     comments: String,
@@ -336,9 +336,9 @@ pub struct AttrWriterDefinition {
 
 impl AttrWriterDefinition {
     #[must_use]
-    pub const fn new(name_id: NameId, uri_id: UriId, offset: Offset, comments: String) -> Self {
+    pub const fn new(declaration_id: DeclarationId, uri_id: UriId, offset: Offset, comments: String) -> Self {
         Self {
-            name_id,
+            declaration_id,
             uri_id,
             offset,
             comments,
@@ -354,7 +354,7 @@ impl AttrWriterDefinition {
 /// ```
 #[derive(Debug, Serialize, Deserialize)]
 pub struct GlobalVariableDefinition {
-    name_id: NameId,
+    declaration_id: DeclarationId,
     uri_id: UriId,
     pub offset: Offset,
     comments: String,
@@ -362,9 +362,9 @@ pub struct GlobalVariableDefinition {
 
 impl GlobalVariableDefinition {
     #[must_use]
-    pub const fn new(name_id: NameId, uri_id: UriId, offset: Offset, comments: String) -> Self {
+    pub const fn new(declaration_id: DeclarationId, uri_id: UriId, offset: Offset, comments: String) -> Self {
         Self {
-            name_id,
+            declaration_id,
             uri_id,
             offset,
             comments,
@@ -380,7 +380,7 @@ impl GlobalVariableDefinition {
 /// ```
 #[derive(Debug, Serialize, Deserialize)]
 pub struct InstanceVariableDefinition {
-    name_id: NameId,
+    declaration_id: DeclarationId,
     uri_id: UriId,
     offset: Offset,
     comments: String,
@@ -388,9 +388,9 @@ pub struct InstanceVariableDefinition {
 
 impl InstanceVariableDefinition {
     #[must_use]
-    pub const fn new(name_id: NameId, uri_id: UriId, offset: Offset, comments: String) -> Self {
+    pub const fn new(declaration_id: DeclarationId, uri_id: UriId, offset: Offset, comments: String) -> Self {
         Self {
-            name_id,
+            declaration_id,
             uri_id,
             offset,
             comments,
@@ -406,7 +406,7 @@ impl InstanceVariableDefinition {
 /// ```
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ClassVariableDefinition {
-    name_id: NameId,
+    declaration_id: DeclarationId,
     uri_id: UriId,
     offset: Offset,
     comments: String,
@@ -414,9 +414,9 @@ pub struct ClassVariableDefinition {
 
 impl ClassVariableDefinition {
     #[must_use]
-    pub const fn new(name_id: NameId, uri_id: UriId, offset: Offset, comments: String) -> Self {
+    pub const fn new(declaration_id: DeclarationId, uri_id: UriId, offset: Offset, comments: String) -> Self {
         Self {
-            name_id,
+            declaration_id,
             uri_id,
             offset,
             comments,

--- a/rust/index/src/model/ids.rs
+++ b/rust/index/src/model/ids.rs
@@ -2,9 +2,9 @@ use crate::model::id::Id;
 use serde::{Deserialize, Serialize};
 
 #[derive(PartialEq, Eq, Debug, Clone, Copy, Serialize, Deserialize)]
-pub struct NameMarker;
-// NameId represents the ID of a fully qualified name, such as `Foo` or `Foo#bar`
-pub type NameId = Id<NameMarker>;
+pub struct DeclarationMarker;
+/// `DeclarationId` represents the ID of a fully qualified name. For example, `Foo::Bar` or `Foo#my_method`
+pub type DeclarationId = Id<DeclarationMarker>;
 
 #[derive(PartialEq, Eq, Debug, Clone, Copy, Serialize, Deserialize)]
 pub struct DefinitionMarker;
@@ -15,3 +15,17 @@ pub type DefinitionId = Id<DefinitionMarker>;
 pub struct UriMarker;
 // UriId represents the ID of a URI, which is the unique identifier for a document
 pub type UriId = Id<UriMarker>;
+
+#[derive(PartialEq, Eq, Debug, Clone, Copy, Serialize, Deserialize)]
+pub struct NameMarker;
+/// `NameId` represents the ID of a non qualified name reference. For example
+///
+/// ```ruby
+/// module Foo
+///   class Bar
+///   end
+/// end
+/// ```
+///
+/// In here, the `NameId` for `Bar` is just the hashed `Bar` string, not `Foo::Bar`
+pub type NameId = Id<NameMarker>;

--- a/rust/index/src/model/integrity.rs
+++ b/rust/index/src/model/integrity.rs
@@ -95,7 +95,7 @@ mod tests {
     use crate::model::definitions::{Definition, ModuleDefinition};
     use crate::model::graph::Graph;
 
-    use crate::model::ids::NameId;
+    use crate::model::ids::DeclarationId;
     use crate::offset::Offset;
 
     #[test]
@@ -122,9 +122,9 @@ mod tests {
         checker.assert_integrity(&graph);
 
         let uri_id = graph.add_uri("file:///foo.rb".to_string());
-        let name_id = NameId::from("Foo");
+        let declaration_id = DeclarationId::from("Foo");
         let definition = Definition::Module(Box::new(ModuleDefinition::new(
-            name_id,
+            declaration_id,
             uri_id,
             Offset::new(0, 15),
             String::new(),

--- a/rust/index/src/model/references.rs
+++ b/rust/index/src/model/references.rs
@@ -1,5 +1,5 @@
 use crate::{
-    model::ids::{NameId, UriId},
+    model::ids::{DeclarationId, UriId},
     offset::Offset,
 };
 
@@ -22,14 +22,14 @@ pub enum UnresolvedReference {
 #[derive(Debug)]
 pub struct UnresolvedConstantRef {
     name: String,
-    nesting: Vec<NameId>,
+    nesting: Vec<DeclarationId>,
     uri_id: UriId,
     offset: Offset,
 }
 
 impl UnresolvedConstantRef {
     #[must_use]
-    pub fn new(name: String, nesting: Vec<NameId>, uri_id: UriId, offset: Offset) -> Self {
+    pub fn new(name: String, nesting: Vec<DeclarationId>, uri_id: UriId, offset: Offset) -> Self {
         Self {
             name,
             nesting,
@@ -44,7 +44,7 @@ impl UnresolvedConstantRef {
     }
 
     #[must_use]
-    pub fn nesting(&self) -> &[NameId] {
+    pub fn nesting(&self) -> &[DeclarationId] {
         &self.nesting
     }
 

--- a/rust/index/src/visualization/dot.rs
+++ b/rust/index/src/visualization/dot.rs
@@ -64,13 +64,16 @@ fn write_definition_nodes(output: &mut String, graph: &Graph) {
         .definitions()
         .iter()
         .filter_map(|(def_id, definition)| {
-            graph.declarations().get(definition.name_id()).map(|declaration| {
-                let def_type = definition.kind();
-                let escaped_name = escape_dot_string(declaration.name());
-                let label = format!("{def_type}({escaped_name})");
-                let line = format!("    \"def_{def_id}\" [label=\"{label}\",shape={DEFINITION_NODE_SHAPE}];\n");
-                (label, line)
-            })
+            graph
+                .declarations()
+                .get(definition.declaration_id())
+                .map(|declaration| {
+                    let def_type = definition.kind();
+                    let escaped_name = escape_dot_string(declaration.name());
+                    let label = format!("{def_type}({escaped_name})");
+                    let line = format!("    \"def_{def_id}\" [label=\"{label}\",shape={DEFINITION_NODE_SHAPE}];\n");
+                    (label, line)
+                })
         })
         .collect();
 


### PR DESCRIPTION
Trying to figure out the resolution phase, @jenny-codes, @Morriar and me figured out that we were missing one type of connection in our graph - that both Sorbet and Pyre have.

We currently don't have a connection between a `Declaration` and everything that it owns through an unqualified name. This makes it impossible to resolve constant references (the reason will be clearer in the next few PRs).

After a bit of studying we concluded that we actually need IDs for BOTH fully qualified names and unqualified names, to save memory on storing strings while representing all of the concepts we need.

This PR doesn't actually implement anything, it just renames `NameId` to `DeclarationId` (the ID of the global representation of an entity) and also _keeps_ `NameId` for unqualified references. The rename touches a lot of files, so I wanted to create a separate PR just for this.

Here's an example of what it will look like:

```ruby
module Foo    # DeclarationId(Foo), NameId(Foo)
  class Bar   # DeclarationId(Foo::Bar), NameId(Bar)
    CONST = 1 # DeclarationId(Foo::Bar::CONST), NameId(CONST)
  end
end
```