### PR TITLE
Support indexing singleton class

### DIFF
--- a/ext/saturn/definition.c
+++ b/ext/saturn/definition.c
@@ -9,6 +9,7 @@ static VALUE mSaturn;
 VALUE cComment;
 VALUE cDefinition;
 VALUE cClassDefinition;
+VALUE cSingletonClassDefinition;
 VALUE cModuleDefinition;
 VALUE cConstantDefinition;
 VALUE cMethodDefinition;
@@ -17,6 +18,7 @@ VALUE cAttrReaderDefinition;
 VALUE cAttrWriterDefinition;
 VALUE cGlobalVariableDefinition;
 VALUE cInstanceVariableDefinition;
+VALUE cClassInstanceVariableDefinition;
 VALUE cClassVariableDefinition;
 
 // Keep this in sync with definition.rs
@@ -24,6 +26,8 @@ VALUE definition_class_for_kind(DefinitionKind kind) {
     switch (kind) {
     case DefinitionKind_Class:
         return cClassDefinition;
+    case DefinitionKind_SingletonClass:
+        return cSingletonClassDefinition;
     case DefinitionKind_Module:
         return cModuleDefinition;
     case DefinitionKind_Constant:
@@ -40,6 +44,8 @@ VALUE definition_class_for_kind(DefinitionKind kind) {
         return cGlobalVariableDefinition;
     case DefinitionKind_InstanceVariable:
         return cInstanceVariableDefinition;
+    case DefinitionKind_ClassInstanceVariable:
+        return cClassInstanceVariableDefinition;
     case DefinitionKind_ClassVariable:
         return cClassVariableDefinition;
     default:
@@ -134,6 +140,10 @@ void initialize_definition(VALUE mod) {
     rb_define_alloc_func(cClassDefinition, sr_handle_alloc);
     rb_define_method(cClassDefinition, "initialize", sr_handle_initialize, 2);
 
+    cSingletonClassDefinition = rb_define_class_under(mSaturn, "SingletonClassDefinition", cDefinition);
+    rb_define_alloc_func(cSingletonClassDefinition, sr_handle_alloc);
+    rb_define_method(cSingletonClassDefinition, "initialize", sr_handle_initialize, 2);
+
     cModuleDefinition = rb_define_class_under(mSaturn, "ModuleDefinition", cDefinition);
     rb_define_alloc_func(cModuleDefinition, sr_handle_alloc);
     rb_define_method(cModuleDefinition, "initialize", sr_handle_initialize, 2);
@@ -165,6 +175,10 @@ void initialize_definition(VALUE mod) {
     cInstanceVariableDefinition = rb_define_class_under(mSaturn, "InstanceVariableDefinition", cDefinition);
     rb_define_alloc_func(cInstanceVariableDefinition, sr_handle_alloc);
     rb_define_method(cInstanceVariableDefinition, "initialize", sr_handle_initialize, 2);
+
+    cClassInstanceVariableDefinition = rb_define_class_under(mSaturn, "ClassInstanceVariableDefinition", cDefinition);
+    rb_define_alloc_func(cClassInstanceVariableDefinition, sr_handle_alloc);
+    rb_define_method(cClassInstanceVariableDefinition, "initialize", sr_handle_initialize, 2);
 
     cClassVariableDefinition = rb_define_class_under(mSaturn, "ClassVariableDefinition", cDefinition);
     rb_define_alloc_func(cClassVariableDefinition, sr_handle_alloc);

--- a/ext/saturn/definition.h
+++ b/ext/saturn/definition.h
@@ -6,6 +6,7 @@
 
 extern VALUE cDefinition;
 extern VALUE cClassDefinition;
+extern VALUE cSingletonClassDefinition;
 extern VALUE cModuleDefinition;
 extern VALUE cConstantDefinition;
 extern VALUE cMethodDefinition;
@@ -14,6 +15,7 @@ extern VALUE cAttrReaderDefinition;
 extern VALUE cAttrWriterDefinition;
 extern VALUE cGlobalVariableDefinition;
 extern VALUE cInstanceVariableDefinition;
+extern VALUE cClassInstanceVariableDefinition;
 extern VALUE cClassVariableDefinition;
 
 void initialize_definition(VALUE mSaturn);

--- a/rust/saturn-sys/src/definition_api.rs
+++ b/rust/saturn-sys/src/definition_api.rs
@@ -13,20 +13,23 @@ use std::ptr;
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum DefinitionKind {
     Class = 0,
-    Module = 1,
-    Constant = 2,
-    Method = 3,
-    AttrAccessor = 4,
-    AttrReader = 5,
-    AttrWriter = 6,
-    GlobalVariable = 7,
-    InstanceVariable = 8,
-    ClassVariable = 9,
+    SingletonClass = 1,
+    Module = 2,
+    Constant = 3,
+    Method = 4,
+    AttrAccessor = 5,
+    AttrReader = 6,
+    AttrWriter = 7,
+    GlobalVariable = 8,
+    InstanceVariable = 9,
+    ClassInstanceVariable = 10,
+    ClassVariable = 11,
 }
 
 pub(crate) fn map_definition_to_kind(defn: &Definition) -> DefinitionKind {
     match defn {
         Definition::Class(_) => DefinitionKind::Class,
+        Definition::SingletonClass(_) => DefinitionKind::SingletonClass,
         Definition::Module(_) => DefinitionKind::Module,
         Definition::Constant(_) => DefinitionKind::Constant,
         Definition::Method(_) => DefinitionKind::Method,
@@ -35,6 +38,7 @@ pub(crate) fn map_definition_to_kind(defn: &Definition) -> DefinitionKind {
         Definition::AttrWriter(_) => DefinitionKind::AttrWriter,
         Definition::GlobalVariable(_) => DefinitionKind::GlobalVariable,
         Definition::InstanceVariable(_) => DefinitionKind::InstanceVariable,
+        Definition::ClassInstanceVariable(_) => DefinitionKind::ClassInstanceVariable,
         Definition::ClassVariable(_) => DefinitionKind::ClassVariable,
     }
 }

--- a/rust/saturn/src/model/definitions.rs
+++ b/rust/saturn/src/model/definitions.rs
@@ -36,6 +36,7 @@ use crate::{
 #[derive(Debug)]
 pub enum Definition {
     Class(Box<ClassDefinition>),
+    SingletonClass(Box<SingletonClassDefinition>),
     Module(Box<ModuleDefinition>),
     Constant(Box<ConstantDefinition>),
     Method(Box<MethodDefinition>),
@@ -44,6 +45,7 @@ pub enum Definition {
     AttrWriter(Box<AttrWriterDefinition>),
     GlobalVariable(Box<GlobalVariableDefinition>),
     InstanceVariable(Box<InstanceVariableDefinition>),
+    ClassInstanceVariable(Box<ClassInstanceVariableDefinition>),
     ClassVariable(Box<ClassVariableDefinition>),
 }
 
@@ -51,10 +53,12 @@ macro_rules! all_definitions {
     ($value:expr, $var:ident => $expr:expr) => {
         match $value {
             Definition::Class($var) => $expr,
+            Definition::SingletonClass($var) => $expr,
             Definition::Module($var) => $expr,
             Definition::Constant($var) => $expr,
             Definition::GlobalVariable($var) => $expr,
             Definition::InstanceVariable($var) => $expr,
+            Definition::ClassInstanceVariable($var) => $expr,
             Definition::ClassVariable($var) => $expr,
             Definition::AttrAccessor($var) => $expr,
             Definition::AttrReader($var) => $expr,
@@ -94,6 +98,7 @@ impl Definition {
     pub fn kind(&self) -> &'static str {
         match self {
             Definition::Class(_) => "Class",
+            Definition::SingletonClass(_) => "SingletonClass",
             Definition::Module(_) => "Module",
             Definition::Constant(_) => "Constant",
             Definition::Method(_) => "Method",
@@ -102,28 +107,31 @@ impl Definition {
             Definition::AttrWriter(_) => "AttrWriter",
             Definition::GlobalVariable(_) => "GlobalVariable",
             Definition::InstanceVariable(_) => "InstanceVariable",
+            Definition::ClassInstanceVariable(_) => "ClassInstanceVariable",
             Definition::ClassVariable(_) => "ClassVariable",
         }
     }
 
     /// # Panics
     ///
-    /// Panics if the definition is not a nesting definition (class or module)
+    /// Panics if the definition is not a nesting definition (class, module, or singleton block)
     pub fn add_member(&mut self, member_id: DefinitionId) {
         match self {
             Definition::Class(class) => class.add_member(member_id),
+            Definition::SingletonClass(block) => block.add_member(member_id),
             Definition::Module(module) => module.add_member(member_id),
             _ => panic!("Cannot add a member to a non-nesting definition"),
         }
     }
 }
 
-/// Represents either an included or a prepended module. Note that `extend` is modeled as an include on the singleton
-/// class
+/// Represents a mixin: include, prepend, or extend.
+/// During resolution, `Extend` mixins are attached to the singleton class.
 #[derive(Debug)]
 pub enum Mixin {
     Include(NameId),
     Prepend(NameId),
+    Extend(NameId),
 }
 
 // Deref implementation to conveniently extract the reference ID with a dereference
@@ -132,7 +140,7 @@ impl Deref for Mixin {
 
     fn deref(&self) -> &Self::Target {
         match self {
-            Mixin::Include(id) | Mixin::Prepend(id) => id,
+            Mixin::Include(id) | Mixin::Prepend(id) | Mixin::Extend(id) => id,
         }
     }
 }
@@ -154,6 +162,118 @@ pub struct ClassDefinition {
     members: Vec<DefinitionId>,
     superclass_ref: Option<NameId>,
     mixins: Vec<Mixin>,
+}
+
+/// A singleton class definition created from `class << X` syntax.
+/// This is created only when `class << X` syntax is encountered, NOT for `def self.foo`.
+/// Methods with receivers (like `def self.foo`) have their `receiver` field set instead.
+///
+/// # Examples
+/// ```ruby
+/// class Foo
+///   class << self     # attached_target = NameId("Foo")
+///     def bar; end
+///   end
+/// end
+///
+/// class << Foo        # attached_target = NameId("Foo")
+///   def baz; end
+/// end
+/// ```
+#[derive(Debug)]
+pub struct SingletonClassDefinition {
+    /// The name of this singleton class (e.g., `<Foo>` for `class << self` inside `class Foo`)
+    name_id: NameId,
+    /// The class/module whose singleton is being opened (aligns with Ruby's `attached_object`).
+    /// - `class << self` inside `class Foo` → NameId("Foo")
+    /// - `class << Bar` → NameId("Bar")
+    /// - Nested `class << self` → `NameId("<Foo>")` (the outer singleton)
+    attached_target: NameId,
+    uri_id: UriId,
+    offset: Offset,
+    comments: Vec<Comment>,
+    /// The definition where `class << X` was found (lexical owner)
+    owner_id: Option<DefinitionId>,
+    /// Members defined directly in this block
+    members: Vec<DefinitionId>,
+    /// Mixins declared in this block
+    mixins: Vec<Mixin>,
+}
+
+impl SingletonClassDefinition {
+    #[must_use]
+    pub const fn new(
+        name_id: NameId,
+        attached_target: NameId,
+        uri_id: UriId,
+        offset: Offset,
+        comments: Vec<Comment>,
+        owner_id: Option<DefinitionId>,
+    ) -> Self {
+        Self {
+            name_id,
+            attached_target,
+            uri_id,
+            offset,
+            comments,
+            owner_id,
+            members: Vec::new(),
+            mixins: Vec::new(),
+        }
+    }
+
+    #[must_use]
+    pub fn id(&self) -> DefinitionId {
+        DefinitionId::from(&format!("{}{}{}", *self.uri_id, self.offset.start(), *self.name_id))
+    }
+
+    #[must_use]
+    pub fn name_id(&self) -> &NameId {
+        &self.name_id
+    }
+
+    #[must_use]
+    pub fn attached_target(&self) -> &NameId {
+        &self.attached_target
+    }
+
+    #[must_use]
+    pub fn uri_id(&self) -> &UriId {
+        &self.uri_id
+    }
+
+    #[must_use]
+    pub fn offset(&self) -> &Offset {
+        &self.offset
+    }
+
+    #[must_use]
+    pub fn comments(&self) -> &[Comment] {
+        &self.comments
+    }
+
+    #[must_use]
+    pub fn owner_id(&self) -> &Option<DefinitionId> {
+        &self.owner_id
+    }
+
+    #[must_use]
+    pub fn members(&self) -> &[DefinitionId] {
+        &self.members
+    }
+
+    #[must_use]
+    pub fn mixins(&self) -> &[Mixin] {
+        &self.mixins
+    }
+
+    pub fn add_member(&mut self, member_id: DefinitionId) {
+        self.members.push(member_id);
+    }
+
+    pub fn add_mixin(&mut self, mixin: Mixin) {
+        self.mixins.push(mixin);
+    }
 }
 
 impl ClassDefinition {
@@ -398,7 +518,12 @@ pub struct MethodDefinition {
     comments: Vec<Comment>,
     owner_id: Option<DefinitionId>,
     parameters: Vec<Parameter>,
-    is_singleton: bool,
+    /// The receiver for this method, if any.
+    /// - `None` for instance methods (`def foo`)
+    /// - `Some(NameId)` for singleton methods:
+    ///   - `def self.foo` inside `class Foo` → Some(NameId("Foo"))
+    ///   - `def Bar.foo` → Some(NameId("Bar"))
+    receiver: Option<NameId>,
 }
 
 impl MethodDefinition {
@@ -410,7 +535,7 @@ impl MethodDefinition {
         comments: Vec<Comment>,
         owner_id: Option<DefinitionId>,
         parameters: Vec<Parameter>,
-        is_singleton: bool,
+        receiver: Option<NameId>,
     ) -> Self {
         Self {
             str_id,
@@ -419,7 +544,7 @@ impl MethodDefinition {
             comments,
             owner_id,
             parameters,
-            is_singleton,
+            receiver,
         }
     }
 
@@ -459,8 +584,8 @@ impl MethodDefinition {
     }
 
     #[must_use]
-    pub fn is_singleton(&self) -> bool {
-        self.is_singleton
+    pub fn receiver(&self) -> &Option<NameId> {
+        &self.receiver
     }
 }
 
@@ -772,6 +897,78 @@ pub struct InstanceVariableDefinition {
 }
 
 impl InstanceVariableDefinition {
+    #[must_use]
+    pub const fn new(
+        str_id: StringId,
+        uri_id: UriId,
+        offset: Offset,
+        comments: Vec<Comment>,
+        owner_id: Option<DefinitionId>,
+    ) -> Self {
+        Self {
+            str_id,
+            uri_id,
+            offset,
+            comments,
+            owner_id,
+        }
+    }
+
+    #[must_use]
+    pub fn id(&self) -> DefinitionId {
+        DefinitionId::from(&format!("{}{}{}", *self.uri_id, self.offset.start(), *self.str_id))
+    }
+
+    #[must_use]
+    pub fn str_id(&self) -> &StringId {
+        &self.str_id
+    }
+
+    #[must_use]
+    pub fn uri_id(&self) -> &UriId {
+        &self.uri_id
+    }
+
+    #[must_use]
+    pub fn offset(&self) -> &Offset {
+        &self.offset
+    }
+
+    #[must_use]
+    pub fn comments(&self) -> &[Comment] {
+        &self.comments
+    }
+
+    #[must_use]
+    pub fn owner_id(&self) -> &Option<DefinitionId> {
+        &self.owner_id
+    }
+}
+
+/// A class instance variable definition.
+/// This represents `@ivar` found in a class/module body (not inside a method).
+///
+/// # Example
+/// ```ruby
+/// class Foo
+///   @class_ivar = 1  # ClassInstanceVariableDefinition
+///
+///   def initialize
+///     @instance_ivar = 2  # InstanceVariableDefinition
+///   end
+/// end
+/// ```
+#[derive(Debug)]
+pub struct ClassInstanceVariableDefinition {
+    str_id: StringId,
+    uri_id: UriId,
+    offset: Offset,
+    comments: Vec<Comment>,
+    /// The class/module definition where this was found
+    owner_id: Option<DefinitionId>,
+}
+
+impl ClassInstanceVariableDefinition {
     #[must_use]
     pub const fn new(
         str_id: StringId,

--- a/rust/saturn/src/resolution.rs
+++ b/rust/saturn/src/resolution.rs
@@ -123,7 +123,8 @@ pub fn resolve_all(graph: &mut Graph) {
             Definition::GlobalVariable(it) => it.str_id(),
             Definition::InstanceVariable(it) => it.str_id(),
             Definition::ClassVariable(it) => it.str_id(),
-            Definition::Class(_) | Definition::Module(_) | Definition::Constant(_) => {
+            Definition::ClassInstanceVariable(it) => it.str_id(),
+            Definition::Class(_) | Definition::Module(_) | Definition::Constant(_) | Definition::SingletonClass(_) => {
                 panic!("Unexpected definition type. This shouldn't happen")
             }
         };


### PR DESCRIPTION
This PR adds singleton class definition indexing for `class << X` expressions:

```rb
class Foo
  def self.bar; end       # method with `receiver` `Foo` (no singleton def created)
  @class_ivar = 1         # `ClassInstanceVariableDefinition` owned by `Foo`

  class << self           # creates `SingletonClassDefinition` `<Foo>`
    def baz; end          # method owned by `<Foo>`

    class << self         # creates `SingletonClassDefinition` `<<Foo>>`
      def qux; end        # method owned by `<<Foo>>`
    end
  end
end

class << Foo              # creates `SingletonClassDefinition` `<Foo>`
  def quux; end           # method owned by `<Foo>`
end

class << some_var         # dynamic expression - no definition created
  def dynamic; end
end
```

Key indexing behaviors:
- Only `class << self` or `class << Constant` creates a `SingletonClassDefinition`
- `def self.method` stores a `receiver` field pointing to the class's `NameId`, without creating a singleton definition
- Instance variables in class/module body (`@ivar`) become `ClassInstanceVariableDefinition`
- Instance variables in method bodies inside `class << self` also become `ClassInstanceVariableDefinition`
- Class variables (`@@var`) bypass singleton blocks. They always belong to the base class/module
- `extend SomeModule` is stored as `Mixin::Extend` on the class/module

Stats from Core:

```
Definition breakdown:
  Method                     321829
  Module                     178383
  Class                      102105
  ClassInstanceVariable       95619
  InstanceVariable            86623
  Constant                    61706
  AttrReader                  31875
  SingletonClass              13557
  AttrAccessor                 5886
  AttrWriter                    384
  GlobalVariable                 30
  ClassVariable                  11

Singleton class definitions (class << X):
    On classes:            11413 (84.2%)
    On modules:             2141 (15.8%)
    Nested:                    3 (0.0%)
  With members:            13526 (99.8%)
```
