### PR TITLE
Make utils C functions non-static

### DIFF
--- a/ext/saturn/utils.c
+++ b/ext/saturn/utils.c
@@ -1,0 +1,27 @@
+#include "utils.h"
+
+// Convert a Ruby array of strings into a double char pointer so that we can
+// pass that to Rust. This copies the data so it must be freed
+char **str_array_to_char(VALUE array, size_t length) {
+    char **converted_array = malloc(length * sizeof(char *));
+
+    for (size_t i = 0; i < length; i++) {
+        VALUE item = rb_ary_entry(array, i);
+        const char *string = StringValueCStr(item);
+
+        converted_array[i] = malloc(strlen(string) + 1);
+        strcpy(converted_array[i], string);
+    }
+
+    return converted_array;
+}
+
+// Verify that the Ruby object is an array of strings or raise `TypeError`
+void check_array_of_strings(VALUE array) {
+    Check_Type(array, T_ARRAY);
+
+    for (long i = 0; i < RARRAY_LEN(array); i++) {
+        VALUE item = rb_ary_entry(array, i);
+        Check_Type(item, T_STRING);
+    }
+}

--- a/ext/saturn/utils.h
+++ b/ext/saturn/utils.h
@@ -5,28 +5,9 @@
 
 // Convert a Ruby array of strings into a double char pointer so that we can
 // pass that to Rust. This copies the data so it must be freed
-static char **str_array_to_char(VALUE array, size_t length) {
-    char **converted_array = malloc(length * sizeof(char *));
-
-    for (size_t i = 0; i < length; i++) {
-        VALUE item = rb_ary_entry(array, i);
-        const char *string = StringValueCStr(item);
-
-        converted_array[i] = malloc(strlen(string) + 1);
-        strcpy(converted_array[i], string);
-    }
-
-    return converted_array;
-}
+char **str_array_to_char(VALUE array, size_t length);
 
 // Verify that the Ruby object is an array of strings or raise `TypeError`
-static void check_array_of_strings(VALUE array) {
-    Check_Type(array, T_ARRAY);
-
-    for (long i = 0; i < RARRAY_LEN(array); i++) {
-        VALUE item = rb_ary_entry(array, i);
-        Check_Type(item, T_STRING);
-    }
-}
+void check_array_of_strings(VALUE array);
 
 #endif // SATURN_UTILS_H


### PR DESCRIPTION
I think it's the better way to answer: https://github.com/Shopify/saturn/pull/231/files#r2449094923.

By making them not static the get reused across C files instead of duplicated.