### PR TITLE
Rename remaining `name_id` cases that are actually `StringId`

### DIFF
--- a/rust/saturn-sys/src/definition_api.rs
+++ b/rust/saturn-sys/src/definition_api.rs
@@ -75,9 +75,9 @@ pub unsafe extern "C" fn sat_definition_name(pointer: GraphPointer, definition_i
     with_graph(pointer, |graph| {
         let def_id = DefinitionId::new(definition_id);
         if let Some(defn) = graph.definitions().get(&def_id) {
-            let name_id = graph.definition_string_id(defn);
+            let string_id = graph.definition_string_id(defn);
 
-            if let Some(name) = graph.strings().get(&name_id) {
+            if let Some(name) = graph.strings().get(&string_id) {
                 CString::new(name.as_str()).unwrap().into_raw().cast_const()
             } else {
                 ptr::null()

--- a/rust/saturn-sys/src/reference_api.rs
+++ b/rust/saturn-sys/src/reference_api.rs
@@ -129,7 +129,7 @@ pub unsafe extern "C" fn sat_method_reference_name(pointer: GraphPointer, refere
         let reference = graph.method_references().get(&ref_id).expect("Reference not found");
         let name = graph
             .strings()
-            .get(reference.name_id())
+            .get(reference.str())
             .expect("Name ID should exist")
             .clone();
         CString::new(name).unwrap().into_raw().cast_const()

--- a/rust/saturn/src/indexing/local_graph.rs
+++ b/rust/saturn/src/indexing/local_graph.rs
@@ -73,9 +73,9 @@ impl LocalGraph {
     }
 
     pub fn intern_string(&mut self, string: String) -> StringId {
-        let name_id = StringId::from(&string);
-        self.strings.insert(name_id, string);
-        name_id
+        let string_id = StringId::from(&string);
+        self.strings.insert(string_id, string);
+        string_id
     }
 
     // Names

--- a/rust/saturn/src/indexing/ruby_indexer.rs
+++ b/rust/saturn/src/indexing/ruby_indexer.rs
@@ -999,7 +999,7 @@ mod tests {
                 .graph()
                 .method_references()
                 .values()
-                .map(|m| (m.offset().start(), $context.graph().strings().get(m.name_id()).unwrap()))
+                .map(|m| (m.offset().start(), $context.graph().strings().get(m.str()).unwrap()))
                 .collect::<Vec<_>>();
 
             actual_references.sort();

--- a/rust/saturn/src/model/declaration.rs
+++ b/rust/saturn/src/model/declaration.rs
@@ -1,6 +1,6 @@
 use crate::model::{
     identity_maps::IdentityHashMap,
-    ids::{DeclarationId, DefinitionId, StringId, ReferenceId},
+    ids::{DeclarationId, DefinitionId, ReferenceId, StringId},
 };
 
 /// A `Declaration` represents the global concept of an entity in Ruby. For example, the class `Foo` may be defined 3
@@ -91,17 +91,17 @@ impl Declaration {
         &self.members
     }
 
-    pub fn add_member(&mut self, name_id: StringId, declaration_id: DeclarationId) {
-        self.members.insert(name_id, declaration_id);
+    pub fn add_member(&mut self, string_id: StringId, declaration_id: DeclarationId) {
+        self.members.insert(string_id, declaration_id);
     }
 
-    pub fn remove_member(&mut self, name_id: &StringId) -> Option<DeclarationId> {
-        self.members.remove(name_id)
+    pub fn remove_member(&mut self, string_id: &StringId) -> Option<DeclarationId> {
+        self.members.remove(string_id)
     }
 
     #[must_use]
-    pub fn get_member(&self, name_id: &StringId) -> Option<&DeclarationId> {
-        self.members.get(name_id)
+    pub fn get_member(&self, string_id: &StringId) -> Option<&DeclarationId> {
+        self.members.get(string_id)
     }
 
     #[must_use]

--- a/rust/saturn/src/model/graph.rs
+++ b/rust/saturn/src/model/graph.rs
@@ -197,8 +197,8 @@ impl Graph {
         member_name: &str,
     ) {
         if let Some(declaration) = self.declarations.get_mut(declaration_id) {
-            let name_id = StringId::from(member_name);
-            declaration.add_member(name_id, member_declaration_id);
+            let string_id = StringId::from(member_name);
+            declaration.add_member(string_id, member_declaration_id);
         }
     }
 

--- a/rust/saturn/src/model/references.rs
+++ b/rust/saturn/src/model/references.rs
@@ -57,7 +57,7 @@ impl ConstantReference {
 #[derive(Debug)]
 pub struct MethodRef {
     /// The unqualified name of the method
-    name_id: StringId,
+    str: StringId,
     /// The document where we found the reference
     uri_id: UriId,
     /// The offsets inside of the document where we found the reference
@@ -66,17 +66,13 @@ pub struct MethodRef {
 
 impl MethodRef {
     #[must_use]
-    pub fn new(name_id: StringId, uri_id: UriId, offset: Offset) -> Self {
-        Self {
-            name_id,
-            uri_id,
-            offset,
-        }
+    pub fn new(str: StringId, uri_id: UriId, offset: Offset) -> Self {
+        Self { str, uri_id, offset }
     }
 
     #[must_use]
-    pub fn name_id(&self) -> &StringId {
-        &self.name_id
+    pub fn str(&self) -> &StringId {
+        &self.str
     }
 
     #[must_use]
@@ -94,7 +90,7 @@ impl MethodRef {
         // M:<uri_id>:<start>-<end>
         let key = format!(
             "M:{}:{}:{}-{}",
-            self.name_id,
+            self.str,
             self.uri_id,
             self.offset.start(),
             self.offset.end()

--- a/rust/saturn/src/resolve.rs
+++ b/rust/saturn/src/resolve.rs
@@ -2,8 +2,8 @@ use crate::model::definitions::Definition;
 use crate::model::graph::Graph;
 
 fn fully_qualify_definition_name(graph: &Graph, definition: &Definition) -> String {
-    let definition_name_id = graph.definition_string_id(definition);
-    let definition_name = graph.strings().get(&definition_name_id).unwrap();
+    let definition_string_id = graph.definition_string_id(definition);
+    let definition_name = graph.strings().get(&definition_string_id).unwrap();
 
     if let Some(fully_qualified_name) = definition_name.strip_prefix("::") {
         return fully_qualified_name.to_string();


### PR DESCRIPTION
Remove part of #331 that's not strictly related to designing the resolution phase. This PR renames some cases in the `StringId` rename that we missed.