### PR TITLE
Add module_function support to indexer

### DIFF
--- a/rust/rubydex/src/model/definitions.rs
+++ b/rust/rubydex/src/model/definitions.rs
@@ -37,7 +37,7 @@ use crate::{
 };
 
 bitflags! {
-    #[derive(Debug)]
+    #[derive(Debug, Clone)]
     pub struct DefinitionFlags: u8 {
         const DEPRECATED = 0b0001;
     }
@@ -565,7 +565,13 @@ impl MethodDefinition {
 
     #[must_use]
     pub fn id(&self) -> DefinitionId {
-        DefinitionId::from(&format!("{}{}{}", *self.uri_id, self.offset.start(), *self.str_id))
+        let mut formatted_id = format!("{}{}{}", *self.uri_id, self.offset.start(), *self.str_id);
+
+        if let Some(receiver) = self.receiver {
+            formatted_id.push_str(&receiver.to_string());
+        }
+
+        DefinitionId::from(&formatted_id)
     }
 
     #[must_use]
@@ -609,7 +615,7 @@ impl MethodDefinition {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum Parameter {
     RequiredPositional(ParameterStruct),
     OptionalPositional(ParameterStruct),
@@ -622,7 +628,7 @@ pub enum Parameter {
     Block(ParameterStruct),
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ParameterStruct {
     offset: Offset,
     str: StringId,

--- a/rust/rubydex/src/model/visibility.rs
+++ b/rust/rubydex/src/model/visibility.rs
@@ -6,6 +6,7 @@ pub enum Visibility {
     Public,
     Protected,
     Private,
+    ModuleFunction,
 }
 
 impl Visibility {
@@ -22,6 +23,7 @@ impl Visibility {
             "public" => Self::Public,
             "protected" => Self::Protected,
             "private" => Self::Private,
+            "module_function" => Self::ModuleFunction,
             _ => panic!("Invalid visibility: {str}"),
         }
     }
@@ -33,6 +35,7 @@ impl Display for Visibility {
             Self::Public => write!(f, "public"),
             Self::Protected => write!(f, "protected"),
             Self::Private => write!(f, "private"),
+            Self::ModuleFunction => write!(f, "module_function"),
         }
     }
 }

--- a/rust/rubydex/src/test_utils/local_graph_test.rs
+++ b/rust/rubydex/src/test_utils/local_graph_test.rs
@@ -43,7 +43,7 @@ impl LocalGraphTest {
     ///
     /// Panics if a definition cannot be found at the given location.
     #[must_use]
-    pub fn definition_at<'a>(&'a self, location: &str) -> &'a Definition {
+    pub fn all_definitions_at<'a>(&'a self, location: &str) -> Vec<&'a Definition> {
         let (uri, offset) = self.parse_location(&format!("{}:{}", self.uri(), location));
         let uri_id = UriId::from(&uri);
 
@@ -73,6 +73,16 @@ impl LocalGraphTest {
                     .collect::<Vec<_>>()
             }
         );
+
+        definitions
+    }
+
+    /// # Panics
+    ///
+    /// Panics if no definition or multiple definitions are found at the given location.
+    #[must_use]
+    pub fn definition_at<'a>(&'a self, location: &str) -> &'a Definition {
+        let definitions = self.all_definitions_at(location);
         assert!(
             definitions.len() < 2,
             "found more than one definition matching {location}"


### PR DESCRIPTION
This PR adds support for indexing `module_function` declarations and closes #91.

 When `module_function` is active, method definitions create two entries:
  - A public singleton method on the module 
  - A private instance method

We model this by creating two `Definition` objects at the same source location, differentiated by their receiver.

For `attr_*` methods, `module_function` acts like `private` without creating singleton methods.

## Changes
  - New `ModuleFunction` visibility variant
  - `MethodDefinition::id()` includes receiver so the two definitions don't collide
  - Test helper `all_definition_at()` for locations with multiple definitions
