### PR TITLE
Remove unused `errors` from Ruby indexer

### DIFF
--- a/rust/saturn/src/indexing.rs
+++ b/rust/saturn/src/indexing.rs
@@ -40,7 +40,7 @@ pub fn index_in_parallel(graph: &mut Graph, file_paths: Vec<String>) -> Result<(
 
         let mut ruby_indexer = RubyIndexer::new(uri, &source);
         ruby_indexer.index();
-        ruby_indexer.into_parts()
+        (ruby_indexer.local_graph(), Vec::new())
     };
 
     with_parallel_workers(graph, file_paths, index_document)

--- a/rust/saturn/src/indexing/ruby_indexer.rs
+++ b/rust/saturn/src/indexing/ruby_indexer.rs
@@ -35,7 +35,6 @@ pub struct RubyIndexer<'a> {
     uri_id: UriId,
     local_graph: LocalGraph,
     source: &'a str,
-    errors: Vec<Errors>,
     comments: Vec<CommentGroup>,
     definitions_stack: Vec<DefinitionId>,
     visibility_stack: Vec<Visibility>,
@@ -51,7 +50,6 @@ impl<'a> RubyIndexer<'a> {
             uri_id,
             local_graph,
             source,
-            errors: Vec::new(),
             comments: Vec::new(),
             definitions_stack: Vec::new(),
             visibility_stack: vec![Visibility::Private],
@@ -59,8 +57,8 @@ impl<'a> RubyIndexer<'a> {
     }
 
     #[must_use]
-    pub fn into_parts(self) -> IndexerParts {
-        (self.local_graph, self.errors)
+    pub fn local_graph(self) -> LocalGraph {
+        self.local_graph
     }
 
     pub fn index(&mut self) {

--- a/rust/saturn/src/test_utils/graph_test.rs
+++ b/rust/saturn/src/test_utils/graph_test.rs
@@ -28,7 +28,7 @@ impl GraphTest {
     fn index_source(uri: &str, source: &str) -> LocalGraph {
         let mut indexer = RubyIndexer::new(uri.to_string(), source);
         indexer.index();
-        indexer.into_parts().0
+        indexer.local_graph()
     }
 
     pub fn index_uri(&mut self, uri: &str, source: &str) {

--- a/rust/saturn/src/test_utils/local_graph_test.rs
+++ b/rust/saturn/src/test_utils/local_graph_test.rs
@@ -24,7 +24,7 @@ impl LocalGraphTest {
 
         let mut indexer = RubyIndexer::new(uri.clone(), &source);
         indexer.index();
-        let graph = indexer.into_parts().0;
+        let graph = indexer.local_graph();
 
         Self { uri, source, graph }
     }


### PR DESCRIPTION
Remnants of the database era.