### PR TITLE
Add open source requirements

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,22 @@
+changelog:
+  exclude:
+    labels:
+      - dependencies
+      - chore
+      - documentation
+    authors:
+      - dependabot
+  categories:
+    - title: 🚧 Breaking Changes
+      labels:
+        - breaking-change
+    - title: ✨ Enhancements
+      labels:
+        - enhancement
+        - feature
+    - title: 🐛 Bug Fixes
+      labels:
+        - bugfix
+    - title: 🛠 Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   lint:
-    runs-on: shopify-ubuntu-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [shopify-ubuntu-latest, macos-latest, shopify-windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         ruby: ["3.3", "3.4", "4.0"]
     runs-on: ${{ matrix.os }}
     name: Ruby ${{ matrix.ruby }} on ${{ matrix.os }}

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,22 @@
+name: Contributor License Agreement (CLA)
+
+on:
+  pull_request_target:
+    types: [opened, synchronize]
+  issue_comment:
+    types: [created]
+
+jobs:
+  cla:
+    runs-on: ubuntu-latest
+    if: |
+      (github.event.issue.pull_request
+        && !github.event.issue.pull_request.merged_at
+        && contains(github.event.comment.body, 'signed')
+      )
+      || (github.event.pull_request && !github.event.pull_request.merged)
+    steps:
+      - uses: Shopify/shopify-cla-action@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          cla-token: ${{ secrets.CLA_TOKEN }}

--- a/.github/workflows/dependabot_automerge.yml
+++ b/.github/workflows/dependabot_automerge.yml
@@ -7,7 +7,7 @@ permissions:
 
 jobs:
   dependabot:
-    runs-on: shopify-ubuntu-latest
+    runs-on: ubuntu-latest
     if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
     steps:
       - name: Dependabot metadata

--- a/.github/workflows/indexing_top_gems.yml
+++ b/.github/workflows/indexing_top_gems.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   indexing_top_gems:
-    runs-on: shopify-ubuntu-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 

--- a/.github/workflows/memleak.yml
+++ b/.github/workflows/memleak.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   memleak:
-    runs-on: shopify-ubuntu-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,76 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to make participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies within all project spaces, and it also applies when
+an individual is representing the project or its community in public spaces.
+Examples of representing a project or community include using an official
+project e-mail address, posting via an official social media account, or acting
+as an appointed representative at an online or offline event. Representation of
+a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at opensource@shopify.com. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see
+https://www.contributor-covenant.org/faq

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,43 @@
+# Contributing
+
+## Project structure
+
+This project is structured in 3 parts:
+
+- `rust/rubydex`: the Rust crate implementing all of the core logic for statically analyzing Ruby code
+- `rust/rubydex-sys`: the Rust crate for FFI bindings that allow using the main crate from C code
+- the top level of the repository is a Ruby gem with a native extension, which uses C code to link against the Rust
+crate and provide a Ruby API for the Rust backed implementation
+
+## Architecture, concepts and analysis
+
+To understand how the analysis is structured, please see [the architecture docs](docs/architecture.md). We also have
+documentation for [Ruby concepts and behavior](docs/ruby-behaviors.md).
+
+## Practical development tips
+
+In general, we strive for consistency in our development environments and techniques. For example, recommended
+extensions and settings for VS Code are already provided in the `.vscode` directory.
+
+Instructions for AI models and agents are in the [agents file](AGENTS.md).
+
+### Rust
+
+The `rust` directory is a worskpace, where all common cargo commands can be used to build, lint or run tests.
+
+- Testing: `cargo test`
+- Linting: `cargo clippy`
+- Formatting: `rustfmt`
+- Compiling: `cargo build`
+
+With the recommended extensions, it's possible to use Rust Analyzer's debug code lens actions to interactively
+debug tests through VS Code.
+
+We try to be on the latest version of Rust and CI always runs against the latest.
+
+### Ruby
+
+- Compiling: `bundle exec rake compile` (triggers the compilation of the Rust crates too)
+- Testing: `bundle exec rake ruby_test`
+- Linting: `bundle exec rubocop`
+- Formatting: `bundle exec rubocop -a`

--- a/README.md
+++ b/README.md
@@ -1,43 +1,25 @@
 # Rubydex
 
-TODO
-
-## Documentation
-
-- [Ruby Language Behaviors](docs/ruby-behaviors.md) - Comprehensive documentation of Ruby language behaviors that the indexer handles, including lexical scoping, constant resolution, method parameters, attribute methods, and more. This document is useful for understanding the nuances of Ruby that affect indexing.
+This project is a high performance static analysis toolkit for the Ruby language. The goal is to be a solid
+foundation to power a variety of tools, such as type checkers, linters, language servers and more.
 
 ## Usage
 
-TODO
+Both Ruby and Rust APIs are made available through a gem and a crate, respectively. Here's a simple example
+of using the Ruby API:
 
-## Development
+```ruby
+# Create a new graph representing the current workspace
+graph = Rubydex::Graph.new
+# Index the entire workspace with all dependencies
+graph.index_workspace
+# Transform the initially collected information into its semantic understanding by running resolution
+graph.resolve
 
-TODO: move to a proper contributing file.
-
-### Compiling the Rust and C code
-
-The command `bundle exec rake compile` can be used to build both the Rust and C libraries. To clean generated files, simply run `bundle exec rake clean`.
-
-### Running tests
-
-Run `bundle exec rake test` to execute both the Ruby and Rust test suites. To run only the Ruby tests, use `bundle exec rake ruby_test`. The combined lint-and-test flow is available through `bundle exec rake check`.
-
-### Running memory leak and other sanitization checks
-
-We have two layers of sanitization checks:
-
-- [ruby_memcheck](https://github.com/Shopify/ruby_memcheck): uses Valgrind to find memory leaks by running our Ruby test suite (only supported for Linux)
-- Rust sanitizers for valid memory addresses, leaks and thread data races
-
-Here's how to run the checks locally:
-
-```shell
-# Run ruby_memcheck in combination with a Rust sanitization mode (Linux only)
-SANITIZER=leak bundle exec rake ruby_test:valgrind
-
-# Run only ruby_memcheck (Linux only)
-bundle exec rake ruby_test:valgrind
-
-# Run Rust sanitization only
-SANITIZER=leak bundle exec rake ruby_test
+# Access the information as needed
+graph["Foo"]
 ```
+
+## Contributing
+
+See [the contributing documentation](CONTRIBUTING.md).


### PR DESCRIPTION
This PR adds some missing requirements for us to open source the gem. The changes are:

- Switching all action runners to the public ones
- Adding a code of conduct (our standard one)
- A few documentation changes in the README and CONTRIBUTING
- Adding the CLA action
- Adding the GitHub release automation

**TODO**: update branch protections to require CLA once this is merged.