### PR TITLE
Save superclass location

### DIFF
--- a/rust/rubydex/src/model/definitions.rs
+++ b/rust/rubydex/src/model/definitions.rs
@@ -214,7 +214,7 @@ pub struct ClassDefinition {
     comments: Vec<Comment>,
     lexical_nesting_id: Option<DefinitionId>,
     members: Vec<DefinitionId>,
-    superclass_ref: Option<NameId>,
+    superclass_ref: Option<ReferenceId>,
     mixins: Vec<Mixin>,
 }
 
@@ -227,7 +227,7 @@ impl ClassDefinition {
         comments: Vec<Comment>,
         flags: DefinitionFlags,
         lexical_nesting_id: Option<DefinitionId>,
-        superclass_ref: Option<NameId>,
+        superclass_ref: Option<ReferenceId>,
     ) -> Self {
         Self {
             name_id,
@@ -273,8 +273,8 @@ impl ClassDefinition {
     }
 
     #[must_use]
-    pub fn superclass_ref(&self) -> Option<NameId> {
-        self.superclass_ref
+    pub fn superclass_ref(&self) -> Option<&ReferenceId> {
+        self.superclass_ref.as_ref()
     }
 
     #[must_use]

--- a/rust/rubydex/src/resolution.rs
+++ b/rust/rubydex/src/resolution.rs
@@ -1371,7 +1371,11 @@ impl<'a> Resolver<'a> {
             if let Definition::Class(class) = definition
                 && let Some(superclass) = class.superclass_ref()
             {
-                let name = self.graph.names().get(&superclass).unwrap();
+                let name = self
+                    .graph
+                    .names()
+                    .get(self.graph.constant_references().get(superclass).unwrap().name_id())
+                    .unwrap();
 
                 match name {
                     NameRef::Resolved(resolved) => {


### PR DESCRIPTION
As I'm trying to implement diagnostics for class ancestors, I realized we do not have a location for them.

Consider this:

```rb
module Foo; end

class Bar < Foo # diag: trying to subclass a module
end
```

We currently have no way to attach the diagnostic to the superclass without a location.