### PR TITLE
Process mixin operations with multiple arguments in reverse order

### DIFF
--- a/rust/rubydex/src/indexing/ruby_indexer.rs
+++ b/rust/rubydex/src/indexing/ruby_indexer.rs
@@ -815,7 +815,9 @@ impl<'a> RubyIndexer<'a> {
 
         let definition = self.local_graph.get_definition_mut(lexical_nesting_id).unwrap();
 
-        for id in reference_ids {
+        // Mixin operations with multiple arguments are inserted in reverse, so that they are processed in the expected
+        // order by resolution
+        for id in reference_ids.into_iter().rev() {
             let mixin = match mixin_type {
                 MixinType::Include => Mixin::Include(id),
                 MixinType::Prepend => Mixin::Prepend(id),
@@ -3991,7 +3993,7 @@ mod tests {
         assert_no_diagnostics!(&context);
 
         assert_definition_at!(&context, "1:1-4:4", Class, |def| {
-            assert_includes_eq!(&context, def, vec!["Bar", "Baz", "Qux"]);
+            assert_includes_eq!(&context, def, vec!["Baz", "Bar", "Qux"]);
         });
     }
 
@@ -4009,7 +4011,7 @@ mod tests {
         assert_no_diagnostics!(&context);
 
         assert_definition_at!(&context, "1:1-4:4", Module, |def| {
-            assert_includes_eq!(&context, def, vec!["Bar", "Baz", "Qux"]);
+            assert_includes_eq!(&context, def, vec!["Baz", "Bar", "Qux"]);
         });
     }
 
@@ -4042,7 +4044,7 @@ mod tests {
         assert_no_diagnostics!(&context);
 
         assert_definition_at!(&context, "1:1-4:4", Class, |def| {
-            assert_prepends_eq!(&context, def, vec!["Bar", "Baz", "Qux"]);
+            assert_prepends_eq!(&context, def, vec!["Baz", "Bar", "Qux"]);
         });
     }
 
@@ -4060,7 +4062,7 @@ mod tests {
         assert_no_diagnostics!(&context);
 
         assert_definition_at!(&context, "1:1-4:4", Module, |def| {
-            assert_prepends_eq!(&context, def, vec!["Bar", "Baz", "Qux"]);
+            assert_prepends_eq!(&context, def, vec!["Baz", "Bar", "Qux"]);
         });
     }
 

--- a/rust/rubydex/src/resolution.rs
+++ b/rust/rubydex/src/resolution.rs
@@ -2470,6 +2470,23 @@ mod tests {
     }
 
     #[test]
+    fn multiple_mixins_in_same_prepend() {
+        let mut context = GraphTest::new();
+        context.index_uri("file:///foo.rb", {
+            r"
+            module A; end
+            module B; end
+
+            class Foo
+              prepend A, B
+            end
+            "
+        });
+        context.resolve();
+        assert_ancestors_eq!(context, "Foo", ["A", "B", "Foo", "Object"]);
+    }
+
+    #[test]
     fn prepends_involving_parent_scopes() {
         let mut context = GraphTest::new();
         context.index_uri("file:///foo.rb", {
@@ -2889,6 +2906,23 @@ mod tests {
         context.resolve();
         assert_ancestors_eq!(context, "Foo", ["A", "Foo", "Parent", "A", "Object"]);
         assert_ancestors_eq!(context, "Bar", ["Bar", "Parent", "A", "Object"]);
+    }
+
+    #[test]
+    fn multiple_mixins_in_same_include() {
+        let mut context = GraphTest::new();
+        context.index_uri("file:///foo.rb", {
+            r"
+            module A; end
+            module B; end
+
+            class Foo
+              include A, B
+            end
+            "
+        });
+        context.resolve();
+        assert_ancestors_eq!(context, "Foo", ["Foo", "A", "B", "Object"]);
     }
 
     #[test]


### PR DESCRIPTION
To my surprise, Ruby processes multiple arguments to `include`, `prepend` and `extend` in reverse.

For example,

```ruby
 module A; end
module B; end

class Foo
  include A, B
end

Foo.ancestors
# => [Foo, A, B, ...]

# This is the same result as
# include B
# include A
#
# and not
# include A
# include B
```

I started reversing them in indexing, so that we preserve the expected order.