### PR TITLE
Make result local graph optional

### DIFF
--- a/rust/saturn/src/indexing/ruby_indexer.rs
+++ b/rust/saturn/src/indexing/ruby_indexer.rs
@@ -14,7 +14,7 @@ use crate::source_location::SourceLocationConverter;
 
 use ruby_prism::{ParseResult, Visit};
 
-pub type IndexerParts = (Graph, Vec<IndexingError>);
+pub type IndexerParts = (Option<Graph>, Vec<IndexingError>);
 
 const MAGIC_AND_RBS_COMMENT_PREFIX: &[&str] = &[
     "frozen_string_literal:",
@@ -70,7 +70,7 @@ impl<'a> RubyIndexer<'a> {
 
     #[must_use]
     pub fn into_parts(self) -> IndexerParts {
-        (self.local_graph, self.errors)
+        (Some(self.local_graph), self.errors)
     }
 
     pub fn add_error(&mut self, error: IndexingError) {

--- a/rust/saturn/src/test_utils/graph_test.rs
+++ b/rust/saturn/src/test_utils/graph_test.rs
@@ -20,7 +20,7 @@ impl GraphTest {
         let content_hash = crate::indexing::Document::calculate_content_hash(source.as_bytes());
         let mut indexer = RubyIndexer::new(uri.to_string(), &converter, source, content_hash);
         indexer.index();
-        indexer.into_parts().0
+        indexer.into_parts().0.unwrap()
     }
 
     pub fn index_uri(&mut self, uri: &str, source: &str) {


### PR DESCRIPTION
Currently when an error happens during file reading we will initialize a
RubyIndexer object, store the file reading errors, skip the indexing,
and return the empty local graph and the list of errors.

We can simplify it by making the local graph an optional return value,
and only return it when there is no error from the file reading step.
This way we save an RubyIndexer initialization as well as an attempt to
merge an empty local graph back to the global one.

This is also paving the way for the incremental sync which will start
skipping the indexing of existing files whose content have not changed.