### PR TITLE
Support LSP location encodings

### DIFF
--- a/ext/rubydex/graph.c
+++ b/ext/rubydex/graph.c
@@ -4,6 +4,7 @@
 #include "document.h"
 #include "location.h"
 #include "reference.h"
+#include "ruby/internal/globals.h"
 #include "rustbindings.h"
 #include "utils.h"
 
@@ -303,6 +304,22 @@ static VALUE sr_graph_resolve(VALUE self) {
     return self;
 }
 
+// Graph#set_encoding: (String) -> void
+// Sets the encoding used for transforming byte offsets into LSP code unit line/column positions
+static VALUE sr_graph_set_encoding(VALUE self, VALUE encoding) {
+    Check_Type(encoding, T_STRING);
+
+    void *graph;
+    TypedData_Get_Struct(self, void *, &graph_type, graph);
+
+    char *encoding_string = StringValueCStr(encoding);
+    if (!rdx_graph_set_encoding(graph, encoding_string)) {
+        rb_raise(rb_eArgError, "invalid encoding `%s` (should be utf8, utf16 or utf32)", encoding_string);
+    }
+
+    return Qnil;
+}
+
 // Graph#diagnostics -> Array[Rubydex::Diagnostic]
 static VALUE sr_graph_diagnostics(VALUE self) {
     void *graph;
@@ -351,4 +368,5 @@ void initialize_graph(VALUE mRubydex) {
     rb_define_method(cGraph, "diagnostics", sr_graph_diagnostics, 0);
     rb_define_method(cGraph, "[]", sr_graph_aref, 1);
     rb_define_method(cGraph, "search", sr_graph_search, 1);
+    rb_define_method(cGraph, "set_encoding", sr_graph_set_encoding, 1);
 }

--- a/rust/rubydex-sys/src/definition_api.rs
+++ b/rust/rubydex-sys/src/definition_api.rs
@@ -204,7 +204,7 @@ pub unsafe extern "C" fn rdx_definition_comments(pointer: GraphPointer, definiti
             .iter()
             .map(|c| CommentEntry {
                 string: CString::new(c.string().as_str()).unwrap().into_raw().cast_const(),
-                location: create_location_for_uri_and_offset(document, c.offset()),
+                location: create_location_for_uri_and_offset(graph, document, c.offset()),
             })
             .collect::<Vec<CommentEntry>>()
             .into_boxed_slice();
@@ -271,7 +271,7 @@ pub unsafe extern "C" fn rdx_definition_location(pointer: GraphPointer, definiti
         };
 
         let document = graph.documents().get(defn.uri_id()).expect("document should exist");
-        create_location_for_uri_and_offset(document, defn.offset())
+        create_location_for_uri_and_offset(graph, document, defn.offset())
     })
 }
 

--- a/rust/rubydex-sys/src/diagnostic_api.rs
+++ b/rust/rubydex-sys/src/diagnostic_api.rs
@@ -47,7 +47,7 @@ pub unsafe extern "C" fn rdx_graph_diagnostics(pointer: GraphPointer) -> *mut Di
             .iter()
             .map(|diagnostic| {
                 let document = graph.documents().get(diagnostic.uri_id()).unwrap();
-                let location = create_location_for_uri_and_offset(document, diagnostic.offset());
+                let location = create_location_for_uri_and_offset(graph, document, diagnostic.offset());
 
                 DiagnosticEntry {
                     rule: CString::new(diagnostic.rule().to_string())

--- a/rust/rubydex-sys/src/reference_api.rs
+++ b/rust/rubydex-sys/src/reference_api.rs
@@ -157,7 +157,7 @@ pub unsafe extern "C" fn rdx_constant_reference_location(pointer: GraphPointer, 
             .get(&reference.uri_id())
             .expect("Document should exist");
 
-        create_location_for_uri_and_offset(document, reference.offset())
+        create_location_for_uri_and_offset(graph, document, reference.offset())
     })
 }
 
@@ -182,6 +182,6 @@ pub unsafe extern "C" fn rdx_method_reference_location(pointer: GraphPointer, re
             .get(&reference.uri_id())
             .expect("Document should exist");
 
-        create_location_for_uri_and_offset(document, reference.offset())
+        create_location_for_uri_and_offset(graph, document, reference.offset())
     })
 }

--- a/rust/rubydex/src/model.rs
+++ b/rust/rubydex/src/model.rs
@@ -2,6 +2,7 @@ pub mod comment;
 pub mod declaration;
 pub mod definitions;
 pub mod document;
+pub mod encoding;
 pub mod graph;
 pub mod id;
 pub mod identity_maps;

--- a/rust/rubydex/src/model/encoding.rs
+++ b/rust/rubydex/src/model/encoding.rs
@@ -1,0 +1,22 @@
+use line_index::WideEncoding;
+
+#[derive(Default, Debug)]
+pub enum Encoding {
+    #[default]
+    Utf8,
+    Utf16,
+    Utf32,
+}
+
+impl Encoding {
+    /// Transform the LSP selected encoding into the expected `WideEncoding` for converting code units with the
+    /// `line_index` crate
+    #[must_use]
+    pub fn to_wide(&self) -> Option<WideEncoding> {
+        match self {
+            Encoding::Utf8 => None,
+            Encoding::Utf16 => Some(WideEncoding::Utf16),
+            Encoding::Utf32 => Some(WideEncoding::Utf32),
+        }
+    }
+}

--- a/rust/rubydex/src/model/graph.rs
+++ b/rust/rubydex/src/model/graph.rs
@@ -6,6 +6,7 @@ use crate::indexing::local_graph::LocalGraph;
 use crate::model::declaration::{Ancestor, Declaration};
 use crate::model::definitions::Definition;
 use crate::model::document::Document;
+use crate::model::encoding::Encoding;
 use crate::model::identity_maps::{IdentityHashMap, IdentityHashSet};
 use crate::model::ids::{DeclarationId, DefinitionId, NameId, ReferenceId, StringId, UriId};
 use crate::model::name::{NameRef, ResolvedName};
@@ -40,6 +41,8 @@ pub struct Graph {
     method_references: IdentityHashMap<ReferenceId, MethodRef>,
 
     diagnostics: Vec<Diagnostic>,
+    /// The position encoding used for LSP line/column locations. Not related to the actual encoding of the file
+    position_encoding: Encoding,
 }
 
 impl Graph {
@@ -55,6 +58,7 @@ impl Graph {
             constant_references: IdentityHashMap::default(),
             method_references: IdentityHashMap::default(),
             diagnostics: Vec::new(),
+            position_encoding: Encoding::default(),
         }
     }
 
@@ -414,6 +418,16 @@ impl Graph {
             Declaration::clear_ancestors(decl);
             Declaration::clear_descendants(decl);
         }
+    }
+
+    /// Sets the encoding that should be used for transforming byte offsets into LSP code unit line/column positions
+    pub fn set_encoding(&mut self, encoding: Encoding) {
+        self.position_encoding = encoding;
+    }
+
+    #[must_use]
+    pub fn encoding(&self) -> &Encoding {
+        &self.position_encoding
     }
 
     /// Asserts that the index is in a valid state.


### PR DESCRIPTION
This PR adds support for configuring the graph's encoding for the LSP, so that returned locations and match what's expected by editors according to the spec.

The idea is to have our own small encoding enum because `line_index::WideEncoding` actually doesn't have a value for `UTF-8`. We then widen the encoding when necessary to get the right columns when multibyte characters are involved.