### PR TITLE
Track strings for cleanup

### DIFF
--- a/rust/rubydex-sys/src/graph_api.rs
+++ b/rust/rubydex-sys/src/graph_api.rs
@@ -446,7 +446,7 @@ mod tests {
                 .names()
                 .iter()
                 .find_map(|(_, name)| {
-                    if graph.strings().get(name.str()).unwrap() == "BAR" {
+                    if graph.strings().get(name.str()).unwrap().as_str() == "BAR" {
                         Some(name)
                     } else {
                         None
@@ -480,7 +480,7 @@ mod tests {
                 .names()
                 .iter()
                 .find_map(|(_, name)| {
-                    if graph.strings().get(name.str()).unwrap() == "BAR" {
+                    if graph.strings().get(name.str()).unwrap().as_str() == "BAR" {
                         Some(name)
                     } else {
                         None

--- a/rust/rubydex-sys/src/name_api.rs
+++ b/rust/rubydex-sys/src/name_api.rs
@@ -1,8 +1,4 @@
-use rubydex::model::{
-    graph::Graph,
-    ids::{NameId, StringId},
-    name::Name,
-};
+use rubydex::model::{graph::Graph, ids::NameId, name::Name};
 
 /// Takes a constant name and a nesting stack (e.g.: `["Foo", "Bar::Baz", "Qux"]`) and transforms it into a `NameId`,
 /// registering each required part in the graph. Returns the `NameId` and a list of name ids that need to be untracked
@@ -18,7 +14,7 @@ pub fn nesting_stack_to_name_id(graph: &mut Graph, const_name: &str, nesting: Ve
 
     for entry in nesting {
         for part in entry.split("::").map(String::from) {
-            let str_id = StringId::from(&part);
+            let str_id = graph.intern_string(part);
             let name_id = graph.add_name(Name::new(str_id, current_name, current_nesting));
             names_to_untrack.push(name_id);
             let new_name = Some(name_id);
@@ -30,7 +26,7 @@ pub fn nesting_stack_to_name_id(graph: &mut Graph, const_name: &str, nesting: Ve
     }
 
     for part in const_name.split("::").map(String::from) {
-        let str_id = StringId::from(&part);
+        let str_id = graph.intern_string(part);
         let name_id = graph.add_name(Name::new(str_id, current_name, current_nesting));
         names_to_untrack.push(name_id);
         let new_name = Some(name_id);

--- a/rust/rubydex-sys/src/reference_api.rs
+++ b/rust/rubydex-sys/src/reference_api.rs
@@ -107,7 +107,11 @@ pub unsafe extern "C" fn rdx_constant_reference_name(pointer: GraphPointer, refe
         let reference = graph.constant_references().get(&ref_id).expect("Reference not found");
         let name = graph.names().get(reference.name_id()).expect("Name ID should exist");
 
-        let name_string = graph.strings().get(name.str()).expect("String ID should exist").clone();
+        let name_string = graph
+            .strings()
+            .get(name.str())
+            .expect("String ID should exist")
+            .to_string();
         CString::new(name_string).unwrap().into_raw().cast_const()
     })
 }
@@ -131,7 +135,7 @@ pub unsafe extern "C" fn rdx_method_reference_name(pointer: GraphPointer, refere
             .strings()
             .get(reference.str())
             .expect("Name ID should exist")
-            .clone();
+            .to_string();
         CString::new(name).unwrap().into_raw().cast_const()
     })
 }

--- a/rust/rubydex/src/model.rs
+++ b/rust/rubydex/src/model.rs
@@ -9,4 +9,5 @@ pub mod identity_maps;
 pub mod ids;
 pub mod name;
 pub mod references;
+pub mod string_ref;
 pub mod visibility;

--- a/rust/rubydex/src/model/string_ref.rs
+++ b/rust/rubydex/src/model/string_ref.rs
@@ -1,0 +1,44 @@
+use std::ops::Deref;
+
+/// A reference-counted string used in the graph.
+///
+/// This struct wraps a `String` with a reference count to track how many times
+/// the string is used across the graph. When a document is removed, we decrement
+/// the reference count for each string it uses, and remove the string from the
+/// graph when its count reaches zero.
+#[derive(Debug)]
+pub struct StringRef {
+    value: String,
+    ref_count: usize,
+}
+
+impl StringRef {
+    #[must_use]
+    pub fn new(value: String) -> Self {
+        Self { value, ref_count: 1 }
+    }
+
+    #[must_use]
+    pub fn ref_count(&self) -> usize {
+        self.ref_count
+    }
+
+    pub fn increment_ref_count(&mut self, count: usize) {
+        self.ref_count += count;
+    }
+
+    #[must_use]
+    pub fn decrement_ref_count(&mut self) -> bool {
+        debug_assert!(self.ref_count > 0);
+        self.ref_count -= 1;
+        self.ref_count > 0
+    }
+}
+
+impl Deref for StringRef {
+    type Target = String;
+
+    fn deref(&self) -> &Self::Target {
+        &self.value
+    }
+}

--- a/rust/rubydex/src/resolution.rs
+++ b/rust/rubydex/src/resolution.rs
@@ -325,7 +325,7 @@ impl<'a> Resolver<'a> {
                 Definition::GlobalVariable(var) => {
                     let owner_id = *OBJECT_ID;
                     let str_id = *var.str_id();
-                    let name = self.graph.strings().get(&str_id).unwrap().clone();
+                    let name = self.graph.strings().get(&str_id).unwrap().as_str().to_string();
                     let declaration_id = DeclarationId::from(&name);
 
                     self.graph.add_declaration(declaration_id, id, || {
@@ -501,7 +501,7 @@ impl<'a> Resolver<'a> {
         let fully_qualified_name = {
             let owner = self.graph.declarations().get(&owner_id).unwrap();
             let name_str = self.graph.strings().get(&str_id).unwrap();
-            format!("{}#{name_str}", owner.name())
+            format!("{}#{}", owner.name(), name_str.as_str())
         };
         let declaration_id = DeclarationId::from(&fully_qualified_name);
 
@@ -924,7 +924,7 @@ impl<'a> Resolver<'a> {
         // depending on whether the name has a parent scope
         match self.name_owner_id(name_id) {
             Outcome::Resolved(owner_id, id_needing_linearization) => {
-                let mut fully_qualified_name = self.graph.strings().get(&str_id).unwrap().clone();
+                let mut fully_qualified_name = self.graph.strings().get(&str_id).unwrap().to_string();
 
                 {
                     let owner = self.graph.declarations().get(&owner_id).unwrap();
@@ -1674,7 +1674,7 @@ mod tests {
                 .unwrap()
                 .members()
                 .iter()
-                .map(|(str_id, _)| $context.graph().strings().get(str_id).unwrap())
+                .map(|(str_id, _)| $context.graph().strings().get(str_id).unwrap().as_str())
                 .collect::<Vec<_>>();
 
             actual_members.sort();
@@ -1742,7 +1742,9 @@ mod tests {
                 .iter()
                 .filter_map(
                     |(str_id, member_id)| match $context.graph().declarations().get(member_id) {
-                        Some(Declaration::InstanceVariable(_)) => Some($context.graph().strings().get(str_id).unwrap()),
+                        Some(Declaration::InstanceVariable(_)) => {
+                            Some($context.graph().strings().get(str_id).unwrap().as_str())
+                        }
                         _ => None,
                     },
                 )


### PR DESCRIPTION
Part of #330.

Similar to how we did ref count tracking for names in #458, this PR adds ref count tracking for strings so they can be cleaned up when a document is changed or removed. This is a little more involved since we needed to add a wrapper struct to store the `ref_count` and update all the places that previously expected `String` to work with `StringRef`. There are also more places we add strings than where we add names.

I tried to keep the diff as small and clean as possible, but I had to change a bunch of places to call `as_str()` which also impacted other things like formatting. The alternative approach would be to implement various traits on `StringRef` so we can use it the same way we did `String`, such as `Eq`, `Ord`, `PartialEq` etc. I'm not sure which is preferable or which is more idiomatic.

The basic mechanism is this: when a string is added to the graph for the first time, the `ref_count` is 1. If we encounter the same string elsewhere, we increment the `ref_count` by one. When we merge a local graph into the main graph we increment the `ref_count` by the number of times that string appears in the local graph. Finally, when we remove a document we loop traverse through all the definitions and references in that document, decrementing the `ref_count` for any strings we find, and then remove the strings from the graph if they are unused.
