### PR TITLE
Populate declaration members

### DIFF
--- a/rust/saturn/src/indexing/scope.rs
+++ b/rust/saturn/src/indexing/scope.rs
@@ -92,6 +92,15 @@ impl Scope {
         }
     }
 
+    /// Returns the declaration ID for the current nesting or `None` if we're not inside any namespace. It's important
+    /// to let the client of this method handle `None` because different concepts handle it differently. For example,
+    /// constants defined at the top level are members of `Object`, but methods defined at the top level are members of
+    /// the special <main> object
+    #[must_use]
+    pub fn current_nesting_id(&self) -> Option<DeclarationId> {
+        self.nesting.as_ref().map(|n| *n.declaration_id())
+    }
+
     #[must_use]
     pub fn nesting(&self) -> &Option<Arc<Nesting>> {
         &self.nesting

--- a/rust/saturn/src/model/db.rs
+++ b/rust/saturn/src/model/db.rs
@@ -426,6 +426,8 @@ mod tests {
             .unwrap()
             .query_row((), |row| row.get(0))
             .unwrap();
-        assert_eq!(name_count, 0,);
+
+        // Only the declaration for <main> should remain
+        assert_eq!(name_count, 1);
     }
 }

--- a/rust/saturn/src/model/declaration.rs
+++ b/rust/saturn/src/model/declaration.rs
@@ -36,6 +36,7 @@ impl Declaration {
     // Extend this declaration with more definitions by moving `other.definition_ids` inside
     pub fn extend(&mut self, other: Declaration) {
         self.definition_ids.extend(other.definition_ids);
+        self.members.extend(other.members);
     }
 
     #[must_use]
@@ -80,6 +81,11 @@ impl Declaration {
         } else {
             false
         }
+    }
+
+    #[must_use]
+    pub fn members(&self) -> &IdentityHashMap<NameId, DeclarationId> {
+        &self.members
     }
 
     pub fn add_member(&mut self, name_id: NameId, declaration_id: DeclarationId) {

--- a/rust/saturn/src/model/integrity.rs
+++ b/rust/saturn/src/model/integrity.rs
@@ -110,8 +110,8 @@ mod tests {
     fn test_integrity_check_with_custom_rule() {
         let mut checker = IntegrityChecker::new();
 
-        checker.add_rule("Index must be empty", |index, errors| {
-            if !index.declarations().is_empty() {
+        checker.add_rule("Index must be empty except for <main>", |index, errors| {
+            if index.declarations().len() != 1 || index.declarations().get(&DeclarationId::from("<main>")).is_none() {
                 errors.push("Index is not empty".to_string());
             }
         });

--- a/rust/saturn/src/visualization/dot.rs
+++ b/rust/saturn/src/visualization/dot.rs
@@ -149,6 +149,7 @@ mod tests {
             r#"digraph {{
     rankdir=TB;
 
+    "Name:<main>" [label="<main>",shape=hexagon];
     "Name:TestClass" [label="TestClass",shape=hexagon];
     "Name:TestClass" -> "def_{class_def_id}" [dir=both];
     "Name:TestModule" [label="TestModule",shape=hexagon];

--- a/test/graph_test.rb
+++ b/test/graph_test.rb
@@ -88,9 +88,9 @@ class GraphTest < Minitest::Test
 
       enumerator = graph.declarations
 
-      assert_equal(2, enumerator.size)
-      assert_equal(2, enumerator.count)
-      assert_equal(2, enumerator.to_a.size)
+      assert_equal(3, enumerator.size)
+      assert_equal(3, enumerator.count)
+      assert_equal(3, enumerator.to_a.size)
     end
   end
 
@@ -107,7 +107,7 @@ class GraphTest < Minitest::Test
         declarations << declaration
       end
 
-      assert_equal(2, declarations.size)
+      assert_equal(3, declarations.size)
     end
   end
 


### PR DESCRIPTION
Start populating the members of each declaration. Being able to inspect which members exist in each global declaration allows us to perform constant resolution, but also provide completion based on what's available within the current context.

This is still missing the logic to handle deletions, but with this we're able to implement resolving constants based on lexical scopes.

### Implementation

An important aspect of the implementation that I had to test out is what things are associated to when they are defined in the top level. There are essentially two cases:

1. Constants of any kind (modules, classes and other constants) are associated to `Object` when defined at the top level
2. Anything else (instance variables, methods and so on) get associated to `<main>`. Ruby uses a special instance of the `Object` class to represent its top level. Performing some tests on a script, you can get a better sense for the behaviour

I started adding the `<main>`​ declaration artificially since it doesn't actually exist anywhere, it's created by Ruby [here](https://github.com/ruby/ruby/blob/9ad902e55c610e66114f528f77f7895295a242de/vm.c#L4693). This is equivalent to Sorbet's `<root>`, but I figured why not call it the same as Ruby does.

```ruby
attr_reader :foo # => crash! <main> is an instance of `Object` and therefore attr_* methods don't exist
@@class_var = 123 # => crash! can't use class variables on <main>

def foo; end

foo() # ok! `foo` was defined in the <main> instance

obj = Object.new
obj.foo # crash! `foo` is not defined in the `Object` class
```