### PR TITLE
Keep track of descendents when linearizing ancestors

### DIFF
--- a/rust/saturn/src/model/declaration.rs
+++ b/rust/saturn/src/model/declaration.rs
@@ -1,7 +1,7 @@
-use std::cell::OnceCell;
+use std::cell::{OnceCell, Ref, RefCell};
 
 use crate::model::{
-    identity_maps::IdentityHashMap,
+    identity_maps::{IdentityHashMap, IdentityHashSet},
     ids::{DeclarationId, DefinitionId, ReferenceId, StringId},
 };
 
@@ -24,6 +24,7 @@ pub struct Declaration {
     /// The ID of the owner of this declaration
     owner_id: DeclarationId,
     ancestors: OnceCell<Vec<DeclarationId>>,
+    descendants: RefCell<IdentityHashSet<DeclarationId>>,
 }
 
 impl Declaration {
@@ -36,6 +37,7 @@ impl Declaration {
             references: Vec::new(),
             owner_id,
             ancestors: OnceCell::new(),
+            descendants: RefCell::new(IdentityHashSet::default()),
         }
     }
 
@@ -125,6 +127,14 @@ impl Declaration {
     #[must_use]
     pub fn ancestors(&self) -> Option<&[DeclarationId]> {
         self.ancestors.get().map(Vec::as_slice)
+    }
+
+    pub fn add_descendant(&self, descendant_id: DeclarationId) {
+        self.descendants.borrow_mut().insert(descendant_id);
+    }
+
+    pub fn descendants(&self) -> Ref<'_, IdentityHashSet<DeclarationId>> {
+        self.descendants.borrow()
     }
 
     // This will change once we fix fully qualified names to not use `::` as separators for everything. Also, we may


### PR DESCRIPTION
This PR starts keeping track of descendants as we linearize ancestors. Knowing descendants is useful for a few things:

- The LSP can show all descendants of a given type
- Linters can have rules that ban inheriting from a certain type (e.g.: a deprecated module or parent class)
- Collecting statistics about a codebase to understand the most used ancestors (higher number of descendants)

The idea of the implementation is to introduce a new parameter `descendant_id` to `linearize_ancestors`. As we recurse during linearization, we have the opportunity to remember the descendants.

### Caveat

At the moment, the implementation doesn't linearize ancestors that we don't have to linearize. They are only linearized if that is required to resolve a constant reference or if you invoke the API directly.

This is an issue for tracking descendants. You can only figure out all descendants by linearizing every single module and class. Unlike ancestor linearization, we wouldn't know _what do analyze_ ahead of time if we had an API like `descendants_of(declaration: DeclarationId)`.

I believe we have two options:

- Always linearize all ancestors. This may prove necessary in the future anyway. Especially when there's a certain amount of type checking going on. While this may sound wasteful at this point in time, I suspect it's probably the easiest path forward and the inevitable path we'll end up taking
- Introduce a `descendants_of` API that first ensures all ancestors have been linearized and then returns the result. This will be more performant right now, but might make the code more complex