### PR TITLE
Don't use `Dir.glob` in the gemspec for files generated at compile:

### DIFF
--- a/rubydex.gemspec
+++ b/rubydex.gemspec
@@ -22,12 +22,16 @@ Gem::Specification.new do |spec|
 
   spec.files = ["README.md", "LICENSE.txt"] +
     Dir.glob("lib/**/*.rb") +
-    Dir.glob("lib/rubydex/*.{so,dylib}") +
     Dir.glob("ext/rubydex/**/*.{c,h}") +
     Dir.glob("rust/**/*.{rs,toml,lock,hbs}").reject { |f| f.start_with?("rust/target") }
 
   if ENV["RELEASE"]
     spec.files << "THIRD_PARTY_LICENSES.html"
+    if RUBY_PLATFORM.include?("darwin")
+      spec.files << "lib/rubydex/librubydex_sys.dylib"
+    elsif RUBY_PLATFORM.include?("linux")
+      spec.files << "lib/rubydex/librubydex_sys.so"
+    end
   end
 
   spec.bindir = "exe"


### PR DESCRIPTION
Don't use `Dir.glob` in the gemspec for files generated at compile time:

- ### Problem

  When cibuildgem (which uses rake-compiler underneath) tries to build a gem, it doesn't include the `librusy_sys.dylib` file in the tarball.

  ### Details

  The reason is because rake-compiler evaluates the gemspec before the compilation and memoize it. When the gemspec gets evaluated, `Dir.glob("librubysys.{dylib,so}")` returns an empty array since those files doesn't exist yet.

  When the gem is about to be packaged, rake-compiler iterates over all files from the memoized gemspec, and since `librubysys` isn't in the list, it doesnt get included in the tarball.

  ### Solution

  Hardcode the `librubysys` file instead of using `Dir.glob`.