### PR TITLE
Error when trying to index a non existing file

### DIFF
--- a/rust/saturn/src/indexing.rs
+++ b/rust/saturn/src/indexing.rs
@@ -193,6 +193,7 @@ pub fn collect_documents(paths: Vec<String>) -> (Vec<Document>, Vec<IndexingErro
                     )));
                 }
             }
+
             continue;
         }
 
@@ -201,7 +202,11 @@ pub fn collect_documents(paths: Vec<String>) -> (Vec<Document>, Vec<IndexingErro
                 Ok(document) => documents.push(document),
                 Err(e) => errors.push(e),
             }
+
+            continue;
         }
+
+        errors.push(IndexingError::FileReadError(format!("Path '{path}' does not exist")));
     }
 
     (documents, errors)
@@ -280,6 +285,16 @@ mod tests {
         ]);
 
         assert!(documents.is_empty());
-        assert!(errors.is_empty());
+
+        assert_eq!(
+            errors
+                .iter()
+                .map(std::string::ToString::to_string)
+                .collect::<Vec<String>>(),
+            vec![format!(
+                "File read error: Path '{}/non_existing_path' does not exist",
+                context.absolute_path().display()
+            )]
+        );
     }
 }

--- a/test/graph_test.rb
+++ b/test/graph_test.rb
@@ -24,6 +24,12 @@ class GraphTest < Minitest::Test
     end
   end
 
+  def test_indexing_invalid_file_paths
+    graph = Saturn::Graph.new
+
+    assert_equal("File read error: Path 'not_found.rb' does not exist", graph.index_all(["not_found.rb"]))
+  end
+
   def test_passing_invalid_arguments_to_index_all
     graph = Saturn::Graph.new
 


### PR DESCRIPTION
If the user passes a path that doesn't exist, we should log an error if we can't index it.