### PR TITLE
Execute rake tasks sequentially

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -43,7 +43,7 @@ task compile_release: :clean do
   Rake::Task[:compile].invoke
 end
 
-multitask test: [:cargo_test, :ruby_test]
-multitask check: [:lint, :test]
+task test: [:cargo_test, :ruby_test]
+task check: [:lint, :test]
 
 task default: :check


### PR DESCRIPTION
Executing the tasks in parallel can bury failed results. We want
our task to exit immediately when one of the sub-tasks fails.

Discussion thread: https://github.com/Shopify/saturn/pull/287#discussion_r2481737385