### PR TITLE
Move LineIndex into Document

### DIFF
--- a/rust/rubydex-sys/src/definition_api.rs
+++ b/rust/rubydex-sys/src/definition_api.rs
@@ -197,18 +197,14 @@ pub unsafe extern "C" fn rdx_definition_comments(pointer: GraphPointer, definiti
         };
 
         let uri_id = *defn.uri_id();
-        let uri = if let Some(doc) = graph.documents().get(&uri_id) {
-            doc.uri().to_string()
-        } else {
-            panic!("Document not found: {uri_id:?}");
-        };
+        let document = graph.documents().get(&uri_id).expect("document should exist");
 
         let mut entries = defn
             .comments()
             .iter()
             .map(|c| CommentEntry {
                 string: CString::new(c.string().as_str()).unwrap().into_raw().cast_const(),
-                location: create_location_for_uri_and_offset(&uri, c.offset()),
+                location: create_location_for_uri_and_offset(document, c.offset()),
             })
             .collect::<Vec<CommentEntry>>()
             .into_boxed_slice();
@@ -274,14 +270,8 @@ pub unsafe extern "C" fn rdx_definition_location(pointer: GraphPointer, definiti
             panic!("Definition not found: {definition_id:?}");
         };
 
-        let uri_id = *defn.uri_id();
-        let uri = if let Some(doc) = graph.documents().get(&uri_id) {
-            doc.uri().to_string()
-        } else {
-            panic!("Document not found: {uri_id:?}");
-        };
-
-        create_location_for_uri_and_offset(&uri, defn.offset())
+        let document = graph.documents().get(defn.uri_id()).expect("document should exist");
+        create_location_for_uri_and_offset(document, defn.offset())
     })
 }
 

--- a/rust/rubydex-sys/src/diagnostic_api.rs
+++ b/rust/rubydex-sys/src/diagnostic_api.rs
@@ -46,8 +46,8 @@ pub unsafe extern "C" fn rdx_graph_diagnostics(pointer: GraphPointer) -> *mut Di
             .diagnostics()
             .iter()
             .map(|diagnostic| {
-                let uri = graph.documents().get(diagnostic.uri_id()).unwrap().uri();
-                let location = create_location_for_uri_and_offset(uri, diagnostic.offset());
+                let document = graph.documents().get(diagnostic.uri_id()).unwrap();
+                let location = create_location_for_uri_and_offset(document, diagnostic.offset());
 
                 DiagnosticEntry {
                     rule: CString::new(diagnostic.rule().to_string())

--- a/rust/rubydex-sys/src/location_api.rs
+++ b/rust/rubydex-sys/src/location_api.rs
@@ -1,11 +1,9 @@
 //! Location-related C API and structs
 
 use libc::c_char;
-use line_index::LineIndex;
+use rubydex::model::document::Document;
 use rubydex::offset::Offset;
 use std::ffi::CString;
-use std::fs;
-use url::Url;
 
 /// C-compatible struct representing a definition location with offsets and line/column positions.
 #[repr(C)]
@@ -18,15 +16,6 @@ pub struct Location {
     pub end_column: u32,
 }
 
-#[must_use]
-fn file_path_from_uri(uri: &str) -> Option<String> {
-    Url::parse(uri)
-        .ok()?
-        .to_file_path()
-        .ok()
-        .map(|p| p.to_string_lossy().into_owned())
-}
-
 /// Helper to create a location for a given URI and byte-offset range.
 /// Allocates and returns a pointer to `Location`. Caller must free with `rdx_location_free`.
 ///
@@ -36,16 +25,13 @@ fn file_path_from_uri(uri: &str) -> Option<String> {
 /// - If the file cannot be read.
 /// - If the offset cannot be converted to a position.
 #[must_use]
-pub(crate) fn create_location_for_uri_and_offset(uri: &str, offset: &Offset) -> *mut Location {
-    let path_str = file_path_from_uri(uri).unwrap_or_else(|| panic!("Failed to convert URI to file path: {uri}"));
-    let source = fs::read_to_string(&path_str).unwrap_or_else(|_| panic!("Failed to read file at path {path_str}"));
-
-    let line_index = LineIndex::new(&source);
+pub(crate) fn create_location_for_uri_and_offset(document: &Document, offset: &Offset) -> *mut Location {
+    let line_index = document.line_index();
     let start_pos = line_index.line_col(offset.start().into());
     let end_pos = line_index.line_col(offset.end().into());
 
     let loc = Location {
-        uri: CString::new(uri).unwrap().into_raw().cast_const(),
+        uri: CString::new(document.uri()).unwrap().into_raw().cast_const(),
         start_line: start_pos.line + 1,
         end_line: end_pos.line + 1,
         start_column: start_pos.col + 1,

--- a/rust/rubydex-sys/src/reference_api.rs
+++ b/rust/rubydex-sys/src/reference_api.rs
@@ -152,13 +152,12 @@ pub unsafe extern "C" fn rdx_constant_reference_location(pointer: GraphPointer, 
     with_graph(pointer, |graph| {
         let ref_id = ReferenceId::new(reference_id);
         let reference = graph.constant_references().get(&ref_id).expect("Reference not found");
-        let uri = graph
+        let document = graph
             .documents()
             .get(&reference.uri_id())
-            .expect("Document should exist")
-            .uri()
-            .to_string();
-        create_location_for_uri_and_offset(&uri, reference.offset())
+            .expect("Document should exist");
+
+        create_location_for_uri_and_offset(document, reference.offset())
     })
 }
 
@@ -178,12 +177,11 @@ pub unsafe extern "C" fn rdx_method_reference_location(pointer: GraphPointer, re
     with_graph(pointer, |graph| {
         let ref_id = ReferenceId::new(reference_id);
         let reference = graph.method_references().get(&ref_id).expect("Reference not found");
-        let uri = graph
+        let document = graph
             .documents()
             .get(&reference.uri_id())
-            .expect("Document should exist")
-            .uri()
-            .to_string();
-        create_location_for_uri_and_offset(&uri, reference.offset())
+            .expect("Document should exist");
+
+        create_location_for_uri_and_offset(document, reference.offset())
     })
 }

--- a/rust/rubydex/src/diagnostic.rs
+++ b/rust/rubydex/src/diagnostic.rs
@@ -1,3 +1,5 @@
+#[cfg(any(test, feature = "test_utils"))]
+use crate::model::document::Document;
 use crate::{model::ids::UriId, offset::Offset};
 
 #[derive(Debug)]
@@ -46,12 +48,12 @@ impl Diagnostic {
 
     #[cfg(any(test, feature = "test_utils"))]
     #[must_use]
-    pub fn formatted(&self, source: &str) -> String {
+    pub fn formatted(&self, document: &Document) -> String {
         format!(
             "{}: {} ({})",
             self.rule(),
             self.message(),
-            self.offset().to_display_range(source)
+            self.offset().to_display_range(document)
         )
     }
 }

--- a/rust/rubydex/src/indexing/local_graph.rs
+++ b/rust/rubydex/src/indexing/local_graph.rs
@@ -50,6 +50,11 @@ impl LocalGraph {
         self.uri_id
     }
 
+    #[must_use]
+    pub fn document(&self) -> &Document {
+        &self.document
+    }
+
     // Definitions
 
     #[must_use]

--- a/rust/rubydex/src/indexing/ruby_indexer.rs
+++ b/rust/rubydex/src/indexing/ruby_indexer.rs
@@ -61,7 +61,7 @@ impl<'a> RubyIndexer<'a> {
     #[must_use]
     pub fn new(uri: String, source: &'a str) -> Self {
         let uri_id = UriId::from(&uri);
-        let local_graph = LocalGraph::new(uri_id, Document::new(uri));
+        let local_graph = LocalGraph::new(uri_id, Document::new(uri, source));
 
         Self {
             uri_id,
@@ -1893,7 +1893,10 @@ mod tests {
         let mut diagnostics = context.graph().diagnostics().iter().collect::<Vec<_>>();
 
         diagnostics.sort_by_key(|d| d.offset());
-        diagnostics.iter().map(|d| d.formatted(context.source())).collect()
+        diagnostics
+            .iter()
+            .map(|d| d.formatted(context.graph().document()))
+            .collect()
     }
 
     macro_rules! assert_diagnostics_eq {

--- a/rust/rubydex/src/model/document.rs
+++ b/rust/rubydex/src/model/document.rs
@@ -1,3 +1,5 @@
+use line_index::LineIndex;
+
 use crate::model::ids::{DefinitionId, ReferenceId};
 
 // Represents a document currently loaded into memory. Identified by its unique URI, it holds the edges to all
@@ -5,6 +7,7 @@ use crate::model::ids::{DefinitionId, ReferenceId};
 #[derive(Debug)]
 pub struct Document {
     uri: String,
+    line_index: LineIndex,
     definition_ids: Vec<DefinitionId>,
     method_reference_ids: Vec<ReferenceId>,
     constant_reference_ids: Vec<ReferenceId>,
@@ -12,9 +15,10 @@ pub struct Document {
 
 impl Document {
     #[must_use]
-    pub fn new(uri: String) -> Self {
+    pub fn new(uri: String, source: &str) -> Self {
         Self {
             uri,
+            line_index: LineIndex::new(source),
             definition_ids: Vec::new(),
             method_reference_ids: Vec::new(),
             constant_reference_ids: Vec::new(),
@@ -24,6 +28,11 @@ impl Document {
     #[must_use]
     pub fn uri(&self) -> &str {
         &self.uri
+    }
+
+    #[must_use]
+    pub fn line_index(&self) -> &LineIndex {
+        &self.line_index
     }
 
     #[must_use]
@@ -66,7 +75,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "Cannot add the same exact definition to a document twice. Duplicate definition IDs")]
     fn inserting_duplicate_definitions() {
-        let mut document = Document::new("file:///foo.rb".to_string());
+        let mut document = Document::new("file:///foo.rb".to_string(), "class Foo; end");
         let def_id = DefinitionId::new(123);
 
         document.add_definition(def_id);
@@ -77,7 +86,7 @@ mod tests {
 
     #[test]
     fn tracking_references() {
-        let mut document = Document::new("file:///foo.rb".to_string());
+        let mut document = Document::new("file:///foo.rb".to_string(), "class Foo; end");
         let method_ref = ReferenceId::new(1);
         let constant_ref = ReferenceId::new(2);
 

--- a/rust/rubydex/src/offset.rs
+++ b/rust/rubydex/src/offset.rs
@@ -5,7 +5,7 @@
 //! between byte offsets and line/column positions.
 
 #[cfg(any(test, feature = "test_utils"))]
-use line_index::LineIndex;
+use crate::model::document::Document;
 
 /// Represents a byte offset range within a specific file.
 ///
@@ -61,8 +61,8 @@ impl Offset {
     /// Converts an offset to a display range like `1:1-1:5`
     #[cfg(any(test, feature = "test_utils"))]
     #[must_use]
-    pub fn to_display_range(&self, source: &str) -> String {
-        let line_index = LineIndex::new(source);
+    pub fn to_display_range(&self, document: &Document) -> String {
+        let line_index = document.line_index();
         let start = line_index.line_col(self.start().into());
         let end = line_index.line_col(self.end().into());
         format!("{}:{}-{}:{}", start.line + 1, start.col + 1, end.line + 1, end.col + 1)

--- a/rust/rubydex/src/resolution.rs
+++ b/rust/rubydex/src/resolution.rs
@@ -1492,10 +1492,8 @@ mod tests {
         diagnostics
             .iter()
             .map(|d| {
-                let uri = context.graph().documents().get(d.uri_id()).unwrap().uri();
-                let source = context.get_source(uri).unwrap();
-
-                d.formatted(source)
+                let document = context.graph().documents().get(d.uri_id()).unwrap();
+                d.formatted(document)
             })
             .collect()
     }

--- a/rust/rubydex/src/test_utils/graph_test.rs
+++ b/rust/rubydex/src/test_utils/graph_test.rs
@@ -4,6 +4,7 @@ use super::normalize_indentation;
 use crate::indexing::local_graph::LocalGraph;
 use crate::indexing::ruby_indexer::RubyIndexer;
 use crate::model::graph::Graph;
+use crate::model::ids::UriId;
 use crate::offset::Offset;
 use crate::position::Position;
 use crate::resolution;
@@ -135,11 +136,10 @@ impl GraphTest {
         );
     }
 
-    fn line_index_for(&self, uri: &str) -> LineIndex {
-        let source = self
-            .get_source(uri)
-            .unwrap_or_else(|| panic!("Source not found for URI: {uri}"));
-        LineIndex::new(source)
+    fn line_index_for(&self, uri: &str) -> &LineIndex {
+        let uri_id = UriId::from(uri);
+        let document = self.graph.documents().get(&uri_id).unwrap();
+        document.line_index()
     }
 
     fn parse_location_positions(location: &str) -> (String, Position, Position) {

--- a/rust/rubydex/src/test_utils/local_graph_test.rs
+++ b/rust/rubydex/src/test_utils/local_graph_test.rs
@@ -1,5 +1,3 @@
-use line_index::LineIndex;
-
 use super::normalize_indentation;
 use crate::indexing::local_graph::LocalGraph;
 use crate::indexing::ruby_indexer::RubyIndexer;
@@ -74,7 +72,7 @@ impl LocalGraphTest {
 
                 offsets
                     .iter()
-                    .map(|offset| offset.to_display_range(&self.source))
+                    .map(|offset| offset.to_display_range(self.graph.document()))
                     .collect::<Vec<_>>()
             }
         );
@@ -107,7 +105,7 @@ impl LocalGraphTest {
     #[must_use]
     pub fn parse_location(&self, location: &str) -> (String, Offset) {
         let (uri, start_position, end_position) = Self::parse_location_positions(location);
-        let line_index = LineIndex::new(&self.source);
+        let line_index = self.graph.document().line_index();
 
         let start_offset = line_index.offset(start_position).unwrap_or(0.into());
         let end_offset = line_index.offset(end_position).unwrap_or(0.into());


### PR DESCRIPTION
The LSP needs to be able to get correct line/column locations for documents that haven't been saved yet and only exist in memory.

Additionally, we only need to re-compute the `LineIndex` structure if the file gets modified and not every time we need a location.

This PR moves the `LineIndex` inside of documents, so that every time we index a file, the structure gets created and can be reused.

This will also account for unsaved files, because in that case we'll just change the `source` we're indexing (it won't be read from disk).