### PR TITLE
Resolve constant from lexical scope and add resolution stats

### DIFF
--- a/rust/saturn/src/lib.rs
+++ b/rust/saturn/src/lib.rs
@@ -1,9 +1,9 @@
 pub mod indexing;
 pub mod model;
 pub mod offset;
+pub mod source_location;
 pub mod stats;
 pub mod visualization;
-pub mod source_location;
 
 #[cfg(test)]
 pub mod test_utils;

--- a/rust/saturn/src/main.rs
+++ b/rust/saturn/src/main.rs
@@ -90,6 +90,9 @@ fn main() -> Result<(), Box<dyn Error>> {
     }
 
     if args.stats {
+        time_it!(resolving, {
+            graph.print_resolution_statistics();
+        });
         time_it!(querying, {
             graph.print_query_statistics();
         });
@@ -108,7 +111,6 @@ fn main() -> Result<(), Box<dyn Error>> {
         println!("Found {} names", graph.declarations().len());
         println!("Found {} definitions", graph.definitions().len());
         println!("Found {} URIs", graph.documents().len());
-        println!("Found {} references", graph.unresolved_references().len());
     }
 
     Ok(())

--- a/rust/saturn/src/source_location.rs
+++ b/rust/saturn/src/source_location.rs
@@ -6,6 +6,11 @@ pub struct Position {
 
 impl Position {
     #[must_use]
+    pub const fn new(line: u32, column: u32) -> Self {
+        Self { line, column }
+    }
+
+    #[must_use]
     pub const fn line(&self) -> u32 {
         self.line
     }

--- a/rust/saturn/src/stats.rs
+++ b/rust/saturn/src/stats.rs
@@ -1,2 +1,9 @@
 pub mod memory;
 pub mod timer;
+
+/// Helper function to compute percentage
+#[allow(clippy::cast_precision_loss)]
+#[must_use]
+pub fn percentage(numerator: usize, denominator: usize) -> f64 {
+    (numerator as f64 / denominator as f64) * 100.0
+}

--- a/rust/saturn/src/stats/timer.rs
+++ b/rust/saturn/src/stats/timer.rs
@@ -121,6 +121,7 @@ make_timer! {
     setup, "Initialization";
     listing, "Listing";
     indexing, "Indexing";
+    resolving, "Resolving";
     querying, "Querying";
     integrity_check, "Integrity Check";
     database, "Database";

--- a/rust/saturn/src/test_utils/graph_test.rs
+++ b/rust/saturn/src/test_utils/graph_test.rs
@@ -1,17 +1,23 @@
 use super::normalize_indentation;
 use crate::indexing::ruby_indexer::RubyIndexer;
 use crate::model::graph::Graph;
-use crate::source_location::UTF8SourceLocationConverter;
+use crate::offset::Offset;
+use crate::source_location::{Position, SourceLocationConverter, UTF8SourceLocationConverter};
+use std::collections::HashMap;
 
 #[derive(Default)]
 pub struct GraphTest {
     pub graph: Graph,
+    sources: HashMap<String, String>,
 }
 
 impl GraphTest {
     #[must_use]
     pub fn new() -> Self {
-        Self { graph: Graph::new() }
+        Self {
+            graph: Graph::new(),
+            sources: HashMap::new(),
+        }
     }
 
     #[must_use]
@@ -26,11 +32,147 @@ impl GraphTest {
     pub fn index_uri(&mut self, uri: &str, source: &str) {
         let source = normalize_indentation(source);
         let local_index = Self::index_source(uri, &source);
+        self.sources.insert(uri.to_string(), source);
         self.graph.update(local_index);
     }
 
     pub fn delete_uri(&mut self, uri: &str) {
+        self.sources.remove(uri);
         self.graph.unload_uri(uri);
+    }
+
+    /// Gets the source code for a URI
+    #[must_use]
+    pub fn get_source(&self, uri: &str) -> Option<&str> {
+        self.sources.get(uri).map(String::as_str)
+    }
+
+    /// Parses a location string like `<file:///foo.rb:3:0-3:5>` into `(uri, start_offset, end_offset)`
+    ///
+    /// Format: uri:start_line:start_column-end_line:end_column
+    /// Line and column numbers are 0-indexed
+    ///
+    /// # Panics
+    ///
+    /// Panics if the location format is invalid, the URI has no source, or the positions are invalid.
+    #[must_use]
+    pub fn parse_location(&self, location: &str) -> (String, u32, u32) {
+        let (uri, start_position, end_position) = Self::parse_location_positions(location);
+        let converter = self.converter_for(uri.as_str());
+
+        let start_offset = converter.byte_offset_from_position(start_position).unwrap_or_else(|| {
+            panic!(
+                "Invalid start position: {}:{}",
+                start_position.line(),
+                start_position.column()
+            )
+        });
+
+        let end_offset = converter.byte_offset_from_position(end_position).unwrap_or_else(|| {
+            panic!(
+                "Invalid end position: {}:{}",
+                end_position.line(),
+                end_position.column()
+            )
+        });
+
+        (uri, start_offset, end_offset)
+    }
+
+    /// Asserts that the given offset matches the expected offset, providing clear error messages
+    /// with line:column positions when they don't match
+    ///
+    /// # Panics
+    ///
+    /// Panics if the source is not found for the URI, byte offsets are invalid, or if the actual
+    /// offset doesn't match the expected offset.
+    pub fn assert_offset_matches(
+        &self,
+        uri: &str,
+        actual_offset: &Offset,
+        expected_start: u32,
+        expected_end: u32,
+        context_message: &str,
+        location: &str,
+    ) {
+        let converter = self.converter_for(uri);
+        let expected_offset = Offset::new(expected_start, expected_end);
+
+        if actual_offset.start() == expected_start && actual_offset.end() == expected_end {
+            return;
+        }
+
+        let (actual_start_pos, actual_end_pos) = converter
+            .offset_to_position(actual_offset)
+            .unwrap_or_else(|| panic!("Invalid byte offset"));
+        let (expected_start_pos, expected_end_pos) = converter
+            .offset_to_position(&expected_offset)
+            .unwrap_or_else(|| panic!("Invalid byte offset"));
+
+        assert!(
+            actual_offset.start() == expected_start,
+            "Start position mismatch for {} at {}\n  actual:   {}\n  expected: {}",
+            context_message,
+            location,
+            Self::format_position(actual_start_pos),
+            Self::format_position(expected_start_pos)
+        );
+
+        assert!(
+            actual_offset.end() == expected_end,
+            "End position mismatch for {} at {}\n  actual:   {}\n  expected: {}",
+            context_message,
+            location,
+            Self::format_position(actual_end_pos),
+            Self::format_position(expected_end_pos)
+        );
+    }
+
+    fn converter_for(&self, uri: &str) -> UTF8SourceLocationConverter<'_> {
+        let source = self
+            .get_source(uri)
+            .unwrap_or_else(|| panic!("Source not found for URI: {uri}"));
+        UTF8SourceLocationConverter::new(source)
+    }
+
+    fn parse_location_positions(location: &str) -> (String, Position, Position) {
+        let trimmed = location.trim().trim_start_matches('<').trim_end_matches('>');
+
+        let (start_part, end_part) = trimmed.rsplit_once('-').unwrap_or_else(|| {
+            panic!("Invalid location format: {location} (expected uri:start_line:start_column-end_line:end_column)")
+        });
+
+        let (start_prefix, start_column_str) = start_part
+            .rsplit_once(':')
+            .unwrap_or_else(|| panic!("Invalid location format: missing start column in {location}"));
+        let (uri, start_line_str) = start_prefix
+            .rsplit_once(':')
+            .unwrap_or_else(|| panic!("Invalid location format: missing start line in {location}"));
+
+        let (end_line_str, end_column_str) = end_part
+            .split_once(':')
+            .unwrap_or_else(|| panic!("Invalid location format: missing end line or column in {location}"));
+
+        let start_line = Self::parse_number(start_line_str, "start line", location);
+        let start_column = Self::parse_number(start_column_str, "start column", location);
+        let end_line = Self::parse_number(end_line_str, "end line", location);
+        let end_column = Self::parse_number(end_column_str, "end column", location);
+
+        (
+            uri.to_string(),
+            Position::new(start_line, start_column),
+            Position::new(end_line, end_column),
+        )
+    }
+
+    fn parse_number(value: &str, field: &str, location: &str) -> u32 {
+        value
+            .parse()
+            .unwrap_or_else(|_| panic!("Invalid {field} '{value}' in location {location}"))
+    }
+
+    fn format_position(position: Position) -> String {
+        format!("line {}, column {}", position.line(), position.column())
     }
 }
 


### PR DESCRIPTION
Resolution stats from Core

```
Overall reference counts:
  Total resolved:         936883
  Total unresolved:       3134499
  Total references:       4071382
  Resolution ratio:       23.0%
```

Entire stats from Core

```
Resolution statistics

Overall reference counts:
  Total resolved:         936883
  Total unresolved:       3134499
  Total references:       4071382
  Resolution ratio:       23.0%

Query statistics
  Total declarations:         697238
  With documentation:         79357 (11.4%)
  Without documentation:      617881 (88.6%)
  Total documentation size:   224973 bytes
  Multi-definition names:     14931 (2.1%)

Definition breakdown:
  Method               321831
  InstanceVariable     182242
  Module               178383
  Class                102105
  Constant              61709
  AttrReader            31875
  AttrAccessor          11766
  AttrWriter              384
  GlobalVariable           30
  ClassVariable            11

Timing breakdown
  Initialization      0.002s (  0.0%)
  Listing             0.946s (  5.4%)
  Indexing            3.814s ( 21.7%)
  Resolving           0.157s (  0.9%)
  Querying            0.201s (  1.1%)
  Database           10.678s ( 60.7%)
  Cleanup             1.789s ( 10.2%)
  Total:             17.587s

Maximum RSS: 736673792 bytes (702.55 MB)

Indexed 86587 files
Found 697238 names
Found 890336 definitions
Found 86587 URIs
```

We don't actually resolve and store any reference in non-stats mode for now. 
But if we do, the max RSS can grow a bit: `654.95 MB` -> `702.55 MB`.