### PR TITLE
Simplify diagnostic creation on local graph

### DIFF
--- a/rust/saturn/src/indexing/local_graph.rs
+++ b/rust/saturn/src/indexing/local_graph.rs
@@ -1,10 +1,11 @@
-use crate::diagnostic::Diagnostic;
+use crate::diagnostic::{Diagnostic, Severity};
 use crate::model::definitions::Definition;
 use crate::model::document::Document;
 use crate::model::identity_maps::IdentityHashMap;
 use crate::model::ids::{DefinitionId, NameId, ReferenceId, StringId, UriId};
 use crate::model::name::{Name, NameRef};
 use crate::model::references::{ConstantReference, MethodRef};
+use crate::offset::Offset;
 
 type LocalGraphParts = (
     UriId,
@@ -127,7 +128,8 @@ impl LocalGraph {
         &self.diagnostics
     }
 
-    pub fn add_diagnostic(&mut self, diagnostic: Diagnostic) {
+    pub fn add_diagnostic(&mut self, offset: Offset, message: String, severity: Severity) {
+        let diagnostic = Diagnostic::new(self.uri_id, offset, message, severity);
         self.diagnostics.push(diagnostic);
     }
 

--- a/rust/saturn/src/indexing/ruby_indexer.rs
+++ b/rust/saturn/src/indexing/ruby_indexer.rs
@@ -1,6 +1,6 @@
 //! Visit the Ruby AST and create the definitions.
 
-use crate::diagnostic::{Diagnostic, Severity};
+use crate::diagnostic::Severity;
 use crate::errors::Errors;
 use crate::indexing::local_graph::LocalGraph;
 use crate::model::comment::Comment;
@@ -64,21 +64,19 @@ impl<'a> RubyIndexer<'a> {
         let result = ruby_prism::parse(self.source.as_bytes());
 
         for error in result.errors() {
-            self.local_graph.add_diagnostic(Diagnostic::new(
-                self.uri_id,
+            self.local_graph.add_diagnostic(
                 Offset::from_prism_location(&error.location()),
                 error.message().to_string(),
                 Severity::Error,
-            ));
+            );
         }
 
         for warning in result.warnings() {
-            self.local_graph.add_diagnostic(Diagnostic::new(
-                self.uri_id,
+            self.local_graph.add_diagnostic(
                 Offset::from_prism_location(&warning.location()),
                 warning.message().to_string(),
                 Severity::Warning,
-            ));
+            );
         }
 
         self.comments = self.parse_comments_into_groups(&result);


### PR DESCRIPTION
No need to specify the URI on a local graph, it's already anchored on a single file. We can simplify the diagnostic creation API.