### PR TITLE
Remove useless `Diagnostic::make`

### DIFF
--- a/rust/rubydex/src/diagnostic.rs
+++ b/rust/rubydex/src/diagnostic.rs
@@ -20,11 +20,6 @@ impl Diagnostic {
     }
 
     #[must_use]
-    pub fn make(rule: Rule, uri_id: UriId, offset: Offset, message: String) -> Self {
-        Self::new(rule, uri_id, offset, message)
-    }
-
-    #[must_use]
     pub fn rule(&self) -> &Rule {
         &self.rule
     }

--- a/rust/rubydex/src/indexing/local_graph.rs
+++ b/rust/rubydex/src/indexing/local_graph.rs
@@ -140,7 +140,7 @@ impl LocalGraph {
     }
 
     pub fn add_diagnostic(&mut self, rule: Rule, offset: Offset, message: String) {
-        let diagnostic = Diagnostic::make(rule, self.uri_id, offset, message);
+        let diagnostic = Diagnostic::new(rule, self.uri_id, offset, message);
         self.diagnostics.push(diagnostic);
     }
 


### PR DESCRIPTION
Since we pass the Rule now we can call `new` directly.