### PR TITLE
Show breakdown of declarations stats

### DIFF
--- a/rust/rubydex/src/model/declaration.rs
+++ b/rust/rubydex/src/model/declaration.rs
@@ -236,6 +236,20 @@ impl Declaration {
     }
 
     #[must_use]
+    pub fn kind(&self) -> &'static str {
+        match self {
+            Declaration::Class(_) => "Class",
+            Declaration::SingletonClass(_) => "SingletonClass",
+            Declaration::Module(_) => "Module",
+            Declaration::Constant(_) => "Constant",
+            Declaration::Method(_) => "Method",
+            Declaration::GlobalVariable(_) => "GlobalVariable",
+            Declaration::InstanceVariable(_) => "InstanceVariable",
+            Declaration::ClassVariable(_) => "ClassVariable",
+        }
+    }
+
+    #[must_use]
     pub fn references(&self) -> &IdentityHashSet<ReferenceId> {
         all_declarations!(self, it => &it.references)
     }

--- a/rust/rubydex/src/model/graph.rs
+++ b/rust/rubydex/src/model/graph.rs
@@ -450,6 +450,7 @@ impl Graph {
 
         let mut declarations_with_docs = 0;
         let mut total_doc_size = 0;
+        let mut declarations_types: HashMap<&str, usize> = HashMap::new();
         let mut definition_types: HashMap<&str, usize> = HashMap::new();
         let mut multi_definition_count = 0;
 
@@ -463,6 +464,8 @@ impl Graph {
                     total_doc_size += doc_size;
                 }
             }
+
+            *declarations_types.entry(declaration.kind()).or_insert(0) += 1;
 
             // Count definitions by type
             let definition_count = declaration.definitions().len();
@@ -497,6 +500,14 @@ impl Graph {
             multi_definition_count,
             stats::percentage(multi_definition_count, total_declarations)
         );
+
+        println!();
+        println!("Declaration breakdown:");
+        let mut types: Vec<_> = declarations_types.iter().collect();
+        types.sort_by_key(|(_, count)| std::cmp::Reverse(**count));
+        for (kind, count) in types {
+            println!("  {kind:20} {count:6}");
+        }
 
         println!();
         println!("Definition breakdown:");


### PR DESCRIPTION
Makes it easier to see which kind of declarations are missing when there is a stats diff:

```
Query statistics
  Total declarations:         701260
  With documentation:         49125 (7.0%)
  Without documentation:      652135 (93.0%)
  Total documentation size:   171854 bytes
  Multi-definition names:     14285 (2.0%)

Declaration breakdown:
  Method               337838
  InstanceVariable     160643
  Class                 94334
  Constant              58298
  SingletonClass        37296
  Module                12556
  ClassVariable           292
  GlobalVariable            3

Definition breakdown:
  Method               298593
  InstanceVariable     182428
  Module               166601
  Class                 97733
  Constant              58306
  AttrReader            29801
  SingletonClass        12762
  AttrAccessor           5651
  AliasMethod            3957
  ClassVariable           577
  AttrWriter              333
  GlobalVariable           19
```