### PR TITLE
Use Scope object to keep track of nesting chain

### DIFF
--- a/rust/saturn/src/indexing.rs
+++ b/rust/saturn/src/indexing.rs
@@ -18,8 +18,10 @@ use std::{
 use std::{sync::mpsc, thread};
 use url::Url;
 use xxhash_rust::xxh3::xxh3_64;
+
 pub mod errors;
 pub mod ruby_indexer;
+pub mod scope;
 
 // Represents a document to be indexed. If `source` is `Some(String)`, we're indexing a file state that's not committed
 // to disk yet and should then use the given `source` instead of reading from disk

--- a/rust/saturn/src/indexing/scope.rs
+++ b/rust/saturn/src/indexing/scope.rs
@@ -1,0 +1,288 @@
+use crate::model::ids::DeclarationId;
+use std::sync::Arc;
+
+/// The nesting structure is a linked list that represents the chain of lexical scopes we found. This is used to resolve
+/// constant references and always links scopes based on their fully qualified name with whatever scope came before.
+/// Take the following example:
+///
+/// ```ruby
+/// module Foo
+///   CONST = 42
+///
+///   class ::Bar
+///     CONST # resolves to Foo::CONST because we're inside the `Foo` namespace
+///   end
+/// end
+///
+/// class Bar
+///   CONST # NameError because this `Bar` is not lexically inside `Foo`
+/// end
+///
+/// ```
+///
+/// In this example, the top level definition of `::Bar` has the fully qualified name `Bar`, but it is _still_ lexically
+/// connected to `Foo` for purposes of constant resolution. The code in the example does not crash and properly finds
+/// `Foo::CONST`. Therefore, to properly resolve constants, we need to remember the exact chain of lexical scopes we
+/// entered, independentally if the fully qualified name was reset by a top level reference.
+#[derive(Debug)]
+pub struct Nesting {
+    /// The parent scope if any
+    parent: Option<Arc<Nesting>>,
+    /// The declaration ID based on the fully qualified name of this scope
+    declaration_id: DeclarationId,
+}
+
+impl Nesting {
+    #[must_use]
+    pub fn new(parent: Option<Arc<Nesting>>, declaration_id: DeclarationId) -> Self {
+        Self { parent, declaration_id }
+    }
+
+    #[must_use]
+    pub fn declaration_id(&self) -> &DeclarationId {
+        &self.declaration_id
+    }
+
+    #[must_use]
+    pub fn parent(&self) -> &Option<Arc<Nesting>> {
+        &self.parent
+    }
+
+    #[cfg(test)]
+    #[must_use]
+    pub fn ids_as_vec(&self) -> Vec<DeclarationId> {
+        if let Some(parent) = &self.parent {
+            let mut vec = parent.ids_as_vec();
+            vec.push(self.declaration_id);
+            vec
+        } else {
+            vec![self.declaration_id]
+        }
+    }
+}
+
+/// The Scope structure maintains both the `Nesting` linked list of all lexical scopes we encountered and a name stack,
+/// so that we can compute fully qualified names ahead of time for all entries in the graph and their respective
+/// declaration IDs
+#[derive(Default)]
+pub struct Scope {
+    /// A vector of **fully qualified names**. For example:
+    ///
+    /// ```ruby
+    /// module Foo
+    ///   class ::Bar
+    ///   end
+    ///   class Baz::Qux
+    ///   end
+    /// end
+    /// ```
+    ///
+    /// Results in the stack being: `["Foo", "Bar", "Foo::Baz::Qux"]`
+    name_stack: Vec<String>,
+    /// The current chain of lexical scopes
+    nesting: Option<Arc<Nesting>>,
+}
+
+impl Scope {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            name_stack: Vec::new(),
+            nesting: None,
+        }
+    }
+
+    #[must_use]
+    pub fn nesting(&self) -> &Option<Arc<Nesting>> {
+        &self.nesting
+    }
+
+    /// Fully qualify the given name according to the current scope. Takes top level references into account. For example:
+    ///
+    /// ```ruby
+    /// module Foo
+    ///   # fully_qualify("Bar") => "Foo::Bar"
+    ///   # fully_qualify("::Bar") => "Bar"
+    ///   class Baz
+    ///     # fully_qualify("::Qux") => "Qux"
+    ///     # fully_qualify("Qux") => "Foo::Baz::Qux"
+    ///   end
+    /// end
+    /// ```
+    #[must_use]
+    pub fn fully_qualify(&self, name: &str) -> String {
+        if let Some(trimmed) = name.strip_prefix("::") {
+            trimmed.to_string()
+        } else if let Some(previous) = self.name_stack.last() {
+            format!("{previous}::{name}")
+        } else {
+            name.to_string()
+        }
+    }
+
+    /// Enters a new namespace (module or class), modifying the scope accordingly
+    pub fn enter(&mut self, name: &str) -> (String, DeclarationId) {
+        let fully_qualified_name = self.fully_qualify(name);
+        let id = DeclarationId::from(&fully_qualified_name);
+        self.name_stack.push(fully_qualified_name.clone());
+        self.enter_nesting(id);
+        (fully_qualified_name, id)
+    }
+
+    /// Leaves the current namespace, restoring the previous scope
+    pub fn leave(&mut self) {
+        self.name_stack.pop();
+
+        if let Some(current) = &self.nesting {
+            self.nesting = current.parent.as_ref().map(Arc::clone);
+        }
+    }
+
+    fn enter_nesting(&mut self, declaration_id: DeclarationId) {
+        if let Some(current) = &self.nesting {
+            let new_nesting = Arc::new(Nesting::new(Some(Arc::clone(current)), declaration_id));
+            self.nesting = Some(new_nesting);
+        } else {
+            let new_nesting = Arc::new(Nesting::new(None, declaration_id));
+            self.nesting = Some(new_nesting);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn regular_nesting() {
+        let mut scope = Scope::new();
+
+        // Foo
+        let (name, id) = scope.enter("Foo");
+        assert_eq!(name, String::from("Foo"));
+        assert_eq!(id, DeclarationId::from("Foo"));
+        assert_eq!(
+            scope.nesting.as_ref().unwrap().ids_as_vec(),
+            vec![DeclarationId::from("Foo")]
+        );
+
+        // Bar
+        let (name, id) = scope.enter("Bar");
+        assert_eq!(name, String::from("Foo::Bar"));
+        assert_eq!(id, DeclarationId::from("Foo::Bar"));
+        assert_eq!(
+            scope.nesting.as_ref().unwrap().ids_as_vec(),
+            vec![DeclarationId::from("Foo"), DeclarationId::from("Foo::Bar")]
+        );
+
+        scope.leave();
+        assert_eq!(
+            scope.nesting.as_ref().unwrap().ids_as_vec(),
+            vec![DeclarationId::from("Foo")]
+        );
+        assert_eq!(scope.fully_qualify("CONST"), String::from("Foo::CONST"));
+
+        scope.leave();
+    }
+
+    #[test]
+    fn compact_namespace_nesting() {
+        let mut scope = Scope::new();
+
+        // Foo
+        let (name, id) = scope.enter("Foo");
+        assert_eq!(name, String::from("Foo"));
+        assert_eq!(id, DeclarationId::from("Foo"));
+        assert_eq!(
+            scope.nesting.as_ref().unwrap().ids_as_vec(),
+            vec![DeclarationId::from("Foo")]
+        );
+
+        // Bar::Baz
+        let (name, id) = scope.enter("Bar::Baz");
+        assert_eq!(name, String::from("Foo::Bar::Baz"));
+        assert_eq!(id, DeclarationId::from("Foo::Bar::Baz"));
+        assert_eq!(scope.fully_qualify("CONST"), String::from("Foo::Bar::Baz::CONST"));
+        assert_eq!(
+            scope.nesting.as_ref().unwrap().ids_as_vec(),
+            vec![DeclarationId::from("Foo"), DeclarationId::from("Foo::Bar::Baz")]
+        );
+
+        scope.leave();
+        assert_eq!(
+            scope.nesting.as_ref().unwrap().ids_as_vec(),
+            vec![DeclarationId::from("Foo")]
+        );
+        assert_eq!(scope.fully_qualify("CONST"), String::from("Foo::CONST"));
+
+        scope.leave();
+    }
+
+    #[test]
+    fn top_level_nesting() {
+        let mut scope = Scope::new();
+
+        // Foo
+        let (name, id) = scope.enter("Foo");
+        assert_eq!(name, String::from("Foo"));
+        assert_eq!(id, DeclarationId::from("Foo"));
+
+        assert_eq!(
+            scope.nesting.as_ref().unwrap().ids_as_vec(),
+            vec![DeclarationId::from("Foo")]
+        );
+
+        // ::Bar
+        let (name, id) = scope.enter("::Bar");
+        assert_eq!(name, String::from("Bar"));
+        assert_eq!(id, DeclarationId::from("Bar"));
+        assert_eq!(scope.fully_qualify("CONST"), String::from("Bar::CONST"));
+        assert_eq!(
+            scope.nesting.as_ref().unwrap().ids_as_vec(),
+            vec![DeclarationId::from("Foo"), DeclarationId::from("Bar")]
+        );
+
+        scope.leave();
+        assert_eq!(
+            scope.nesting.as_ref().unwrap().ids_as_vec(),
+            vec![DeclarationId::from("Foo")]
+        );
+        assert_eq!(scope.fully_qualify("CONST"), String::from("Foo::CONST"));
+
+        scope.leave();
+    }
+
+    #[test]
+    fn top_level_compact_nesting() {
+        let mut scope = Scope::new();
+
+        // Foo
+        let (name, id) = scope.enter("Foo");
+        assert_eq!(name, String::from("Foo"));
+        assert_eq!(id, DeclarationId::from("Foo"));
+
+        assert_eq!(
+            scope.nesting.as_ref().unwrap().ids_as_vec(),
+            vec![DeclarationId::from("Foo")]
+        );
+
+        // ::Bar::Baz
+        let (name, id) = scope.enter("::Bar::Baz");
+        assert_eq!(name, String::from("Bar::Baz"));
+        assert_eq!(id, DeclarationId::from("Bar::Baz"));
+        assert_eq!(scope.fully_qualify("CONST"), String::from("Bar::Baz::CONST"));
+        assert_eq!(
+            scope.nesting.as_ref().unwrap().ids_as_vec(),
+            vec![DeclarationId::from("Foo"), DeclarationId::from("Bar::Baz")]
+        );
+
+        scope.leave();
+        assert_eq!(
+            scope.nesting.as_ref().unwrap().ids_as_vec(),
+            vec![DeclarationId::from("Foo")]
+        );
+        assert_eq!(scope.fully_qualify("CONST"), String::from("Foo::CONST"));
+
+        scope.leave();
+    }
+}

--- a/rust/saturn/src/model/declaration.rs
+++ b/rust/saturn/src/model/declaration.rs
@@ -89,6 +89,11 @@ impl Declaration {
     pub fn remove_member(&mut self, name_id: &NameId) -> Option<DeclarationId> {
         self.members.remove(name_id)
     }
+
+    #[must_use]
+    pub fn get_member(&self, name_id: &NameId) -> Option<&DeclarationId> {
+        self.members.get(name_id)
+    }
 }
 
 #[cfg(test)]

--- a/rust/saturn/src/model/references.rs
+++ b/rust/saturn/src/model/references.rs
@@ -1,4 +1,7 @@
+use std::sync::Arc;
+
 use crate::{
+    indexing::scope::Nesting,
     model::ids::{NameId, UriId},
     offset::Offset,
 };
@@ -7,9 +10,9 @@ use crate::{
 pub struct ConstantReference {
     /// The unqualified name of the constant
     name_id: NameId,
-    /// The nesting where we found the constant reference. This is a list of unqualified name IDs, so that we can
-    /// traverse the graph through the member relationships
-    nesting: Vec<NameId>,
+    /// The nesting where we found the constant reference. This is a chain of nesting objects representing the lexical
+    /// scopes surrounding the reference
+    nesting: Option<Arc<Nesting>>,
     /// The document where we found the reference
     uri_id: UriId,
     /// The offsets inside of the document where we found the reference
@@ -40,7 +43,7 @@ pub enum ResolvedReference {
 
 impl ConstantReference {
     #[must_use]
-    pub fn new(name_id: NameId, nesting: Vec<NameId>, uri_id: UriId, offset: Offset) -> Self {
+    pub fn new(name_id: NameId, nesting: Option<Arc<Nesting>>, uri_id: UriId, offset: Offset) -> Self {
         Self {
             name_id,
             nesting,
@@ -55,7 +58,7 @@ impl ConstantReference {
     }
 
     #[must_use]
-    pub fn nesting(&self) -> &[NameId] {
+    pub fn nesting(&self) -> &Option<Arc<Nesting>> {
         &self.nesting
     }
 


### PR DESCRIPTION
This PR introduces a `Scope` object. This structure has the responsibility to track scope information that we need to build our graph. I tried to be thorough in documenting it to avoid confusion, but please let me know how we can make it clearer.

Basically, this is how `Scope` keeps track of things:

```ruby
# Values are name_stack | nesting

module Foo # ["Foo"] | { DeclarationId(Foo), parent: None }
  class ::Bar  # ["Bar"] | { DeclarationId(Bar), parent: Scope(Foo) }
  end
  # ["Foo"] | { DeclarationId(Foo), parent: None }


  class Baz::Qux # ["Foo::Baz::Qux"] | { DeclarationId([Foo](Foo::Baz::Qux)), parent: Scope(Foo) }
  end
end
```

All names in the stack are always fully qualified and the `Nesting` is a linked list to represent the chain of lexical scopes we find. There's one major gotcha here to pay attention. Consider this:

```ruby
module Foo
  CONST = 42
  class ::Bar
    CONST
  end
end
```
This code does not crash, it works as intended. The reason is because a top level reference resets the fully qualified name, **but not the lexical scope chain**. This was a lightbulb moment for me during implementation. We need to adjust the names for top level references, but lexical scopes should always be linked directly as we find them in the code.

With this code, we can finally properly resolve constants based on lexical scope. All we have to do is traverse the chain of nestings checking if any of them have the constant defined as part of their `members` hash (**we still need to populate members though**).


<details>
<summary>Benchmarks (minor performance difference, some good memory savings)</summary>

```
BEFORE
Initialization      0.002s (  0.1%)
Listing             1.273s ( 36.5%)
Indexing            2.207s ( 63.4%)
Cleanup             0.001s (  0.0%)
Total:              3.482s
Maximum Resident Set Size: 663404544 bytes (632.67 MB)
Peak Memory Footprint:     635208520 bytes (605.78 MB)
Execution Time:            4.05 seconds
---------
AFTER
Initialization      0.003s (  0.1%)
Listing             1.266s ( 36.9%)
Indexing            2.166s ( 63.1%)
Cleanup             0.001s (  0.0%)
Total:              3.436s
Maximum Resident Set Size: 598786048 bytes (571.04 MB)
Peak Memory Footprint:     574800688 bytes (548.17 MB)
Execution Time:            4.01 seconds
```

</details>