### PR TITLE
Remove duplicated `Document` concept

### DIFF
--- a/rust/saturn-sys/src/graph_api.rs
+++ b/rust/saturn-sys/src/graph_api.rs
@@ -53,7 +53,7 @@ pub unsafe extern "C" fn sat_index_all(
     let file_paths: Vec<String> = unsafe { utils::convert_double_pointer_to_vec(file_paths, count).unwrap() };
     let mut all_errors = Vec::new();
 
-    let (documents, document_errors) = indexing::collect_documents(file_paths);
+    let (documents, document_errors) = indexing::collect_file_paths(file_paths);
     all_errors.extend(document_errors);
 
     with_graph(pointer, |graph| {

--- a/rust/saturn/src/main.rs
+++ b/rust/saturn/src/main.rs
@@ -60,13 +60,13 @@ fn main() -> Result<(), Box<dyn Error>> {
         graph
     });
 
-    let (documents, errors) = time_it!(listing, { indexing::collect_documents(vec![args.dir]) });
+    let (file_paths, errors) = time_it!(listing, { indexing::collect_file_paths(vec![args.dir]) });
 
     if !errors.is_empty() {
         return Err(Box::new(MultipleErrors(errors)));
     }
 
-    time_it!(indexing, { indexing::index_in_parallel(&mut graph, documents) })?;
+    time_it!(indexing, { indexing::index_in_parallel(&mut graph, file_paths) })?;
 
     // Run integrity checks if requested
     if args.check_integrity {

--- a/rust/saturn/src/test_utils/graph_test.rs
+++ b/rust/saturn/src/test_utils/graph_test.rs
@@ -17,7 +17,7 @@ impl GraphTest {
     #[must_use]
     fn index_source(uri: &str, source: &str) -> Graph {
         let converter = UTF8SourceLocationConverter::new(source);
-        let content_hash = crate::indexing::Document::calculate_content_hash(source.as_bytes());
+        let content_hash = crate::indexing::calculate_content_hash(source.as_bytes());
         let mut indexer = RubyIndexer::new(uri.to_string(), &converter, source, content_hash);
         indexer.index();
         indexer.into_parts().0.unwrap()


### PR DESCRIPTION
The `Document` here was bringing a few issues:

- Name confusion with the main `Document` struct we store in the graph
- We kept passing from a path to a uri back to a path for no reason
- The struct field `source` was hinting at memoization but we were not really using it

I removed the struct and simplifed the approach by just calling local functions.

There is still some complexity I want to address in a follow up.

Comparison on huge corpus:

|  | Before | After |
| --- | --- | --- |
| time | 19\.236s | 18\.977s |
| mmrs | 8831\.52 MB | 8409\.31 MB |

Comparison on Shopify:

|  | Before | After |
| --- | --- | --- |
| time | 3\.039s | 3\.015s |
| mmrs | 702\.42 MB | 655\.72 MB |

