### PR TITLE
Fix rust formatting

### DIFF
--- a/rakelib/cargo.rake
+++ b/rakelib/cargo.rake
@@ -21,11 +21,11 @@ end
 desc "Lint Rust code"
 task :lint_rust do
   sh "cargo clippy --all-targets --all-features -- -D warnings", chdir: "rust"
-  sh "rustfmt --check **/*.rs", chdir: "rust"
+  sh "cargo fmt --check", chdir: "rust"
 end
 
 desc "Format and auto fix violations for Rust code"
 task :format_rust do
   sh "cargo clippy --all-targets --all-features --fix --allow-dirty", chdir: "rust"
-  sh "rustfmt **/*.rs", chdir: "rust"
+  sh "cargo fmt", chdir: "rust"
 end

--- a/rust/rubydex/src/model/graph.rs
+++ b/rust/rubydex/src/model/graph.rs
@@ -704,12 +704,14 @@ mod tests {
         assert!(matches!(baz_ancestors, Ancestors::Complete(_)));
 
         {
-            let Declaration::Module(bar) = context.graph().declarations().get(&DeclarationId::from("Bar")).unwrap() else {
+            let Declaration::Module(bar) = context.graph().declarations().get(&DeclarationId::from("Bar")).unwrap()
+            else {
                 panic!("Expected Bar to be a module");
             };
             assert!(bar.descendants().contains(&DeclarationId::from("Foo")));
 
-            let Declaration::Class(foo) = context.graph().declarations().get(&DeclarationId::from("Foo")).unwrap() else {
+            let Declaration::Class(foo) = context.graph().declarations().get(&DeclarationId::from("Foo")).unwrap()
+            else {
                 panic!("Expected Foo to be a class");
             };
             assert!(foo.descendants().contains(&DeclarationId::from("Baz")));
@@ -718,19 +720,22 @@ mod tests {
         context.index_uri("file:///a.rb", "");
 
         {
-            let Declaration::Class(foo) = context.graph().declarations().get(&DeclarationId::from("Foo")).unwrap() else {
+            let Declaration::Class(foo) = context.graph().declarations().get(&DeclarationId::from("Foo")).unwrap()
+            else {
                 panic!("Expected Foo to be a class");
             };
             assert!(matches!(foo.clone_ancestors(), Ancestors::Partial(a) if a.is_empty()));
             assert!(foo.descendants().is_empty());
 
-            let Declaration::Class(baz) = context.graph().declarations().get(&DeclarationId::from("Baz")).unwrap() else {
+            let Declaration::Class(baz) = context.graph().declarations().get(&DeclarationId::from("Baz")).unwrap()
+            else {
                 panic!("Expected Baz to be a class");
             };
             assert!(matches!(baz.clone_ancestors(), Ancestors::Partial(a) if a.is_empty()));
             assert!(baz.descendants().is_empty());
 
-            let Declaration::Module(bar) = context.graph().declarations().get(&DeclarationId::from("Bar")).unwrap() else {
+            let Declaration::Module(bar) = context.graph().declarations().get(&DeclarationId::from("Bar")).unwrap()
+            else {
                 panic!("Expected Bar to be a module");
             };
             assert!(!bar.descendants().contains(&DeclarationId::from("Foo")));
@@ -742,7 +747,8 @@ mod tests {
         assert!(matches!(baz_ancestors, Ancestors::Complete(_)));
 
         {
-            let Declaration::Class(foo) = context.graph().declarations().get(&DeclarationId::from("Foo")).unwrap() else {
+            let Declaration::Class(foo) = context.graph().declarations().get(&DeclarationId::from("Foo")).unwrap()
+            else {
                 panic!("Expected Foo to be a class");
             };
             assert!(foo.descendants().contains(&DeclarationId::from("Baz")));


### PR DESCRIPTION
I'm not sure why but `rustfmt` wasn't working as expected on my machine, nor seemingly in CI (see the diff for some badly formatted code I was able to ship previously by mistake). This PR switches for `cargo fmt` which I understand wraps `rustfmt`—this seems to work.