### PR TITLE
Rename `Scope` to `NestingStack`

### DIFF
--- a/rust/saturn/src/indexing.rs
+++ b/rust/saturn/src/indexing.rs
@@ -13,8 +13,8 @@ use std::{sync::mpsc, thread};
 use url::Url;
 use xxhash_rust::xxh3::xxh3_64;
 
+pub mod nesting_stack;
 pub mod ruby_indexer;
-pub mod scope;
 
 /// Indexes the given items, reading the content from disk and populating the given `Graph` instance.
 ///

--- a/rust/saturn/src/indexing/nesting_stack.rs
+++ b/rust/saturn/src/indexing/nesting_stack.rs
@@ -61,11 +61,11 @@ impl Nesting {
     }
 }
 
-/// The Scope structure maintains both the `Nesting` linked list of all lexical scopes we encountered and a name stack,
-/// so that we can compute fully qualified names ahead of time for all entries in the graph and their respective
-/// declaration IDs
+/// The `NestingStack` structure maintains both the `Nesting` linked list of all lexical scopes we encountered and a
+/// name stack, so that we can compute fully qualified names ahead of time for all entries in the graph and their
+/// respective declaration IDs
 #[derive(Default)]
-pub struct Scope {
+pub struct NestingStack {
     /// A vector of **fully qualified names**. For example:
     ///
     /// ```ruby
@@ -83,7 +83,7 @@ pub struct Scope {
     nesting: Option<Arc<Nesting>>,
 }
 
-impl Scope {
+impl NestingStack {
     #[must_use]
     pub fn new() -> Self {
         Self {
@@ -164,7 +164,7 @@ mod tests {
 
     #[test]
     fn regular_nesting() {
-        let mut scope = Scope::new();
+        let mut scope = NestingStack::new();
 
         // Foo
         let (name, id) = scope.enter("Foo");
@@ -196,7 +196,7 @@ mod tests {
 
     #[test]
     fn compact_namespace_nesting() {
-        let mut scope = Scope::new();
+        let mut scope = NestingStack::new();
 
         // Foo
         let (name, id) = scope.enter("Foo");
@@ -229,7 +229,7 @@ mod tests {
 
     #[test]
     fn top_level_nesting() {
-        let mut scope = Scope::new();
+        let mut scope = NestingStack::new();
 
         // Foo
         let (name, id) = scope.enter("Foo");
@@ -263,7 +263,7 @@ mod tests {
 
     #[test]
     fn top_level_compact_nesting() {
-        let mut scope = Scope::new();
+        let mut scope = NestingStack::new();
 
         // Foo
         let (name, id) = scope.enter("Foo");

--- a/rust/saturn/src/indexing/ruby_indexer.rs
+++ b/rust/saturn/src/indexing/ruby_indexer.rs
@@ -3,7 +3,7 @@
 use std::sync::{Arc, LazyLock};
 
 use crate::errors::Errors;
-use crate::indexing::scope::Scope;
+use crate::indexing::nesting_stack::NestingStack;
 use crate::model::comment::Comment;
 use crate::model::definitions::{
     AttrAccessorDefinition, AttrReaderDefinition, AttrWriterDefinition, ClassDefinition, ClassVariableDefinition,
@@ -31,7 +31,7 @@ pub struct RubyIndexer<'a> {
     errors: Vec<Errors>,
     comments: Vec<CommentGroup>,
     source: &'a str,
-    scope: Scope,
+    scope: NestingStack,
     namespace_stack: Vec<DefinitionId>,
 }
 
@@ -47,7 +47,7 @@ impl<'a> RubyIndexer<'a> {
             errors: Vec::new(),
             comments: Vec::new(),
             source,
-            scope: Scope::new(),
+            scope: NestingStack::new(),
             namespace_stack: Vec::new(),
         }
     }

--- a/rust/saturn/src/model/references.rs
+++ b/rust/saturn/src/model/references.rs
@@ -1,5 +1,5 @@
 use crate::{
-    indexing::scope::Nesting,
+    indexing::nesting_stack::Nesting,
     model::ids::{DeclarationId, NameId, ReferenceId, UriId},
     offset::Offset,
 };


### PR DESCRIPTION
Rename `Scope` to `NestingStack` since the term scope is what we'll use to describe the parts of a constant path.