### PR TITLE
Rename C extension prefixes for consistent naming conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,17 @@ the Ruby VM to the Rust crate logic.
 - `lib`: The rest of the Ruby code
 - `test`: Ruby test files
 
+### Naming Conventions
+
+The C extension uses prefixed function names to distinguish between abstraction layers:
+
+| Prefix | Layer | Purpose |
+|--------|-------|---------|
+| `rdx_` | Rust FFI | Functions exported from Rust via `#[no_mangle]`, callable from C |
+| `rdxr_` | Ruby callbacks | C functions registered with Ruby VM (e.g., `rb_define_method`) |
+| `rdxi_` | Internal helpers | Non-static C functions shared across files (declared in headers) |
+| (none) | File-local | Static helper functions used only within one C file |
+
 ### Commands
 
 When necessary, commands can be executed for the Ruby code.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -107,3 +107,14 @@ Connections between nodes use hashed IDs defined in `ids.rs`:
 - `UriId`: Hash of file URI
 - `StringId`: ID for interned string values
 - `ReferenceId`: ID for constant or method reference occurrences (combines reference kind, URI, and offset)
+
+## FFI Layer
+
+The Rust crate exposes a C-compatible FFI API through `rubydex-sys`. The C extension in `ext/rubydex/` wraps this API for Ruby.
+
+### Naming Conventions
+
+- `rdx_*`: Rust FFI exports (e.g., `rdx_graph_new()`)
+- `rdxr_*`: Ruby method callbacks (e.g., `rdxr_graph_alloc()`)
+- `rdxi_*`: Shared C helpers (e.g., `rdxi_str_array_to_char()`)
+- Static functions have no prefix

--- a/ext/rubydex/declaration.c
+++ b/ext/rubydex/declaration.c
@@ -7,7 +7,7 @@
 VALUE cDeclaration;
 
 // Declaration#name -> String
-static VALUE sr_declaration_name(VALUE self) {
+static VALUE rdxr_declaration_name(VALUE self) {
     HandleData *data;
     TypedData_Get_Struct(self, HandleData, &handle_type, data);
 
@@ -26,7 +26,7 @@ static VALUE sr_declaration_name(VALUE self) {
 }
 
 // Declaration#unqualified_name -> String
-static VALUE sr_declaration_unqualified_name(VALUE self) {
+static VALUE rdxr_declaration_unqualified_name(VALUE self) {
     HandleData *data;
     TypedData_Get_Struct(self, HandleData, &handle_type, data);
 
@@ -56,7 +56,7 @@ static VALUE declaration_definitions_yield(VALUE args) {
     DefinitionKind kind;
     while (rdx_definitions_iter_next(iter, &id, &kind)) {
         VALUE argv[] = {data->graph_obj, LL2NUM(id)};
-        VALUE defn_class = definition_class_for_kind(kind);
+        VALUE defn_class = rdxi_definition_class_for_kind(kind);
         VALUE handle = rb_class_new_instance(2, argv, defn_class);
         rb_yield(handle);
     }
@@ -89,7 +89,7 @@ static VALUE declaration_definitions_size(VALUE self, VALUE _args, VALUE _eobj) 
 
 // Declaration#definitions: () -> Enumerator[Definition]
 // Returns an enumerator that yields all definitions for this declaration lazily
-static VALUE sr_declaration_definitions(VALUE self) {
+static VALUE rdxr_declaration_definitions(VALUE self) {
     if (!rb_block_given_p()) {
         return rb_enumeratorize_with_size(self, rb_str_new2("definitions"), 0, NULL, declaration_definitions_size);
     }
@@ -109,7 +109,7 @@ static VALUE sr_declaration_definitions(VALUE self) {
 
 // Declaration#member: (String member) -> Declaration
 // Returns a declaration handle for the given member
-static VALUE sr_declaration_member(VALUE self, VALUE name) {
+static VALUE rdxr_declaration_member(VALUE self, VALUE name) {
     HandleData *data;
     TypedData_Get_Struct(self, HandleData, &handle_type, data);
 
@@ -132,15 +132,15 @@ static VALUE sr_declaration_member(VALUE self, VALUE name) {
     return rb_class_new_instance(2, argv, cDeclaration);
 }
 
-void initialize_declaration(VALUE mRubydex) {
+void rdxi_initialize_declaration(VALUE mRubydex) {
     cDeclaration = rb_define_class_under(mRubydex, "Declaration", rb_cObject);
 
-    rb_define_alloc_func(cDeclaration, sr_handle_alloc);
-    rb_define_method(cDeclaration, "initialize", sr_handle_initialize, 2);
-    rb_define_method(cDeclaration, "name", sr_declaration_name, 0);
-    rb_define_method(cDeclaration, "unqualified_name", sr_declaration_unqualified_name, 0);
-    rb_define_method(cDeclaration, "definitions", sr_declaration_definitions, 0);
-    rb_define_method(cDeclaration, "member", sr_declaration_member, 1);
+    rb_define_alloc_func(cDeclaration, rdxr_handle_alloc);
+    rb_define_method(cDeclaration, "initialize", rdxr_handle_initialize, 2);
+    rb_define_method(cDeclaration, "name", rdxr_declaration_name, 0);
+    rb_define_method(cDeclaration, "unqualified_name", rdxr_declaration_unqualified_name, 0);
+    rb_define_method(cDeclaration, "definitions", rdxr_declaration_definitions, 0);
+    rb_define_method(cDeclaration, "member", rdxr_declaration_member, 1);
 
     rb_funcall(rb_singleton_class(cDeclaration), rb_intern("private"), 1, ID2SYM(rb_intern("new")));
 }

--- a/ext/rubydex/declaration.h
+++ b/ext/rubydex/declaration.h
@@ -5,6 +5,6 @@
 
 extern VALUE cDeclaration;
 
-void initialize_declaration(VALUE mRubydex);
+void rdxi_initialize_declaration(VALUE mRubydex);
 
 #endif // RUBYDEX_DECLARATION_H

--- a/ext/rubydex/definition.c
+++ b/ext/rubydex/definition.c
@@ -24,7 +24,7 @@ VALUE cMethodAliasDefinition;
 VALUE cGlobalVariableAliasDefinition;
 
 // Keep this in sync with definition.rs
-VALUE definition_class_for_kind(DefinitionKind kind) {
+VALUE rdxi_definition_class_for_kind(DefinitionKind kind) {
     switch (kind) {
     case DefinitionKind_Class:
         return cClassDefinition;
@@ -60,7 +60,7 @@ VALUE definition_class_for_kind(DefinitionKind kind) {
 }
 
 // Definition#location -> Rubydex::Location
-static VALUE sr_definition_location(VALUE self) {
+static VALUE rdxr_definition_location(VALUE self) {
     HandleData *data;
     TypedData_Get_Struct(self, HandleData, &handle_type, data);
 
@@ -68,14 +68,14 @@ static VALUE sr_definition_location(VALUE self) {
     TypedData_Get_Struct(data->graph_obj, void *, &graph_type, graph);
 
     Location *loc = rdx_definition_location(graph, data->id);
-    VALUE location = build_location_value(loc);
+    VALUE location = rdxi_build_location_value(loc);
     rdx_location_free(loc);
 
     return location;
 }
 
 // Definition#comments -> [Rubydex::Comment]
-static VALUE sr_definition_comments(VALUE self) {
+static VALUE rdxr_definition_comments(VALUE self) {
     HandleData *data;
     TypedData_Get_Struct(self, HandleData, &handle_type, data);
 
@@ -97,7 +97,7 @@ static VALUE sr_definition_comments(VALUE self) {
         VALUE string = rb_utf8_str_new_cstr(entry.string);
 
         Location *loc = entry.location;
-        VALUE location = build_location_value(loc);
+        VALUE location = rdxi_build_location_value(loc);
 
         VALUE comment_kwargs = rb_hash_new();
         rb_hash_aset(comment_kwargs, ID2SYM(rb_intern("string")), string);
@@ -113,7 +113,7 @@ static VALUE sr_definition_comments(VALUE self) {
 }
 
 // Definition#name -> String
-static VALUE sr_definition_name(VALUE self) {
+static VALUE rdxr_definition_name(VALUE self) {
     HandleData *data;
     TypedData_Get_Struct(self, HandleData, &handle_type, data);
 
@@ -130,84 +130,84 @@ static VALUE sr_definition_name(VALUE self) {
 }
 
 // Definition#deprecated? -> bool
-static VALUE sr_definition_deprecated(VALUE self) {
+static VALUE rdxr_definition_deprecated(VALUE self) {
     HandleData *data;
     TypedData_Get_Struct(self, HandleData, &handle_type, data);
 
     void *graph;
     TypedData_Get_Struct(data->graph_obj, void *, &graph_type, graph);
 
-    bool deprecated = sat_definition_is_deprecated(graph, data->id);
+    bool deprecated = rdx_definition_is_deprecated(graph, data->id);
     return deprecated ? Qtrue : Qfalse;
 }
 
-void initialize_definition(VALUE mod) {
+void rdxi_initialize_definition(VALUE mod) {
     mRubydex = mod;
 
     cComment = rb_define_class_under(mRubydex, "Comment", rb_cObject);
 
     cDefinition = rb_define_class_under(mRubydex, "Definition", rb_cObject);
-    rb_define_alloc_func(cDefinition, sr_handle_alloc);
-    rb_define_method(cDefinition, "initialize", sr_handle_initialize, 2);
+    rb_define_alloc_func(cDefinition, rdxr_handle_alloc);
+    rb_define_method(cDefinition, "initialize", rdxr_handle_initialize, 2);
     rb_funcall(rb_singleton_class(cDefinition), rb_intern("private"), 1, ID2SYM(rb_intern("new")));
-    rb_define_method(cDefinition, "location", sr_definition_location, 0);
-    rb_define_method(cDefinition, "comments", sr_definition_comments, 0);
-    rb_define_method(cDefinition, "name", sr_definition_name, 0);
-    rb_define_method(cDefinition, "deprecated?", sr_definition_deprecated, 0);
+    rb_define_method(cDefinition, "location", rdxr_definition_location, 0);
+    rb_define_method(cDefinition, "comments", rdxr_definition_comments, 0);
+    rb_define_method(cDefinition, "name", rdxr_definition_name, 0);
+    rb_define_method(cDefinition, "deprecated?", rdxr_definition_deprecated, 0);
 
     cClassDefinition = rb_define_class_under(mRubydex, "ClassDefinition", cDefinition);
-    rb_define_alloc_func(cClassDefinition, sr_handle_alloc);
-    rb_define_method(cClassDefinition, "initialize", sr_handle_initialize, 2);
+    rb_define_alloc_func(cClassDefinition, rdxr_handle_alloc);
+    rb_define_method(cClassDefinition, "initialize", rdxr_handle_initialize, 2);
 
     cSingletonClassDefinition = rb_define_class_under(mRubydex, "SingletonClassDefinition", cDefinition);
-    rb_define_alloc_func(cSingletonClassDefinition, sr_handle_alloc);
-    rb_define_method(cSingletonClassDefinition, "initialize", sr_handle_initialize, 2);
+    rb_define_alloc_func(cSingletonClassDefinition, rdxr_handle_alloc);
+    rb_define_method(cSingletonClassDefinition, "initialize", rdxr_handle_initialize, 2);
 
     cModuleDefinition = rb_define_class_under(mRubydex, "ModuleDefinition", cDefinition);
-    rb_define_alloc_func(cModuleDefinition, sr_handle_alloc);
-    rb_define_method(cModuleDefinition, "initialize", sr_handle_initialize, 2);
+    rb_define_alloc_func(cModuleDefinition, rdxr_handle_alloc);
+    rb_define_method(cModuleDefinition, "initialize", rdxr_handle_initialize, 2);
 
     cConstantDefinition = rb_define_class_under(mRubydex, "ConstantDefinition", cDefinition);
-    rb_define_alloc_func(cConstantDefinition, sr_handle_alloc);
-    rb_define_method(cConstantDefinition, "initialize", sr_handle_initialize, 2);
+    rb_define_alloc_func(cConstantDefinition, rdxr_handle_alloc);
+    rb_define_method(cConstantDefinition, "initialize", rdxr_handle_initialize, 2);
 
     cConstantAliasDefinition = rb_define_class_under(mRubydex, "ConstantAliasDefinition", cDefinition);
-    rb_define_alloc_func(cConstantAliasDefinition, sr_handle_alloc);
-    rb_define_method(cConstantAliasDefinition, "initialize", sr_handle_initialize, 2);
+    rb_define_alloc_func(cConstantAliasDefinition, rdxr_handle_alloc);
+    rb_define_method(cConstantAliasDefinition, "initialize", rdxr_handle_initialize, 2);
 
     cMethodDefinition = rb_define_class_under(mRubydex, "MethodDefinition", cDefinition);
-    rb_define_alloc_func(cMethodDefinition, sr_handle_alloc);
-    rb_define_method(cMethodDefinition, "initialize", sr_handle_initialize, 2);
+    rb_define_alloc_func(cMethodDefinition, rdxr_handle_alloc);
+    rb_define_method(cMethodDefinition, "initialize", rdxr_handle_initialize, 2);
 
     cAttrAccessorDefinition = rb_define_class_under(mRubydex, "AttrAccessorDefinition", cDefinition);
-    rb_define_alloc_func(cAttrAccessorDefinition, sr_handle_alloc);
-    rb_define_method(cAttrAccessorDefinition, "initialize", sr_handle_initialize, 2);
+    rb_define_alloc_func(cAttrAccessorDefinition, rdxr_handle_alloc);
+    rb_define_method(cAttrAccessorDefinition, "initialize", rdxr_handle_initialize, 2);
 
     cAttrReaderDefinition = rb_define_class_under(mRubydex, "AttrReaderDefinition", cDefinition);
-    rb_define_alloc_func(cAttrReaderDefinition, sr_handle_alloc);
-    rb_define_method(cAttrReaderDefinition, "initialize", sr_handle_initialize, 2);
+    rb_define_alloc_func(cAttrReaderDefinition, rdxr_handle_alloc);
+    rb_define_method(cAttrReaderDefinition, "initialize", rdxr_handle_initialize, 2);
 
     cAttrWriterDefinition = rb_define_class_under(mRubydex, "AttrWriterDefinition", cDefinition);
-    rb_define_alloc_func(cAttrWriterDefinition, sr_handle_alloc);
-    rb_define_method(cAttrWriterDefinition, "initialize", sr_handle_initialize, 2);
+    rb_define_alloc_func(cAttrWriterDefinition, rdxr_handle_alloc);
+    rb_define_method(cAttrWriterDefinition, "initialize", rdxr_handle_initialize, 2);
 
     cGlobalVariableDefinition = rb_define_class_under(mRubydex, "GlobalVariableDefinition", cDefinition);
-    rb_define_alloc_func(cGlobalVariableDefinition, sr_handle_alloc);
-    rb_define_method(cGlobalVariableDefinition, "initialize", sr_handle_initialize, 2);
+    rb_define_alloc_func(cGlobalVariableDefinition, rdxr_handle_alloc);
+    rb_define_method(cGlobalVariableDefinition, "initialize", rdxr_handle_initialize, 2);
 
     cInstanceVariableDefinition = rb_define_class_under(mRubydex, "InstanceVariableDefinition", cDefinition);
-    rb_define_alloc_func(cInstanceVariableDefinition, sr_handle_alloc);
-    rb_define_method(cInstanceVariableDefinition, "initialize", sr_handle_initialize, 2);
+    rb_define_alloc_func(cInstanceVariableDefinition, rdxr_handle_alloc);
+    rb_define_method(cInstanceVariableDefinition, "initialize", rdxr_handle_initialize, 2);
 
     cClassVariableDefinition = rb_define_class_under(mRubydex, "ClassVariableDefinition", cDefinition);
-    rb_define_alloc_func(cClassVariableDefinition, sr_handle_alloc);
-    rb_define_method(cClassVariableDefinition, "initialize", sr_handle_initialize, 2);
+    rb_define_alloc_func(cClassVariableDefinition, rdxr_handle_alloc);
+    rb_define_method(cClassVariableDefinition, "initialize", rdxr_handle_initialize, 2);
 
     cMethodAliasDefinition = rb_define_class_under(mRubydex, "MethodAliasDefinition", cDefinition);
-    rb_define_alloc_func(cMethodAliasDefinition, sr_handle_alloc);
-    rb_define_method(cMethodAliasDefinition, "initialize", sr_handle_initialize, 2);
+    rb_define_alloc_func(cMethodAliasDefinition, rdxr_handle_alloc);
+    rb_define_method(cMethodAliasDefinition, "initialize", rdxr_handle_initialize, 2);
 
     cGlobalVariableAliasDefinition = rb_define_class_under(mRubydex, "GlobalVariableAliasDefinition", cDefinition);
-    rb_define_alloc_func(cGlobalVariableAliasDefinition, sr_handle_alloc);
-    rb_define_method(cGlobalVariableAliasDefinition, "initialize", sr_handle_initialize, 2);
+    rb_define_alloc_func(cGlobalVariableAliasDefinition, rdxr_handle_alloc);
+    rb_define_method(cGlobalVariableAliasDefinition, "initialize", rdxr_handle_initialize, 2);
 }

--- a/ext/rubydex/definition.h
+++ b/ext/rubydex/definition.h
@@ -20,9 +20,9 @@ extern VALUE cClassVariableDefinition;
 extern VALUE cMethodAliasDefinition;
 extern VALUE cGlobalVariableAliasDefinition;
 
-void initialize_definition(VALUE mRubydex);
+void rdxi_initialize_definition(VALUE mRubydex);
 
 // Returns the Ruby class for a given DefinitionKind without calling back into Rust
-VALUE definition_class_for_kind(DefinitionKind kind);
+VALUE rdxi_definition_class_for_kind(DefinitionKind kind);
 
 #endif // RUBYDEX_DEFINITION_H

--- a/ext/rubydex/diagnostic.c
+++ b/ext/rubydex/diagnostic.c
@@ -3,4 +3,4 @@
 
 VALUE cDiagnostic;
 
-void initialize_diagnostic(VALUE mRubydex) { cDiagnostic = rb_define_class_under(mRubydex, "Diagnostic", rb_cObject); }
+void rdxi_initialize_diagnostic(VALUE mRubydex) { cDiagnostic = rb_define_class_under(mRubydex, "Diagnostic", rb_cObject); }

--- a/ext/rubydex/diagnostic.h
+++ b/ext/rubydex/diagnostic.h
@@ -6,6 +6,6 @@
 
 extern VALUE cDiagnostic;
 
-void initialize_diagnostic(VALUE mRubydex);
+void rdxi_initialize_diagnostic(VALUE mRubydex);
 
 #endif // RUBYDEX_DIAGNOSTIC_H

--- a/ext/rubydex/document.c
+++ b/ext/rubydex/document.c
@@ -7,7 +7,7 @@
 VALUE cDocument;
 
 // Document#uri -> String
-static VALUE sr_document_uri(VALUE self) {
+static VALUE rdxr_document_uri(VALUE self) {
     HandleData *data;
     TypedData_Get_Struct(self, HandleData, &handle_type, data);
 
@@ -37,7 +37,7 @@ static VALUE document_definitions_yield(VALUE args) {
     DefinitionKind kind;
     while (rdx_definitions_iter_next(iter, &id, &kind)) {
         VALUE argv[] = {data->graph_obj, LL2NUM(id)};
-        VALUE defn_class = definition_class_for_kind(kind);
+        VALUE defn_class = rdxi_definition_class_for_kind(kind);
         VALUE handle = rb_class_new_instance(2, argv, defn_class);
         rb_yield(handle);
     }
@@ -69,7 +69,7 @@ static VALUE document_definitions_size(VALUE self, VALUE _args, VALUE _eobj) {
 
 // Document#definitions: () -> Enumerator[Definition]
 // Returns an enumerator that yields all definitions for this document lazily
-static VALUE sr_document_definitions(VALUE self) {
+static VALUE rdxr_document_definitions(VALUE self) {
     if (!rb_block_given_p()) {
         return rb_enumeratorize_with_size(self, rb_str_new2("definitions"), 0, NULL, document_definitions_size);
     }
@@ -86,13 +86,13 @@ static VALUE sr_document_definitions(VALUE self) {
     return self;
 }
 
-void initialize_document(VALUE mRubydex) {
+void rdxi_initialize_document(VALUE mRubydex) {
     cDocument = rb_define_class_under(mRubydex, "Document", rb_cObject);
 
-    rb_define_alloc_func(cDocument, sr_handle_alloc);
-    rb_define_method(cDocument, "initialize", sr_handle_initialize, 2);
-    rb_define_method(cDocument, "uri", sr_document_uri, 0);
-    rb_define_method(cDocument, "definitions", sr_document_definitions, 0);
+    rb_define_alloc_func(cDocument, rdxr_handle_alloc);
+    rb_define_method(cDocument, "initialize", rdxr_handle_initialize, 2);
+    rb_define_method(cDocument, "uri", rdxr_document_uri, 0);
+    rb_define_method(cDocument, "definitions", rdxr_document_definitions, 0);
 
     rb_funcall(rb_singleton_class(cDocument), rb_intern("private"), 1, ID2SYM(rb_intern("new")));
 }

--- a/ext/rubydex/document.h
+++ b/ext/rubydex/document.h
@@ -5,6 +5,6 @@
 
 extern VALUE cDocument;
 
-void initialize_document(VALUE mRubydex);
+void rdxi_initialize_document(VALUE mRubydex);
 
 #endif // RUBYDEX_DOCUMENT_H

--- a/ext/rubydex/graph.h
+++ b/ext/rubydex/graph.h
@@ -5,6 +5,6 @@
 
 extern const rb_data_type_t graph_type;
 
-void initialize_graph(VALUE mRubydex);
+void rdxi_initialize_graph(VALUE mRubydex);
 
 #endif // RUBYDEX_GRAPH_H

--- a/ext/rubydex/handle.h
+++ b/ext/rubydex/handle.h
@@ -24,7 +24,7 @@ static void handle_free(void *ptr) {
 static const rb_data_type_t handle_type = {
     "RubydexHandle", {handle_mark, handle_free, 0}, 0, 0, RUBY_TYPED_FREE_IMMEDIATELY};
 
-static VALUE sr_handle_alloc(VALUE klass) {
+static VALUE rdxr_handle_alloc(VALUE klass) {
     HandleData *data = ALLOC(HandleData);
     data->graph_obj = Qnil;
     data->id = 0;
@@ -32,7 +32,7 @@ static VALUE sr_handle_alloc(VALUE klass) {
     return TypedData_Wrap_Struct(klass, &handle_type, data);
 }
 
-static VALUE sr_handle_initialize(VALUE self, VALUE graph_obj, VALUE id_val) {
+static VALUE rdxr_handle_initialize(VALUE self, VALUE graph_obj, VALUE id_val) {
     HandleData *data;
     TypedData_Get_Struct(self, HandleData, &handle_type, data);
     data->graph_obj = graph_obj;

--- a/ext/rubydex/location.c
+++ b/ext/rubydex/location.c
@@ -2,7 +2,7 @@
 
 VALUE cLocation;
 
-VALUE build_location_value(Location *loc) {
+VALUE rdxi_build_location_value(Location *loc) {
     if (loc == NULL) {
         return Qnil;
     }
@@ -19,4 +19,4 @@ VALUE build_location_value(Location *loc) {
     return rb_class_new_instance_kw(1, &kwargs, cLocation, RB_PASS_KEYWORDS);
 }
 
-void initialize_location(VALUE mRubydex) { cLocation = rb_define_class_under(mRubydex, "Location", rb_cObject); }
+void rdxi_initialize_location(VALUE mRubydex) { cLocation = rb_define_class_under(mRubydex, "Location", rb_cObject); }

--- a/ext/rubydex/location.h
+++ b/ext/rubydex/location.h
@@ -6,10 +6,10 @@
 
 extern VALUE cLocation;
 
-void initialize_location(VALUE mRubydex);
+void rdxi_initialize_location(VALUE mRubydex);
 
 // Helper to build a Ruby Rubydex::Location from a C Location pointer.
 // Does not take ownership; caller remains responsible for freeing the C Location on the Rust side.
-VALUE build_location_value(Location *loc);
+VALUE rdxi_build_location_value(Location *loc);
 
 #endif // RUBYDEX_LOCATION_H

--- a/ext/rubydex/reference.c
+++ b/ext/rubydex/reference.c
@@ -9,7 +9,7 @@ VALUE cConstantReference;
 VALUE cMethodReference;
 
 // ConstantReference#name -> String
-static VALUE sr_constant_reference_name(VALUE self) {
+static VALUE rdxr_constant_reference_name(VALUE self) {
     HandleData *data;
     TypedData_Get_Struct(self, HandleData, &handle_type, data);
 
@@ -27,7 +27,7 @@ static VALUE sr_constant_reference_name(VALUE self) {
 }
 
 // ConstantReference#location -> Rubydex::Location
-static VALUE sr_constant_reference_location(VALUE self) {
+static VALUE rdxr_constant_reference_location(VALUE self) {
     HandleData *data;
     TypedData_Get_Struct(self, HandleData, &handle_type, data);
 
@@ -35,13 +35,13 @@ static VALUE sr_constant_reference_location(VALUE self) {
     TypedData_Get_Struct(data->graph_obj, void *, &graph_type, graph);
 
     Location *loc = rdx_constant_reference_location(graph, data->id);
-    VALUE location = build_location_value(loc);
+    VALUE location = rdxi_build_location_value(loc);
     rdx_location_free(loc);
     return location;
 }
 
 // MethodReference#name -> String
-static VALUE sr_method_reference_name(VALUE self) {
+static VALUE rdxr_method_reference_name(VALUE self) {
     HandleData *data;
     TypedData_Get_Struct(self, HandleData, &handle_type, data);
 
@@ -59,7 +59,7 @@ static VALUE sr_method_reference_name(VALUE self) {
 }
 
 // MethodReference#location -> Rubydex::Location
-static VALUE sr_method_reference_location(VALUE self) {
+static VALUE rdxr_method_reference_location(VALUE self) {
     HandleData *data;
     TypedData_Get_Struct(self, HandleData, &handle_type, data);
 
@@ -67,13 +67,13 @@ static VALUE sr_method_reference_location(VALUE self) {
     TypedData_Get_Struct(data->graph_obj, void *, &graph_type, graph);
 
     Location *loc = rdx_method_reference_location(graph, data->id);
-    VALUE location = build_location_value(loc);
+    VALUE location = rdxi_build_location_value(loc);
     rdx_location_free(loc);
     return location;
 }
 
 // Keep this in sync with unresolved_reference_api.rs
-VALUE reference_class_for_kind(ReferenceKind kind) {
+VALUE rdxi_reference_class_for_kind(ReferenceKind kind) {
     switch (kind) {
     case ReferenceKind_Constant:
         return cConstantReference;
@@ -84,21 +84,21 @@ VALUE reference_class_for_kind(ReferenceKind kind) {
     }
 }
 
-void initialize_reference(VALUE mRubydex) {
+void rdxi_initialize_reference(VALUE mRubydex) {
     cReference = rb_define_class_under(mRubydex, "Reference", rb_cObject);
-    rb_define_alloc_func(cReference, sr_handle_alloc);
-    rb_define_method(cReference, "initialize", sr_handle_initialize, 2);
+    rb_define_alloc_func(cReference, rdxr_handle_alloc);
+    rb_define_method(cReference, "initialize", rdxr_handle_initialize, 2);
     rb_funcall(rb_singleton_class(cReference), rb_intern("private"), 1, ID2SYM(rb_intern("new")));
 
     cConstantReference = rb_define_class_under(mRubydex, "ConstantReference", cReference);
-    rb_define_alloc_func(cConstantReference, sr_handle_alloc);
-    rb_define_method(cConstantReference, "initialize", sr_handle_initialize, 2);
-    rb_define_method(cConstantReference, "name", sr_constant_reference_name, 0);
-    rb_define_method(cConstantReference, "location", sr_constant_reference_location, 0);
+    rb_define_alloc_func(cConstantReference, rdxr_handle_alloc);
+    rb_define_method(cConstantReference, "initialize", rdxr_handle_initialize, 2);
+    rb_define_method(cConstantReference, "name", rdxr_constant_reference_name, 0);
+    rb_define_method(cConstantReference, "location", rdxr_constant_reference_location, 0);
 
     cMethodReference = rb_define_class_under(mRubydex, "MethodReference", cReference);
-    rb_define_alloc_func(cMethodReference, sr_handle_alloc);
-    rb_define_method(cMethodReference, "initialize", sr_handle_initialize, 2);
-    rb_define_method(cMethodReference, "name", sr_method_reference_name, 0);
-    rb_define_method(cMethodReference, "location", sr_method_reference_location, 0);
+    rb_define_alloc_func(cMethodReference, rdxr_handle_alloc);
+    rb_define_method(cMethodReference, "initialize", rdxr_handle_initialize, 2);
+    rb_define_method(cMethodReference, "name", rdxr_method_reference_name, 0);
+    rb_define_method(cMethodReference, "location", rdxr_method_reference_location, 0);
 }

--- a/ext/rubydex/reference.h
+++ b/ext/rubydex/reference.h
@@ -8,9 +8,9 @@ extern VALUE cReference;
 extern VALUE cConstantReference;
 extern VALUE cMethodReference;
 
-void initialize_reference(VALUE mRubydex);
+void rdxi_initialize_reference(VALUE mRubydex);
 
 // Returns the Ruby class for a given UnresolvedReferenceKind without calling back into Rust
-VALUE reference_class_for_kind(ReferenceKind kind);
+VALUE rdxi_reference_class_for_kind(ReferenceKind kind);
 
 #endif // RUBYDEX_REFERENCE_H

--- a/ext/rubydex/rubydex.c
+++ b/ext/rubydex/rubydex.c
@@ -12,11 +12,11 @@ void Init_rubydex(void) {
     rb_ext_ractor_safe(true);
 
     mRubydex = rb_define_module("Rubydex");
-    initialize_graph(mRubydex);
-    initialize_declaration(mRubydex);
-    initialize_document(mRubydex);
-    initialize_definition(mRubydex);
-    initialize_location(mRubydex);
-    initialize_diagnostic(mRubydex);
-    initialize_reference(mRubydex);
+    rdxi_initialize_graph(mRubydex);
+    rdxi_initialize_declaration(mRubydex);
+    rdxi_initialize_document(mRubydex);
+    rdxi_initialize_definition(mRubydex);
+    rdxi_initialize_location(mRubydex);
+    rdxi_initialize_diagnostic(mRubydex);
+    rdxi_initialize_reference(mRubydex);
 }

--- a/ext/rubydex/utils.c
+++ b/ext/rubydex/utils.c
@@ -2,7 +2,7 @@
 
 // Convert a Ruby array of strings into a double char pointer so that we can pass that to Rust.
 // This copies the data so it must be freed
-char **str_array_to_char(VALUE array, size_t length) {
+char **rdxi_str_array_to_char(VALUE array, size_t length) {
     char **converted_array = malloc(length * sizeof(char *));
 
     for (size_t i = 0; i < length; i++) {
@@ -17,7 +17,7 @@ char **str_array_to_char(VALUE array, size_t length) {
 }
 
 // Verify that the Ruby object is an array of strings or raise `TypeError`
-void check_array_of_strings(VALUE array) {
+void rdxi_check_array_of_strings(VALUE array) {
     Check_Type(array, T_ARRAY);
 
     for (long i = 0; i < RARRAY_LEN(array); i++) {

--- a/ext/rubydex/utils.h
+++ b/ext/rubydex/utils.h
@@ -5,9 +5,9 @@
 
 // Convert a Ruby array of strings into a double char pointer so that we can pass that to Rust.
 // This copies the data so it must be freed
-char **str_array_to_char(VALUE array, size_t length);
+char **rdxi_str_array_to_char(VALUE array, size_t length);
 
 // Verify that the Ruby object is an array of strings or raise `TypeError`
-void check_array_of_strings(VALUE array);
+void rdxi_check_array_of_strings(VALUE array);
 
 #endif // RUBYDEX_UTILS_H

--- a/rust/rubydex-sys/src/definition_api.rs
+++ b/rust/rubydex-sys/src/definition_api.rs
@@ -308,13 +308,13 @@ where
 /// Returns true if the definition is deprecated.
 ///
 /// # Safety
-/// - `pointer` must be a valid pointer previously returned by `sat_graph_new`.
+/// - `pointer` must be a valid pointer previously returned by `rdx_graph_new`.
 /// - `definition_id` must be a valid definition id.
 ///
 /// # Panics
 /// This function will panic if a definition cannot be found.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn sat_definition_is_deprecated(pointer: GraphPointer, definition_id: i64) -> bool {
+pub unsafe extern "C" fn rdx_definition_is_deprecated(pointer: GraphPointer, definition_id: i64) -> bool {
     with_graph(pointer, |graph| {
         let def_id = DefinitionId::new(definition_id);
         let defn = graph.definitions().get(&def_id).expect("definition not found");


### PR DESCRIPTION
| Prefix   | Layer           | Purpose                                      |
|----------|-----------------|----------------------------------------------|
| `rdx_`   | Rust FFI        | Exports from Rust via `#[no_mangle]`         |
| `rdxr_`  | Ruby callbacks  | C functions registered with `rb_define_method` |
| `rdxi_`  | Internal helpers| Non-static C functions shared across files   |
| (none)   | File-local      | Static helper functions                      |

Changes:
- `sr_*` → `rdxr_*` (Ruby callback functions)
- `sat_*` → `rdx_*` (Rust FFI export)
- Add `rdxi_*` prefix to unprefixed internal helpers
  - I think we need this for functions like `build_location_value`, which could conflict with other C extensions?
- Document conventions in AGENTS.md and docs/architecture.md