### PR TITLE
Setup "EasyCompile" to allow packaging gem with precompiled binaries

### DIFF
--- a/.github/workflows/easy-compile.yaml
+++ b/.github/workflows/easy-compile.yaml
@@ -1,0 +1,82 @@
+name: "Release gems with precompiled binaries"
+on:
+  workflow_dispatch:
+    inputs:
+      release:
+        description: "If the whole build passes on all platforms, release the gems on RubyGems.org"
+        required: false
+        type: boolean
+        default: false
+jobs:
+  compile:
+    timeout-minutes: 20
+    name: "Cross compile the gem on different ruby versions"
+    strategy:
+      matrix:
+        os: ["macos-latest", "shopify-ubuntu-20.04"]
+    runs-on: "${{ matrix.os }}"
+    steps:
+      - name: "Checkout code"
+        uses: "actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd"
+      - name: "Setup Ruby"
+        uses: "ruby/setup-ruby@8aeb6ff8030dd539317f8e1769a044873b56ea71"
+        with:
+          ruby-version: "3.2.9"
+          bundler-cache: true
+      - name: "Run easy compile"
+        uses: "shopify-playground/edouard-playground/.github/actions/easy_compile@main"
+        with:
+          step: "compile"
+  test:
+    timeout-minutes: 20
+    name: "Run the test suite"
+    needs: compile
+    strategy:
+      matrix:
+        os: ["macos-latest", "shopify-ubuntu-20.04"]
+        rubies: ["3.2", "3.3", "3.4"]
+        type: ["cross", "native"]
+    runs-on: "${{ matrix.os }}"
+    steps:
+      - name: "Checkout code"
+        uses: "actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd"
+      - name: "Setup Ruby"
+        uses: "ruby/setup-ruby@8aeb6ff8030dd539317f8e1769a044873b56ea71"
+        with:
+          ruby-version: "${{ matrix.rubies }}"
+          bundler-cache: true
+      - name: "Run easy compile"
+        uses: "shopify-playground/edouard-playground/.github/actions/easy_compile@main"
+        with:
+          step: "test_${{ matrix.type }}"
+  install:
+    timeout-minutes: 5
+    name: "Verify the gem can be installed"
+    needs: test
+    strategy:
+      matrix:
+        os: ["macos-latest", "shopify-ubuntu-20.04"]
+    runs-on: "${{ matrix.os }}"
+    steps:
+      - name: "Setup Ruby"
+        uses: "ruby/setup-ruby@8aeb6ff8030dd539317f8e1769a044873b56ea71"
+      - name: "Run easy compile"
+        uses: "shopify-playground/edouard-playground/.github/actions/easy_compile@main"
+        with:
+          step: "install"
+  release:
+    permissions:
+      id-token: write
+      contents: read
+    timeout-minutes: 5
+    if: ${{ inputs.release }}
+    name: "Release all gems with RubyGems"
+    needs: install
+    runs-on: "shopify-ubuntu-latest"
+    steps:
+      - name: "Setup Ruby"
+        uses: "ruby/setup-ruby@8aeb6ff8030dd539317f8e1769a044873b56ea71"
+      - name: "Run easy compile"
+        uses: "shopify-playground/edouard-playground/.github/actions/easy_compile@main"
+        with:
+          step: "release"

--- a/lib/saturn.rb
+++ b/lib/saturn.rb
@@ -4,7 +4,15 @@ require "bundler"
 require "uri"
 
 require "saturn/version"
-require "saturn/saturn"
+begin
+  # Load the precompiled version of the library
+  ruby_version = /(\d+\.\d+)/.match(RUBY_VERSION)
+  require "saturn/#{ruby_version}/saturn"
+rescue LoadError
+  # It's important to leave for users that can not or don't want to use the gem with precompiled binaries.
+  require "saturn/saturn"
+end
+
 require "saturn/location"
 require "saturn/comment"
 require "saturn/graph"


### PR DESCRIPTION
👋 Thanks for letting me try our tool in this project.

TL;DR This workflow allows with a single click on the GitHub UI to compile/package/test and publish (optionally) a gem with precompiled binaries.

-----------

This workflow was generated running the `easy_compile ci_template` command from the [EasyCompile tool](https://github.com/shopify-playground/edouard-playground) we are currently developing..

I confirmed that it works on this project https://github.com/Shopify/saturn/actions/runs/19342620213.

----------

### How does it work

When you'd like to cut a new release, you can head to the [GitHub action page](https://github.com/Shopify/saturn/actions), select the workflow and click on "Run workflow".

Once clicked here is what happened:

- We spin up machines on various platforms (MacOS and Linux are configured here). And start the compilation. Since the gem supports multiple ruby versions, we perform the compilation for each ruby minor versions supported (3.2, 3.3, 3.4).
- Once the compilation is done on all platforms, we create a matrix of jobs to test against all ruby versions that we compiled and all platforms.
- If all job passes we package the gem with the precompiled binaries.
- Finally, you have the option to publish the gems on RubyGems by ticking this box (for this to work we need to do a small setup on RubyGems.org and setup trusted publishing).
<img width="374" height="234" alt="image" src="https://github.com/user-attachments/assets/ce624b96-f54c-4f8a-b17d-7ad10b15b441" />


If you have any questions, please ask :D !