### PR TITLE
Re-enable Windows CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,9 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # TODO: Put back windows once we have figured how to compile Prism on it.
-        # os: [shopify-ubuntu-latest, macos-latest, shopify-windows-latest]
-        os: [shopify-ubuntu-latest, macos-latest]
+        os: [shopify-ubuntu-latest, macos-latest, shopify-windows-latest]
         ruby: ["3.4"]
     runs-on: ${{ matrix.os }}
     name: Ruby ${{ matrix.ruby }} on ${{ matrix.os }}

--- a/Gemfile
+++ b/Gemfile
@@ -11,4 +11,8 @@ gem "minitest"
 gem "rubocop"
 gem "rubocop-shopify"
 gem "extconf_compile_commands_json"
-gem "ruby_memcheck"
+
+# Gems that aren't supported on Windows
+platforms :ruby do
+  gem "ruby_memcheck"
+end

--- a/Rakefile
+++ b/Rakefile
@@ -4,7 +4,6 @@ require "bundler/gem_tasks"
 require "rubocop/rake_task"
 require "rake/extensiontask"
 require "rake/testtask"
-require "ruby_memcheck"
 
 GEMSPEC = Gem::Specification.load("saturn.gemspec")
 
@@ -19,7 +18,13 @@ test_config = lambda do |t|
   t.test_files = FileList["test/**/*_test.rb"]
 end
 Rake::TestTask.new(ruby_test: :compile, &test_config)
-namespace(:ruby_test) { RubyMemcheck::TestTask.new(valgrind: :compile, &test_config) }
+
+begin
+  require "ruby_memcheck"
+  namespace(:ruby_test) { RubyMemcheck::TestTask.new(valgrind: :compile, &test_config) }
+rescue LoadError
+  # ruby_memcheck is not available on Windows
+end
 
 RuboCop::RakeTask.new
 

--- a/lib/saturn/location.rb
+++ b/lib/saturn/location.rb
@@ -24,7 +24,10 @@ module Saturn
       uri = URI(@uri)
       raise Saturn::Error, "URI is not a file:// URI: #{@uri}" unless uri.scheme == "file"
 
-      uri.path
+      path = uri.path
+      # TODO: This has to go away once we have a proper URI abstraction
+      path.delete_prefix!("/") if Gem.win_platform?
+      path
     end
 
     #: (other: BasicObject) -> Integer

--- a/test/document_test.rb
+++ b/test/document_test.rb
@@ -23,7 +23,7 @@ class DocumentTest < Minitest::Test
 
       document = graph.documents.first
       assert_instance_of(Saturn::Document, document)
-      assert_equal("file://#{context.absolute_path}/file1.rb", document.uri)
+      assert_equal(context.uri_to("file1.rb"), document.uri)
     end
   end
 

--- a/test/helpers/context.rb
+++ b/test/helpers/context.rb
@@ -26,6 +26,14 @@ module Test
         ::File.join(@absolute_path, relative_path)
       end
 
+      #: (String) -> String
+      def uri_to(relative_path)
+        path = absolute_path_to(relative_path)
+        # TODO: This has to go away once we have a proper URI abstraction
+        path.prepend("/") if Gem.win_platform?
+        URI::File.build(path: path).to_s
+      end
+
       #: (String relative_path, ?String contents, ?append: bool) -> void
       def write!(relative_path, contents = "", append: false)
         absolute_path = absolute_path_to(relative_path)


### PR DESCRIPTION
Closes #68

It seems that https://github.com/ruby/prism/pull/3594 _did_ fix the Windows build 🎉. This PR re-enables it so that we don't accidentally add Windows incompatible code.

Most of the fixes are related to assuming forward slashes in file paths or not accounting for the carriage return character where it may happen.