### PR TITLE
Move `Definition::add_member` as a private function in the indexer

### DIFF
--- a/rust/saturn/src/model/definitions.rs
+++ b/rust/saturn/src/model/definitions.rs
@@ -109,18 +109,6 @@ impl Definition {
             Definition::ClassVariable(_) => "ClassVariable",
         }
     }
-
-    /// # Panics
-    ///
-    /// Panics if the definition is not a nesting definition (class, module, or singleton class)
-    pub fn add_member(&mut self, member_id: DefinitionId) {
-        match self {
-            Definition::Class(class) => class.add_member(member_id),
-            Definition::SingletonClass(singleton_class) => singleton_class.add_member(member_id),
-            Definition::Module(module) => module.add_member(member_id),
-            _ => panic!("Cannot add a member to a non-nesting definition"),
-        }
-    }
 }
 
 /// Represents a mixin: include, prepend, or extend.


### PR DESCRIPTION
From https://github.com/Shopify/saturn/pull/376#discussion_r2599530264, I don't think we should expose this method as a public API on Definition.

We can use it in the indexer though since we control the logic.