### PR TITLE
Add the runtime dependency in the gemspec:

### DIFF
--- a/ext/saturn/extconf.rb
+++ b/ext/saturn/extconf.rb
@@ -71,6 +71,10 @@ new_makefile.gsub!("$(Q) $(POSTLINK)", <<~MAKEFILE.chomp)
 MAKEFILE
 File.write("Makefile", new_makefile)
 
-require "extconf_compile_commands_json"
-ExtconfCompileCommandsJson.generate!
-ExtconfCompileCommandsJson.symlink!
+begin
+  require "extconf_compile_commands_json"
+
+  ExtconfCompileCommandsJson.generate!
+  ExtconfCompileCommandsJson.symlink!
+rescue LoadError # rubocop:disable Lint/SuppressedException
+end


### PR DESCRIPTION
- The "extconf_compile_commands_json" dependency is needed by the gem it self at compilation time.

  If we add it to the Gemfile, then running `gem install saturn` can't work as the dependency from the Gemfile don't get installed b RubyGems.