### PR TITLE
Put declarations in a RwLock

### DIFF
--- a/rust/saturn-sys/src/graph_api.rs
+++ b/rust/saturn-sys/src/graph_api.rs
@@ -92,12 +92,16 @@ pub struct DeclarationsIter {
 ///
 /// - `pointer` must be a valid `GraphPointer` previously returned by this crate.
 /// - The returned pointer must be freed with `sat_graph_declarations_iter_free`.
+///
+/// # Panics
+///
+/// Will panic if acquiring a read lock on the graph's declarations fails
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn sat_graph_declarations_iter_new(pointer: GraphPointer) -> *mut DeclarationsIter {
     // Snapshot the IDs at iterator creation to avoid borrowing across FFI calls
     let ids = with_graph(pointer, |graph| {
-        graph
-            .declarations()
+        let read_lock = graph.declarations().read().unwrap();
+        read_lock
             .keys()
             .map(|name_id| **name_id)
             .collect::<Vec<i64>>()
@@ -258,6 +262,10 @@ pub unsafe extern "C" fn sat_graph_documents_iter_free(iter: *mut DocumentsIter)
 /// - `pointer` must be a valid `GraphPointer`
 /// - `name` must be a valid, null-terminated UTF-8 string
 /// - `out_id` must be a valid, writable pointer
+///
+/// # Panics
+///
+/// Will panic if acquiring a read lock on the graph's declarations fails
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn sat_graph_get_declaration(pointer: GraphPointer, name: *const c_char) -> *const i64 {
     let Ok(name_str) = (unsafe { utils::convert_char_ptr_to_string(name) }) else {
@@ -267,7 +275,8 @@ pub unsafe extern "C" fn sat_graph_get_declaration(pointer: GraphPointer, name: 
     with_graph(pointer, |graph| {
         // TODO: We should perform name resolution instead of accessing the graph with the canonical ID
         let decl_id = DeclarationId::from(name_str.as_str());
-        if graph.declarations().contains_key(&decl_id) {
+        let read_lock = graph.declarations().read().unwrap();
+        if read_lock.contains_key(&decl_id) {
             Box::into_raw(Box::new(*decl_id)).cast_const()
         } else {
             ptr::null()

--- a/rust/saturn/src/main.rs
+++ b/rust/saturn/src/main.rs
@@ -82,7 +82,8 @@ fn main() -> Result<(), Box<dyn Error>> {
         println!("{}", dot::generate(&graph));
     } else {
         println!("Indexed {} files", graph.documents().len());
-        println!("Found {} names", graph.declarations().len());
+        let read_lock = graph.declarations().read().unwrap();
+        println!("Found {} names", read_lock.len());
         println!("Found {} definitions", graph.definitions().len());
         println!("Found {} URIs", graph.documents().len());
     }

--- a/rust/saturn/src/visualization/dot.rs
+++ b/rust/saturn/src/visualization/dot.rs
@@ -39,7 +39,8 @@ pub fn generate(graph: &Graph) -> String {
 }
 
 fn write_declaration_nodes(output: &mut String, graph: &Graph) {
-    let mut declarations: Vec<_> = graph.declarations().values().collect();
+    let read_lock = graph.declarations().read().unwrap();
+    let mut declarations: Vec<_> = read_lock.values().collect();
     declarations.sort_by(|a, b| a.name().cmp(b.name()));
 
     for declaration in declarations {
@@ -64,8 +65,8 @@ fn write_definition_nodes(output: &mut String, graph: &Graph) {
         .definitions()
         .iter()
         .filter_map(|(def_id, definition)| {
-            graph
-                .declarations()
+            let read_lock = graph.declarations().read().unwrap();
+            read_lock
                 .get(graph.definitions_to_declarations().get(def_id).unwrap())
                 .map(|declaration| {
                     let def_type = definition.kind();


### PR DESCRIPTION
To linearize singleton ancestors, we need to be able to create singleton concepts lazily. Without internal mutability, this is nearly impossible as we get into all sorts of borrow issues.

We will need internal mutability for parallelism anyway, so this PR puts `declarations` in a `RwLock`, so that reads aren't blocking and only writes require a lock. That way, we can reduce thread contention a bit.