### PR TITLE
Remove unused `RubyIndexer::add_error`

### DIFF
--- a/rust/saturn/src/indexing/ruby_indexer.rs
+++ b/rust/saturn/src/indexing/ruby_indexer.rs
@@ -55,10 +55,6 @@ impl<'a> RubyIndexer<'a> {
         (self.local_graph, self.errors)
     }
 
-    pub fn add_error(&mut self, error: Errors) {
-        self.errors.push(error);
-    }
-
     pub fn index(&mut self) {
         let result = ruby_prism::parse(self.source.as_bytes());
         self.comments = self.parse_comments_into_groups(&result);


### PR DESCRIPTION
Not sure why we need this method? It's not used anywhere.