### PR TITLE
Add content_hash to load_uri query

### DIFF
--- a/rust/saturn/src/db/load_document.sql
+++ b/rust/saturn/src/db/load_document.sql
@@ -1,9 +1,10 @@
 SELECT
+    documents.content_hash,
     declarations.id,
     declarations.name,
     definitions.id,
     definitions.data
 FROM documents
-JOIN definitions ON documents.id = definitions.document_id
-JOIN declarations ON declarations.id = definitions.declaration_id
+LEFT JOIN definitions ON documents.id = definitions.document_id
+LEFT JOIN declarations ON declarations.id = definitions.declaration_id
 WHERE documents.id = ?

--- a/rust/saturn/src/model/graph.rs
+++ b/rust/saturn/src/model/graph.rs
@@ -141,7 +141,7 @@ impl Graph {
         let uri_id = self.add_uri(uri);
         let loaded_data = self.db.load_uri(uri_id)?;
 
-        for load_result in loaded_data {
+        for load_result in loaded_data.definitions {
             let declaration_id = load_result.declaration_id;
             let definition_id = load_result.definition_id;
 


### PR DESCRIPTION
This is to ensure we will always have a content hash for the Document
model.