### PR TITLE
Add partial resolution alternative

### DIFF
--- a/rust/rubydex/src/model/definitions.rs
+++ b/rust/rubydex/src/model/definitions.rs
@@ -142,6 +142,7 @@ impl Definition {
             Definition::SingletonClass(d) => Some(d.name_id()),
             Definition::Module(d) => Some(d.name_id()),
             Definition::Constant(d) => Some(d.name_id()),
+            Definition::ConstantAlias(d) => Some(d.name_id()),
             _ => None,
         }
     }


### PR DESCRIPTION
This PR implements an alternative approach to partial resolution (see #481 for the original approach). There are two main differences:

1. Instead of adding "pending" units to the Graph, we track "dirty" URIs and ancestors. This is preferable because we currently do partial resolution at the granularity of a single document, so we don't need to track individual definitions and references within that document as pending. We can simply reprocess the whole document.
2. This makes it cleaner for `sorted_units` to process either _all_ documents or only dirty ones. If we sometimes operated on all documents (initial resolution) and sometimes operated on a list of pending units (partial updates) then we'd need two different code paths. The previous approach involved us generating pending units even for the initial resolution, which meant a reasonably big increase in memory.

We add a `dirty` property to `Graph` which is either `All` (indicating that we need to resolve everything) or `Partial` which has a set of URIs to reprocess and a set of declarations to relinearize ancestors. The first time we run resolution it processes all documents and then sets dirty to partial with empty sets. When we update a document the URI is added to the dirty URIs set and any declarations that need to have their ancestors relinearized are added to the dirty ancestors set.  The next time we do resolution, we'll only process those dirty documents and ancestors.

## Initial indexing/resolution against core

### Summary

| Branch | Resolution (avg) | Memory (avg) |
|--------|------------------|--------------|
| `main` | 17.99s | 4920 MB |
| `resolve-single-document` | 12.58s | 5349 MB |
| `resolve-single-document-alt` | 12.38s | 5086 MB |

### Range (5 runs each)

| Branch | Resolution | Memory |
|--------|------------|--------|
| `main` | 17.4 - 18.9s | 4884 - 4915 MB |
| `resolve-single-document` | 12.1 - 13.0s | 5201 - 5464 MB |
| `resolve-single-document-alt` | 11.7 - 13.0s | 5084 - 5091 MB |

### Comparison to main

| Branch | Resolution | Memory |
|--------|-----------|--------|
| `resolve-single-document` | 31% faster | +429 MB (+8.7%) |
| `resolve-single-document-alt` | 31% faster | +166 MB (+3.4%) |

**Why does `resolve-single-document-alt` still have higher Max RSS than `main`?**

On `main` we loop through all `graph.constant_references()` sequentially, whereas on `resolve-single-document-alt` we iterate the `document.constant_references()` and look them up in the graph in a less sequential order. I suspect this causes more pages to be accessed simultaneously within the measurement window.

Both approaches make resolution faster.