### PR TITLE
Add partial resolution

### DIFF
--- a/rust/rubydex/src/model/graph.rs
+++ b/rust/rubydex/src/model/graph.rs
@@ -416,11 +416,8 @@ impl Graph {
                     }
                 }
                 NameRef::Resolved(_) => {
-                    if let NameRef::Resolved(resolved) = entry.remove() {
-                        let new_resolved =
-                            NameRef::Resolved(Box::new(ResolvedName::new(resolved.name().clone(), declaration_id)));
-                        self.names.insert(name_id, new_resolved);
-                    }
+                    // TODO: consider if this is a valid scenario with the resolution phase design. Either collect
+                    // metrics here or panic if it's never supposed to occur
                 }
             },
             Entry::Vacant(_) => panic!("Trying to record resolved name for a name ID that does not exist"),


### PR DESCRIPTION
Part of #330.

This PR implements partial resolution when a document changes or is removed. We have already implemented the logic that removes definitions, references, names, strings, potentially declarations, and invalidates ancestor chains, whenever a document changes or is removed. This commit ensures the `resolve_all` method only resolves newly added definitions and references, and linearizes ancestors for declarations that were cleared.

I tried a bunch of different approaches to this, such as returning a list of units from `update` and passing them into `resolve_all`, but they were all a little ugly because the first resolution worked differently to subsequent ones. There were lots of conditionals and awkward refactors.

Instead, I quite like the approach here of stashing "pending" IDs on the graph object and then generating sorted units for them. Whenever we add a definition or constant reference to the graph during indexing, we also add its ID to `pending_definitions` or `pending_constant_references`, which are then processed the next time we call `resolve_all`. This way, the first full resolve works exactly the same as subsequent calls.

I think this approach is quite neat and tidy, but very open to other ideas.