### PR TITLE
Remove `Graph#definitions_to_declarations` map

### DIFF
--- a/rust/rubydex/src/resolution.rs
+++ b/rust/rubydex/src/resolution.rs
@@ -408,8 +408,7 @@ impl<'a> Resolver<'a> {
                         Definition::Class(_) | Definition::Module(_) => {
                             let nesting_decl_id = self
                                 .graph
-                                .definitions_to_declarations()
-                                .get(&nesting_id)
+                                .definition_id_to_declaration_id(nesting_id)
                                 .copied()
                                 .unwrap_or(*OBJECT_ID);
                             let owner_id = self.get_or_create_singleton_class(nesting_decl_id);
@@ -433,8 +432,7 @@ impl<'a> Resolver<'a> {
                         Definition::SingletonClass(_) => {
                             let singleton_class_decl_id = self
                                 .graph
-                                .definitions_to_declarations()
-                                .get(&nesting_id)
+                                .definition_id_to_declaration_id(nesting_id)
                                 .copied()
                                 .unwrap_or(*OBJECT_ID);
                             let owner_id = self.get_or_create_singleton_class(singleton_class_decl_id);
@@ -523,7 +521,7 @@ impl<'a> Resolver<'a> {
                 break;
             }
         }
-        current_nesting.and_then(|id| self.graph.definitions_to_declarations().get(&id).copied())
+        current_nesting.and_then(|id| self.graph.definition_id_to_declaration_id(id).copied())
     }
 
     /// Resolves owner from lexical nesting.
@@ -535,7 +533,7 @@ impl<'a> Resolver<'a> {
         // If no declaration exists yet for this definition, walk up the lexical chain.
         // This handles the case where attr_* definitions inside methods are processed
         // before the method definition itself.
-        let Some(declaration_id) = self.graph.definitions_to_declarations().get(&id) else {
+        let Some(declaration_id) = self.graph.definition_id_to_declaration_id(id) else {
             let definition = self.graph.definitions().get(&id).unwrap();
             return self.resolve_lexical_owner(*definition.lexical_nesting_id());
         };

--- a/rust/rubydex/src/visualization/dot.rs
+++ b/rust/rubydex/src/visualization/dot.rs
@@ -66,7 +66,7 @@ fn write_definition_nodes(output: &mut String, graph: &Graph) {
         .filter_map(|(def_id, definition)| {
             graph
                 .declarations()
-                .get(graph.definitions_to_declarations().get(def_id).unwrap())
+                .get(graph.definition_to_declaration_id(definition).unwrap())
                 .map(|declaration| {
                     let def_type = definition.kind();
                     let escaped_name = escape_dot_string(declaration.name());


### PR DESCRIPTION
We maintain a huge hash to map a definition to a declaration but in practice we don't use it that much.

It looks like we can do without it and be 1) faster while 2) using less memory:

```
# Before

Timing breakdown
  Listing             0.776s (  2.6%)
  Indexing            5.264s ( 17.5%)
  Resolution         23.504s ( 78.2%)
  Querying            0.502s (  1.7%)
  Cleanup             0.000s (  0.0%)
  Total:             30.047s

# After

Timing breakdown
  Listing             0.919s (  3.3%)
  Indexing            4.933s ( 17.8%)
  Resolution         21.274s ( 77.0%)
  Querying            0.512s (  1.9%)
  Cleanup             0.000s (  0.0%)
  Total:             27.639s
```

I'm experimenting with this direction so we can replace the N:1 mapping from a definition to a declaration by a N:M without cost.