### PR TITLE
Keep track of original nesting on top level references

### DIFF
--- a/rust/rubydex-sys/src/name_api.rs
+++ b/rust/rubydex-sys/src/name_api.rs
@@ -1,4 +1,8 @@
-use rubydex::model::{graph::Graph, ids::NameId, name::Name};
+use rubydex::model::{
+    graph::Graph,
+    ids::NameId,
+    name::{Name, ParentScope},
+};
 
 /// Takes a constant name and a nesting stack (e.g.: `["Foo", "Bar::Baz", "Qux"]`) and transforms it into a `NameId`,
 /// registering each required part in the graph. Returns the `NameId` and a list of name ids that need to be untracked
@@ -9,28 +13,36 @@ use rubydex::model::{graph::Graph, ids::NameId, name::Name};
 /// Should not panic because `const_name` will always be turned into a name
 pub fn nesting_stack_to_name_id(graph: &mut Graph, const_name: &str, nesting: Vec<String>) -> (NameId, Vec<NameId>) {
     let mut current_nesting = None;
-    let mut current_name = None;
+    let mut current_name = ParentScope::None;
     let mut names_to_untrack = Vec::new();
 
     for entry in nesting {
         for part in entry.split("::").map(String::from) {
+            if part.is_empty() {
+                current_name = ParentScope::TopLevel;
+                continue;
+            }
+
             let str_id = graph.intern_string(part);
             let name_id = graph.add_name(Name::new(str_id, current_name, current_nesting));
             names_to_untrack.push(name_id);
-            let new_name = Some(name_id);
-            current_name = new_name;
+            current_name = ParentScope::Some(name_id);
         }
 
-        current_nesting = current_name;
-        current_name = None;
+        current_nesting = current_name.map_or(None, |id| Some(*id));
+        current_name = ParentScope::None;
     }
 
     for part in const_name.split("::").map(String::from) {
+        if part.is_empty() {
+            current_name = ParentScope::TopLevel;
+            continue;
+        }
+
         let str_id = graph.intern_string(part);
         let name_id = graph.add_name(Name::new(str_id, current_name, current_nesting));
         names_to_untrack.push(name_id);
-        let new_name = Some(name_id);
-        current_name = new_name;
+        current_name = ParentScope::Some(name_id);
     }
 
     (
@@ -58,7 +70,10 @@ mod tests {
         let const_name = graph.names().get(&name_id).unwrap();
         assert_eq!(StringId::from("CONST"), *const_name.str());
 
-        let some_name = graph.names().get(&const_name.parent_scope().unwrap()).unwrap();
+        let some_name = graph
+            .names()
+            .get(&const_name.parent_scope().expect("Parent scope should exist"))
+            .unwrap();
         assert_eq!(StringId::from("Some"), *some_name.str());
         assert_eq!(const_name.nesting(), some_name.nesting());
 
@@ -69,9 +84,48 @@ mod tests {
         let zip_name = graph.names().get(&qux_name.nesting().unwrap()).unwrap();
         assert_eq!(StringId::from("Zip"), *zip_name.str());
 
-        let bar_name = graph.names().get(&zip_name.parent_scope().unwrap()).unwrap();
+        let bar_name = graph
+            .names()
+            .get(&zip_name.parent_scope().expect("Parent scope should exist"))
+            .unwrap();
         assert_eq!(StringId::from("Bar"), *bar_name.str());
         assert_eq!(zip_name.nesting(), bar_name.nesting());
+
+        let foo_name = graph.names().get(&bar_name.nesting().unwrap()).unwrap();
+        assert_eq!(StringId::from("Foo"), *foo_name.str());
+        assert!(foo_name.parent_scope().is_none());
+        assert!(foo_name.nesting().is_none());
+    }
+
+    #[test]
+    fn top_level_reference_is_converted_to_name_id() {
+        let mut graph = Graph::new();
+
+        let (name_id, _) = nesting_stack_to_name_id(&mut graph, "::CONST", vec!["Foo".into()]);
+
+        let const_name = graph.names().get(&name_id).unwrap();
+        assert_eq!(StringId::from("CONST"), *const_name.str());
+        assert!(const_name.parent_scope().is_top_level());
+
+        let foo_name = graph.names().get(&const_name.nesting().unwrap()).unwrap();
+        assert_eq!(StringId::from("Foo"), *foo_name.str());
+        assert!(foo_name.nesting().is_none());
+        assert!(foo_name.parent_scope().is_none());
+    }
+
+    #[test]
+    fn top_level_nesting_is_converted_to_name_id() {
+        let mut graph = Graph::new();
+
+        let (name_id, _) = nesting_stack_to_name_id(&mut graph, "CONST", vec!["Foo".into(), "::Bar".into()]);
+
+        let const_name = graph.names().get(&name_id).unwrap();
+        assert_eq!(StringId::from("CONST"), *const_name.str());
+        assert!(const_name.parent_scope().is_none());
+
+        let bar_name = graph.names().get(&const_name.nesting().unwrap()).unwrap();
+        assert_eq!(StringId::from("Bar"), *bar_name.str());
+        assert!(bar_name.parent_scope().is_top_level());
 
         let foo_name = graph.names().get(&bar_name.nesting().unwrap()).unwrap();
         assert_eq!(StringId::from("Foo"), *foo_name.str());

--- a/rust/rubydex/src/model/graph.rs
+++ b/rust/rubydex/src/model/graph.rs
@@ -9,7 +9,7 @@ use crate::model::document::Document;
 use crate::model::encoding::Encoding;
 use crate::model::identity_maps::{IdentityHashMap, IdentityHashSet};
 use crate::model::ids::{DeclarationId, DefinitionId, NameId, ReferenceId, StringId, UriId};
-use crate::model::name::{Name, NameRef, ResolvedName};
+use crate::model::name::{Name, NameRef, ParentScope, ResolvedName};
 use crate::model::references::{ConstantReference, MethodRef};
 use crate::model::string_ref::StringRef;
 use crate::stats;
@@ -421,18 +421,18 @@ impl Graph {
             return;
         };
 
-        let parent_scope = *name_ref.parent_scope();
+        let parent_scope = name_ref.parent_scope();
         let nesting = *name_ref.nesting();
 
-        self.untrack_name(name_id);
-
-        if let Some(parent_scope_id) = parent_scope {
-            self.untrack_name_recursive(parent_scope_id);
+        if let ParentScope::Some(parent_scope_id) = parent_scope {
+            self.untrack_name_recursive(*parent_scope_id);
         }
 
         if let Some(nesting_id) = nesting {
             self.untrack_name_recursive(nesting_id);
         }
+
+        self.untrack_name(name_id);
     }
 
     /// Register a member relationship from a declaration to another declaration through its unqualified name id. For example, in


### PR DESCRIPTION
We originally took a shortcut for representing top level constant references. We were simply ignoring (and effectively erasing) its nesting information. This works for almost everything, but it unfortunately falls short for the case of completion.

For example:

```ruby
module Foo
  CONST = 1
  
  class ::Bar
    # Completion triggered here without a character (CTRL + space)
  end
end

class Bar
  # Completion triggered here without a character (CTRL + space)
end
```

In this example, both cases of `Bar` refers to the same class, but the lexical scope in which they are inserted in is different. The first `::Bar` has access to `Foo::CONST` through lexical scope and the second `Bar` does not.

We can't support this correctly without remembering the original nesting for constant references while at the same time recording that we found a top level reference.

### Implementation

I tested two approaches:

1. Using a new enum for `ParentScope`. This gives us type safety as the compiler forces us to handle each case.
2. I originally thought the new enum would consume more memory, so I also experimented with using a special `NameId` for a fake name `<!top-level!>`. To my surprise, based on `mem::size_of` and our benchmarks on Core, there's no memory difference with the extra enum

Because of this, I went with the new enum, so that we can have extra type safety.