### PR TITLE
Remove diagnostics when documents change

### DIFF
--- a/rust/rubydex/src/diagnostic.rs
+++ b/rust/rubydex/src/diagnostic.rs
@@ -1,4 +1,4 @@
-use crate::{model::ids::UriId, offset::Offset};
+use crate::{model::ids::{DiagnosticId, UriId}, offset::Offset};
 
 #[derive(Debug)]
 pub struct Diagnostic {
@@ -24,6 +24,11 @@ impl Diagnostic {
     #[must_use]
     pub fn make(diagnostics: Diagnostics, uri_id: UriId, offset: Offset, message: String) -> Self {
         Self::new(diagnostics.code(), uri_id, offset, message, diagnostics.severity())
+    }
+
+    #[must_use]
+    pub fn id(&self) -> DiagnosticId {
+        DiagnosticId::from(&format!("{}{}{}{}", *self.uri_id, self.offset.start(), self.code, self.message))
     }
 
     #[must_use]

--- a/rust/rubydex/src/model/document.rs
+++ b/rust/rubydex/src/model/document.rs
@@ -1,4 +1,4 @@
-use crate::model::ids::{DefinitionId, ReferenceId};
+use crate::model::ids::{DefinitionId, DiagnosticId, ReferenceId};
 
 // Represents a document currently loaded into memory. Identified by its unique URI, it holds the edges to all
 // definitions and references discovered in it
@@ -8,6 +8,7 @@ pub struct Document {
     definition_ids: Vec<DefinitionId>,
     method_reference_ids: Vec<ReferenceId>,
     constant_reference_ids: Vec<ReferenceId>,
+    diagnostic_ids: Vec<DiagnosticId>,
 }
 
 impl Document {
@@ -18,6 +19,7 @@ impl Document {
             definition_ids: Vec::new(),
             method_reference_ids: Vec::new(),
             constant_reference_ids: Vec::new(),
+            diagnostic_ids: Vec::new(),
         }
     }
 
@@ -56,6 +58,15 @@ impl Document {
 
     pub fn add_constant_reference(&mut self, reference_id: ReferenceId) {
         self.constant_reference_ids.push(reference_id);
+    }
+
+    #[must_use]
+    pub fn diagnostic_ids(&self) -> &[DiagnosticId] {
+        &self.diagnostic_ids
+    }
+
+    pub fn add_diagnostic_id(&mut self, diagnostic_id: DiagnosticId) {
+        self.diagnostic_ids.push(diagnostic_id);
     }
 }
 

--- a/rust/rubydex/src/model/ids.rs
+++ b/rust/rubydex/src/model/ids.rs
@@ -30,3 +30,8 @@ pub type ReferenceId = Id<ReferenceMarker>;
 pub struct NameMarker;
 /// `NameId` represents an ID for any constant name that we find as part of a reference or definition
 pub type NameId = Id<NameMarker>;
+
+#[derive(PartialEq, Eq, Debug, Clone, Copy)]
+pub struct DiagnosticMarker;
+/// `DiagnosticId` represents the ID of a diagnostic found in a specific file
+pub type DiagnosticId = Id<DiagnosticMarker>;


### PR DESCRIPTION
This PR is part of #330. When a document changes or is removed, we want to clear/invalidate any parts of the graph that were created by or associated to that document. Eventually we will implement a more granular approach that clears/invalidates as little as possible, but for now we'll blow away everything to do with the document.

This ensures the diagnostics related to a document are removed when it is changed or deleted. It does so by moving the diagnostics from the top-level of the graph to be stored in the `Document` itself. @vinistock suggested this approach, as there is currently nothing else in the graph that connects to diagnostics and they are always (currently?) associated to a single document.