### PR TITLE
Add member method to Declaration for looking up namespace methods

### DIFF
--- a/ext/rubydex/declaration.c
+++ b/ext/rubydex/declaration.c
@@ -107,6 +107,31 @@ static VALUE sr_declaration_definitions(VALUE self) {
     return self;
 }
 
+// Declaration#member: (String member) -> Declaration
+// Returns a declaration handle for the given member
+static VALUE sr_declaration_member(VALUE self, VALUE name) {
+    HandleData *data;
+    TypedData_Get_Struct(self, HandleData, &handle_type, data);
+
+    void *graph;
+    TypedData_Get_Struct(data->graph_obj, void *, &graph_type, graph);
+
+    if (TYPE(name) != T_STRING) {
+        rb_raise(rb_eTypeError, "expected String");
+    }
+
+    const int64_t *id_ptr = rdx_declaration_member(graph, data->id, StringValueCStr(name));
+    if (id_ptr == NULL) {
+        return Qnil;
+    }
+
+    int64_t id = *id_ptr;
+    free_i64(id_ptr);
+    VALUE argv[] = {data->graph_obj, LL2NUM(id)};
+
+    return rb_class_new_instance(2, argv, cDeclaration);
+}
+
 void initialize_declaration(VALUE mRubydex) {
     cDeclaration = rb_define_class_under(mRubydex, "Declaration", rb_cObject);
 
@@ -115,6 +140,7 @@ void initialize_declaration(VALUE mRubydex) {
     rb_define_method(cDeclaration, "name", sr_declaration_name, 0);
     rb_define_method(cDeclaration, "unqualified_name", sr_declaration_unqualified_name, 0);
     rb_define_method(cDeclaration, "definitions", sr_declaration_definitions, 0);
+    rb_define_method(cDeclaration, "member", sr_declaration_member, 1);
 
     rb_funcall(rb_singleton_class(cDeclaration), rb_intern("private"), 1, ID2SYM(rb_intern("new")));
 }

--- a/rust/rubydex-sys/src/declaration_api.rs
+++ b/rust/rubydex-sys/src/declaration_api.rs
@@ -1,12 +1,14 @@
 //! This file provides the C API for the Graph object
 
 use libc::c_char;
+use rubydex::model::declaration::Declaration;
 use std::ffi::CString;
 use std::ptr;
 
 use crate::definition_api::{DefinitionKind, DefinitionsIter, rdx_definitions_iter_new_from_ids};
 use crate::graph_api::{GraphPointer, with_graph};
-use rubydex::model::ids::DeclarationId;
+use crate::utils;
+use rubydex::model::ids::{DeclarationId, StringId};
 
 /// Returns the UTF-8 name string for a declaration id.
 /// Caller must free with `free_c_string`.
@@ -27,6 +29,35 @@ pub unsafe extern "C" fn rdx_declaration_name(pointer: GraphPointer, name_id: i6
         } else {
             ptr::null()
         }
+    })
+}
+
+/// Returns the declaration ID for a member from a declaration.
+/// Returns NULL if the member is not found.
+///
+/// # Safety
+/// - `member` must be a valid, null-terminated UTF-8 string
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rdx_declaration_member(
+    pointer: GraphPointer,
+    name_id: i64,
+    member: *const c_char,
+) -> *const i64 {
+    let Ok(member_str) = (unsafe { utils::convert_char_ptr_to_string(member) }) else {
+        return ptr::null();
+    };
+
+    with_graph(pointer, |graph| {
+        let name_id = DeclarationId::new(name_id);
+        if let Some(Declaration::Namespace(decl)) = graph.declarations().get(&name_id) {
+            let member_id = StringId::from(member_str.as_str());
+
+            if let Some(member_decl_id) = decl.member(&member_id) {
+                return Box::into_raw(Box::new(**member_decl_id)).cast_const();
+            }
+        }
+
+        ptr::null()
     })
 }
 

--- a/test/declaration_test.rb
+++ b/test/declaration_test.rb
@@ -28,6 +28,27 @@ class DeclarationTest < Minitest::Test
     end
   end
 
+  def test_declaration_member
+    with_context do |context|
+      context.write!("file1.rb", <<~RUBY)
+        class A
+          def foo; end
+        end
+      RUBY
+
+      graph = Rubydex::Graph.new
+      graph.index_all(context.glob("**/*.rb"))
+      graph.resolve
+
+      declaration = graph["A"]
+      assert_instance_of(Rubydex::Declaration, declaration)
+
+      member_declaration = declaration.member("foo()")
+      assert_instance_of(Rubydex::Declaration, member_declaration)
+      assert_equal("A#foo()", member_declaration.name)
+    end
+  end
+
   def test_definitions_enumerator
     with_context do |context|
       context.write!("file1.rb", "class A; end")


### PR DESCRIPTION
Adds the `members` method to `Declaration` to expose the declarations that belong to that specific declaration. For traversing the ancestor chain, see this PR: https://github.com/Shopify/saturn/pull/403 