### PR TITLE
Add parent class linearization

### DIFF
--- a/rust/saturn/src/model/declaration.rs
+++ b/rust/saturn/src/model/declaration.rs
@@ -1,3 +1,5 @@
+use std::cell::OnceCell;
+
 use crate::model::{
     identity_maps::IdentityHashMap,
     ids::{DeclarationId, DefinitionId, ReferenceId, StringId},
@@ -21,6 +23,7 @@ pub struct Declaration {
     references: Vec<ReferenceId>,
     /// The ID of the owner of this declaration
     owner_id: DeclarationId,
+    ancestors: OnceCell<Vec<DeclarationId>>,
 }
 
 impl Declaration {
@@ -32,6 +35,7 @@ impl Declaration {
             members: IdentityHashMap::default(),
             references: Vec::new(),
             owner_id,
+            ancestors: OnceCell::new(),
         }
     }
 
@@ -107,6 +111,20 @@ impl Declaration {
     #[must_use]
     pub fn owner_id(&self) -> &DeclarationId {
         &self.owner_id
+    }
+
+    /// # Panics
+    ///
+    /// Will panic if invoked twice without clearing ancestors
+    pub fn set_ancestors(&self, ancestors: Vec<DeclarationId>) {
+        self.ancestors
+            .set(ancestors)
+            .expect("ancestors should only be set once per declaration");
+    }
+
+    #[must_use]
+    pub fn ancestors(&self) -> Option<&[DeclarationId]> {
+        self.ancestors.get().map(Vec::as_slice)
     }
 
     // This will change once we fix fully qualified names to not use `::` as separators for everything. Also, we may

--- a/rust/saturn/src/model/definitions.rs
+++ b/rust/saturn/src/model/definitions.rs
@@ -303,8 +303,8 @@ impl ClassDefinition {
     }
 
     #[must_use]
-    pub fn superclass_ref(&self) -> &Option<NameId> {
-        &self.superclass_ref
+    pub fn superclass_ref(&self) -> Option<NameId> {
+        self.superclass_ref
     }
 
     #[must_use]


### PR DESCRIPTION
Add parent class linearization. I'm more interested in seeing how this fits into the general resolution algorithm at this point, but I think this PR also uncovers the need for specializing declarations.

For example, if we turn `Declaration`​ into an enum, we can always pick the first definition we find as the truth for error scenarios, which makes it easier to emit diagnostics. Imagine we find `class Foo`​ and `module Foo`​. When we're processing the second `Foo`​, it would be easier to recognize the mistake by looking at the `Declaration`​. Same thing for superclass mismatches.

In terms of the implications for the resolution phase, I used a `OnceCell`​for ancestors, which gives us interior mutability (avoiding borrow issues). This makes it easier to work with than `RefCell`​ because we never expect to mutate the ancestor vector. We always erase and set the entire vector in one go. By using `OnceCell`​, we don't pay the runtime price of `RefCell`​.