### PR TITLE
Use unique IDs for unresolved references

### DIFF
--- a/rust/saturn/src/indexing/ruby_indexer.rs
+++ b/rust/saturn/src/indexing/ruby_indexer.rs
@@ -1014,9 +1014,27 @@ mod tests {
         };
     }
 
+    fn collect_unresolved_references(graph: &Graph) -> Vec<&UnresolvedReference> {
+        let mut unresolved_references = graph.unresolved_references().values().collect::<Vec<_>>();
+
+        unresolved_references.sort_by_key(|r| match r {
+            UnresolvedReference::Constant(constant) => (
+                graph.documents().get(&constant.uri_id()).unwrap().uri().to_string(),
+                constant.offset().start(),
+                graph.names().get(constant.name_id()).unwrap(),
+            ),
+            UnresolvedReference::Method(method) => (
+                graph.documents().get(&method.uri_id()).unwrap().uri().to_string(),
+                method.offset().start(),
+                graph.names().get(method.name_id()).unwrap(),
+            ),
+        });
+
+        unresolved_references
+    }
+
     fn collect_constant_reference_names(graph: &Graph) -> Vec<&String> {
-        graph
-            .unresolved_references()
+        collect_unresolved_references(graph)
             .iter()
             .filter_map(|r| match r {
                 UnresolvedReference::Constant(constant) => Some(graph.names().get(constant.name_id()).unwrap()),
@@ -1026,8 +1044,7 @@ mod tests {
     }
 
     fn collect_method_reference_names(graph: &Graph) -> Vec<&String> {
-        graph
-            .unresolved_references()
+        collect_unresolved_references(graph)
             .iter()
             .filter_map(|r| match r {
                 UnresolvedReference::Constant(_) => None,
@@ -2071,7 +2088,7 @@ mod tests {
             "
         });
 
-        let refs = context.graph.unresolved_references();
+        let refs = context.graph.unresolved_references().values().collect::<Vec<_>>();
         assert_eq!(refs.len(), 2);
 
         let reference = &refs[0];
@@ -2123,7 +2140,7 @@ mod tests {
             "
         });
 
-        let refs = context.graph.unresolved_references();
+        let refs = context.graph.unresolved_references().values().collect::<Vec<_>>();
         assert_eq!(refs.len(), 1);
 
         let reference = &refs[0];
@@ -2158,7 +2175,7 @@ mod tests {
             "
         });
 
-        let refs = context.graph.unresolved_references();
+        let refs = context.graph.unresolved_references().values().collect::<Vec<_>>();
         assert_eq!(refs.len(), 2);
 
         let reference = &refs[0];
@@ -2384,7 +2401,7 @@ mod tests {
             collect_method_reference_names(&context.graph),
             vec![
                 "m1", "m2", "m3", "m4", "m5", "m6", "m7", "m8", "m9", "m10", "m11", "m12", "m13", "m14", "m15", "m16",
-                "m17", "m18", "m19", "m20", "m21", "m22", "m23", "m24", "m25", "m26", "m27", "!", "m28", "m29", "m30",
+                "m17", "m18", "m19", "m20", "m21", "m22", "m23", "m24", "m25", "m26", "!", "m27", "m28", "m29", "m30",
                 "m31", "m32", "m33", "m34", "m35", "m36", "[]", "m37", "m38", "m39", "m40", "m41", "m42", "m43", "m44",
                 "m45", "m46", "m47", "m48", "m49", "m50"
             ]
@@ -2522,7 +2539,7 @@ mod tests {
 
         assert_eq!(
             collect_method_reference_names(&context.graph),
-            vec!["x", ">", "<=>", "y"]
+            vec!["x", "<=>", ">", "y"]
         );
     }
 
@@ -2538,7 +2555,7 @@ mod tests {
 
         assert_eq!(
             collect_method_reference_names(&context.graph),
-            vec!["x", ">=", "<=>", "y"]
+            vec!["x", "<=>", ">=", "y"]
         );
     }
 

--- a/rust/saturn/src/model/ids.rs
+++ b/rust/saturn/src/model/ids.rs
@@ -29,3 +29,9 @@ pub struct NameMarker;
 ///
 /// In here, the `NameId` for `Bar` is just the hashed `Bar` string, not `Foo::Bar`
 pub type NameId = Id<NameMarker>;
+
+#[derive(PartialEq, Eq, Debug, Clone, Copy, Serialize, Deserialize)]
+pub struct ReferenceMarker;
+/// `ReferenceId` represents the ID of a reference occurrence in a file.
+/// It is built from the reference kind, `uri_id` and the reference `offset`.
+pub type ReferenceId = Id<ReferenceMarker>;

--- a/rust/saturn/src/model/references.rs
+++ b/rust/saturn/src/model/references.rs
@@ -1,6 +1,6 @@
 use crate::{
     indexing::scope::Nesting,
-    model::ids::{NameId, UriId},
+    model::ids::{NameId, ReferenceId, UriId},
     offset::Offset,
 };
 use serde::{Deserialize, Serialize};
@@ -63,6 +63,36 @@ pub enum UnresolvedReference {
 pub enum ResolvedReference {
     Constant(Box<ConstantReference>),
     Method(Box<MethodReference>),
+}
+
+impl UnresolvedReference {
+    #[must_use]
+    pub fn id(&self) -> ReferenceId {
+        match self {
+            UnresolvedReference::Constant(constant) => {
+                // C:<uri_id>:<start>-<end>
+                let key = format!(
+                    "C:{}:{}:{}-{}",
+                    constant.name_id(),
+                    constant.uri_id(),
+                    constant.offset().start(),
+                    constant.offset().end()
+                );
+                ReferenceId::from(&key)
+            }
+            UnresolvedReference::Method(method) => {
+                // M:<uri_id>:<start>-<end>
+                let key = format!(
+                    "M:{}:{}:{}-{}",
+                    method.name_id(),
+                    method.uri_id(),
+                    method.offset().start(),
+                    method.offset().end()
+                );
+                ReferenceId::from(&key)
+            }
+        }
+    }
 }
 
 impl ConstantReference {


### PR DESCRIPTION
Iterating from Ruby on unresolved references without the ID handle trick is painful, I think we need to create unique IDs for the references.

Take this simple script:

```rb
graph = Saturn::Graph.new
graph.index_all([path])

refs = graph.unresolved_references
  .grep(Saturn::UnresolvedConstantReference)
  .select { |ref| ref.name.include?("Shopify") }

puts "Selected: #{refs.size}"
```

Here's a comparison of performances between an array of references and an array of reference ids:

```
# array of references

Maximum Resident Set Size: 7427211264 bytes (7083.14 MB)
Peak Memory Footprint:     9216089600 bytes (8789.14 MB)
Execution Time:            1301.68 seconds

# array of ID handles

Maximum Resident Set Size: 2281750528 bytes (2176.04 MB)    x3.2 smaller
Peak Memory Footprint:     1567594496 bytes (1494.97 MB)    x5.8 smaller
Execution Time:            125.06 seconds                   x10.4 faster
```