### PR TITLE
Add global graph diagnostics

### DIFF
--- a/rust/saturn/src/indexing/local_graph.rs
+++ b/rust/saturn/src/indexing/local_graph.rs
@@ -14,6 +14,7 @@ type LocalGraphParts = (
     IdentityHashMap<NameId, NameRef>,
     IdentityHashMap<ReferenceId, ConstantReference>,
     IdentityHashMap<ReferenceId, MethodRef>,
+    Vec<Diagnostic>,
 );
 
 #[derive(Debug)]
@@ -142,6 +143,7 @@ impl LocalGraph {
             self.names,
             self.constant_references,
             self.method_references,
+            self.diagnostics,
         )
     }
 }


### PR DESCRIPTION
One more step towards https://github.com/Shopify/saturn/issues/340. 

* Local diagnostics are collected into the global list.
* Global diagnostics can be added during resolution.

I believe the last step will be to produce diagnostics during indexing and resolution according to the list in https://github.com/Shopify/saturn/issues/340.