### PR TITLE
Fix .clangd compile flags

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,2 +1,2 @@
 CompileFlags:
-    CompilationDatabase: ext/index
+    CompilationDatabase: ext/saturn


### PR DESCRIPTION
@alexcrocha I think we missed this one in the renaming