### PR TITLE
Fix dynamic linking paths and on-demand compiling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            target
+            rust/target
           key: ${{ runner.os }}-rust
 
       - name: Run Rust tests
@@ -71,5 +71,5 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            target
+            rust/target
           key: ${{ steps.rust-compile-cache-restore.outputs.cache-primary-key }}

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ ext/rubydex/compile_commands.json
 ext/rubydex/.cache
 THIRD_PARTY_LICENSES.html
 rust/THIRD_PARTY_LICENSES.html
+lib/rubydex/*.dylib
+lib/rubydex/*.so

--- a/rubydex.gemspec
+++ b/rubydex.gemspec
@@ -20,7 +20,11 @@ Gem::Specification.new do |spec|
   spec.metadata["source_code_uri"] = spec.homepage
   spec.metadata["changelog_uri"] = "#{spec.homepage}/releases"
 
-  spec.files = Dir.glob("lib/**/*.rb") + ["README.md", "LICENSE.txt"]
+  spec.files = ["README.md", "LICENSE.txt"] +
+    Dir.glob("lib/**/*.rb") +
+    Dir.glob("lib/rubydex/*.{so,dylib}") +
+    Dir.glob("ext/rubydex/**/*.{c,h}") +
+    Dir.glob("rust/**/*.{rs,toml,lock,hbs}").reject { |f| f.start_with?("rust/target") }
 
   if ENV["RELEASE"]
     spec.files << "THIRD_PARTY_LICENSES.html"

--- a/rust/rubydex-sys/build.rs
+++ b/rust/rubydex-sys/build.rs
@@ -4,4 +4,11 @@ fn main() {
     cbindgen::generate(".")
         .expect("Unable to generate bindings")
         .write_to_file("rustbindings.h");
+
+    // Set the install name for macOS dylibs so they can be found via @rpath at runtime.
+    // This works for both native and cross-compilation scenarios.
+    let target = std::env::var("TARGET").unwrap_or_default();
+    if target.contains("apple") {
+        println!("cargo::rustc-cdylib-link-arg=-Wl,-install_name,@rpath/librubydex_sys.dylib");
+    }
 }


### PR DESCRIPTION
Our beta release failed and exposed two issues with our gem configs:

- For precompiled binaries, we need to ensure the dynamically linked `librubydex_sys` can be successfully found by the gem's native extension (i.e.: the `.bundle` or `.so` file). For that to work, we need to ensure that the gem ships with the `dylib` or `so` files and we need a couple of configuration tweaks (like configuring the `@rpath` in Macos or `$ORIGIN` on Linux)
- For platforms where we don't ship precompiled binaries, we need all of the sources to be included in the gemspec so that it can get compiled at the user's machine. This use case has a hard dependency on `cargo` being installed on their machine. This is probably fine, but it would be nice to eventually expand the support of `cibuildgem` to support Intel macs and Windows (compiling on release mode takes a loong time, we're going to be the 2026 Nokogiri of gems)

We tested the second case by bundling the gem on my machine and sending it to @st0012, who successfully managed to `gem install`, which compiled everything and resulted in a working gem.

For the precompiled ones, I'll run the action without publishing to rubygems and download the artifact, so that I can verify it works.