### PR TITLE
Add Declaration#ancestors to the Ruby API

### DIFF
--- a/ext/rubydex/graph.c
+++ b/ext/rubydex/graph.c
@@ -58,30 +58,6 @@ static VALUE rdxr_graph_index_all(VALUE self, VALUE file_paths) {
     return Qnil;
 }
 
-// Body function for rb_ensure in Graph#declarations
-static VALUE graph_declarations_yield(VALUE args) {
-    VALUE self = rb_ary_entry(args, 0);
-    void *iter = (void *)(uintptr_t)NUM2ULL(rb_ary_entry(args, 1));
-
-    CDeclaration decl;
-    while (rdx_graph_declarations_iter_next(iter, &decl)) {
-        VALUE decl_class = rdxi_declaration_class_for_kind(decl.kind);
-        VALUE argv[] = {self, UINT2NUM(decl.id)};
-        VALUE handle = rb_class_new_instance(2, argv, decl_class);
-        rb_yield(handle);
-    }
-
-    return Qnil;
-}
-
-// Ensure function for rb_ensure in Graph#declarations to always free the iterator
-static VALUE graph_declarations_ensure(VALUE args) {
-    void *iter = (void *)(uintptr_t)NUM2ULL(rb_ary_entry(args, 1));
-    rdx_graph_declarations_iter_free(iter);
-
-    return Qnil;
-}
-
 // Size function for the declarations enumerator
 static VALUE graph_declarations_size(VALUE self, VALUE _args, VALUE _eobj) {
     void *graph;
@@ -106,7 +82,7 @@ static VALUE rdxr_graph_declarations(VALUE self) {
 
     void *iter = rdx_graph_declarations_iter_new(graph);
     VALUE args = rb_ary_new_from_args(2, self, ULL2NUM((uintptr_t)iter));
-    rb_ensure(graph_declarations_yield, args, graph_declarations_ensure, args);
+    rb_ensure(rdxi_declarations_yield, args, rdxi_declarations_ensure, args);
 
     return self;
 }
@@ -132,7 +108,7 @@ static VALUE rdxr_graph_search(VALUE self, VALUE query) {
     }
 
     VALUE args = rb_ary_new_from_args(2, self, ULL2NUM((uintptr_t)iter));
-    rb_ensure(graph_declarations_yield, args, graph_declarations_ensure, args);
+    rb_ensure(rdxi_declarations_yield, args, rdxi_declarations_ensure, args);
 
     return self;
 }

--- a/ext/rubydex/utils.c
+++ b/ext/rubydex/utils.c
@@ -1,4 +1,6 @@
 #include "utils.h"
+#include "declaration.h"
+#include "rustbindings.h"
 
 // Convert a Ruby array of strings into a double char pointer so that we can pass that to Rust.
 // This copies the data so it must be freed
@@ -24,4 +26,27 @@ void rdxi_check_array_of_strings(VALUE array) {
         VALUE item = rb_ary_entry(array, i);
         Check_Type(item, T_STRING);
     }
+}
+
+// Yield body for iterating over declarations
+VALUE rdxi_declarations_yield(VALUE args) {
+    VALUE self = rb_ary_entry(args, 0);
+    void *iter = (void *)(uintptr_t)NUM2ULL(rb_ary_entry(args, 1));
+
+    CDeclaration decl;
+    while (rdx_graph_declarations_iter_next(iter, &decl)) {
+        VALUE decl_class = rdxi_declaration_class_for_kind(decl.kind);
+        VALUE argv[] = {self, UINT2NUM(decl.id)};
+        VALUE handle = rb_class_new_instance(2, argv, decl_class);
+        rb_yield(handle);
+    }
+
+    return Qnil;
+}
+
+// Ensure function for iterating over declarations to always free the iterator
+VALUE rdxi_declarations_ensure(VALUE args) {
+    void *iter = (void *)(uintptr_t)NUM2ULL(rb_ary_entry(args, 1));
+    rdx_graph_declarations_iter_free(iter);
+    return Qnil;
 }

--- a/ext/rubydex/utils.h
+++ b/ext/rubydex/utils.h
@@ -10,4 +10,10 @@ char **rdxi_str_array_to_char(VALUE array, size_t length);
 // Verify that the Ruby object is an array of strings or raise `TypeError`
 void rdxi_check_array_of_strings(VALUE array);
 
+// Yield body for iterating over declarations
+VALUE rdxi_declarations_yield(VALUE args);
+
+// Ensure function for iterating over declarations to always free the iterator
+VALUE rdxi_declarations_ensure(VALUE args);
+
 #endif // RUBYDEX_UTILS_H

--- a/rust/rubydex/src/model/declaration.rs
+++ b/rust/rubydex/src/model/declaration.rs
@@ -412,11 +412,13 @@ impl Namespace {
         all_namespaces!(self, it => std::mem::take(&mut it.diagnostics))
     }
 
-    /// # Panics
-    ///
-    /// Panics if the declaration is not a namespace or a constant
     #[must_use]
-    pub fn ancestors(&self) -> Ancestors {
+    pub fn ancestors(&self) -> &Ancestors {
+        all_namespaces!(self, it => it.ancestors())
+    }
+
+    #[must_use]
+    pub fn clone_ancestors(&self) -> Ancestors {
         all_namespaces!(self, it => it.clone_ancestors())
     }
 

--- a/rust/rubydex/src/model/graph.rs
+++ b/rust/rubydex/src/model/graph.rs
@@ -652,7 +652,7 @@ impl Graph {
                 .as_namespace_mut()
                 .expect("expected namespace declaration");
 
-            for ancestor in &namespace.ancestors() {
+            for ancestor in &namespace.clone_ancestors() {
                 if let Ancestor::Complete(ancestor_id) = ancestor {
                     self.declarations_mut()
                         .get_mut(ancestor_id)
@@ -924,7 +924,7 @@ mod tests {
             else {
                 panic!("Expected Foo to be a class");
             };
-            assert!(matches!(foo.clone_ancestors(), Ancestors::Partial(a) if a.is_empty()));
+            assert!(matches!(foo.ancestors(), Ancestors::Partial(a) if a.is_empty()));
             assert!(foo.descendants().is_empty());
 
             let Declaration::Namespace(Namespace::Class(baz)) =
@@ -932,7 +932,7 @@ mod tests {
             else {
                 panic!("Expected Baz to be a class");
             };
-            assert!(matches!(baz.clone_ancestors(), Ancestors::Partial(a) if a.is_empty()));
+            assert!(matches!(baz.ancestors(), Ancestors::Partial(a) if a.is_empty()));
             assert!(baz.descendants().is_empty());
 
             let Declaration::Namespace(Namespace::Module(bar)) =
@@ -947,7 +947,7 @@ mod tests {
 
         let baz_declaration = context.graph().declarations().get(&DeclarationId::from("Baz")).unwrap();
         assert!(matches!(
-            baz_declaration.as_namespace().unwrap().ancestors(),
+            baz_declaration.as_namespace().unwrap().clone_ancestors(),
             Ancestors::Complete(_)
         ));
 

--- a/rust/rubydex/src/resolution.rs
+++ b/rust/rubydex/src/resolution.rs
@@ -625,7 +625,7 @@ impl<'a> Resolver<'a> {
             // Return the cached ancestors if we already computed them. If they are partial ancestors, ignore the cache to try
             // again
             if declaration.as_namespace().unwrap().has_complete_ancestors() {
-                let cached = declaration.as_namespace().unwrap().ancestors();
+                let cached = declaration.as_namespace().unwrap().clone_ancestors();
                 self.propagate_descendants(&mut context.descendants, &cached);
                 context.descendants.remove(&declaration_id);
                 return cached;
@@ -2117,7 +2117,7 @@ mod tests {
 
         let declaration = context.graph().declarations().get(&DeclarationId::from("Bar")).unwrap();
         assert!(matches!(
-            declaration.as_namespace().unwrap().ancestors(),
+            declaration.as_namespace().unwrap().clone_ancestors(),
             Ancestors::Partial(_)
         ));
     }

--- a/rust/rubydex/src/test_utils/graph_test.rs
+++ b/rust/rubydex/src/test_utils/graph_test.rs
@@ -285,7 +285,7 @@ macro_rules! assert_ancestors_eq {
                             $crate::model::declaration::Ancestor::Complete($crate::model::ids::DeclarationId::from(*n))
                         })
                         .collect::<Vec<_>>(),
-                    ancestors,
+                    *ancestors,
                     "Incorrect ancestors {}",
                     ancestors
                         .iter()


### PR DESCRIPTION
This PR exposes `Declaration#ancestors` to the Ruby API and demonstrates how it can be used to resolve a method or instance variable reference (necessary for hover, go to definition and signature help).