### PR TITLE
Add documentation to clarify untrack_name

### DIFF
--- a/rust/rubydex/src/model/graph.rs
+++ b/rust/rubydex/src/model/graph.rs
@@ -254,11 +254,36 @@ impl Graph {
         &self.names
     }
 
+    /// Decrements the ref count for a name and removes it if the count reaches zero.
+    ///
+    /// This does not recursively untrack `parent_scope` or `nesting` names.
     pub fn untrack_name(&mut self, name_id: NameId) {
         if let Some(name_ref) = self.names.get_mut(&name_id)
             && !name_ref.decrement_ref_count()
         {
             self.names.remove(&name_id);
+        }
+    }
+
+    /// Decrements the ref count for a name and removes it if the count reaches zero.
+    ///
+    /// This recursively untracks `parent_scope` and `nesting` names.
+    pub fn untrack_name_recursive(&mut self, name_id: NameId) {
+        let Some(name_ref) = self.names.get(&name_id) else {
+            return;
+        };
+
+        let parent_scope = *name_ref.parent_scope();
+        let nesting = *name_ref.nesting();
+
+        self.untrack_name(name_id);
+
+        if let Some(parent_scope_id) = parent_scope {
+            self.untrack_name_recursive(parent_scope_id);
+        }
+
+        if let Some(nesting_id) = nesting {
+            self.untrack_name_recursive(nesting_id);
         }
     }
 


### PR DESCRIPTION
This PR adds a note to explain that names in `parent_scope` or `nesting` are tracked and untracked separately.

For example:

```rb
class Foo::Bar::Baz
end
```

This will create and `Foo` and `Bar` names with count `1` via the constant references and the `Baz` name with count `1` via the definition.

```rb
module A
  B
end
```

This will create the `A` name with count `1` via a definition and the `B` name with count `1` via a constant reference.

In both cases, when the document is cleared, we loop through each constant reference and definition and decrement the associated names once. Since each name is accessed via its own constant reference or definition, it's not necessary to increment or decrement the counts for `parent_scope` or `nesting` names.

It also adds a new `untrack_name_recursive` that will help with other use-cases, such as temporarily adding a name to the graph as proposed in #449.