### PR TITLE
Split declaration member types

### DIFF
--- a/rust/rubydex/src/resolution.rs
+++ b/rust/rubydex/src/resolution.rs
@@ -1655,8 +1655,7 @@ mod tests {
 
         for member in members {
             assert!(
-                constant_members.contains_key(&StringId::from(*member))
-                    || other_members.contains_key(&StringId::from(*member)),
+                actual_members.contains_key(&StringId::from(*member)),
                 "Expected member '{member}' not found"
             );
         }
@@ -1889,7 +1888,7 @@ mod tests {
         assert_no_diagnostics!(&context);
 
         let foo = context.graph().declarations().get(&DeclarationId::from("Foo")).unwrap();
-        assert_members(foo, &["initialize", "@name"]);
+        assert_members(foo, &["initialize()", "@name"]);
         assert_owner(foo, "Object");
     }
 
@@ -2072,7 +2071,7 @@ mod tests {
             .declarations()
             .get(&DeclarationId::from("Foo::<Foo>"))
             .unwrap();
-        assert_members(singleton, &["bar", "BAZ"]);
+        assert_members(singleton, &["bar()", "BAZ"]);
         assert_owner(singleton, "Foo");
     }
 
@@ -2117,7 +2116,7 @@ mod tests {
             .declarations()
             .get(&DeclarationId::from("Foo::<Foo>::<<Foo>>"))
             .unwrap();
-        assert_members(nested_singleton, &["baz"]);
+        assert_members(nested_singleton, &["baz()"]);
         assert_owner(nested_singleton, "Foo::<Foo>");
     }
 
@@ -2157,7 +2156,7 @@ mod tests {
             .declarations()
             .get(&DeclarationId::from("Foo::<Foo>"))
             .unwrap();
-        assert_members(singleton, &["baz", "Baz"]);
+        assert_members(singleton, &["baz()", "Baz"]);
         assert_owner(singleton, "Foo");
     }
 
@@ -2203,7 +2202,7 @@ mod tests {
         assert_no_diagnostics!(&context);
 
         let foo = context.graph().declarations().get(&DeclarationId::from("Foo")).unwrap();
-        assert_members(foo, &["bar", "@@baz"]);
+        assert_members(foo, &["bar()", "@@baz"]);
     }
 
     #[test]
@@ -2316,7 +2315,7 @@ mod tests {
             .declarations()
             .get(&DeclarationId::from("Foo::<Foo>"))
             .unwrap();
-        assert_members(foo_singleton, &["bar", "baz"]);
+        assert_members(foo_singleton, &["bar()", "baz()"]);
         assert_owner(foo_singleton, "Foo");
 
         let nested_foo_singleton = context
@@ -2324,7 +2323,7 @@ mod tests {
             .declarations()
             .get(&DeclarationId::from("Foo::<Foo>::<<Foo>>"))
             .unwrap();
-        assert_members(nested_foo_singleton, &["nested_bar"]);
+        assert_members(nested_foo_singleton, &["nested_bar()"]);
         assert_owner(nested_foo_singleton, "Foo::<Foo>");
 
         let bar_singleton = context
@@ -2332,7 +2331,7 @@ mod tests {
             .declarations()
             .get(&DeclarationId::from("Bar::<Bar>"))
             .unwrap();
-        assert_members(bar_singleton, &["qux"]);
+        assert_members(bar_singleton, &["qux()"]);
         assert_owner(bar_singleton, "Bar");
     }
 
@@ -2646,7 +2645,7 @@ mod tests {
         assert_no_diagnostics!(&context);
 
         let foo_class = context.graph().declarations().get(&DeclarationId::from("Foo")).unwrap();
-        assert_members(foo_class, &["foo", "bar"]);
+        assert_members(foo_class, &["foo()", "bar()"]);
     }
 
     #[test]
@@ -3679,7 +3678,7 @@ mod tests {
 
         let foo_class = context.graph().declarations().get(&DeclarationId::from("Foo")).unwrap();
         // inner_method should be owned by Foo, not by setup
-        assert_members(foo_class, &["setup", "inner_method"]);
+        assert_members(foo_class, &["setup()", "inner_method()"]);
     }
 
     #[test]
@@ -3705,11 +3704,11 @@ mod tests {
             .declarations()
             .get(&DeclarationId::from("Foo::<Foo>"))
             .unwrap();
-        assert_members(foo_singleton_class, &["setup"]);
+        assert_members(foo_singleton_class, &["setup()"]);
 
         // All attr_* should be owned by Foo, not by setup
         let foo_class = context.graph().declarations().get(&DeclarationId::from("Foo")).unwrap();
-        assert_members(foo_class, &["reader_attr", "writer_attr", "accessor_attr"]);
+        assert_members(foo_class, &["reader_attr()", "writer_attr()", "accessor_attr()"]);
     }
 
     #[test]
@@ -4343,8 +4342,7 @@ mod tests {
         let foo = context.graph().declarations().get(&DeclarationId::from("Foo")).unwrap();
 
         // Both entries exist as unique members
-        assert!(Declaration::members_of(foo).contains_key(&StringId::from("Array")));
-        assert!(Declaration::constant_members_of(foo).contains_key(&StringId::from("Array")));
+        assert_members(foo, &["Array", "Array()"]);
 
         // Both declarations exist with unique IDs
         assert!(
@@ -4358,7 +4356,7 @@ mod tests {
             context
                 .graph()
                 .declarations()
-                .get(&DeclarationId::from("Foo#Array"))
+                .get(&DeclarationId::from("Foo#Array()"))
                 .is_some()
         );
     }

--- a/test/definition_test.rb
+++ b/test/definition_test.rb
@@ -93,7 +93,7 @@ class DefinitionTest < Minitest::Test
       assert_equal(3, location.end_line)
       assert_equal(4, location.end_column)
 
-      def_foo = graph.documents.first.definitions.find { |d| d.name == "foo" }
+      def_foo = graph.documents.first.definitions.find { |d| d.name == "foo()" }
       refute_nil(def_foo)
       location = def_foo.location
       refute_nil(location)
@@ -129,7 +129,7 @@ class DefinitionTest < Minitest::Test
         foo_comments.map { |c| "#{c.string} (#{normalized_comment_location(c)})" },
       )
 
-      bar_comments = graph.documents.first.definitions.find { |d| d.name == "bar" }.comments
+      bar_comments = graph.documents.first.definitions.find { |d| d.name == "bar()" }.comments
       assert_equal(
         ["# Method comment (#{context.absolute_path_to("file1.rb")}:4:3-4:19)"],
         bar_comments.map { |c| "#{c.string} (#{normalized_comment_location(c)})" },
@@ -162,9 +162,9 @@ class DefinitionTest < Minitest::Test
 
       assert(graph.documents.first.definitions.find { |d| d.name == "Deprecated" }.deprecated?)
       refute(graph.documents.first.definitions.find { |d| d.name == "NotDeprecated" }.deprecated?)
-      assert(graph.documents.first.definitions.find { |d| d.name == "deprecated_method" }.deprecated?)
-      assert(graph.documents.first.definitions.find { |d| d.name == "also_deprecated_method" }.deprecated?)
-      refute(graph.documents.first.definitions.find { |d| d.name == "not_deprecated_method" }.deprecated?)
+      assert(graph.documents.first.definitions.find { |d| d.name == "deprecated_method()" }.deprecated?)
+      assert(graph.documents.first.definitions.find { |d| d.name == "also_deprecated_method()" }.deprecated?)
+      refute(graph.documents.first.definitions.find { |d| d.name == "not_deprecated_method()" }.deprecated?)
     end
   end
 
@@ -198,8 +198,8 @@ class DefinitionTest < Minitest::Test
 
       assert(graph.documents.first.definitions.find { |d| d.name == "DeprecatedWithBlank" }.deprecated?)
       assert(graph.documents.first.definitions.find { |d| d.name == "DeprecatedWithMessage" }.deprecated?)
-      assert(graph.documents.first.definitions.find { |d| d.name == "deprecated_method" }.deprecated?)
-      assert(graph.documents.first.definitions.find { |d| d.name == "also_deprecated_method" }.deprecated?)
+      assert(graph.documents.first.definitions.find { |d| d.name == "deprecated_method()" }.deprecated?)
+      assert(graph.documents.first.definitions.find { |d| d.name == "also_deprecated_method()" }.deprecated?)
       refute(graph.documents.first.definitions.find { |d| d.name == "NotDeprecated" }.deprecated?)
     end
   end

--- a/test/graph_test.rb
+++ b/test/graph_test.rb
@@ -180,7 +180,7 @@ class GraphTest < Minitest::Test
       graph.index_all(context.glob("**/*.rb"))
       graph.resolve
 
-      foo = graph["Foo::@叫聲😍x"].definitions.first
+      foo = graph["Foo\#@叫聲😍x"].definitions.first
 
       # UTF-8: code units => number of bytes
       loc = foo.location


### PR DESCRIPTION
We had a bug with two facets for this example:

```ruby
module Kernel
  class Array; end

  def Array(*elements); end
end
```

1. The first facet of the bug is that all members (both constants and others) are stored in the same `members` hash. The keys are the `StringId` for the interned name, which are identical. This meant that members could override other members and we missed the information
2. The second part of the bug is that the declarations for the array constant and method were incorrectly sharing the same fully qualified name. We depend on `DeclarationId` being both deterministic and unique, so this caused us to also incorrectly override declarations

This PR does two things to fully fix the bug:

1. Splits constant members into their own storage. There's never a situation where we don't know what kind of member we are looking for. Even if that was so, we could search both `constant_members` and `members` hashes. This avoids the conflicting name issue while preserving our ability to find things based on unqualified names (like asking is `baz` defined in `Foo`)
2. I switched all non-constant declarations to use the `#` name separator. This is something we already knew was missing. It both looks nicer and eliminates the lack of uniqueness since now the two array declarations are identified by:

- Foo::Array (constant)
- Foo#Array (method)