### PR TITLE
Linearize included modules

### DIFF
--- a/rust/saturn/src/model/declaration.rs
+++ b/rust/saturn/src/model/declaration.rs
@@ -5,36 +5,40 @@ use crate::model::{
     ids::{DeclarationId, DefinitionId, NameId, ReferenceId, StringId},
 };
 
+/// A single ancestor in the linearized ancestor chain
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Ancestor {
+    /// A complete ancestor that we have fully linearized
     Complete(DeclarationId),
+    /// A partial ancestor that is missing linearization
     Partial(NameId),
 }
 
+/// The ancestor chain and its current state
 #[derive(Debug, Clone)]
 pub enum Ancestors {
     /// A complete linearization of ancestors with all parts resolved
     Complete(Vec<Ancestor>),
     /// A cyclic linearization of ancestors (e.g.: a module that includes itself)
     Cyclic(Vec<Ancestor>),
-    /// A partial linearization of ancestors with some parts unresolved
+    /// A partial linearization of ancestors with some parts unresolved. This chain state always triggers retries
     Partial(Vec<Ancestor>),
 }
 
 impl Ancestors {
-    #[must_use]
-    pub fn is_empty(&self) -> bool {
-        match self {
-            Ancestors::Complete(ancestors) | Ancestors::Partial(ancestors) | Ancestors::Cyclic(ancestors) => {
-                ancestors.is_empty()
-            }
-        }
-    }
-
     pub fn iter(&self) -> std::slice::Iter<'_, Ancestor> {
         match self {
             Ancestors::Complete(ancestors) | Ancestors::Partial(ancestors) | Ancestors::Cyclic(ancestors) => {
                 ancestors.iter()
+            }
+        }
+    }
+
+    #[must_use]
+    pub fn to_partial(self) -> Self {
+        match self {
+            Ancestors::Complete(ancestors) | Ancestors::Cyclic(ancestors) | Ancestors::Partial(ancestors) => {
+                Ancestors::Partial(ancestors)
             }
         }
     }
@@ -46,16 +50,6 @@ impl<'a> IntoIterator for &'a Ancestors {
 
     fn into_iter(self) -> Self::IntoIter {
         self.iter()
-    }
-}
-
-impl AsRef<[Ancestor]> for Ancestors {
-    fn as_ref(&self) -> &[Ancestor] {
-        match self {
-            Ancestors::Complete(ancestors) | Ancestors::Partial(ancestors) | Ancestors::Cyclic(ancestors) => {
-                ancestors.as_ref()
-            }
-        }
     }
 }
 
@@ -142,33 +136,6 @@ macro_rules! namespace_declaration {
 
             pub fn set_ancestors(&self, ancestors: Ancestors) {
                 *self.ancestors.borrow_mut() = ancestors;
-            }
-
-            /// Inserts a partial linearization of ancestors at the given index. This is used to replace unresolved name
-            /// IDs with their actual linearization once we have resolved them
-            pub fn insert_linearized_ancestors(&self, index: usize, ancestors: Vec<Ancestor>) {
-                match *self.ancestors.borrow_mut() {
-                    Ancestors::Cyclic(ref mut current_ancestors) | Ancestors::Partial(ref mut current_ancestors) => {
-                        current_ancestors.splice(index..index + 1, ancestors);
-                    }
-                    Ancestors::Complete(_) => {
-                        panic!("Tried to insert linearized ancestors into a declaration that already has a complete linearization");
-                    }
-                }
-            }
-
-            /// Marks that ancestor linearization has been completed for a list that was originally a partial
-            /// linearization. In practice, turns `Ancestors::Partial` into `Ancestors::Complete`
-            pub fn complete_ancestors(&self) {
-                let mut ancestors = self.ancestors.borrow_mut();
-                let old = std::mem::replace(&mut *ancestors, Ancestors::Complete(vec![]));
-
-                *ancestors = match old {
-                    Ancestors::Partial(list) | Ancestors::Cyclic(list) => Ancestors::Complete(list),
-                    Ancestors::Complete(_) => {
-                        panic!("Tried to mark already completed ancestors as completed");
-                    }
-                };
             }
 
             #[must_use]
@@ -373,40 +340,5 @@ mod tests {
             DeclarationId::from("Foo::Bar"),
         )));
         assert_eq!(decl.unqualified_name(), "baz");
-    }
-
-    #[test]
-    fn inserting_partial_linearizations() {
-        let Declaration::Class(decl) = Declaration::Class(Box::new(ClassDeclaration::new(
-            "Foo".to_string(),
-            DeclarationId::from("Foo"),
-        ))) else {
-            panic!("Expected a class declaration");
-        };
-
-        let name_id = NameId::from("Bar");
-        decl.set_ancestors(Ancestors::Partial(vec![
-            Ancestor::Complete(DeclarationId::from("Foo")),
-            Ancestor::Partial(name_id),
-            Ancestor::Complete(DeclarationId::from("Object")),
-        ]));
-
-        decl.insert_linearized_ancestors(
-            1,
-            vec![
-                Ancestor::Complete(DeclarationId::from("Bar")),
-                Ancestor::Complete(DeclarationId::from("Baz")),
-            ],
-        );
-
-        assert_eq!(
-            &[
-                Ancestor::Complete(DeclarationId::from("Foo")),
-                Ancestor::Complete(DeclarationId::from("Bar")),
-                Ancestor::Complete(DeclarationId::from("Baz")),
-                Ancestor::Complete(DeclarationId::from("Object")),
-            ],
-            decl.ancestors().as_ref(),
-        );
     }
 }


### PR DESCRIPTION
Closes #346

This PR adds included module linearization and greatly simplifies the related code.

The main mistake I was making in the prepended PR was trying to substitute partial ancestors individually in ancestor chains during retries. The problem is that deduping ancestors in that case becomes super complex because dedups are based on the order of the `prepend` and `include` operations and not on the order that their linearizations ultimately appear.

If we just linearize the entire chain again, it's significantly simpler to dedup, which is critical for correct linearizations since transitive ancestors are also deduped.

I added a bunch of test cases with everything I could find in terms of edge cases. We're now only missing singleton class ancestor chain and then we can verify our resolution phase against Core.