### PR TITLE
Add owner_id relationship to declarations

### DIFF
--- a/rust/saturn/src/model/declaration.rs
+++ b/rust/saturn/src/model/declaration.rs
@@ -22,16 +22,19 @@ pub struct Declaration {
     members: IdentityHashMap<NameId, DeclarationId>,
     /// The list of references that are made to this declaration
     references: Vec<ResolvedReference>,
+    /// The ID of the owner of this declaration
+    owner_id: DeclarationId,
 }
 
 impl Declaration {
     #[must_use]
-    pub fn new(name: String) -> Self {
+    pub fn new(name: String, owner_id: DeclarationId) -> Self {
         Self {
             name,
             definition_ids: Vec::new(),
             members: IdentityHashMap::default(),
             references: Vec::new(),
+            owner_id,
         }
     }
 
@@ -103,6 +106,11 @@ impl Declaration {
     pub fn get_member(&self, name_id: &NameId) -> Option<&DeclarationId> {
         self.members.get(name_id)
     }
+
+    #[must_use]
+    pub fn owner_id(&self) -> &DeclarationId {
+        &self.owner_id
+    }
 }
 
 impl Serializable for Declaration {}
@@ -114,7 +122,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "Cannot add the same exact definition to a declaration twice. Duplicate definition IDs")]
     fn inserting_duplicate_definitions() {
-        let mut decl = Declaration::new("MyDecl".to_string());
+        let mut decl = Declaration::new("MyDecl".to_string(), DeclarationId::from("Object"));
         let def_id = DefinitionId::new(123);
 
         decl.add_definition(def_id);
@@ -125,7 +133,7 @@ mod tests {
 
     #[test]
     fn adding_and_removing_members() {
-        let mut decl = Declaration::new("Foo".to_string());
+        let mut decl = Declaration::new("Foo".to_string(), DeclarationId::from("Object"));
         let member_name_id = NameId::from("Bar");
         let member_decl_id = DeclarationId::from("Foo::Bar");
 

--- a/rust/saturn/src/model/graph.rs
+++ b/rust/saturn/src/model/graph.rs
@@ -39,7 +39,8 @@ impl Graph {
         let mut declarations = IdentityHashMap::default();
         // Insert the magic top level self <main> object into the graph, so that we can associate global variables or
         // definitions made at the top level with it
-        declarations.insert(DeclarationId::from("<main>"), Declaration::new(String::from("<main>")));
+        let main_id = DeclarationId::from("<main>");
+        declarations.insert(main_id, Declaration::new(String::from("<main>"), main_id));
 
         Self {
             declarations,
@@ -161,14 +162,14 @@ impl Graph {
     }
 
     // Registers a definition into the `Graph`, automatically creating all relationships
-    pub fn add_definition(&mut self, name: String, definition: Definition) {
+    pub fn add_definition(&mut self, name: String, definition: Definition, owner_id: &DeclarationId) {
         let uri_id = *definition.uri_id();
         let definition_id = DefinitionId::from(&format!("{uri_id}{}{}", definition.start(), &name));
         let declaration_id = *definition.declaration_id();
 
         self.declarations
             .entry(declaration_id)
-            .or_insert_with(|| Declaration::new(name))
+            .or_insert_with(|| Declaration::new(name, *owner_id))
             .add_definition(definition_id);
         self.definitions.insert(definition_id, definition);
         self.documents

--- a/rust/saturn/src/model/integrity.rs
+++ b/rust/saturn/src/model/integrity.rs
@@ -129,7 +129,7 @@ mod tests {
             Offset::new(0, 15),
             Vec::new(),
         )));
-        graph.add_definition("Foo".to_string(), definition);
+        graph.add_definition("Foo".to_string(), definition, &DeclarationId::from("Object"));
 
         // Should fail since the index is not empty
         let errors = checker.apply(&graph);


### PR DESCRIPTION
We're now indexing the `members` information, but we have no way of removing entries from it when someone deletes an existing definition. To be able to work backwards from the definition to the members that must be cleaned, we need the reverse of the `members` relationship.

This PR introduces the `owner_id` to declarations, so that we can walk the graph in the opposite direction as well. I'll follow up with the PR to delete `members` entries when definitions are removed, which should be the last piece in managing the `members` data.