### PR TITLE
Expose singleton_class to the Ruby API

### DIFF
--- a/ext/rubydex/declaration.c
+++ b/ext/rubydex/declaration.c
@@ -132,6 +132,26 @@ static VALUE rdxr_declaration_member(VALUE self, VALUE name) {
     return rb_class_new_instance(2, argv, cDeclaration);
 }
 
+// Declaration#singleton_class -> Declaration
+static VALUE rdxr_declaration_singleton_class(VALUE self) {
+    HandleData *data;
+    TypedData_Get_Struct(self, HandleData, &handle_type, data);
+
+    void *graph;
+    TypedData_Get_Struct(data->graph_obj, void *, &graph_type, graph);
+    const uint32_t *singleton_id = rdx_declaration_singleton_class(graph, data->id);
+
+    if (singleton_id == NULL) {
+        return Qnil;
+    }
+
+    uint32_t id = *singleton_id;
+    free_u32(singleton_id);
+    VALUE argv[] = {data->graph_obj, UINT2NUM(id)};
+
+    return rb_class_new_instance(2, argv, cDeclaration);
+}
+
 void rdxi_initialize_declaration(VALUE mRubydex) {
     cDeclaration = rb_define_class_under(mRubydex, "Declaration", rb_cObject);
 
@@ -141,6 +161,7 @@ void rdxi_initialize_declaration(VALUE mRubydex) {
     rb_define_method(cDeclaration, "unqualified_name", rdxr_declaration_unqualified_name, 0);
     rb_define_method(cDeclaration, "definitions", rdxr_declaration_definitions, 0);
     rb_define_method(cDeclaration, "member", rdxr_declaration_member, 1);
+    rb_define_method(cDeclaration, "singleton_class", rdxr_declaration_singleton_class, 0);
 
     rb_funcall(rb_singleton_class(cDeclaration), rb_intern("private"), 1, ID2SYM(rb_intern("new")));
 }

--- a/rust/rubydex-sys/src/declaration_api.rs
+++ b/rust/rubydex-sys/src/declaration_api.rs
@@ -108,3 +108,30 @@ pub unsafe extern "C" fn rdx_declaration_definitions_iter_new(
         }
     })
 }
+
+/// Returns the declaration for the singleton class of the declaration
+///
+/// # Safety
+///
+/// Assumes pointer is valid
+///
+/// # Panics
+///
+/// Will panic if invoked on a non-existing or non-namespace declaration
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rdx_declaration_singleton_class(pointer: GraphPointer, decl_id: u32) -> *const u32 {
+    with_graph(pointer, |graph| {
+        let declaration = graph
+            .declarations()
+            .get(&DeclarationId::new(decl_id))
+            .unwrap()
+            .as_namespace()
+            .unwrap();
+
+        if let Some(singleton_id) = declaration.singleton_class() {
+            Box::into_raw(Box::new(**singleton_id)).cast_const()
+        } else {
+            ptr::null()
+        }
+    })
+}

--- a/test/declaration_test.rb
+++ b/test/declaration_test.rb
@@ -106,4 +106,27 @@ class DeclarationTest < Minitest::Test
       assert_equal("B", decl_b.unqualified_name)
     end
   end
+
+  def test_singleton_class
+    with_context do |context|
+      context.write!("file1.rb", <<~RUBY)
+        module Foo
+          class Bar
+            class << self
+              def something; end
+            end
+          end
+        end
+      RUBY
+
+      graph = Rubydex::Graph.new
+      graph.index_all(context.glob("**/*.rb"))
+      graph.resolve
+
+      assert_nil(graph["Foo"].singleton_class)
+
+      bar = graph["Foo::Bar"]
+      assert_equal("Foo::Bar::<Bar>", bar.singleton_class.name)
+    end
+  end
 end


### PR DESCRIPTION
As part of the public Ruby APIs for querying data, we will need to provide a way of accessing the singleton class of a declaration. This PR exposes the `singleton_class` method, which is basically our original `get_or_create_singleton_class` method.

**Note**: cleanup of lazily created singletons will happen alongside their attached objects, but I just realized that we are missing that and created #488 to address it