### PR TITLE
Upgrade Prism to v1.6.0

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -85,17 +85,15 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "bindgen"
-version = "0.66.1"
+version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b84e06fc203107bfbad243f4aba2af864eb7db3b1cf46ea0a023b0b433d2a7"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
- "lazy_static",
- "lazycell",
+ "itertools",
  "log",
- "peeking_take_while",
  "prettyplease",
  "proc-macro2",
  "quote",
@@ -103,7 +101,6 @@ dependencies = [
  "rustc-hash",
  "shlex",
  "syn",
- "which",
 ]
 
 [[package]]
@@ -329,15 +326,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "home"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
-dependencies = [
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "icu_collections"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -461,22 +449,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
-
-[[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
@@ -493,12 +478,6 @@ dependencies = [
  "cfg-if",
  "windows-targets 0.53.3",
 ]
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.4.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -566,12 +545,6 @@ name = "once_cell_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
-
-[[package]]
-name = "peeking_take_while"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "percent-encoding"
@@ -683,9 +656,9 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "ruby-prism"
-version = "1.4.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a3a71142531d9dcb33cf162543a68c1d1e5567dd96ac5cc38b8b99b3166b8b"
+checksum = "f2486ac87dae4e4cbc31f5b7a5aa711a51d3c3fcd412d88745a34fa2f4721df8"
 dependencies = [
  "ruby-prism-sys",
  "serde",
@@ -694,9 +667,9 @@ dependencies = [
 
 [[package]]
 name = "ruby-prism-sys"
-version = "1.4.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f77ce848645f060a1f3d60af962f481c58618863390184f96adf5d107e48954"
+checksum = "2646504a4f369cad36018453a60b1b69b8068ae054db40fdb343e224b86d8061"
 dependencies = [
  "bindgen",
  "cc",
@@ -704,22 +677,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "1.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
-
-[[package]]
-name = "rustix"
-version = "0.38.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
-dependencies = [
- "bitflags",
- "errno",
- "libc",
- "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
-]
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustix"
@@ -730,7 +690,7 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys 0.9.4",
+ "linux-raw-sys",
  "windows-sys 0.60.2",
 ]
 
@@ -876,7 +836,7 @@ dependencies = [
  "fastrand",
  "getrandom",
  "once_cell",
- "rustix 1.0.8",
+ "rustix",
  "windows-sys 0.59.0",
 ]
 
@@ -988,18 +948,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
 dependencies = [
  "wit-bindgen-rt",
-]
-
-[[package]]
-name = "which"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
-dependencies = [
- "either",
- "home",
- "once_cell",
- "rustix 0.38.44",
 ]
 
 [[package]]

--- a/rust/saturn/Cargo.toml
+++ b/rust/saturn/Cargo.toml
@@ -12,7 +12,7 @@ path = "src/main.rs"
 crate-type = ["rlib"]
 
 [dependencies]
-ruby-prism = "1.4.0"
+ruby-prism = "1.6.0"
 url = "2.5.4"
 xxhash-rust = { version = "0.8.15", features = ["xxh3"] }
 clap = { version = "4.5.16", features = ["derive"] }

--- a/rust/saturn/src/indexing/ruby_indexer.rs
+++ b/rust/saturn/src/indexing/ruby_indexer.rs
@@ -120,7 +120,7 @@ impl<'a> RubyIndexer<'a> {
         let mut parameters: Vec<Parameter> = Vec::new();
 
         if let Some(parameters_list) = node.parameters() {
-            for parameter in parameters_list.requireds().iter() {
+            for parameter in &parameters_list.requireds() {
                 let location = parameter.location();
 
                 parameters.push(Parameter::RequiredPositional(ParameterStruct::new(
@@ -129,7 +129,7 @@ impl<'a> RubyIndexer<'a> {
                 )));
             }
 
-            for parameter in parameters_list.optionals().iter() {
+            for parameter in &parameters_list.optionals() {
                 let opt_param = parameter.as_optional_parameter_node().unwrap();
                 let name_loc = opt_param.name_loc();
 
@@ -149,7 +149,7 @@ impl<'a> RubyIndexer<'a> {
                 )));
             }
 
-            for post in parameters_list.posts().iter() {
+            for post in &parameters_list.posts() {
                 let location = post.location();
 
                 parameters.push(Parameter::Post(ParameterStruct::new(
@@ -158,7 +158,7 @@ impl<'a> RubyIndexer<'a> {
                 )));
             }
 
-            for keyword in parameters_list.keywords().iter() {
+            for keyword in &parameters_list.keywords() {
                 match keyword {
                     ruby_prism::Node::RequiredKeywordParameterNode { .. } => {
                         let required = keyword.as_required_keyword_parameter_node().unwrap();
@@ -234,7 +234,7 @@ impl<'a> RubyIndexer<'a> {
         if (receiver.is_none() || receiver.unwrap().as_self_node().is_some())
             && let Some(arguments) = node.arguments()
         {
-            for argument in arguments.arguments().iter() {
+            for argument in &arguments.arguments() {
                 match argument {
                     ruby_prism::Node::SymbolNode { .. } => {
                         let symbol = argument.as_symbol_node().unwrap();
@@ -590,7 +590,7 @@ impl Visit<'_> for RubyIndexer<'_> {
     }
 
     fn visit_multi_write_node(&mut self, node: &ruby_prism::MultiWriteNode) {
-        for left in node.lefts().iter() {
+        for left in &node.lefts() {
             match left {
                 ruby_prism::Node::ConstantTargetNode { .. } | ruby_prism::Node::ConstantPathTargetNode { .. } => {
                     let location = left.location();


### PR DESCRIPTION
Upgrade to the latest Prism version.

The new version made Clippy realize that we were invoking `iter` on a few places where it isn't necessary and flagged it as less efficient than just iterating over a reference. I fixed all of those.