### PR TITLE
Pass Offset instead of start/end pair

### DIFF
--- a/rust/saturn-sys/src/definition_api.rs
+++ b/rust/saturn-sys/src/definition_api.rs
@@ -204,7 +204,7 @@ pub unsafe extern "C" fn sat_definition_comments(pointer: GraphPointer, definiti
             .iter()
             .map(|c| CommentEntry {
                 string: CString::new(c.string().as_str()).unwrap().into_raw().cast_const(),
-                location: create_location_for_uri_and_offset(&uri, c.offset().start(), c.offset().end()),
+                location: create_location_for_uri_and_offset(&uri, c.offset()),
             })
             .collect::<Vec<CommentEntry>>()
             .into_boxed_slice();
@@ -277,8 +277,7 @@ pub unsafe extern "C" fn sat_definition_location(pointer: GraphPointer, definiti
             panic!("Document not found: {uri_id:?}");
         };
 
-        let offset = defn.offset();
-        create_location_for_uri_and_offset(&uri, offset.start(), offset.end())
+        create_location_for_uri_and_offset(&uri, defn.offset())
     })
 }
 

--- a/rust/saturn-sys/src/graph_api.rs
+++ b/rust/saturn-sys/src/graph_api.rs
@@ -1,6 +1,5 @@
 //! This file provides the C API for the Graph object
 
-// use crate::location_api::create_location_for_uri_and_offset; // no longer used here
 use crate::reference_api::{ReferenceKind, ReferencesIter};
 use crate::utils;
 use libc::{c_char, c_void};

--- a/rust/saturn-sys/src/location_api.rs
+++ b/rust/saturn-sys/src/location_api.rs
@@ -2,6 +2,7 @@
 
 use libc::c_char;
 use line_index::LineIndex;
+use saturn::offset::Offset;
 use std::ffi::CString;
 use std::fs;
 use url::Url;
@@ -35,13 +36,13 @@ fn file_path_from_uri(uri: &str) -> Option<String> {
 /// - If the file cannot be read.
 /// - If the offset cannot be converted to a position.
 #[must_use]
-pub(crate) fn create_location_for_uri_and_offset(uri: &str, start: u32, end: u32) -> *mut Location {
+pub(crate) fn create_location_for_uri_and_offset(uri: &str, offset: &Offset) -> *mut Location {
     let path_str = file_path_from_uri(uri).unwrap_or_else(|| panic!("Failed to convert URI to file path: {uri}"));
     let source = fs::read_to_string(&path_str).unwrap_or_else(|_| panic!("Failed to read file at path {path_str}"));
 
     let line_index = LineIndex::new(&source);
-    let start_pos = line_index.line_col(start.into());
-    let end_pos = line_index.line_col(end.into());
+    let start_pos = line_index.line_col(offset.start().into());
+    let end_pos = line_index.line_col(offset.end().into());
 
     let loc = Location {
         uri: CString::new(uri).unwrap().into_raw().cast_const(),

--- a/rust/saturn-sys/src/reference_api.rs
+++ b/rust/saturn-sys/src/reference_api.rs
@@ -158,7 +158,7 @@ pub unsafe extern "C" fn sat_constant_reference_location(pointer: GraphPointer, 
             .expect("Document should exist")
             .uri()
             .to_string();
-        create_location_for_uri_and_offset(&uri, reference.offset().start(), reference.offset().end())
+        create_location_for_uri_and_offset(&uri, reference.offset())
     })
 }
 
@@ -184,6 +184,6 @@ pub unsafe extern "C" fn sat_method_reference_location(pointer: GraphPointer, re
             .expect("Document should exist")
             .uri()
             .to_string();
-        create_location_for_uri_and_offset(&uri, reference.offset().start(), reference.offset().end())
+        create_location_for_uri_and_offset(&uri, reference.offset())
     })
 }


### PR DESCRIPTION
We can directly call it with the offset:

```rs
create_location_for_uri_and_offset(&uri, c.offset())
```

instead of separate start and end:

```rs
create_location_for_uri_and_offset(&uri, c.offset().start(), c.offset().end())
```