### PR TITLE
Fix linting errors

### DIFF
--- a/rust/saturn/src/model/db.rs
+++ b/rust/saturn/src/model/db.rs
@@ -376,7 +376,7 @@ mod tests {
             .definition
             .comments()
             .iter()
-            .map(|c| c.string().to_string())
+            .map(|c| c.string().clone())
             .collect::<Vec<String>>();
         assert_eq!(*comments, vec!["# Class comment", "# Another class comment"]);
     }

--- a/rust/saturn/src/model/graph.rs
+++ b/rust/saturn/src/model/graph.rs
@@ -724,7 +724,7 @@ mod tests {
         assert_eq!(
             def.comments()
                 .iter()
-                .map(|c| c.string().to_string())
+                .map(|c| c.string().clone())
                 .collect::<Vec<String>>(),
             vec!["# This is a class comment", "# Multi-line comment"]
         );
@@ -734,7 +734,7 @@ mod tests {
         assert_eq!(
             def.comments()
                 .iter()
-                .map(|c| c.string().to_string())
+                .map(|c| c.string().clone())
                 .collect::<Vec<String>>(),
             vec!["# Module comment"]
         );


### PR DESCRIPTION
```
error: implicitly cloning a `String` by calling `to_string` on its dereferenced type
   --> saturn/src/model/db.rs:379:22
    |
379 |             .map(|c| c.string().to_string())
    |                      ^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `c.string().clone()`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.91.0/index.html#implicit_clone
    = note: `-D clippy::implicit-clone` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::implicit_clone)]`

error: implicitly cloning a `String` by calling `to_string` on its dereferenced type
   --> saturn/src/model/graph.rs:727:26
    |
727 |                 .map(|c| c.string().to_string())
    |                          ^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `c.string().clone()`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.91.0/index.html#implicit_clone

error: implicitly cloning a `String` by calling `to_string` on its dereferenced type
   --> saturn/src/model/graph.rs:737:26
    |
737 |                 .map(|c| c.string().to_string())
    |                          ^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `c.string().clone()`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.91.0/index.html#implicit_clone

```