### PR TITLE
Use unqualified NameIDs for tracking constant references

### DIFF
--- a/rust/saturn/src/indexing/ruby_indexer.rs
+++ b/rust/saturn/src/indexing/ruby_indexer.rs
@@ -7,7 +7,7 @@ use crate::model::definitions::{
     ModuleDefinition, Parameter, ParameterStruct,
 };
 use crate::model::graph::Graph;
-use crate::model::ids::{DeclarationId, UriId};
+use crate::model::ids::{DeclarationId, NameId, UriId};
 use crate::model::references::{UnresolvedConstantRef, UnresolvedReference};
 use crate::offset::Offset;
 use crate::source_location::SourceLocationConverter;
@@ -314,15 +314,16 @@ impl<'a> RubyIndexer<'a> {
     fn index_constant_reference(&mut self, location: &ruby_prism::Location) {
         let offset = Offset::from_prism_location(location);
         let name = Self::location_to_string(location);
+        let name_id = self.local_index.add_name(name);
         let nesting = self
             .nesting_stacks
             .last()
             .expect("There should always be at least one stack. This is a bug")
             .clone();
-        let name_id_nesting: Vec<DeclarationId> = nesting.iter().map(DeclarationId::from).collect();
+        let name_id_nesting: Vec<NameId> = nesting.iter().map(NameId::from).collect();
 
         let reference = UnresolvedReference::Constant(Box::new(UnresolvedConstantRef::new(
-            name,
+            name_id,
             name_id_nesting,
             self.uri_id,
             offset,

--- a/rust/saturn/src/model/references.rs
+++ b/rust/saturn/src/model/references.rs
@@ -1,5 +1,5 @@
 use crate::{
-    model::ids::{DeclarationId, UriId},
+    model::ids::{NameId, UriId},
     offset::Offset,
 };
 
@@ -8,30 +8,35 @@ pub enum UnresolvedReference {
     Constant(Box<UnresolvedConstantRef>),
 }
 
-// An unresolved constant reference is a usage of a constant in a context where we can't immediately determine what it
-// refers to. For example:
-//
-// ```ruby
-// module Foo
-//   BAR
-// end
-// ```
-//
-// Here, we don't immediately know if `BAR` refers to `Foo::BAR` or top level `BAR`. Until we resolve it, it is
-// considered an unresolved constant
+/// An unresolved constant reference is a usage of a constant in a context where we can't immediately determine what it
+/// refers to. For example:
+///
+/// ```ruby
+/// module Foo
+///   BAR
+/// end
+/// ```
+///
+/// Here, we don't immediately know if `BAR` refers to `Foo::BAR` or top level `BAR`. Until we resolve it, it is
+/// considered an unresolved constant
 #[derive(Debug)]
 pub struct UnresolvedConstantRef {
-    name: String,
-    nesting: Vec<DeclarationId>,
+    /// The unqualified name of the constant
+    name_id: NameId,
+    /// The nesting where we found the constant reference. This is a list of unqualified name IDs, so that we can
+    /// traverse the graph through the member relationships
+    nesting: Vec<NameId>,
+    /// The document where we found the reference
     uri_id: UriId,
+    /// The offsets inside of the document where we found the reference
     offset: Offset,
 }
 
 impl UnresolvedConstantRef {
     #[must_use]
-    pub fn new(name: String, nesting: Vec<DeclarationId>, uri_id: UriId, offset: Offset) -> Self {
+    pub fn new(name_id: NameId, nesting: Vec<NameId>, uri_id: UriId, offset: Offset) -> Self {
         Self {
-            name,
+            name_id,
             nesting,
             uri_id,
             offset,
@@ -39,12 +44,12 @@ impl UnresolvedConstantRef {
     }
 
     #[must_use]
-    pub fn name(&self) -> &str {
-        &self.name
+    pub fn name_id(&self) -> &NameId {
+        &self.name_id
     }
 
     #[must_use]
-    pub fn nesting(&self) -> &[DeclarationId] {
+    pub fn nesting(&self) -> &[NameId] {
         &self.nesting
     }
 


### PR DESCRIPTION
This PR continues the work to unlock constant resolution. This one adds an identity map of unqualified names using the `NameId` from #213 and starts using it for constant references.

With unqualified Name IDs + listing namespace members (next PR), we can actually resolve constant references based on lexical scope - unblocking a good chunk of the resolution phase.

**Note**: there's not much difference in terms of indexing time from this change, but memory was reduced quite a bit. Maybe we can store method parameter names as unqualified name ids too?

<details>
<summary>Benchmark on Core</summary>

```
BEFORE

Initialization      0.001s (  0.0%)
Listing             1.234s ( 34.1%)
Indexing            2.156s ( 59.5%)
Querying            0.230s (  6.4%)
Cleanup             0.000s (  0.0%)
Total:              3.621s

Indexed 87014 files
Found 700824 names
Found 894881 definitions
Found 87014 URIs
----------------------------------------
Maximum Resident Set Size: 708247552 bytes (675.43 MB)
Peak Memory Footprint:     685114280 bytes (653.37 MB)
Execution Time:            3.86 seconds

AFTER

Initialization      0.001s (  0.0%)
Listing             1.230s ( 33.4%)
Indexing            2.173s ( 59.0%)
Querying            0.277s (  7.5%)
Cleanup             0.000s (  0.0%)
Total:              3.681s

Indexed 87014 files
Found 700824 names
Found 894881 definitions
Found 87014 URIs
----------------------------------------
Maximum Resident Set Size: 577536000 bytes (550.78 MB)
Peak Memory Footprint:     551961392 bytes (526.39 MB)
Execution Time:            3.90 seconds
```

</details>