### PR TITLE
Make document serializable

### DIFF
--- a/rust/saturn/src/db/load_document.sql
+++ b/rust/saturn/src/db/load_document.sql
@@ -1,5 +1,5 @@
 SELECT
-    documents.content_hash,
+    documents.data,
     declarations.id,
     declarations.name,
     definitions.id,

--- a/rust/saturn/src/db/schema.sql
+++ b/rust/saturn/src/db/schema.sql
@@ -1,26 +1,26 @@
 -- SQLite schema for the index database
--- Contains tables and indexes for storing code declarations and their relationships
 
--- Table for storing documents
 CREATE TABLE IF NOT EXISTS documents (
+    -- Queryable fields
     id INTEGER PRIMARY KEY,  -- Hashed document ID
-    uri TEXT NOT NULL UNIQUE,
-    content_hash INTEGER NOT NULL
+    content_hash INTEGER NOT NULL,
+    -- Serialized struct
+    data BLOB NOT NULL
 );
 
--- Table for storing code declarations (classes, modules, methods, etc.)
 CREATE TABLE IF NOT EXISTS declarations (
+    -- Queryable fields
     id INTEGER PRIMARY KEY,  -- Hashed declaration ID
     name TEXT NOT NULL
 );
 
--- Table for storing definitions that make up declarations
 CREATE TABLE IF NOT EXISTS definitions (
+    -- Queryable fields
     id INTEGER PRIMARY KEY,  -- Hashed definition ID
     declaration_id INTEGER NOT NULL,
     document_id INTEGER NOT NULL,
-    data BLOB NOT NULL -- Serialized definition data
+    -- Serialized struct
+    data BLOB NOT NULL
 );
 
--- Indexes for fast lookups
 CREATE INDEX IF NOT EXISTS names_name_index ON declarations (name);

--- a/rust/saturn/src/model/definitions.rs
+++ b/rust/saturn/src/model/definitions.rs
@@ -105,6 +105,25 @@ impl Definition {
     pub fn comments(&self) -> &Vec<Comment> {
         all_definitions!(self, it => &it.comments)
     }
+
+    /// Serializes the definition into the byte vector we store in the database
+    ///
+    /// # Panics
+    ///
+    /// This method will only panic if serialization fails, which should never happen
+    #[must_use]
+    pub fn serialize(&self) -> Vec<u8> {
+        rmp_serde::to_vec(self).expect("Serializing document should always succeed")
+    }
+
+    /// # Panics
+    ///
+    /// This method will only panic if serialization fails, which should never happen unless there's corrupt data stored
+    /// in the database
+    #[must_use]
+    pub fn deserialize(data: &[u8]) -> Self {
+        rmp_serde::from_slice(data).expect("Deserializing document should always succeed")
+    }
 }
 
 /// A class definition

--- a/rust/saturn/src/model/document.rs
+++ b/rust/saturn/src/model/document.rs
@@ -1,8 +1,9 @@
 use crate::model::ids::DefinitionId;
+use serde::{Deserialize, Serialize};
 
 // Represents a document currently loaded into memory. Identified by its unique URI, it holds the edges to all
 // definitions discovered in it
-#[derive(Debug)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct Document {
     uri: String,
     definition_ids: Vec<DefinitionId>,
@@ -41,6 +42,25 @@ impl Document {
         );
 
         self.definition_ids.push(definition_id);
+    }
+
+    /// Serializes the document into the byte vector we store in the database
+    ///
+    /// # Panics
+    ///
+    /// This method will only panic if serialization fails, which should never happen
+    #[must_use]
+    pub fn serialize(&self) -> Vec<u8> {
+        rmp_serde::to_vec(self).expect("Serializing document should always succeed")
+    }
+
+    /// # Panics
+    ///
+    /// This method will only panic if serialization fails, which should never happen unless there's corrupt data stored
+    /// in the database
+    #[must_use]
+    pub fn deserialize(data: &[u8]) -> Self {
+        rmp_serde::from_slice(data).expect("Deserializing document should always succeed")
     }
 }
 


### PR DESCRIPTION
I noticed that I forgot to add `members` handling for the database and that got me thinking that something in our approach to the db wasn't right. I think the issue clicked for me now.

If we keep queryable fields separate from the serialized structures (even if minimal duplication is required), loading things from the database becomes trivial and requires no code changes when adding more fields to an existing struct.

For example, we can make `Declaration` serializable and _still_ keep `name` as a separate column for query only purposes, which allows the load logic to be extremely simple while still allowing the queries we need.

This PR makes `Document` serializable and adds the `serialize` and `deserialize` convenience methods. `Declaration` is a bit more complicated, so I'll do it in a follow up PR.