### PR TITLE
Automatically promote constants to namespaces

### DIFF
--- a/rust/rubydex/src/model/declaration.rs
+++ b/rust/rubydex/src/model/declaration.rs
@@ -125,11 +125,14 @@ macro_rules! namespace_declaration {
                 }
             }
 
-            pub fn extend(&mut self, mut other: Namespace) {
+            pub fn extend(&mut self, mut other: Declaration) {
                 self.definition_ids.extend(other.definitions());
                 self.references.extend(other.references());
-                self.members.extend(other.members());
                 self.diagnostics.extend(other.take_diagnostics());
+
+                if let Declaration::Namespace(namespace) = other {
+                    self.members.extend(namespace.members());
+                }
             }
 
             pub fn set_singleton_class_id(&mut self, declaration_id: DeclarationId) {
@@ -412,6 +415,10 @@ impl Namespace {
         all_namespaces!(self, it => std::mem::take(&mut it.diagnostics))
     }
 
+    pub fn extend(&mut self, other: Declaration) {
+        all_namespaces!(self, it => it.extend(other));
+    }
+
     #[must_use]
     pub fn ancestors(&self) -> &Ancestors {
         all_namespaces!(self, it => it.ancestors())
@@ -483,6 +490,11 @@ impl Namespace {
     #[must_use]
     pub fn owner_id(&self) -> &DeclarationId {
         all_namespaces!(self, it => &it.owner_id)
+    }
+
+    #[must_use]
+    pub fn name(&self) -> &str {
+        all_namespaces!(self, it => &it.name)
     }
 }
 

--- a/rust/rubydex/src/model/definitions.rs
+++ b/rust/rubydex/src/model/definitions.rs
@@ -39,6 +39,7 @@ bitflags! {
     #[derive(Debug, Clone)]
     pub struct DefinitionFlags: u8 {
         const DEPRECATED = 0b0001;
+        const PROMOTABLE = 0b0010;
     }
 }
 
@@ -46,6 +47,11 @@ impl DefinitionFlags {
     #[must_use]
     pub fn is_deprecated(&self) -> bool {
         self.contains(Self::DEPRECATED)
+    }
+
+    #[must_use]
+    pub fn is_promotable(&self) -> bool {
+        self.contains(Self::PROMOTABLE)
     }
 }
 

--- a/rust/rubydex/src/test_utils/graph_test.rs
+++ b/rust/rubydex/src/test_utils/graph_test.rs
@@ -88,6 +88,26 @@ macro_rules! assert_declaration_exists {
 
 #[cfg(test)]
 #[macro_export]
+macro_rules! assert_declaration_kind_eq {
+    ($context:expr, $declaration_name:expr, $expected_kind:expr) => {
+        let declaration = $context
+            .graph()
+            .declarations()
+            .get(&$crate::model::ids::DeclarationId::from($declaration_name))
+            .unwrap();
+        assert_eq!(
+            declaration.kind(),
+            $expected_kind,
+            "Expected declaration `{}` to be a {}, got {}",
+            $declaration_name,
+            $expected_kind,
+            declaration.kind()
+        );
+    };
+}
+
+#[cfg(test)]
+#[macro_export]
 macro_rules! assert_declaration_does_not_exist {
     ($context:expr, $declaration_name:expr) => {
         assert!(


### PR DESCRIPTION
This PR does two main things:

- Removes all of the todos with the skips we had in resolution for constants
- Handles some meta-programming scenarios without crashing

Although we can't provide first class features when there's meta-programming, we absolutely cannot crash. Consider these examples (or the ones added as tests):

```ruby
Foo = dynamic_module

class Bar
  include Foo
end

Baz = dynamic_class

class Qux < Baz
end

module Zip; end

Boop = dynamic_class do
  include Zip
end
```

This PR takes two strategies to prevent crashing completely in these scenarios:

- The most straightforward one is just skipping things that aren't namespaces during ancestor linearization. If we find an include for something that's not a namespace, we need to skip it
- The second part is auto-promoting constants to namespaces if they get re-opened. This allows us to handle this scenario correctly (which we actually have in Core):

```ruby
# At this point, we have no idea this is a class. We create a Constant declaration for it
Const = dynamic_class

# Then it gets re-opened as a class with proper includes
class Const
  include Foo
end
```

By auto-promoting, we correctly handle ancestors and constant resolution for `Const`. Of course, there's a concession being made to the user here: we trust that they didn't make a mistake by making an incompatible re-opening (i.e.: it was a module, then gets reopened as a class).