### PR TITLE
Use mutable graph instead of rwlock on declarations

### DIFF
--- a/rust/rubydex-sys/src/declaration_api.rs
+++ b/rust/rubydex-sys/src/declaration_api.rs
@@ -22,9 +22,7 @@ use rubydex::model::ids::DeclarationId;
 pub unsafe extern "C" fn rdx_declaration_name(pointer: GraphPointer, name_id: i64) -> *const c_char {
     with_graph(pointer, |graph| {
         let name_id = DeclarationId::new(name_id);
-        let read_lock = graph.declarations().read().unwrap();
-
-        if let Some(decl) = read_lock.get(&name_id) {
+        if let Some(decl) = graph.declarations().get(&name_id) {
             CString::new(decl.name()).unwrap().into_raw().cast_const()
         } else {
             ptr::null()
@@ -46,8 +44,7 @@ pub unsafe extern "C" fn rdx_declaration_name(pointer: GraphPointer, name_id: i6
 pub unsafe extern "C" fn rdx_declaration_unqualified_name(pointer: GraphPointer, name_id: i64) -> *const c_char {
     with_graph(pointer, |graph| {
         let name_id = DeclarationId::new(name_id);
-        let read_lock = graph.declarations().read().unwrap();
-        if let Some(decl) = read_lock.get(&name_id) {
+        if let Some(decl) = graph.declarations().get(&name_id) {
             CString::new(decl.unqualified_name()).unwrap().into_raw().cast_const()
         } else {
             ptr::null()
@@ -77,8 +74,7 @@ pub unsafe extern "C" fn rdx_declaration_definitions_iter_new(
     // Snapshot the IDs and kinds at iterator creation to avoid borrowing across FFI calls
     with_graph(pointer, |graph| {
         let decl_id = DeclarationId::new(decl_id);
-        let read_lock = graph.declarations().read().unwrap();
-        if let Some(decl) = read_lock.get(&decl_id) {
+        if let Some(decl) = graph.declarations().get(&decl_id) {
             rdx_definitions_iter_new_from_ids(graph, decl.definitions())
         } else {
             DefinitionsIter::new(Vec::<(i64, DefinitionKind)>::new().into_boxed_slice())

--- a/rust/rubydex-sys/src/graph_api.rs
+++ b/rust/rubydex-sys/src/graph_api.rs
@@ -139,8 +139,8 @@ pub struct DeclarationsIter {
 pub unsafe extern "C" fn rdx_graph_declarations_iter_new(pointer: GraphPointer) -> *mut DeclarationsIter {
     // Snapshot the IDs at iterator creation to avoid borrowing across FFI calls
     let ids = with_graph(pointer, |graph| {
-        let read_lock = graph.declarations().read().unwrap();
-        read_lock
+        graph
+            .declarations()
             .keys()
             .map(|name_id| **name_id)
             .collect::<Vec<i64>>()
@@ -314,8 +314,7 @@ pub unsafe extern "C" fn rdx_graph_get_declaration(pointer: GraphPointer, name: 
     with_graph(pointer, |graph| {
         // TODO: We should perform name resolution instead of accessing the graph with the canonical ID
         let decl_id = DeclarationId::from(name_str.as_str());
-        let read_lock = graph.declarations().read().unwrap();
-        if read_lock.contains_key(&decl_id) {
+        if graph.declarations().contains_key(&decl_id) {
             Box::into_raw(Box::new(*decl_id)).cast_const()
         } else {
             ptr::null()

--- a/rust/rubydex/src/main.rs
+++ b/rust/rubydex/src/main.rs
@@ -89,8 +89,7 @@ fn main() {
         println!("{}", dot::generate(&graph));
     } else {
         println!("Indexed {} files", graph.documents().len());
-        let read_lock = graph.declarations().read().unwrap();
-        println!("Found {} names", read_lock.len());
+        println!("Found {} names", graph.declarations().len());
         println!("Found {} definitions", graph.definitions().len());
         println!("Found {} URIs", graph.documents().len());
     }

--- a/rust/rubydex/src/model/definitions.rs
+++ b/rust/rubydex/src/model/definitions.rs
@@ -140,7 +140,7 @@ impl Definition {
 
 /// Represents a mixin: include, prepend, or extend.
 /// During resolution, `Extend` mixins are attached to the singleton class.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum Mixin {
     Include(NameId),
     Prepend(NameId),

--- a/rust/rubydex/src/model/name.rs
+++ b/rust/rubydex/src/model/name.rs
@@ -1,6 +1,6 @@
 use crate::model::ids::{DeclarationId, NameId, StringId};
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Name {
     /// The unqualified name of the constant
     str: StringId,
@@ -55,7 +55,7 @@ impl Name {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ResolvedName {
     name: Name,
     declaration_id: DeclarationId,
@@ -79,7 +79,7 @@ impl ResolvedName {
 }
 
 /// A usage of a constant name. This could be a constant reference or a definition like a class or module
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum NameRef {
     /// This name has not yet been resolved. We don't yet know what this name refers to or if it refers to an existing
     /// declaration

--- a/rust/rubydex/src/query.rs
+++ b/rust/rubydex/src/query.rs
@@ -8,7 +8,7 @@ use crate::model::ids::DeclarationId;
 /// Will panic if any of the threads panic
 pub fn declaration_search(graph: &Graph, query: &str) -> Vec<DeclarationId> {
     let num_threads = thread::available_parallelism().map(std::num::NonZero::get).unwrap_or(4);
-    let declarations = graph.declarations().read().unwrap();
+    let declarations = graph.declarations();
     let ids: Vec<DeclarationId> = declarations.keys().copied().collect();
     let chunk_size = ids.len().div_ceil(num_threads);
 
@@ -79,8 +79,6 @@ mod tests {
                     .map(|id| $context
                         .graph()
                         .declarations()
-                        .read()
-                        .unwrap()
                         .get(id)
                         .unwrap()
                         .name()

--- a/rust/rubydex/src/test_utils/graph_test.rs
+++ b/rust/rubydex/src/test_utils/graph_test.rs
@@ -30,6 +30,11 @@ impl GraphTest {
     }
 
     #[must_use]
+    pub fn graph_mut(&mut self) -> &mut Graph {
+        &mut self.graph
+    }
+
+    #[must_use]
     fn index_source(uri: &str, source: &str) -> LocalGraph {
         let mut indexer = RubyIndexer::new(uri.to_string(), source);
         indexer.index();

--- a/rust/rubydex/src/visualization/dot.rs
+++ b/rust/rubydex/src/visualization/dot.rs
@@ -39,8 +39,7 @@ pub fn generate(graph: &Graph) -> String {
 }
 
 fn write_declaration_nodes(output: &mut String, graph: &Graph) {
-    let read_lock = graph.declarations().read().unwrap();
-    let mut declarations: Vec<_> = read_lock.values().collect();
+    let mut declarations: Vec<_> = graph.declarations().values().collect();
     declarations.sort_by(|a, b| a.name().cmp(b.name()));
 
     for declaration in declarations {
@@ -65,8 +64,8 @@ fn write_definition_nodes(output: &mut String, graph: &Graph) {
         .definitions()
         .iter()
         .filter_map(|(def_id, definition)| {
-            let read_lock = graph.declarations().read().unwrap();
-            read_lock
+            graph
+                .declarations()
                 .get(graph.definitions_to_declarations().get(def_id).unwrap())
                 .map(|declaration| {
                     let def_type = definition.kind();


### PR DESCRIPTION
In many places of resolution we pass an immutable graph then modify its content using a rwlock. Passing an immutable graph makes it harder to add diagnostics (for #354) during resolution.

It seems we can actually use a mutable graph in most places if we avoid keeping references to `Definition`/`Declaration` and pass around `DefinitionId`/`DeclarationId`.