### PR TITLE
Add members mapping to declarations

### DIFF
--- a/rust/saturn/src/model/declaration.rs
+++ b/rust/saturn/src/model/declaration.rs
@@ -1,9 +1,22 @@
-use crate::model::ids::DefinitionId;
+use crate::model::{
+    identity_maps::IdentityHashMap,
+    ids::{DeclarationId, DefinitionId, NameId},
+};
 
+/// A `Declaration` represents the global concept of an entity in Ruby. For example, the class `Foo` may be defined 3
+/// times in different files and the `Foo` declaration is the combination of all of those definitions that contribute to
+/// the same fully qualified name
 #[derive(Debug)]
 pub struct Declaration {
+    /// The fully qualified name of this declaration
     name: String,
+    /// The list of definition IDs that compose this declaration
     definition_ids: Vec<DefinitionId>,
+    /// The entities that are owned by this declaration. For example, constants and methods that are defined inside of
+    /// the namespace. Note that this is a hashmap of unqualified name IDs to declaration IDs. That assists the
+    /// traversal of the graph when trying to resolve constant references or trying to discover which methods exist in a
+    /// class
+    members: IdentityHashMap<NameId, DeclarationId>,
 }
 
 impl Declaration {
@@ -12,6 +25,7 @@ impl Declaration {
         Self {
             name,
             definition_ids: Vec::new(),
+            members: IdentityHashMap::default(),
         }
     }
 
@@ -30,6 +44,20 @@ impl Declaration {
         &self.definition_ids
     }
 
+    #[must_use]
+    pub fn has_no_definitions(&self) -> bool {
+        self.definition_ids.is_empty()
+    }
+
+    pub fn add_definition(&mut self, definition_id: DefinitionId) {
+        debug_assert!(
+            !self.definition_ids.contains(&definition_id),
+            "Cannot add the same exact definition to a declaration twice. Duplicate definition IDs"
+        );
+
+        self.definition_ids.push(definition_id);
+    }
+
     // Deletes a definition from this declaration
     pub fn remove_definition(&mut self, definition_id: &DefinitionId) -> bool {
         if let Some(pos) = self.definition_ids.iter().position(|id| id == definition_id) {
@@ -41,18 +69,12 @@ impl Declaration {
         }
     }
 
-    #[must_use]
-    pub fn is_empty(&self) -> bool {
-        self.definition_ids.is_empty()
+    pub fn add_member(&mut self, name_id: NameId, declaration_id: DeclarationId) {
+        self.members.insert(name_id, declaration_id);
     }
 
-    pub fn add_definition(&mut self, definition_id: DefinitionId) {
-        debug_assert!(
-            !self.definition_ids.contains(&definition_id),
-            "Cannot add the same exact definition to a declaration twice. Duplicate definition IDs"
-        );
-
-        self.definition_ids.push(definition_id);
+    pub fn remove_member(&mut self, name_id: &NameId) -> Option<DeclarationId> {
+        self.members.remove(name_id)
     }
 }
 
@@ -70,5 +92,19 @@ mod tests {
         decl.add_definition(def_id);
 
         assert_eq!(decl.definitions().len(), 1);
+    }
+
+    #[test]
+    fn adding_and_removing_members() {
+        let mut decl = Declaration::new("Foo".to_string());
+        let member_name_id = NameId::from("Bar");
+        let member_decl_id = DeclarationId::from("Foo::Bar");
+
+        decl.add_member(member_name_id, member_decl_id);
+        assert_eq!(decl.members.len(), 1);
+
+        let removed = decl.remove_member(&member_name_id);
+        assert_eq!(removed, Some(member_decl_id));
+        assert_eq!(decl.members.len(), 0);
     }
 }

--- a/rust/saturn/src/model/graph.rs
+++ b/rust/saturn/src/model/graph.rs
@@ -227,7 +227,7 @@ impl Graph {
                 if let Some(definition) = self.definitions.remove(def_id)
                     && let Some(declaration) = self.declarations.get_mut(definition.declaration_id())
                     && declaration.remove_definition(def_id)
-                    && declaration.is_empty()
+                    && declaration.has_no_definitions()
                 {
                     self.declarations.remove(definition.declaration_id());
                     removed.declaration_ids.push(*definition.declaration_id());


### PR DESCRIPTION
Another step towards constant reference resolution. This PR adds the `members` mapping to the global declarations, so that we can keep track of what is "owned" by each namespace.

For example

```ruby
module Foo
  class Bar
    def baz; end
  end
end
```

In this case, `Foo` is a member of `Object` (which owns all top level constants), `Bar` is a member of `Foo` and `baz` is a member of `Bar`.

The connection is made with `NameId` (unqualified name) to `DeclarationId` (fully qualified name). This allows us to traverse the graph checking if something is defined at each step - which enables resolution.

**Note**: this is currently not being used. The reason is that we need more changes to the indexer to track a stack of owners. We need to remember which namespace we're currently inside to add new definitions as members. We don't currently track that, so I will follow up with a PR to do so, which allows us to populate the `members` map.