### PR TITLE
Sync indexing result with database

### DIFF
--- a/rust/saturn/src/indexing.rs
+++ b/rust/saturn/src/indexing.rs
@@ -1,7 +1,7 @@
 use crate::{
     errors::{Errors, MultipleErrors},
     indexing::ruby_indexer::{IndexerParts, RubyIndexer},
-    model::{graph::Graph, ids::UriId},
+    model::{graph::Graph, identity_maps::IdentityHashSet, ids::UriId},
     source_location::UTF8SourceLocationConverter,
 };
 use glob::glob;
@@ -102,10 +102,18 @@ fn index_and_sync(graph: &mut Graph, file_paths: Vec<String>) -> Result<(), Mult
         }
     };
 
+    let mut deleted_uris: IdentityHashSet<UriId> = cached_hashes.keys().copied().collect();
+    for file_path in &file_paths {
+        if let Ok(uri) = uri_from_file_path(file_path) {
+            let uri_id = UriId::from(uri.as_str());
+            deleted_uris.remove(&uri_id);
+        }
+    }
+
     let merge_result = |local_graph: Graph| graph.update(local_graph);
     with_parallel_workers(file_paths, index_document, merge_result)?;
 
-    graph.save_to_database().map_err(MultipleErrors::from)?;
+    graph.sync_with_database(deleted_uris.into_iter().collect())?;
 
     Ok(())
 }
@@ -386,5 +394,173 @@ mod tests {
             final_definition_count, 2,
             "definitions should remain available after skipping unchanged content"
         );
+    }
+
+    #[test]
+    fn index_in_parallel_removes_cached_uris_from_db() {
+        use rusqlite::Connection;
+
+        let temp_db_path = "file:index_in_parallel_removes_cached_uris_from_db?mode=memory&cache=shared".to_string();
+        let ruby_source = "module TestModule\nend";
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let file_path = temp_dir.path().join("test.rb");
+        fs::write(&file_path, ruby_source).unwrap();
+        let file_path = file_path.to_string_lossy().into_owned();
+
+        let mut first_graph = Graph::new();
+        first_graph.set_configuration(temp_db_path.clone()).unwrap();
+
+        index_in_parallel(&mut first_graph, vec![file_path.clone()]).unwrap();
+
+        let mut second_graph = Graph::new();
+        second_graph.set_configuration(temp_db_path.clone()).unwrap();
+
+        index_in_parallel(&mut second_graph, vec![]).unwrap();
+
+        let conn = Connection::open(&temp_db_path).unwrap();
+        let doc_count: i64 = conn
+            .prepare("SELECT COUNT(*) FROM documents")
+            .unwrap()
+            .query_row([], |row| row.get(0))
+            .unwrap();
+        assert_eq!(doc_count, 0, "documents should be removed from the database");
+
+        let def_count: i64 = conn
+            .prepare("SELECT COUNT(*) FROM definitions")
+            .unwrap()
+            .query_row([], |row| row.get(0))
+            .unwrap();
+        assert_eq!(def_count, 0);
+    }
+
+    #[test]
+    fn index_in_parallel_persists_updated_entries() {
+        use rusqlite::Connection;
+
+        let db_path = "file:index_in_parallel_persists_updated_entries?mode=memory&cache=shared".to_string();
+        let initial_source = "module Foo; end";
+        let updated_source = "module Foo\n  def bar; end\nend";
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let file_path = temp_dir.path().join("foo.rb");
+        fs::write(&file_path, initial_source).unwrap();
+        let file_path = file_path.to_string_lossy().into_owned();
+
+        let mut graph = Graph::new();
+        graph.set_configuration(db_path.clone()).unwrap();
+        index_in_parallel(&mut graph, vec![file_path.clone()]).unwrap();
+
+        let uri = uri_from_file_path(&file_path).unwrap();
+        let uri_id = UriId::from(uri.as_str());
+        let conn = Connection::open(&db_path).unwrap();
+        let initial_hash: i64 = conn
+            .prepare("SELECT content_hash FROM documents WHERE id = ?")
+            .unwrap()
+            .query_row([*uri_id], |row| row.get(0))
+            .unwrap();
+        assert_eq!(
+            initial_hash,
+            i64::from(calculate_content_hash(initial_source.as_bytes()))
+        );
+
+        drop(conn);
+
+        fs::write(&file_path, updated_source).unwrap();
+
+        let mut graph = Graph::new();
+        graph.set_configuration(db_path.clone()).unwrap();
+        index_in_parallel(&mut graph, vec![file_path.clone()]).unwrap();
+
+        let conn = Connection::open(&db_path).unwrap();
+        let updated_hash: i64 = conn
+            .prepare("SELECT content_hash FROM documents WHERE id = ?")
+            .unwrap()
+            .query_row([*uri_id], |row| row.get(0))
+            .unwrap();
+        assert_eq!(
+            updated_hash,
+            i64::from(calculate_content_hash(updated_source.as_bytes()))
+        );
+
+        let updated_row_exists: i64 = conn
+            .prepare("SELECT COUNT(*) FROM documents WHERE id = ? AND content_hash = ?")
+            .unwrap()
+            .query_row(
+                [*uri_id, i64::from(calculate_content_hash(updated_source.as_bytes()))],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(updated_row_exists, 1);
+
+        let definition_count: i64 = conn
+            .prepare("SELECT COUNT(*) FROM definitions")
+            .unwrap()
+            .query_row([], |row| row.get(0))
+            .unwrap();
+        assert!(definition_count >= 1);
+
+        let declaration_count: i64 = conn
+            .prepare("SELECT COUNT(*) FROM declarations")
+            .unwrap()
+            .query_row([], |row| row.get(0))
+            .unwrap();
+        assert!(declaration_count >= 1);
+    }
+
+    #[test]
+    fn index_in_parallel_handles_duplicate_declarations() {
+        use rusqlite::Connection;
+
+        let db_path = "file:index_in_parallel_handles_duplicate_declarations?mode=memory&cache=shared".to_string();
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let first_path = temp_dir.path().join("existing.rb");
+        fs::write(&first_path, "module Foo; end").unwrap();
+        let second_path = temp_dir.path().join("second.rb");
+        fs::write(&second_path, "module Foo; end").unwrap();
+        let first_path = first_path.to_string_lossy().into_owned();
+        let second_path = second_path.to_string_lossy().into_owned();
+
+        let mut initial_graph = Graph::new();
+        initial_graph.set_configuration(db_path.clone()).unwrap();
+        index_in_parallel(&mut initial_graph, vec![first_path.clone()]).unwrap();
+
+        let conn = Connection::open(&db_path).unwrap();
+        let existing_declarations: i64 = conn
+            .prepare("SELECT COUNT(*) FROM declarations")
+            .unwrap()
+            .query_row([], |row| row.get(0))
+            .unwrap();
+        // two declarations here because we also have <main>
+        assert_eq!(existing_declarations, 2);
+        drop(conn);
+
+        let mut graph = Graph::new();
+        graph.set_configuration(db_path.clone()).unwrap();
+        index_in_parallel(&mut graph, vec![first_path, second_path]).unwrap();
+
+        let conn = Connection::open(&db_path).unwrap();
+
+        let doc_count: i64 = conn
+            .prepare("SELECT COUNT(*) FROM documents")
+            .unwrap()
+            .query_row([], |row| row.get(0))
+            .unwrap();
+        assert_eq!(doc_count, 2, "both documents should be persisted");
+
+        let declaration_count: i64 = conn
+            .prepare("SELECT COUNT(*) FROM declarations")
+            .unwrap()
+            .query_row([], |row| row.get(0))
+            .unwrap();
+        assert_eq!(declaration_count, 2, "duplicate declarations should be ignored");
+
+        let definition_count: i64 = conn
+            .prepare("SELECT COUNT(*) FROM definitions")
+            .unwrap()
+            .query_row([], |row| row.get(0))
+            .unwrap();
+        assert_eq!(definition_count, 2, "each document should have a definition row");
     }
 }

--- a/rust/saturn/src/model/graph.rs
+++ b/rust/saturn/src/model/graph.rs
@@ -585,11 +585,11 @@ mod tests {
         initial.graph.set_configuration(db_path.clone()).unwrap();
         initial.graph.save_to_database().unwrap();
 
-        let unchanged_hash = crate::indexing::Document::calculate_content_hash(unchanged_source.as_bytes());
+        let unchanged_hash = crate::indexing::calculate_content_hash(unchanged_source.as_bytes());
         let new_source = "module NewFile; end";
         let updated_source = "module Updated; def original; end; def extra; end; end";
-        let new_hash = crate::indexing::Document::calculate_content_hash(new_source.as_bytes());
-        let updated_hash = crate::indexing::Document::calculate_content_hash(updated_source.as_bytes());
+        let new_hash = crate::indexing::calculate_content_hash(new_source.as_bytes());
+        let updated_hash = crate::indexing::calculate_content_hash(updated_source.as_bytes());
 
         let mut updated = GraphTest::new();
         updated.graph.set_configuration(db_path.clone()).unwrap();


### PR DESCRIPTION
When a database is configured, the index_in_parallel will now start
saving data to the db.