### PR TITLE
Split file listing out of `indexing`

### DIFF
--- a/rust/saturn-sys/src/graph_api.rs
+++ b/rust/saturn-sys/src/graph_api.rs
@@ -5,7 +5,7 @@ use crate::utils;
 use libc::{c_char, c_void};
 use saturn::model::graph::Graph;
 use saturn::model::ids::DeclarationId;
-use saturn::{indexing, resolution};
+use saturn::{indexing, listing, resolution};
 use std::ffi::CString;
 use std::{mem, ptr};
 
@@ -54,7 +54,7 @@ pub unsafe extern "C" fn sat_index_all(
     let file_paths: Vec<String> = unsafe { utils::convert_double_pointer_to_vec(file_paths, count).unwrap() };
     let mut all_errors = Vec::new();
 
-    let (documents, document_errors) = indexing::collect_file_paths(file_paths);
+    let (documents, document_errors) = listing::collect_file_paths(file_paths);
     all_errors.extend(document_errors);
 
     with_graph(pointer, |graph| {

--- a/rust/saturn/src/indexing.rs
+++ b/rust/saturn/src/indexing.rs
@@ -3,12 +3,11 @@ use crate::{
     indexing::{local_graph::LocalGraph, ruby_indexer::RubyIndexer},
     model::graph::Graph,
 };
-use glob::glob;
+use std::fs;
 use std::sync::{
     Arc, Mutex,
     mpsc::{Receiver, Sender},
 };
-use std::{fs, path::Path};
 use std::{sync::mpsc, thread};
 use url::Url;
 
@@ -96,144 +95,13 @@ where
     }
 }
 
-/// Recursively collects all Ruby files for the given workspace and dependencies, returning a vector of document instances
-///
-/// # Panics
-///
-/// Panics if there's a bug in how we're handling the arc mutex, like trying to acquire locks twice
-#[must_use]
-pub fn collect_file_paths(paths: Vec<String>) -> (Vec<String>, Vec<Errors>) {
-    let mut errors = Vec::new();
-    let mut file_paths = Vec::new();
-
-    for path in paths {
-        let path_obj = Path::new(&path);
-
-        if path_obj.is_dir() {
-            match glob(&format!("{path}/**/*.rb")) {
-                Ok(entries) => {
-                    for entry in entries {
-                        match entry {
-                            Ok(path) => file_paths.push(path.to_string_lossy().into_owned()),
-                            Err(e) => errors.push(Errors::FileReadError(format!(
-                                "Failed to read glob entry in '{path}': {e}"
-                            ))),
-                        }
-                    }
-                }
-                Err(e) => {
-                    errors.push(Errors::FileReadError(format!(
-                        "Failed to read glob pattern '{path}/**/*.rb': {e}"
-                    )));
-                }
-            }
-
-            continue;
-        }
-
-        if path_obj.exists() {
-            file_paths.push(path);
-
-            continue;
-        }
-
-        errors.push(Errors::FileReadError(format!("Path '{path}' does not exist")));
-    }
-
-    (file_paths, errors)
-}
-
 #[cfg(test)]
 mod tests {
     use std::path::PathBuf;
 
     use super::*;
     use crate::test_utils::Context;
-
-    fn collect_document_paths(context: &Context, paths: &[&str]) -> (Vec<String>, Vec<Errors>) {
-        let (file_paths, errors) = collect_file_paths(
-            paths
-                .iter()
-                .map(|p| context.absolute_path_to(p).to_string_lossy().into_owned())
-                .collect(),
-        );
-
-        let mut paths: Vec<String> = file_paths
-            .iter()
-            .map(|path| context.relative_path_to(path).to_string_lossy().into_owned())
-            .collect();
-
-        paths.sort();
-
-        (paths, errors)
-    }
-
-    #[test]
-    fn collect_all_documents() {
-        let context = Context::new();
-        let baz = Path::new("bar").join("baz.rb");
-        let qux = Path::new("bar").join("qux.rb");
-        let bar = Path::new("foo").join("bar.rb");
-        context.touch(&baz);
-        context.touch(&qux);
-        context.touch(&bar);
-
-        let (paths, errors) = collect_document_paths(&context, &["foo", "bar"]);
-
-        assert_eq!(
-            paths,
-            vec![
-                baz.to_str().unwrap().to_string(),
-                qux.to_str().unwrap().to_string(),
-                bar.to_str().unwrap().to_string()
-            ]
-        );
-        assert!(errors.is_empty());
-    }
-
-    #[test]
-    fn collect_some_documents_based_on_paths() {
-        let context = Context::new();
-        let baz = Path::new("bar").join("baz.rb");
-        let qux = Path::new("bar").join("qux.rb");
-        let bar = Path::new("foo").join("bar.rb");
-
-        context.touch(&baz);
-        context.touch(&qux);
-        context.touch(&bar);
-        let (paths, errors) = collect_document_paths(&context, &["bar"]);
-
-        assert_eq!(
-            paths,
-            vec![baz.to_str().unwrap().to_string(), qux.to_str().unwrap().to_string()]
-        );
-        assert!(errors.is_empty());
-    }
-
-    #[test]
-    fn collect_non_existing_paths() {
-        let context = Context::new();
-
-        let (documents, errors) = collect_file_paths(vec![
-            context
-                .absolute_path_to("non_existing_path")
-                .to_string_lossy()
-                .into_owned(),
-        ]);
-
-        assert!(documents.is_empty());
-
-        assert_eq!(
-            errors
-                .iter()
-                .map(std::string::ToString::to_string)
-                .collect::<Vec<String>>(),
-            vec![format!(
-                "File read error: Path '{}' does not exist",
-                context.absolute_path_to("non_existing_path").display()
-            )]
-        );
-    }
+    use std::path::Path;
 
     #[test]
     fn index_relative_paths() {

--- a/rust/saturn/src/lib.rs
+++ b/rust/saturn/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod diagnostic;
 pub mod errors;
 pub mod indexing;
+pub mod listing;
 pub mod model;
 pub mod offset;
 pub mod position;

--- a/rust/saturn/src/listing.rs
+++ b/rust/saturn/src/listing.rs
@@ -1,0 +1,141 @@
+use crate::errors::Errors;
+use glob::glob;
+use std::path::Path;
+
+/// Recursively collects all Ruby files for the given workspace and dependencies, returning a vector of document instances
+///
+/// # Panics
+///
+/// Panics if there's a bug in how we're handling the arc mutex, like trying to acquire locks twice
+#[must_use]
+pub fn collect_file_paths(paths: Vec<String>) -> (Vec<String>, Vec<Errors>) {
+    let mut errors = Vec::new();
+    let mut file_paths = Vec::new();
+
+    for path in paths {
+        let path_obj = Path::new(&path);
+
+        if path_obj.is_dir() {
+            match glob(&format!("{path}/**/*.rb")) {
+                Ok(entries) => {
+                    for entry in entries {
+                        match entry {
+                            Ok(path) => file_paths.push(path.to_string_lossy().into_owned()),
+                            Err(e) => errors.push(Errors::FileReadError(format!(
+                                "Failed to read glob entry in '{path}': {e}"
+                            ))),
+                        }
+                    }
+                }
+                Err(e) => {
+                    errors.push(Errors::FileReadError(format!(
+                        "Failed to read glob pattern '{path}/**/*.rb': {e}"
+                    )));
+                }
+            }
+
+            continue;
+        }
+
+        if path_obj.exists() {
+            file_paths.push(path);
+
+            continue;
+        }
+
+        errors.push(Errors::FileReadError(format!("Path '{path}' does not exist")));
+    }
+
+    (file_paths, errors)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_utils::Context;
+
+    fn collect_document_paths(context: &Context, paths: &[&str]) -> (Vec<String>, Vec<Errors>) {
+        let (file_paths, errors) = collect_file_paths(
+            paths
+                .iter()
+                .map(|p| context.absolute_path_to(p).to_string_lossy().into_owned())
+                .collect(),
+        );
+
+        let mut paths: Vec<String> = file_paths
+            .iter()
+            .map(|path| context.relative_path_to(path).to_string_lossy().into_owned())
+            .collect();
+
+        paths.sort();
+
+        (paths, errors)
+    }
+
+    #[test]
+    fn collect_all_documents() {
+        let context = Context::new();
+        let baz = Path::new("bar").join("baz.rb");
+        let qux = Path::new("bar").join("qux.rb");
+        let bar = Path::new("foo").join("bar.rb");
+        context.touch(&baz);
+        context.touch(&qux);
+        context.touch(&bar);
+
+        let (paths, errors) = collect_document_paths(&context, &["foo", "bar"]);
+
+        assert_eq!(
+            paths,
+            vec![
+                baz.to_str().unwrap().to_string(),
+                qux.to_str().unwrap().to_string(),
+                bar.to_str().unwrap().to_string()
+            ]
+        );
+        assert!(errors.is_empty());
+    }
+
+    #[test]
+    fn collect_some_documents_based_on_paths() {
+        let context = Context::new();
+        let baz = Path::new("bar").join("baz.rb");
+        let qux = Path::new("bar").join("qux.rb");
+        let bar = Path::new("foo").join("bar.rb");
+
+        context.touch(&baz);
+        context.touch(&qux);
+        context.touch(&bar);
+        let (paths, errors) = collect_document_paths(&context, &["bar"]);
+
+        assert_eq!(
+            paths,
+            vec![baz.to_str().unwrap().to_string(), qux.to_str().unwrap().to_string()]
+        );
+        assert!(errors.is_empty());
+    }
+
+    #[test]
+    fn collect_non_existing_paths() {
+        let context = Context::new();
+
+        let (documents, errors) = collect_file_paths(vec![
+            context
+                .absolute_path_to("non_existing_path")
+                .to_string_lossy()
+                .into_owned(),
+        ]);
+
+        assert!(documents.is_empty());
+
+        assert_eq!(
+            errors
+                .iter()
+                .map(std::string::ToString::to_string)
+                .collect::<Vec<String>>(),
+            vec![format!(
+                "File read error: Path '{}' does not exist",
+                context.absolute_path_to("non_existing_path").display()
+            )]
+        );
+    }
+}

--- a/rust/saturn/src/main.rs
+++ b/rust/saturn/src/main.rs
@@ -4,7 +4,7 @@ use clap::Parser;
 
 use saturn::{
     errors::MultipleErrors,
-    indexing::{self},
+    indexing, listing,
     model::graph::Graph,
     resolution,
     stats::{
@@ -42,7 +42,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     }
 
     let mut graph = Graph::new();
-    let (file_paths, errors) = time_it!(listing, { indexing::collect_file_paths(vec![args.dir]) });
+    let (file_paths, errors) = time_it!(listing, { listing::collect_file_paths(vec![args.dir]) });
 
     if !errors.is_empty() {
         return Err(Box::new(MultipleErrors(errors)));


### PR DESCRIPTION
As I'm working to bring back https://github.com/Shopify/saturn/pull/205, it just makes more sense to have the listing and indexing concepts separate.