### PR TITLE
Positions and locations are 1 indexed

### DIFF
--- a/rust/saturn-sys/src/location_api.rs
+++ b/rust/saturn-sys/src/location_api.rs
@@ -48,10 +48,10 @@ pub(crate) fn create_location_for_uri_and_offset(uri: &str, start: u32, end: u32
 
     let loc = Location {
         uri: CString::new(uri).unwrap().into_raw().cast_const(),
-        start_line: start_line + 1,
-        end_line: end_line + 1,
-        start_column: start_column + 1,
-        end_column: end_column + 1,
+        start_line,
+        end_line,
+        start_column,
+        end_column,
     };
 
     Box::into_raw(Box::new(loc))

--- a/rust/saturn/src/model/graph.rs
+++ b/rust/saturn/src/model/graph.rs
@@ -1010,8 +1010,8 @@ mod tests {
 
         let foo_declaration = context.graph.declarations.get(&DeclarationId::from("Foo")).unwrap();
         assert_eq!(foo_declaration.references().len(), 2, "Foo should have 2 references");
-        assert_constant_reference_to!(context, "Foo", "file:///foo.rb:11:0-11:3");
-        assert_constant_reference_to!(context, "Foo", "file:///bar.rb:1:2-1:7");
+        assert_constant_reference_to!(context, "Foo", "file:///foo.rb:12:1-12:4");
+        assert_constant_reference_to!(context, "Foo", "file:///bar.rb:2:3-2:8");
 
         let foo_const_declaration = context
             .graph
@@ -1023,12 +1023,12 @@ mod tests {
             2,
             "Foo::CONST should have 2 references"
         );
-        assert_constant_reference_to!(context, "Foo::CONST", "file:///foo.rb:3:4-3:9");
-        assert_constant_reference_to!(context, "Foo::CONST", "file:///foo.rb:11:0-11:10");
+        assert_constant_reference_to!(context, "Foo::CONST", "file:///foo.rb:4:5-4:10");
+        assert_constant_reference_to!(context, "Foo::CONST", "file:///foo.rb:12:1-12:11");
 
         let bar_declaration = context.graph.declarations.get(&DeclarationId::from("Bar")).unwrap();
         assert_eq!(bar_declaration.references().len(), 1, "Bar should have 1 reference");
-        assert_constant_reference_to!(context, "Bar", "file:///foo.rb:4:4-4:9");
+        assert_constant_reference_to!(context, "Bar", "file:///foo.rb:5:5-5:10");
 
         let foo_bar_declaration = context
             .graph
@@ -1040,16 +1040,16 @@ mod tests {
             1,
             "Foo::Bar should have 1 reference"
         );
-        assert_constant_reference_to!(context, "Foo::Bar", "file:///bar.rb:1:2-1:12");
+        assert_constant_reference_to!(context, "Foo::Bar", "file:///bar.rb:2:3-2:13");
 
         assert_eq!(
             context.graph.unresolved_references.len(),
             3,
             "Should have 3 unresolved references"
         );
-        assert_unresolved_constant!(context, "Baz", None, "file:///foo.rb:5:4-5:9");
-        assert_unresolved_constant!(context, "String", Some("Foo::Bar"), "file:///foo.rb:6:4-6:10");
-        assert_unresolved_constant!(context, "Object", None, "file:///foo.rb:7:4-7:12");
+        assert_unresolved_constant!(context, "Baz", None, "file:///foo.rb:6:5-6:10");
+        assert_unresolved_constant!(context, "String", Some("Foo::Bar"), "file:///foo.rb:7:5-7:11");
+        assert_unresolved_constant!(context, "Object", None, "file:///foo.rb:8:5-8:13");
     }
 
     #[test]


### PR DESCRIPTION
We have 3 different concepts to express the location of something:

* `Offset` - this is the bytes location in the stream. From byte X to byte Y.
* `Position` - this is the line/column position in the document: At line X, column Y
* `Location` (only exposed to the Ruby API) - this is span between a start line/column and an end line/column in the document: From line X1, column Y1 to line X2 column Y2

While if makes sense for offsets to be 0-indexed as they are aimed at computers, we're talking about the index of a byte in an array, it doesn't when talking about a location which is aimed at humans.

For example, the first line of a document in VSCode is line 1, the first column is 1, and going to `:1,1` brings you to the first column:

<img width="166" height="44" alt="image" src="https://github.com/user-attachments/assets/1218faed-75d2-493d-9188-51c0d4aaf59f" />
<img width="73" height="20" alt="image" src="https://github.com/user-attachments/assets/80d58e00-654a-4820-a64a-11b57ded3b82" />

Same in Vim: 
<img width="175" height="90" alt="image" src="https://github.com/user-attachments/assets/c487d5fb-7810-43f8-80f8-f0b1f7b0ab46" />

Rubocop also agrees:

<img width="851" height="52" alt="image" src="https://github.com/user-attachments/assets/d6f5291f-5d55-43ce-b607-c291f97c3c52" />

Same on Github, the first line is 1: https://github.com/Shopify/saturn/blob/main/saturn.gemspec#L1.

Even in Slack, the first line is 1:
<img width="552" height="312" alt="image" src="https://github.com/user-attachments/assets/2eb482b1-34f6-4a05-b556-98edad61d1e2" />

A notable difference is Prism where lines are 1-indexed but columns 0-indexed, which may be the most confusing:

<img width="724" height="425" alt="image" src="https://github.com/user-attachments/assets/1d77d5e7-8f2b-413a-9010-009097f0605f" />
