### PR TITLE
Add memory stats to `--stats` output

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -843,6 +843,7 @@ dependencies = [
  "bytecount",
  "clap",
  "glob",
+ "libc",
  "predicates",
  "regex",
  "rmp-serde",

--- a/rust/saturn/Cargo.toml
+++ b/rust/saturn/Cargo.toml
@@ -21,6 +21,7 @@ serde = { version = "1.0", features = ["derive"] }
 rmp-serde = "1.3.0"
 glob = "0.3.2"
 bytecount = "0.6.9"
+libc = "0.2"
 
 [dev-dependencies]
 tempfile = "3.0"

--- a/rust/saturn/src/lib.rs
+++ b/rust/saturn/src/lib.rs
@@ -1,7 +1,7 @@
 pub mod indexing;
 pub mod model;
 pub mod offset;
-pub mod timer;
+pub mod stats;
 pub mod visualization;
 pub mod source_location;
 

--- a/rust/saturn/src/main.rs
+++ b/rust/saturn/src/main.rs
@@ -5,7 +5,7 @@ use clap::Parser;
 use saturn::{
     indexing::{self, errors::MultipleErrors},
     model::graph::Graph,
-    timer::{Timer, time_it},
+    stats::{memory::MemoryStats, timer::{Timer, time_it}},
     visualization::dot,
 };
 
@@ -87,6 +87,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     if args.stats {
         Timer::print_breakdown();
+        MemoryStats::print_memory_usage();
     }
 
     // Generate visualization or print statistics

--- a/rust/saturn/src/stats.rs
+++ b/rust/saturn/src/stats.rs
@@ -1,0 +1,2 @@
+pub mod memory;
+pub mod timer;

--- a/rust/saturn/src/stats/memory.rs
+++ b/rust/saturn/src/stats/memory.rs
@@ -1,0 +1,71 @@
+use std::io;
+
+#[cfg(unix)]
+use libc::{RUSAGE_SELF, getrusage, rusage};
+
+/// Memory statistics for the current process
+#[derive(Debug, Clone, Copy)]
+pub struct MemoryStats {
+    /// Maximum resident set size in bytes
+    pub max_rss_bytes: i64,
+}
+
+impl MemoryStats {
+    /// Get current memory statistics using getrusage
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the `getrusage` system call fails.
+    #[cfg(unix)]
+    pub fn current() -> Result<Self, io::Error> {
+        unsafe {
+            let mut usage = std::mem::MaybeUninit::<rusage>::uninit();
+            let result = getrusage(RUSAGE_SELF, usage.as_mut_ptr());
+
+            if result == 0 {
+                let usage = usage.assume_init();
+                // On macOS and BSD, ru_maxrss is in bytes
+                // On Linux, ru_maxrss is in kilobytes
+                let max_rss_bytes = if cfg!(target_os = "linux") {
+                    usage.ru_maxrss * 1024
+                } else {
+                    usage.ru_maxrss
+                };
+
+                Ok(Self { max_rss_bytes })
+            } else {
+                Err(io::Error::last_os_error())
+            }
+        }
+    }
+
+    /// Get current memory statistics (not supported on non-Unix platforms)
+    ///
+    /// # Errors
+    ///
+    /// Returns an error on non-Unix platforms where memory statistics are not supported.
+    #[cfg(not(unix))]
+    pub fn current() -> Result<Self, io::Error> {
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "Memory statistics not supported on this platform",
+        ))
+    }
+
+    /// Print memory statistics in a human-readable format
+    #[allow(clippy::cast_precision_loss)]
+    pub fn print(&self) {
+        let mrss_mb = self.max_rss_bytes as f64 / 1024.0 / 1024.0;
+
+        println!("Maximum RSS: {} bytes ({:.2} MB)", self.max_rss_bytes, mrss_mb);
+        println!();
+    }
+
+    /// Retrieve and print memory usage statistics
+    pub fn print_memory_usage() {
+        match Self::current() {
+            Ok(stats) => stats.print(),
+            Err(e) => eprintln!("Warning: Could not retrieve memory statistics: {e}"),
+        }
+    }
+}

--- a/rust/saturn/src/stats/timer.rs
+++ b/rust/saturn/src/stats/timer.rs
@@ -72,16 +72,15 @@ macro_rules! make_timer {
 
                     println!();
                     println!("Timing breakdown");
-                    println!();
 
                     $(
                         if timer.$phase != Duration::ZERO {
-                            println!("{}", format_breakdown!($label, timer.$phase, total_duration));
+                            println!("  {}", format_breakdown!($label, timer.$phase, total_duration));
                         }
                     )*
 
-                    println!("{}", format_breakdown!("Cleanup", cleanup, total_duration));
-                    println!("Total:           {:8.3}s", total_duration.as_secs_f64());
+                    println!("  {}", format_breakdown!("Cleanup", cleanup, total_duration));
+                    println!("  Total:           {:8.3}s", total_duration.as_secs_f64());
                     println!();
                 }
             }
@@ -93,7 +92,7 @@ macro_rules! make_timer {
                 ($phase, $body:block) => {
                     {
                         let timer_enabled = {
-                            let guard = $crate::timer::TIMER.lock().unwrap();
+                            let guard = $crate::stats::timer::TIMER.lock().unwrap();
                             guard.is_some()
                         };
 
@@ -102,7 +101,7 @@ macro_rules! make_timer {
                             let result = $body;
                             let elapsed = start.elapsed();
 
-                            if let Some(ref mut timer) = *$crate::timer::TIMER.lock().unwrap() {
+                            if let Some(ref mut timer) = *$crate::stats::timer::TIMER.lock().unwrap() {
                                 timer.$phase = elapsed;
                             }
                             result


### PR DESCRIPTION
Old output with `mem-use` + `--stats`

```
Query statistics

Total declarations:         38736
With documentation:         1734 (4.5%)
Without documentation:      37002 (95.5%)
Total documentation size:   293289 bytes
Multi-definition names:     894 (2.3%)

Definition breakdown:
  Method                19617
  InstanceVariable       7030
  Class                  6244
  Module                 5887
  Constant               3490
  AttrReader             1186
  AttrAccessor            988
  AttrWriter               51
  GlobalVariable            6
  ClassVariable             3

Timing breakdown

Initialization      0.002s (  0.5%)
Listing             0.031s (  8.9%)
Indexing            0.093s ( 26.7%)
Querying            0.004s (  1.3%)
Database            0.219s ( 62.6%)
Cleanup             0.000s (  0.0%)
Total:              0.350s

Indexed 4652 files
Found 38736 names
Found 44502 definitions
Found 4652 URIs
----------------------------------------
Maximum Resident Set Size: 46497792 bytes (44.34 MB)
Peak Memory Footprint:     40437184 bytes (38.56 MB)
Execution Time:            0.37 seconds
```

New `--stats` output:

```
Query statistics

Total declarations:         38736
With documentation:         1734 (4.5%)
Without documentation:      37002 (95.5%)
Total documentation size:   293289 bytes
Multi-definition names:     894 (2.3%)

Definition breakdown:
  Method                19617
  InstanceVariable       7030
  Class                  6244
  Module                 5887
  Constant               3490
  AttrReader             1186
  AttrAccessor            988
  AttrWriter               51
  GlobalVariable            6
  ClassVariable             3

Timing breakdown
  Initialization      0.002s (  0.4%)
  Listing             0.035s (  8.8%)
  Indexing            0.144s ( 36.2%)
  Querying            0.005s (  1.2%)
  Database            0.213s ( 53.3%)
  Cleanup             0.000s (  0.0%)
  Total:              0.399s

  Maximum RSS: 46989312 bytes (44.81 MB)

Indexed 4652 files
Found 38736 names
Found 44502 definitions
Found 4652 URIs
```