### PR TITLE
Capture DSL definitions and support `Class|Module.new`

### DIFF
--- a/rust/rubydex-sys/src/definition_api.rs
+++ b/rust/rubydex-sys/src/definition_api.rs
@@ -26,6 +26,9 @@ pub enum DefinitionKind {
     ClassVariable = 11,
     MethodAlias = 12,
     GlobalVariableAlias = 13,
+    Dsl = 14,
+    DynamicClass = 15,
+    DynamicModule = 16,
 }
 
 pub(crate) fn map_definition_to_kind(defn: &Definition) -> DefinitionKind {
@@ -44,6 +47,9 @@ pub(crate) fn map_definition_to_kind(defn: &Definition) -> DefinitionKind {
         Definition::ClassVariable(_) => DefinitionKind::ClassVariable,
         Definition::MethodAlias(_) => DefinitionKind::MethodAlias,
         Definition::GlobalVariableAlias(_) => DefinitionKind::GlobalVariableAlias,
+        Definition::Dsl(_) => DefinitionKind::Dsl,
+        Definition::DynamicClass(_) => DefinitionKind::DynamicClass,
+        Definition::DynamicModule(_) => DefinitionKind::DynamicModule,
     }
 }
 

--- a/rust/rubydex-sys/src/graph_api.rs
+++ b/rust/rubydex-sys/src/graph_api.rs
@@ -458,6 +458,7 @@ mod tests {
               BAR = 1
             end
             ",
+            vec![],
         );
         indexer.index();
 

--- a/rust/rubydex/src/model.rs
+++ b/rust/rubydex/src/model.rs
@@ -2,6 +2,8 @@ pub mod comment;
 pub mod declaration;
 pub mod definitions;
 pub mod document;
+pub mod dsl;
+pub mod dsl_processors;
 pub mod encoding;
 pub mod graph;
 pub mod id;

--- a/rust/rubydex/src/model/dsl.rs
+++ b/rust/rubydex/src/model/dsl.rs
@@ -1,0 +1,114 @@
+//! DSL-related types for capturing DSL method calls during indexing.
+
+use crate::model::ids::ReferenceId;
+use crate::offset::Offset;
+
+/// Represents a value in a DSL argument.
+/// Can be either a raw string or a resolved constant reference.
+#[derive(Debug, Clone)]
+pub enum DslValue {
+    /// A raw string value (e.g., `"123"`, `some_var`)
+    String(String),
+    /// A constant reference (e.g., `Foo`, `Bar::Baz`)
+    Reference(ReferenceId),
+}
+
+impl DslValue {
+    /// Returns the value as a string if it is a `String` variant.
+    #[must_use]
+    pub fn as_str(&self) -> Option<&str> {
+        match self {
+            Self::String(s) => Some(s.as_str()),
+            Self::Reference(_) => None,
+        }
+    }
+
+    /// Returns the reference ID if it is a `Reference` variant.
+    #[must_use]
+    pub fn as_reference(&self) -> Option<ReferenceId> {
+        match self {
+            Self::Reference(id) => Some(*id),
+            Self::String(_) => None,
+        }
+    }
+}
+
+/// Represents a single argument in a DSL call.
+#[derive(Debug, Clone)]
+pub enum DslArgument {
+    /// A positional argument (e.g., `Parent` in `Class.new(Parent)`)
+    Positional(DslValue),
+    /// A keyword argument (e.g., `class_name: "User"`)
+    KeywordArg { key: String, value: DslValue },
+    /// A splat argument (e.g., `*args`)
+    Splat(String),
+    /// A double splat argument (e.g., `**kwargs`)
+    DoubleSplat(String),
+    /// A block argument (e.g., `&block`)
+    BlockArg(String),
+}
+
+/// Represents the arguments passed to a DSL method call.
+#[derive(Debug, Clone, Default)]
+pub struct DslArgumentList {
+    arguments: Vec<DslArgument>,
+    block_offset: Option<Offset>,
+}
+
+impl DslArgumentList {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn add(&mut self, arg: DslArgument) {
+        self.arguments.push(arg);
+    }
+
+    pub fn set_block_offset(&mut self, offset: Offset) {
+        self.block_offset = Some(offset);
+    }
+
+    #[must_use]
+    pub fn arguments(&self) -> &[DslArgument] {
+        &self.arguments
+    }
+
+    #[must_use]
+    pub fn block_offset(&self) -> Option<&Offset> {
+        self.block_offset.as_ref()
+    }
+
+    #[must_use]
+    pub fn has_block(&self) -> bool {
+        self.block_offset.is_some()
+    }
+
+    /// Returns the first positional argument as a reference ID if it is a constant reference.
+    #[must_use]
+    pub fn first_positional_reference(&self) -> Option<ReferenceId> {
+        self.arguments.iter().find_map(|arg| match arg {
+            DslArgument::Positional(value) => value.as_reference(),
+            _ => None,
+        })
+    }
+
+    #[must_use]
+    pub fn positional_args(&self) -> Vec<&DslValue> {
+        self.arguments
+            .iter()
+            .filter_map(|arg| match arg {
+                DslArgument::Positional(v) => Some(v),
+                _ => None,
+            })
+            .collect()
+    }
+
+    #[must_use]
+    pub fn keyword_arg(&self, key: &str) -> Option<&DslValue> {
+        self.arguments.iter().find_map(|arg| match arg {
+            DslArgument::KeywordArg { key: k, value } if k == key => Some(value),
+            _ => None,
+        })
+    }
+}

--- a/rust/rubydex/src/model/dsl_processors.rs
+++ b/rust/rubydex/src/model/dsl_processors.rs
@@ -1,0 +1,224 @@
+//! DSL processor types for matching and handling specific DSL patterns.
+
+use crate::model::comment::Comment;
+use crate::model::definitions::{Definition, DefinitionFlags, DynamicClassDefinition, DynamicModuleDefinition, Mixin};
+use crate::model::graph::{CLASS_ID, Graph, MODULE_ID};
+use crate::model::ids::{DeclarationId, DefinitionId, NameId, UriId};
+use crate::model::name::{Name, ParentScope};
+use crate::offset::Offset;
+
+/// Type alias for DSL processor handle function.
+/// Processes the DSL and mutates the graph accordingly.
+///
+/// Parameters:
+/// - `graph`: The graph to mutate
+/// - `dsl_def_id`: The DSL definition ID being processed
+///
+/// Returns the `DefinitionId` of any newly created definition.
+pub type DslHandleFn = fn(graph: &mut Graph, dsl_def_id: DefinitionId) -> Option<DefinitionId>;
+
+/// A DSL processor that can match and handle specific DSL patterns.
+///
+/// The `method_name` field is used for pre-filtering during indexing.
+/// The `matches` function performs full matching after resolution, when the receiver has been
+/// resolved to a `DeclarationId`.
+#[derive(Clone, Copy, Debug)]
+pub struct DslProcessor {
+    /// The method name this processor is interested in (e.g., "new")
+    pub method_name: &'static str,
+    /// Returns true if this processor handles the given receiver/method combination
+    pub matches: fn(receiver_decl_id: Option<DeclarationId>) -> bool,
+    /// The handler function for this DSL pattern
+    pub handle: DslHandleFn,
+}
+
+/// Matches `Class.new` DSL calls.
+#[must_use]
+pub fn class_new_matches(receiver_decl_id: Option<DeclarationId>) -> bool {
+    receiver_decl_id == Some(*CLASS_ID)
+}
+
+/// Matches `Module.new` DSL calls.
+#[must_use]
+pub fn module_new_matches(receiver_decl_id: Option<DeclarationId>) -> bool {
+    receiver_decl_id == Some(*MODULE_ID)
+}
+
+/// Common data extracted from a DSL definition and its associated constant.
+struct DslContext {
+    uri_id: UriId,
+    offset: Offset,
+    lexical_nesting_id: Option<DefinitionId>,
+    mixins: Vec<Mixin>,
+    constant_def_id: Option<DefinitionId>,
+    name_id: Option<NameId>,
+    comments: Vec<Comment>,
+    flags: DefinitionFlags,
+}
+
+/// Gets the reparented name from a processed parent DSL (`DynamicClass` or `DynamicModule`).
+/// Uses the deterministic ID format to look up directly without iteration.
+/// Returns None if the parent hasn't been processed yet or has no name.
+fn get_processed_parent_name(graph: &Graph, parent_dsl_id: DefinitionId) -> Option<NameId> {
+    // Try DynamicClass first (more common)
+    let dynamic_class_id = DynamicClassDefinition::id_for_dsl(parent_dsl_id);
+    if let Some(Definition::DynamicClass(dc)) = graph.definitions().get(&dynamic_class_id) {
+        return dc.name_id().copied();
+    }
+
+    // Try DynamicModule
+    let dynamic_module_id = DynamicModuleDefinition::id_for_dsl(parent_dsl_id);
+    if let Some(Definition::DynamicModule(dm)) = graph.definitions().get(&dynamic_module_id) {
+        return dm.name_id().copied();
+    }
+
+    None
+}
+
+/// Returns true if the parent DSL has been processed (converted to DynamicClass/Module).
+/// Uses the deterministic ID format to check directly without iteration.
+#[must_use]
+pub fn is_parent_dsl_processed(graph: &Graph, parent_dsl_id: DefinitionId) -> bool {
+    let dynamic_class_id = DynamicClassDefinition::id_for_dsl(parent_dsl_id);
+    if graph.definitions().contains_key(&dynamic_class_id) {
+        return true;
+    }
+
+    let dynamic_module_id = DynamicModuleDefinition::id_for_dsl(parent_dsl_id);
+    graph.definitions().contains_key(&dynamic_module_id)
+}
+
+/// Extracts common data from a DSL definition and computes the reparented name.
+fn extract_dsl_context(graph: &mut Graph, dsl_def_id: DefinitionId) -> Option<DslContext> {
+    let (uri_id, offset, lexical_nesting_id, mixins, constant_def_id) = {
+        let Definition::Dsl(dsl_def) = graph.definitions().get(&dsl_def_id)? else {
+            return None;
+        };
+        (
+            *dsl_def.uri_id(),
+            dsl_def.offset().clone(),
+            *dsl_def.lexical_nesting_id(),
+            dsl_def.mixins().to_vec(),
+            dsl_def.assigned_to(),
+        )
+    };
+
+    let (original_name_id, comments, flags, parent_dsl_id) = constant_def_id
+        .and_then(|id| {
+            let Definition::Constant(c) = graph.definitions().get(&id)? else {
+                return None;
+            };
+            Some((
+                Some(*c.name_id()),
+                c.comments().to_vec(),
+                c.flags().clone(),
+                *c.lexical_nesting_id(),
+            ))
+        })
+        .unwrap_or_else(|| (None, Vec::new(), DefinitionFlags::empty(), None));
+
+    // Eagerly reparent the name if nested inside another DynamicClass/Module
+    // Parent must already be processed (depth-first ordering guarantees this)
+    let name_id = match (original_name_id, parent_dsl_id) {
+        (Some(orig_name), Some(parent_id)) => {
+            if let Some(parent_name_id) = get_processed_parent_name(graph, parent_id) {
+                Some(create_reparented_name(graph, orig_name, parent_name_id))
+            } else {
+                Some(orig_name)
+            }
+        }
+        (Some(orig_name), None) => Some(orig_name),
+        (None, _) => None,
+    };
+
+    Some(DslContext {
+        uri_id,
+        offset,
+        lexical_nesting_id,
+        mixins,
+        constant_def_id,
+        name_id,
+        comments,
+        flags,
+    })
+}
+
+/// Creates a reparented name by setting the parent name.
+fn create_reparented_name(graph: &mut Graph, original_name_id: NameId, parent_name_id: NameId) -> NameId {
+    let name_ref = graph.names().get(&original_name_id).expect("name must exist");
+    let new_name = Name::new(*name_ref.str(), ParentScope::Some(parent_name_id), *name_ref.nesting());
+    let new_name_id = new_name.id();
+    graph.add_name(new_name);
+    new_name_id
+}
+
+/// Handles `Class.new` DSL calls by creating a `DynamicClassDefinition`.
+///
+/// Creates a dynamic class definition from the DSL, reparenting names if nested.
+/// The original `ConstantDefinition` is removed after creating the dynamic definition.
+pub fn handle_class_new(graph: &mut Graph, dsl_def_id: DefinitionId) -> Option<DefinitionId> {
+    // Get superclass reference from DSL arguments before extracting context
+    let superclass_ref = {
+        let Definition::Dsl(dsl_def) = graph.definitions().get(&dsl_def_id)? else {
+            return None;
+        };
+        dsl_def.arguments().first_positional_reference()
+    };
+
+    let ctx = extract_dsl_context(graph, dsl_def_id)?;
+
+    let dynamic_class = DynamicClassDefinition::new(
+        dsl_def_id,
+        ctx.name_id,
+        superclass_ref,
+        ctx.comments,
+        ctx.flags,
+        ctx.uri_id,
+        ctx.offset,
+        ctx.lexical_nesting_id,
+        ctx.mixins,
+    );
+
+    let definition_id = dynamic_class.id();
+    graph
+        .definitions_mut()
+        .insert(definition_id, Definition::DynamicClass(Box::new(dynamic_class)));
+
+    if let Some(id) = ctx.constant_def_id {
+        graph.definitions_mut().remove(&id);
+        Some(definition_id)
+    } else {
+        None
+    }
+}
+
+/// Handles `Module.new` DSL calls by creating a `DynamicModuleDefinition`.
+///
+/// Creates a dynamic module definition from the DSL, reparenting names if nested.
+/// The original `ConstantDefinition` is removed after creating the dynamic definition.
+pub fn handle_module_new(graph: &mut Graph, dsl_def_id: DefinitionId) -> Option<DefinitionId> {
+    let ctx = extract_dsl_context(graph, dsl_def_id)?;
+
+    let dynamic_module = DynamicModuleDefinition::new(
+        dsl_def_id,
+        ctx.name_id,
+        ctx.comments,
+        ctx.flags,
+        ctx.uri_id,
+        ctx.offset,
+        ctx.lexical_nesting_id,
+        ctx.mixins,
+    );
+
+    let definition_id = dynamic_module.id();
+    graph
+        .definitions_mut()
+        .insert(definition_id, Definition::DynamicModule(Box::new(dynamic_module)));
+
+    if let Some(id) = ctx.constant_def_id {
+        graph.definitions_mut().remove(&id);
+        Some(definition_id)
+    } else {
+        None
+    }
+}

--- a/rust/rubydex/src/resolution.rs
+++ b/rust/rubydex/src/resolution.rs
@@ -136,6 +136,7 @@ impl<'a> Resolver<'a> {
         }
 
         self.handle_remaining_definitions(other_ids);
+        self.graph.remove_orphan_dsl_definitions();
     }
 
     fn initialize_builtin_declarations(&mut self) {

--- a/rust/rubydex/src/test_utils/graph_test.rs
+++ b/rust/rubydex/src/test_utils/graph_test.rs
@@ -23,15 +23,16 @@ impl GraphTest {
     }
 
     #[must_use]
-    fn index_source(uri: &str, source: &str) -> LocalGraph {
-        let mut indexer = RubyIndexer::new(uri.to_string(), source);
+    fn index_source(uri: &str, source: &str, dsl_method_names: Vec<&'static str>) -> LocalGraph {
+        let mut indexer = RubyIndexer::new(uri.to_string(), source, dsl_method_names);
         indexer.index();
         indexer.local_graph()
     }
 
     pub fn index_uri(&mut self, uri: &str, source: &str) {
         let source = normalize_indentation(source);
-        let local_index = Self::index_source(uri, &source);
+        let dsl_method_names = self.graph.dsl_method_names();
+        let local_index = Self::index_source(uri, &source, dsl_method_names);
         self.graph.update(local_index);
     }
 

--- a/rust/rubydex/src/test_utils/local_graph_test.rs
+++ b/rust/rubydex/src/test_utils/local_graph_test.rs
@@ -2,6 +2,7 @@ use super::normalize_indentation;
 use crate::indexing::local_graph::LocalGraph;
 use crate::indexing::ruby_indexer::RubyIndexer;
 use crate::model::definitions::Definition;
+use crate::model::graph::Graph;
 use crate::model::ids::UriId;
 use crate::offset::Offset;
 use crate::position::Position;
@@ -18,8 +19,10 @@ impl LocalGraphTest {
     pub fn new(uri: &str, source: &str) -> Self {
         let uri = uri.to_string();
         let source = normalize_indentation(source);
+        // Get DSL method names from a default Graph instance
+        let dsl_method_names = Graph::new().dsl_method_names();
 
-        let mut indexer = RubyIndexer::new(uri.clone(), &source);
+        let mut indexer = RubyIndexer::new(uri.clone(), &source, dsl_method_names);
         indexer.index();
         let graph = indexer.local_graph();
 


### PR DESCRIPTION
# DSL Support for Class.new and Module.new

## 1. Overview

### Supported Ruby Patterns

This implementation adds support for dynamically created classes and modules:

```ruby
# Named dynamic class with inheritance and mixins
Foo = Class.new(Parent) do
  include SomeMixin

  def instance_method
    @ivar = 1
  end

  def self.class_method; end

  CONST = "value"
end

# Named dynamic module
Bar = Module.new do
  def helper; end
end

# Nested dynamic classes
Outer = Class.new do
  Inner = Class.new { def foo; end }
end

# Anonymous (indexed but no declaration)
Class.new { def bar; end }


# Singleton class inside anonymous classes
Baz = Class.new do
  class << self
    def self.qux; end
  end
end
```

### High-Level Approach

```text
┌────────────────────────────────────┐      ┌────────────────────────────────────┐
│             INDEXING               │      │            RESOLUTION              │
├────────────────────────────────────┤      ├────────────────────────────────────┤
│                                    │      │                                    │
│  Foo = Class.new(Parent) { ... }   │      │  1. Resolve receiver "Class"       │
│            │                       │      │     → CLASS_ID                     │
│            ▼                       │      │                                    │
│  ┌──────────────────────────────┐  │      │  2. Match DSL processor            │
│  │ ConstantDefinition(Foo)      │  │      │     class_new_matches() = true     │
│  └──────────────────────────────┘  │      │                                    │
│  ┌──────────────────────────────┐  │      │  3. Create DynamicClassDefinition  │
│  │ DslDefinition                │  │ ───► │     - name_id from Constant        │
│  │   receiver: Class (NameId)   │  │      │     - superclass from args(Parent) │
│  │   method: "new"              │  │      │     - mixins from block            │
│  │   args: [Parent]             │  │      │                                    │
│  │   assigned_to: Foo.id        │  │      │  4. Remove ConstantDefinition      │
│  └──────────────────────────────┘  │      │                                    │
│  ┌──────────────────────────────┐  │      │  5. Resolve DynamicClassDefinition │
│  │ Block contents assigned with │  │      │     → ClassDeclaration(Foo)        │
│  │ lexical_nesting_id = DSL     │  │      │     → Members resolved with        │
│  └──────────────────────────────┘  │      │       owner = Foo                  │
│                                    │      │                                    │
└────────────────────────────────────┘      └────────────────────────────────────┘
```

## 2. Class.new and Module.new

### Named vs Anonymous

```text
┌─────────────────────────────────────────────────────────────────────────────┐
│                              NAMED                                          │
│  Foo = Class.new { ... }                                                    │
│                                                                             │
│  Creates ClassDeclaration(Foo)                                              │
│  Creates SingletonClassDeclaration(Foo::<Foo>) when applicable              │
│  Members get declarations (Foo#method, Foo::CONST)                          │
│  Inheritance and mixins tracked                                             │
└─────────────────────────────────────────────────────────────────────────────┘

┌─────────────────────────────────────────────────────────────────────────────┐
│                            ANONYMOUS                                        │
│  Class.new { ... }                                                          │
│                                                                             │
│  No declaration created (can't be referenced by name)                       │
│  Members exist at definition level only (under DyanmicClassDefinition)      │
└─────────────────────────────────────────────────────────────────────────────┘
```

### Superclass and Mixins

```ruby
Foo = Class.new(Parent) do
  include M1
  prepend M2
  extend E1
end
```

- First positional argument to `Class.new` is captured as superclass reference
- `include`/`prepend`/`extend` calls inside the block are attached to the DSL
- During resolution, these are transferred to the `DynamicClassDefinition`
- Inheritance linearization works the same as `class Foo < Parent`

### Nested Dynamic Classes

```ruby
Outer = Class.new do
  Inner = Class.new { def foo; end }
end
```

```text
Challenge: Inner's name must be "Outer::Inner", not just "Inner"

Solution: Depth-first processing with name reparenting

┌────────────────────────────────────────────────────────────────────────┐
│  1. Sort DSLs by name depth (shallower first)                          │
│     → Outer (depth 1) processed before Inner (depth 2)                 │
│                                                                        │
│  2. When processing Inner:                                             │
│     → Check: is parent DSL (Outer) already processed?                  │
│     → If no: re-enqueue Inner, wait for Outer                          │
│     → If yes: reparent name from "Inner" to "Outer::Inner"             │
│                                                                        │
│  Final declarations:                                                   │
│     • Outer                                                            │
│     • Outer::Inner                                                     │
│     • Outer::Inner#foo                                                 │
└────────────────────────────────────────────────────────────────────────┘
```

## 3. Elements Inside DSL Blocks

### Methods

```ruby
Foo = Class.new do
  def instance_method; end      # → Foo#instance_method
  def self.class_method; end    # → Foo::<Foo>#class_method (singleton method)
end
```

- Instance methods: owned by the dynamic class (`Foo`)
- Singleton methods (`def self.x`): owned by the class's singleton class (`Foo::<Foo>`)
- `self` inside the block resolves to the constant name being assigned

### Instance Variables

```ruby
# Case 1: Named Class.new/Module.new
# @x owned by Foo class
Foo = Class.new do
  @x = 1
end
```

```ruby
# Case 2: Anonymous Class.new/Module.new
# @x belongs to anonymous class, no declaration created
Class.new do
  @x = 1
end
```

```ruby
# Case 3: Non-namespace DSL (e.g., some_gem's DSL)
# @x falls back to enclosing class Outer
class Outer
  Bar.new do
    @x = 1
  end
end
```

### Constants

Constants inside `Class.new`/`Module.new` blocks follow **lexical scope**, not the dynamic class:

```ruby
# CONST goes to enclosing lexical scope, NOT Foo
Foo = Class.new do
  CONST = 1           # → ::CONST (top-level)
end
```

```ruby
# Inside a lexical class, constants go to that class
class Outer
  Bar = Class.new do
    CONST = 1         # → Outer::CONST
  end
end
```

### Singleton Classes

```ruby
Foo = Class.new do
  class << self
    def class_method; end
  end
end
```

```text
Indexing:
  • SingletonClassDefinition created with lexical_nesting_id = DSL
  • parent_for_singleton_class() recognizes DSL assigned to constant

Resolution:
  • DSL processed → DynamicClass(Foo) created
  • Singleton class resolves owner via get_dsl_namespace_declaration()
  • Method declared in Foo::<Foo>
```

## 4. Implementation Details

### DSL Indexing

When the indexer encounters a `.new` call that matches a DSL target:

```text
┌───────────────────────────────────────────────────────────────────────────────┐
│  Ruby: Foo = Class.new(Parent) { include M; def bar; end }                    │
│                                                                               │
│  RubyIndexer:                                                                 │
│  1. Encounters constant assignment `Foo = ...`                                │
│  2. Sees RHS is a call to `.new` (a DSL target method)                        │
│  3. Creates ConstantDefinition for `Foo`                                      │
│  4. Creates DslDefinition:                                                    │
│     - receiver: `Class` (as NameId)                                           │
│     - method_name: "new"                                                      │
│     - arguments: [Parent]                                                     │
│     - assigned_to: ConstantDefinition.id                                      │
│  5. Pushes Nesting::Dsl onto nesting stack                                    │
│  6. Visits block → members get lexical_nesting_id = DSL                       │
│  7. Pops DSL from nesting stack                                               │
└───────────────────────────────────────────────────────────────────────────────┘

Nesting Stack Types:
┌───────────────────────────────┬─────────────────────────────────────────────┐
│  Nesting::LexicalScope(id)    │  class/module keywords - Ruby lexical scope │
│  Nesting::Method(id)          │  method definitions - owns instance vars    │
│  Nesting::Dsl(id)             │  DSL blocks - owns members, no lexical scope│
└───────────────────────────────┴─────────────────────────────────────────────┘
```

### Resolution Loop

Resolution processes definitions, references, ancestors, and DSLs in a unified loop:

```text
                                    ┌─────────────────────────────────────────────────────┐
                                    │              OUTER LOOP: loop { ... }               │
                                    │  Continues until: !made_progress || queue.is_empty()│
                                    └─────────────────────────────┬───────────────────────┘
                                                                  │
                                                                  ▼
┌─────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│  START OF PASS                                                                                                  │
│  made_progress = false                                                                                          │
│  pass_length = queue.len()  ◄─── snapshot length (retries go to back, next pass)                                │
└─────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
                                                                  │
                                                                  ▼
┌─────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│  INNER LOOP: for _ in 0..pass_length { pop_front and process }                                                  │
│                                                                                                                 │
│    ┌────────────────────────┬────────────────────────┬────────────────────────┬────────────────────────┐        │
│    │ Unit::Definition       │ Unit::ConstantRef      │ Unit::Dsl              │ Unit::Ancestors        │        │
│    └───────────┬────────────┴───────────┬────────────┴───────────┬────────────┴───────────┬────────────┘        │
│                │                        │                        │                        │                     │
│                ▼                        ▼                        ▼                        ▼                     │
│    ┌────────────────────────┐ ┌────────────────────────┐ ┌────────────────────────┐ ┌────────────────────────┐  │
│    │ handle_definition_unit │ │ handle_reference_unit  │ │ handle_dsl_unit        │ │ handle_ancestor_unit   │  │
│    │                        │ │                        │ │                        │ │                        │  │
│    │ • maybe_handle_        │ │ • resolve_constant_    │ │ • resolve receiver     │ │ • linearize ancestors  │  │
│    │   constant_inside_dsl  │ │   internal             │ │ • match processor      │ │                        │  │
│    │ • handle_constant_     │ │                        │ │ • call handler         │ │                        │  │
│    │   declaration          │ │                        │ │                        │ │                        │  │
│    └───────────┬────────────┘ └───────────┬────────────┘ └───────────┬────────────┘ └───────────┬────────────┘  │
│                │                          │                          │                          │               │
│                └──────────────────────────┴─────────────┬────────────┴──────────────────────────┘               │
│                                                         ▼                                                       │
│    ┌────────────────────────────────────────────────────────────────────────────────────────────────────────┐   │
│    │  OUTCOMES                                                                                              │   │
│    │  Resolved ─────► made_progress = true, may enqueue Unit::Ancestors                                     │   │
│    │  Retry ────────► push_back(unit), processed in NEXT pass                                               │   │
│    │  DSL matched ──► creates DynamicClass/Module, enqueues Unit::Definition                                │   │
│    └────────────────────────────────────────────────────────────────────────────────────────────────────────┘   │
└─────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
                                                                  │
                                                                  ▼
┌─────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│  END OF PASS: if !made_progress || queue.is_empty() → EXIT                                                      │
│               else → CONTINUE (retries might succeed now)                                                       │
└─────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
```

**Example: Processing `Foo = Class.new { def bar; end }`**

```text
Pass 1: Queue = [Def(Foo/Const), Dsl(Class.new)]
  • Def(Foo) → resolves, creates ConstantDeclaration
  • Dsl → receiver "Class" not resolved → Retry
  made_progress = true → continue

Pass 2: Queue = [Dsl(Class.new)]
  • Dsl → receiver resolved to CLASS_ID
       → class_new_matches() = true
       → handle_class_new() creates DynamicClassDefinition
       → Removes ConstantDefinition, enqueues Unit::Definition(DynamicClass)
  made_progress = true → continue

Pass 3: Queue = [Def(DynamicClass)]
  • DynamicClass → creates ClassDeclaration(Foo)
  made_progress = true → continue

... (method resolution, ancestors) ...

Pass N: Queue = [] → EXIT
```

### Key Functions Reference

| Function                           | Location           | Purpose                                     |
| ---------------------------------- | ------------------ | ------------------------------------------- |
| `try_index_dsl_call`               | ruby_indexer.rs    | Index DSL call as DslDefinition             |
| `handle_dsl_unit`                  | resolution.rs      | Process DSL, match processors               |
| `handle_class_new`                 | dsl_processors.rs  | Create DynamicClassDefinition               |
| `handle_module_new`                | dsl_processors.rs  | Create DynamicModuleDefinition              |
| `extract_dsl_context`              | dsl_processors.rs  | Get name, comments, flags from DSL+Constant |
| `is_parent_dsl_processed`          | dsl_processors.rs  | Check if parent DSL is processed            |
| `get_dsl_namespace_declaration`    | resolution.rs      | Get declaration for processed DSL           |
| `maybe_handle_constant_inside_dsl` | resolution.rs      | Handle constants nested in DSL              |
| `resolve_lexical_owner`            | resolution.rs      | Resolve owner, handles DSL nesting          |

### Definition Type Summary

| Definition Type         | When Created                    | Declaration Created?          |
| ----------------------- | ------------------------------- | ----------------------------- |
| DslDefinition           | Indexing (for any `.new` call)  | No (captured for processing)  |
| ConstantDefinition      | Indexing (`Foo = ...`)          | Removed if DSL matches        |
| DynamicClassDefinition  | Resolution (Class.new matches)  | Yes if named, No if anonymous |
| DynamicModuleDefinition | Resolution (Module.new matches) | Yes if named, No if anonymous |

## Benchmark Diff

Benchmark diff against Core compared to `main` 

```
                                      implement-497          main              diff                                                    
  ─────────────────────────────────────────────────────────────────────────────────────
  QUERY STATISTICS                                                                                                                     
    Total declarations:                   858,592         862,281           -3,689
    With documentation:                   145,908         146,000              -92
    Without documentation:                712,684         716,281           -3,597
    Multi-definition names:                16,654          16,716              -62

  DECLARATION BREAKDOWN
    Method                                409,543         410,329             -786
    InstanceVariable                      190,112         190,227             -115
    Class                                 107,185         107,981             -796
    SingletonClass                         69,310          70,175             -865
    Constant                               64,382          65,468           -1,086
    Module                                 13,881          13,924              -43
    ConstantAlias                           3,746           3,744               +2
    ClassVariable                             429             429                0
    GlobalVariable                              4               4                0

  DEFINITION BREAKDOWN
    Method                                359,263         360,083             -820
    InstanceVariable                      214,997         215,139             -142
    Module                                197,167         197,217              -50
    Class                                 110,793         112,063           -1,270
    Constant                               64,394          65,478           -1,084
    AttrReader                             36,851          36,902              -51
    SingletonClass                         15,982          15,993              -11
    AliasMethod                             7,165           7,166               -1
    AttrAccessor                            6,411           6,425              -14
    ConstantAlias                           3,746           3,744               +2
    ClassVariable                             856             856                0
    DynamicClass                              469             N/A             +469  ← NEW
    AttrWriter                                418             419               -1
    GlobalVariable                             36              36                0
    DynamicModule                               1             N/A               +1  ← NEW

  TIMING
    Listing                                0.92s           0.90s           +0.02s
    Indexing                              11.73s          10.99s           +0.74s
    Resolution                            21.00s          65.84s          -44.84s  ← 68% FASTER
    Querying                               1.33s           1.09s           +0.24s
    Total                                 34.97s          78.81s          -43.84s  ← 56% FASTER

  MEMORY
    Maximum RSS                         3,510 MB        2,885 MB          +625 MB  (+22%)

  SUMMARY
    Indexed files                         93,096          93,096                0
    Total definitions                  1,021,363       1,021,561             -198
    Total URIs                            93,096          93,096                0
```
