### PR TITLE
Update rake tasks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,8 @@ When necessary, commands can be executed for the Ruby code.
 - `bundle exec rake compile`: compiles both the Rust crate and C extension
 - `bundle exec rake lint`: lints both the Ruby and Rust code
 - `bundle exec rake format`: auto formats both the Ruby and Rust code
-- `bundle exec rake test`: runs all automated Ruby tests
+- `bundle exec rake test`: runs the Ruby and Rust test suites
+- `bundle exec rake ruby_test`: runs all automated Ruby tests
 - `bundle exec ruby -Itest test/specific_test.rb`: runs a specific test file
 
 ## Rust workspace

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The command `bundle exec rake compile` can be used to build both the Rust and C 
 
 ### Running tests
 
-Simply use the command `bundle exec rake test`, and the project will be built and tests located within `test/` will be run.
+Run `bundle exec rake test` to execute both the Ruby and Rust test suites. To run only the Ruby tests, use `bundle exec rake ruby_test`. The combined lint-and-test flow is available through `bundle exec rake check`.
 
 ### Running memory leak and other sanitization checks
 
@@ -33,11 +33,11 @@ Here's how to run the checks locally:
 
 ```shell
 # Run ruby_memcheck in combination with a Rust sanitization mode (Linux only)
-SANITIZER=leak bundle exec rake test:valgrind
+SANITIZER=leak bundle exec rake ruby_test:valgrind
 
 # Run only ruby_memcheck (Linux only)
-bundle exec rake test:valgrind
+bundle exec rake ruby_test:valgrind
 
 # Run Rust sanitization only
-SANITIZER=leak bundle exec rake test
+SANITIZER=leak bundle exec rake ruby_test
 ```

--- a/Rakefile
+++ b/Rakefile
@@ -18,8 +18,8 @@ test_config = lambda do |t|
   t.ruby_opts << ["--enable=frozen_string_literal"]
   t.test_files = FileList["test/**/*_test.rb"]
 end
-Rake::TestTask.new(test: :compile, &test_config)
-namespace(:test) { RubyMemcheck::TestTask.new(valgrind: :compile, &test_config) }
+Rake::TestTask.new(ruby_test: :compile, &test_config)
+namespace(:ruby_test) { RubyMemcheck::TestTask.new(valgrind: :compile, &test_config) }
 
 RuboCop::RakeTask.new
 
@@ -43,4 +43,7 @@ task compile_release: :clean do
   Rake::Task[:compile].invoke
 end
 
-task default: [:lint, :cargo_test, :test]
+multitask test: [:cargo_test, :ruby_test]
+multitask check: [:lint, :test]
+
+task default: :check

--- a/dev.yml
+++ b/dev.yml
@@ -6,9 +6,7 @@ up:
 commands:
   test:
     desc: Run Ruby and Rust test suites via Rake
-    run: |
-      bundle exec rake test
-      bundle exec rake cargo_test
+    run: bundle exec rake test
   lint:
     desc: Run RuboCop and Rust linting
     run: bundle exec rake lint
@@ -16,8 +14,5 @@ commands:
     desc: Format Ruby and Rust sources
     run: bundle exec rake format
 
-# dev check by default runs each command in parallel across available cores
 check:
-  test_ruby: bundle exec rake test
-  test_rust: bundle exec rake cargo_test
-  lint: bundle exec rake lint
+  all: bundle exec rake check


### PR DESCRIPTION
- `bundle exec rake ruby_test` now houses the Ruby test suite, replacing the old `bundle exec
  rake test` role.
 - `bundle exec rake test` now runs both ruby_test and cargo_test.
 - `bundle exec rake check` fan-outs into linting plus both test suites; `dev check` now
  delegates to this command.

This makes the `dev` tasks a very thin layer of the Rake tasks. 