### PR TITLE
Replace unnecessary clones with moves

### DIFF
--- a/rust/saturn/src/indexing/ruby_indexer.rs
+++ b/rust/saturn/src/indexing/ruby_indexer.rs
@@ -649,7 +649,7 @@ impl Visit<'_> for RubyIndexer<'_> {
                             writer_declaration_id,
                             indexer.uri_id,
                             Offset::from_prism_location(&location),
-                            comments.clone(),
+                            comments,
                         ))),
                     );
                 }

--- a/rust/saturn/src/main.rs
+++ b/rust/saturn/src/main.rs
@@ -46,7 +46,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     });
 
     let (documents, errors) = time_it!(listing, {
-        let (documents, errors) = indexing::collect_documents(vec![args.dir.clone()]);
+        let (documents, errors) = indexing::collect_documents(vec![args.dir]);
         Ok::<_, Box<dyn Error>>((documents, errors))
     })?;
 


### PR DESCRIPTION
I found an extra `clone()` and went looking for more. This PR replaces unnecessary clones with moves for better memory efficiency.

- `ruby_indexer.rs`: Reduce double clone of `comments` to single clone, and move on final use
- `main.rs`: Move `args.dir` instead of cloning on final use since `args.dir` isn't used after `collect_documents()`
- `indexing.rs`: Consume documents instead of borrowing to avoid cloning `document.source`
  - Changed `index_document` closure to take ownership of Document
  - `read_document_source` now consumes the document and moves out the source string when present
  - Updated `with_parallel_workers` signature to match the ownership changes

This change did not have much of an impact in performance. See benchmarking in Core below:
<details><summary>Benchmarking Core Image</summary>

<img width="959" height="58" alt="image" src="https://github.com/user-attachments/assets/51cfdb94-e18c-4ebc-a295-a1fbc60dbd17" />

</details> 