### PR TITLE
Track includes and prepends

### DIFF
--- a/rust/saturn/src/model/definitions.rs
+++ b/rust/saturn/src/model/definitions.rs
@@ -23,6 +23,8 @@
 //! 1. The declaration for the name `Foo`
 //! 2. The declaration for the name `Foo::Bar`
 
+use std::ops::Deref;
+
 use crate::{
     model::{
         comment::Comment,
@@ -105,6 +107,25 @@ impl Definition {
     }
 }
 
+/// Represents either an included or a prepended module. Note that `extend` is modeled as an include on the singleton
+/// class
+#[derive(Debug)]
+pub enum Mixin {
+    Include(ReferenceId),
+    Prepend(ReferenceId),
+}
+
+// Deref implementation to conveniently extract the reference ID with a dereference
+impl Deref for Mixin {
+    type Target = ReferenceId;
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            Mixin::Include(id) | Mixin::Prepend(id) => id,
+        }
+    }
+}
+
 /// A class definition
 ///
 /// # Example
@@ -119,6 +140,7 @@ pub struct ClassDefinition {
     offset: Offset,
     comments: Vec<Comment>,
     superclass_ref: Option<ReferenceId>,
+    mixins: Vec<Mixin>,
 }
 
 impl ClassDefinition {
@@ -136,7 +158,17 @@ impl ClassDefinition {
             offset,
             comments,
             superclass_ref,
+            mixins: Vec::new(),
         }
+    }
+
+    #[must_use]
+    pub fn mixins(&self) -> &[Mixin] {
+        &self.mixins
+    }
+
+    pub fn add_mixin(&mut self, mixin: Mixin) {
+        self.mixins.push(mixin);
     }
 
     #[must_use]
@@ -158,6 +190,7 @@ pub struct ModuleDefinition {
     uri_id: UriId,
     offset: Offset,
     comments: Vec<Comment>,
+    mixins: Vec<Mixin>,
 }
 
 impl ModuleDefinition {
@@ -168,7 +201,17 @@ impl ModuleDefinition {
             uri_id,
             offset,
             comments,
+            mixins: Vec::new(),
         }
+    }
+
+    #[must_use]
+    pub fn mixins(&self) -> &[Mixin] {
+        &self.mixins
+    }
+
+    pub fn add_mixin(&mut self, mixin: Mixin) {
+        self.mixins.push(mixin);
     }
 }
 

--- a/rust/saturn/src/model/graph.rs
+++ b/rust/saturn/src/model/graph.rs
@@ -101,6 +101,11 @@ impl Graph {
         )
     }
 
+    #[must_use]
+    pub(crate) fn get_definition_mut(&mut self, definition_id: DefinitionId) -> Option<&mut Definition> {
+        self.definitions.get_mut(&definition_id)
+    }
+
     // Registers a URI into the graph and returns the generated ID. This happens once when starting to index the URI and
     // then all definitions discovered in it get associated to the ID
     pub fn add_uri(&mut self, uri: String) -> UriId {
@@ -145,7 +150,7 @@ impl Graph {
     }
 
     // Registers a definition into the `Graph`, automatically creating all relationships
-    pub fn add_definition(&mut self, name: String, definition: Definition, owner_id: &DeclarationId) {
+    pub fn add_definition(&mut self, name: String, definition: Definition, owner_id: &DeclarationId) -> DefinitionId {
         let uri_id = *definition.uri_id();
         let definition_id = DefinitionId::from(&format!("{uri_id}{}{}", definition.start(), &name));
         let declaration_id = *definition.declaration_id();
@@ -158,6 +163,8 @@ impl Graph {
         self.documents
             .entry(uri_id)
             .and_modify(|doc| doc.add_definition(definition_id));
+
+        definition_id
     }
 
     // Register an unresolved constant reference


### PR DESCRIPTION
This PR starts tracking includes and prepends. It only comprehends remembering includes and prepends and not resolving inheritance chain.

### Implementation notes

1. We're currently not handling include and prepend at the top level, which end up in the `Object` class. I think we can solve this by creating a lazy `Definition` for `Object` whenever we find top level includes or prepends, so that we can attach them to a specific definition. It would be a bit weird to put the includes and prepends into any random definition for `Object`, so I think lazily creating a new one will probably be less surprising. Sorbet handles this by always considering the top level like a re-opening of `Object`, but that would force us to use a lot more memory. In a Rails app, people rarely define anything at the top level
2. There are minimal changes to how constant path references are tracked, which are still a symptom of #253