### PR TITLE
Remove unused `location_converter` from `RubyIndexer`

### DIFF
--- a/rust/saturn/src/indexing.rs
+++ b/rust/saturn/src/indexing.rs
@@ -2,7 +2,6 @@ use crate::{
     errors::{Errors, MultipleErrors},
     indexing::ruby_indexer::{IndexerParts, RubyIndexer},
     model::graph::Graph,
-    source_location::UTF8SourceLocationConverter,
 };
 use glob::glob;
 use std::sync::{
@@ -39,14 +38,8 @@ pub fn index_in_parallel(graph: &mut Graph, file_paths: Vec<String>) -> Result<(
             return IndexResult::Errored(errors);
         }
 
-        let converter = UTF8SourceLocationConverter::new(&source);
         let content_hash = calculate_content_hash(source.as_bytes());
-        let mut ruby_indexer = RubyIndexer::new(
-            uri_from_file_path(file_path).unwrap(),
-            &converter,
-            &source,
-            content_hash,
-        );
+        let mut ruby_indexer = RubyIndexer::new(uri_from_file_path(file_path).unwrap(), &source, content_hash);
         ruby_indexer.index();
         IndexResult::Completed(Box::new(ruby_indexer.into_parts()))
     };

--- a/rust/saturn/src/test_utils/graph_test.rs
+++ b/rust/saturn/src/test_utils/graph_test.rs
@@ -22,9 +22,8 @@ impl GraphTest {
 
     #[must_use]
     fn index_source(uri: &str, source: &str) -> Graph {
-        let converter = UTF8SourceLocationConverter::new(source);
         let content_hash = crate::indexing::calculate_content_hash(source.as_bytes());
-        let mut indexer = RubyIndexer::new(uri.to_string(), &converter, source, content_hash);
+        let mut indexer = RubyIndexer::new(uri.to_string(), source, content_hash);
         indexer.index();
         indexer.into_parts().0
     }


### PR DESCRIPTION
This was added #167 in but we don't actually need it during the indexing. It's not much, but it's wasteful:

```
# before

Timing breakdown
  Indexing            3.821s ( 60.3%)

Maximum RSS: 750731264 bytes (715.95 MB)

# after

Timing breakdown
  Indexing            3.546s ( 78.0%)

Maximum RSS: 737067008 bytes (702.92 MB)
```