### PR TITLE
Add declaration search

### DIFF
--- a/lib/rubydex/graph.rb
+++ b/lib/rubydex/graph.rb
@@ -13,8 +13,12 @@ module Rubydex
     # Index all files and dependencies of the workspace that exists in `@workspace_path`
     #: -> String?
     def index_workspace
-      paths = workspace_dependency_paths
-      paths.unshift(@workspace_path)
+      paths = Dir.glob("#{@workspace_path}/**/*.rb")
+      paths.concat(
+        workspace_dependency_paths.flat_map do |path|
+          Dir.glob("#{path}/**/*.rb")
+        end,
+      )
       index_all(paths)
     end
 

--- a/rust/rubydex/src/lib.rs
+++ b/rust/rubydex/src/lib.rs
@@ -6,6 +6,7 @@ pub mod listing;
 pub mod model;
 pub mod offset;
 pub mod position;
+pub mod query;
 pub mod resolution;
 pub mod stats;
 pub mod visualization;

--- a/rust/rubydex/src/query.rs
+++ b/rust/rubydex/src/query.rs
@@ -1,0 +1,105 @@
+use std::thread;
+
+use crate::model::graph::Graph;
+use crate::model::ids::DeclarationId;
+
+/// # Panics
+///
+/// Will panic if any of the threads panic
+pub fn declaration_search(graph: &Graph, query: &str) -> Vec<DeclarationId> {
+    let num_threads = thread::available_parallelism().map(std::num::NonZero::get).unwrap_or(4);
+    let declarations = graph.declarations().read().unwrap();
+    let ids: Vec<DeclarationId> = declarations.keys().copied().collect();
+    let chunk_size = ids.len().div_ceil(num_threads);
+
+    if chunk_size == 0 {
+        return Vec::new();
+    }
+
+    thread::scope(|s| {
+        let handles: Vec<_> = ids
+            .chunks(chunk_size)
+            .map(|chunk| {
+                s.spawn(|| {
+                    chunk
+                        .iter()
+                        .filter(|id| {
+                            let declaration = declarations.get(id).unwrap();
+                            // When the query is empty, we return everything as per the LSP specification.
+                            // Otherwise, we compute the match score and return anything with a score greater than zero
+                            query.is_empty() || match_score(query, declaration.name()) > 0
+                        })
+                        .copied()
+                        .collect::<Vec<_>>()
+                })
+            })
+            .collect();
+
+        handles.into_iter().flat_map(|h| h.join().unwrap()).collect()
+    })
+}
+
+#[must_use]
+fn match_score(query: &str, target: &str) -> usize {
+    let mut query_chars = query.chars().peekable();
+    let mut score = 0;
+
+    // Count the number of matches in the order of the query, so that character ordering is taken into account
+    for t_char in target.chars() {
+        if let Some(&q_char) = query_chars.peek()
+            && q_char.eq_ignore_ascii_case(&t_char)
+        {
+            score += 1;
+            query_chars.next();
+        }
+    }
+
+    // If after going through the target, there are still query characters left, then some of the query can't be found
+    // in this target and we return zero to indicate a non-match
+    if query_chars.peek().is_some() { 0 } else { score }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_utils::GraphTest;
+
+    macro_rules! assert_results_eq {
+        ($context:expr, $query:expr, $expected:expr) => {
+            let actual = declaration_search(&$context.graph(), $query);
+            assert_eq!(
+                actual,
+                $expected
+                    .into_iter()
+                    .map(|s| DeclarationId::from(s))
+                    .collect::<Vec<DeclarationId>>(),
+                "Unexpected search results: {:?}",
+                actual
+                    .iter()
+                    .map(|id| $context
+                        .graph()
+                        .declarations()
+                        .read()
+                        .unwrap()
+                        .get(id)
+                        .unwrap()
+                        .name()
+                        .to_string())
+                    .collect::<Vec<String>>()
+            );
+        };
+    }
+
+    #[test]
+    fn fuzzy_search_returns_partial_matches() {
+        let mut context = GraphTest::new();
+        context.index_uri("file:///foo.rb", {
+            r"
+            class Foo
+            end
+            "
+        });
+        context.resolve();
+        assert_results_eq!(context, "Fo", vec!["Foo"]);
+    }
+}

--- a/test/graph_test.rb
+++ b/test/graph_test.rb
@@ -152,6 +152,20 @@ class GraphTest < Minitest::Test
     end
   end
 
+  def test_graph_search
+    with_context do |context|
+      context.write!("foo.rb", "class Foo; end")
+      context.write!("bar.rb", "class Bar; end")
+
+      graph = Rubydex::Graph.new
+      graph.index_all(context.glob("**/*.rb"))
+      graph.resolve
+
+      results = graph.search("Fo")
+      assert_equal(["Foo"], results.map(&:name))
+    end
+  end
+
   private
 
   def assert_diagnostics(expected, actual)


### PR DESCRIPTION
This PR implements a simple version of searching declarations based on their name. This will be used to back the LSP's workspace symbol search.

Right now, it's not super smart. It calculates a match score based on character matches that happen in the right order. It already works okay, but we can make it more sophisticated later.

**Note**

I tried using our job infrastructure for this, but I couldn't make it work. The jobs need an `Arc<&Graph>`, so that they can lock declarations for reading. However, if you try to implement that, you get into trouble because Rust will say that the `&'a Graph` reference does not outlive the Job's `'static` requirement.

On the other hand, we shouldn't need to move the graph (pass it without being a reference) just to query its data. For now, I just used scoped threads.