### PR TITLE
Make declaration serializable

### DIFF
--- a/rust/saturn/Cargo.toml
+++ b/rust/saturn/Cargo.toml
@@ -17,7 +17,7 @@ url = "2.5.4"
 rusqlite = { version = "0.37.0", features = ["bundled"] }
 xxhash-rust = { version = "0.8.15", features = ["xxh3"] }
 clap = { version = "4.5.16", features = ["derive"] }
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1.0", features = ["derive", "rc"] }
 rmp-serde = "1.3.0"
 glob = "0.3.2"
 bytecount = "0.6.9"

--- a/rust/saturn/src/db/load_document.sql
+++ b/rust/saturn/src/db/load_document.sql
@@ -1,7 +1,7 @@
 SELECT
     documents.data,
     declarations.id,
-    declarations.name,
+    declarations.data,
     definitions.id,
     definitions.data
 FROM documents

--- a/rust/saturn/src/db/schema.sql
+++ b/rust/saturn/src/db/schema.sql
@@ -11,7 +11,9 @@ CREATE TABLE IF NOT EXISTS documents (
 CREATE TABLE IF NOT EXISTS declarations (
     -- Queryable fields
     id INTEGER PRIMARY KEY,  -- Hashed declaration ID
-    name TEXT NOT NULL
+    name TEXT NOT NULL,
+    -- Serialized struct
+    data BLOB NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS definitions (

--- a/rust/saturn/src/indexing/scope.rs
+++ b/rust/saturn/src/indexing/scope.rs
@@ -1,4 +1,5 @@
 use crate::model::ids::DeclarationId;
+use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 /// The nesting structure is a linked list that represents the chain of lexical scopes we found. This is used to resolve
@@ -24,7 +25,7 @@ use std::sync::Arc;
 /// connected to `Foo` for purposes of constant resolution. The code in the example does not crash and properly finds
 /// `Foo::CONST`. Therefore, to properly resolve constants, we need to remember the exact chain of lexical scopes we
 /// entered, independentally if the fully qualified name was reset by a top level reference.
-#[derive(Debug)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct Nesting {
     /// The parent scope if any
     parent: Option<Arc<Nesting>>,

--- a/rust/saturn/src/model.rs
+++ b/rust/saturn/src/model.rs
@@ -9,3 +9,4 @@ pub mod identity_maps;
 pub mod ids;
 pub mod integrity;
 pub mod references;
+pub mod serializable;

--- a/rust/saturn/src/model/declaration.rs
+++ b/rust/saturn/src/model/declaration.rs
@@ -2,12 +2,14 @@ use crate::model::{
     identity_maps::IdentityHashMap,
     ids::{DeclarationId, DefinitionId, NameId},
     references::ResolvedReference,
+    serializable::Serializable,
 };
+use serde::{Deserialize, Serialize};
 
 /// A `Declaration` represents the global concept of an entity in Ruby. For example, the class `Foo` may be defined 3
 /// times in different files and the `Foo` declaration is the combination of all of those definitions that contribute to
 /// the same fully qualified name
-#[derive(Debug)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct Declaration {
     /// The fully qualified name of this declaration
     name: String,
@@ -37,6 +39,7 @@ impl Declaration {
     pub fn extend(&mut self, other: Declaration) {
         self.definition_ids.extend(other.definition_ids);
         self.members.extend(other.members);
+        self.references.extend(other.references);
     }
 
     #[must_use]
@@ -101,6 +104,8 @@ impl Declaration {
         self.members.get(name_id)
     }
 }
+
+impl Serializable for Declaration {}
 
 #[cfg(test)]
 mod tests {

--- a/rust/saturn/src/model/definitions.rs
+++ b/rust/saturn/src/model/definitions.rs
@@ -29,6 +29,7 @@ use crate::{
     model::{
         comment::Comment,
         ids::{DeclarationId, UriId},
+        serializable::Serializable,
     },
     offset::Offset,
 };
@@ -105,26 +106,9 @@ impl Definition {
     pub fn comments(&self) -> &Vec<Comment> {
         all_definitions!(self, it => &it.comments)
     }
-
-    /// Serializes the definition into the byte vector we store in the database
-    ///
-    /// # Panics
-    ///
-    /// This method will only panic if serialization fails, which should never happen
-    #[must_use]
-    pub fn serialize(&self) -> Vec<u8> {
-        rmp_serde::to_vec(self).expect("Serializing document should always succeed")
-    }
-
-    /// # Panics
-    ///
-    /// This method will only panic if serialization fails, which should never happen unless there's corrupt data stored
-    /// in the database
-    #[must_use]
-    pub fn deserialize(data: &[u8]) -> Self {
-        rmp_serde::from_slice(data).expect("Deserializing document should always succeed")
-    }
 }
+
+impl Serializable for Definition {}
 
 /// A class definition
 ///

--- a/rust/saturn/src/model/document.rs
+++ b/rust/saturn/src/model/document.rs
@@ -1,4 +1,4 @@
-use crate::model::ids::DefinitionId;
+use crate::model::{ids::DefinitionId, serializable::Serializable};
 use serde::{Deserialize, Serialize};
 
 // Represents a document currently loaded into memory. Identified by its unique URI, it holds the edges to all
@@ -43,26 +43,9 @@ impl Document {
 
         self.definition_ids.push(definition_id);
     }
-
-    /// Serializes the document into the byte vector we store in the database
-    ///
-    /// # Panics
-    ///
-    /// This method will only panic if serialization fails, which should never happen
-    #[must_use]
-    pub fn serialize(&self) -> Vec<u8> {
-        rmp_serde::to_vec(self).expect("Serializing document should always succeed")
-    }
-
-    /// # Panics
-    ///
-    /// This method will only panic if serialization fails, which should never happen unless there's corrupt data stored
-    /// in the database
-    #[must_use]
-    pub fn deserialize(data: &[u8]) -> Self {
-        rmp_serde::from_slice(data).expect("Deserializing document should always succeed")
-    }
 }
+
+impl Serializable for Document {}
 
 #[cfg(test)]
 mod tests {

--- a/rust/saturn/src/model/graph.rs
+++ b/rust/saturn/src/model/graph.rs
@@ -211,15 +211,17 @@ impl Graph {
         self.documents.entry(uri_id).or_insert_with(|| loaded_data.document);
 
         for load_result in loaded_data.definitions {
-            let declaration_id = load_result.declaration_id;
-            let definition_id = load_result.definition_id;
+            match self.declarations.entry(load_result.declaration_id) {
+                Entry::Vacant(entry) => {
+                    entry.insert(load_result.declaration);
+                }
+                Entry::Occupied(mut entry) => {
+                    entry.get_mut().extend(load_result.declaration);
+                }
+            }
 
-            self.declarations
-                .entry(declaration_id)
-                .or_insert_with(|| Declaration::new(load_result.name))
-                .add_definition(definition_id);
-
-            self.definitions.insert(definition_id, load_result.definition);
+            self.definitions
+                .insert(load_result.definition_id, load_result.definition);
         }
 
         Ok(())

--- a/rust/saturn/src/model/references.rs
+++ b/rust/saturn/src/model/references.rs
@@ -1,12 +1,12 @@
-use std::sync::Arc;
-
 use crate::{
     indexing::scope::Nesting,
     model::ids::{NameId, UriId},
     offset::Offset,
 };
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct ConstantReference {
     /// The unqualified name of the constant
     name_id: NameId,
@@ -19,7 +19,7 @@ pub struct ConstantReference {
     offset: Offset,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Serialize, Deserialize)]
 pub enum UnresolvedReference {
     /// An unresolved constant reference is a usage of a constant in a context where we can't immediately determine what it
     /// refers to. For example:
@@ -36,7 +36,7 @@ pub enum UnresolvedReference {
     Constant(Box<ConstantReference>),
 }
 
-#[derive(Debug)]
+#[derive(Debug, Serialize, Deserialize)]
 pub enum ResolvedReference {
     Constant(Box<ConstantReference>),
 }

--- a/rust/saturn/src/model/serializable.rs
+++ b/rust/saturn/src/model/serializable.rs
@@ -1,0 +1,22 @@
+use serde::{Deserialize, Serialize};
+
+pub trait Serializable: Serialize + for<'a> Deserialize<'a> {
+    /// Serializes the entity into the byte vector we store in the database
+    ///
+    /// # Panics
+    ///
+    /// This method will only panic if serialization fails, which should never happen
+    #[must_use]
+    fn serialize(&self) -> Vec<u8> {
+        rmp_serde::to_vec(self).expect("Serializing document should always succeed")
+    }
+
+    /// # Panics
+    ///
+    /// This method will only panic if serialization fails, which should never happen unless there's corrupt data stored
+    /// in the database
+    #[must_use]
+    fn deserialize(data: &[u8]) -> Self {
+        rmp_serde::from_slice(data).expect("Deserializing document should always succeed")
+    }
+}


### PR DESCRIPTION
This PR makes `Declaration` serializable, which fixes the fact that we're not remembering `references` or `members` in the database. Through the same principle as in #264, it also simplifies loading things a bit further and I want to follow up with a PR that should make this even more straightforward.

Two points to this PR:

1. We need to enable the `rc` feature from `serde` to be able to serialize `Nesting`
2. I noticed that the serialize/deserialize convenience methods are identical no matter what struct we define them on, so I extracted that to a trait that can only be applied to structs that already derive `Serialize` and `Deserialize`