### PR TITLE
Remove a bunch of `vec!` from tests

### DIFF
--- a/rust/rubydex-sys/src/graph_api.rs
+++ b/rust/rubydex-sys/src/graph_api.rs
@@ -461,7 +461,7 @@ mod tests {
         let graph_ptr = Box::into_raw(Box::new(graph)) as GraphPointer;
 
         // Build the nesting array: ["Foo"] since BAR is inside class Foo
-        let nesting_strings: Vec<CString> = vec![CString::new("Foo").unwrap()];
+        let nesting_strings = [CString::new("Foo").unwrap()];
         let nesting_ptrs: Vec<*const c_char> = nesting_strings.iter().map(|s| s.as_ptr()).collect();
 
         unsafe {

--- a/rust/rubydex/src/indexing/ruby_indexer.rs
+++ b/rust/rubydex/src/indexing/ruby_indexer.rs
@@ -1892,9 +1892,11 @@ mod tests {
         ($context:expr, $def:expr, $expected_comments:expr) => {{
             let actual_comments: Vec<String> = $def.comments().iter().map(|c| c.string().to_string()).collect();
             assert_eq!(
-                $expected_comments, actual_comments,
+                $expected_comments,
+                actual_comments.as_slice(),
                 "comments mismatch: expected `{:?}`, got `{:?}`",
-                $expected_comments, actual_comments
+                $expected_comments,
+                actual_comments
             );
         }};
     }
@@ -1930,9 +1932,11 @@ mod tests {
                 .collect::<Vec<_>>();
 
             assert_eq!(
-                $expected_names, actual_names,
+                $expected_names,
+                actual_names.as_slice(),
                 "mixins mismatch: expected `{:?}`, got `{:?}`",
-                $expected_names, actual_names
+                $expected_names,
+                actual_names
             );
         }};
     }
@@ -2076,9 +2080,11 @@ mod tests {
             let actual_names = actual_references.iter().map(|(_, name)| *name).collect::<Vec<_>>();
 
             assert_eq!(
-                $expected_names, actual_names,
+                $expected_names,
+                actual_names.as_slice(),
                 "constant references mismatch: expected `{:?}`, got `{:?}`",
-                $expected_names, actual_names
+                $expected_names,
+                actual_names
             );
         }};
     }
@@ -2105,9 +2111,11 @@ mod tests {
                 .collect::<Vec<_>>();
 
             assert_eq!(
-                $expected_names, actual_names,
+                $expected_names,
+                actual_names.as_slice(),
                 "method references mismatch: expected `{:?}`, got `{:?}`",
-                $expected_names, actual_names
+                $expected_names,
+                actual_names
             );
         }};
     }
@@ -2128,7 +2136,7 @@ mod tests {
         ($context:expr, $expected_diagnostics:expr) => {{
             assert_eq!(
                 $expected_diagnostics,
-                format_diagnostics($context),
+                format_diagnostics($context).as_slice(),
                 "diagnostics mismatch: expected `{:?}`, got `{:?}`",
                 $expected_diagnostics,
                 format_diagnostics($context)
@@ -2160,7 +2168,7 @@ mod tests {
 
         assert_diagnostics_eq!(
             &context,
-            vec![
+            [
                 "parse-error: expected an `end` to close the `class` statement (1:1-1:6)",
                 "parse-error: unexpected end-of-input, assuming it is closing the parent top level context (1:10-2:1)"
             ]
@@ -2183,7 +2191,7 @@ mod tests {
 
         assert_diagnostics_eq!(
             &context,
-            vec!["parse-warning: assigned but unused variable - foo (1:1-1:4)"]
+            ["parse-warning: assigned but unused variable - foo (1:1-1:4)"]
         );
     }
 
@@ -2294,7 +2302,7 @@ mod tests {
 
         assert_diagnostics_eq!(
             &context,
-            vec!["dynamic-constant-reference: Dynamic constant reference (1:7-1:10)"]
+            ["dynamic-constant-reference: Dynamic constant reference (1:7-1:10)"]
         );
         assert!(context.graph().definitions().is_empty());
     }
@@ -2398,7 +2406,7 @@ mod tests {
 
         assert_diagnostics_eq!(
             &context,
-            vec!["dynamic-constant-reference: Dynamic constant reference (1:8-1:11)"]
+            ["dynamic-constant-reference: Dynamic constant reference (1:8-1:11)"]
         );
         assert!(context.graph().definitions().is_empty());
     }
@@ -2502,7 +2510,7 @@ mod tests {
             });
         });
 
-        assert_constant_references_eq!(&context, vec!["FOO", "BAZ"]);
+        assert_constant_references_eq!(&context, ["FOO", "BAZ"]);
     }
 
     #[test]
@@ -2544,7 +2552,7 @@ mod tests {
             });
         });
 
-        assert_constant_references_eq!(&context, vec!["FOO", "BAR", "FOO", "BAR", "BAZ"]);
+        assert_constant_references_eq!(&context, ["FOO", "BAR", "FOO", "BAR", "BAZ"]);
     }
 
     #[test]
@@ -2666,10 +2674,10 @@ mod tests {
 
         assert_diagnostics_eq!(
             &context,
-            vec!["dynamic-singleton-definition: Dynamic receiver for singleton method definition (1:1-1:17)"]
+            ["dynamic-singleton-definition: Dynamic receiver for singleton method definition (1:1-1:17)"]
         );
         assert_eq!(context.graph().definitions().len(), 0);
-        assert_method_references_eq!(&context, vec!["foo"]);
+        assert_method_references_eq!(&context, ["foo"]);
     }
 
     #[test]
@@ -2773,7 +2781,7 @@ mod tests {
             });
         });
 
-        assert_constant_references_eq!(&context, vec!["Foo"]);
+        assert_constant_references_eq!(&context, ["Foo"]);
     }
 
     #[test]
@@ -2813,7 +2821,7 @@ mod tests {
 
         assert_diagnostics_eq!(
             &context,
-            vec!["dynamic-singleton-definition: Dynamic singleton class definition (1:1-3:4)"]
+            ["dynamic-singleton-definition: Dynamic singleton class definition (1:1-3:4)"]
         );
         assert_eq!(context.graph().definitions().len(), 0);
     }
@@ -3738,7 +3746,7 @@ mod tests {
 
         assert_diagnostics_eq!(
             &context,
-            vec![
+            [
                 "dynamic-constant-reference: Dynamic constant reference (3:6-3:14)",
                 "parse-warning: assigned but unused variable - foo (5:1-5:4)",
             ]
@@ -3746,7 +3754,7 @@ mod tests {
 
         assert_constant_references_eq!(
             &context,
-            vec![
+            [
                 "C1", "C2", "C3", "C4", "C6", "C7", "C8", "C9", "C10", "C11", "C12", "C13", "C14", "C15", "C16", "C17",
                 "C18", "C19", "C20", "C21", "C22", "C23"
             ]
@@ -3771,7 +3779,7 @@ mod tests {
 
         assert_constant_references_eq!(
             &context,
-            vec![
+            [
                 "C1", "C2", "C3", "C4", "C5", "C6", "C7", "C8", "C9", "C10", "C11", "C12", "C13", "C14"
             ]
         );
@@ -3789,7 +3797,7 @@ mod tests {
 
         assert_no_diagnostics!(&context);
 
-        assert_constant_references_eq!(&context, vec!["C1", "C2", "C3", "C4", "C5", "C6", "C7", "C8", "C9"]);
+        assert_constant_references_eq!(&context, ["C1", "C2", "C3", "C4", "C5", "C6", "C7", "C8", "C9"]);
     }
 
     #[test]
@@ -3813,7 +3821,7 @@ mod tests {
 
         assert_constant_references_eq!(
             &context,
-            vec!["C1", "C2", "C3", "C4", "C5", "C6", "C7", "C8", "C9", "C10", "C11"]
+            ["C1", "C2", "C3", "C4", "C5", "C6", "C7", "C8", "C9", "C10", "C11"]
         );
     }
 
@@ -3856,7 +3864,7 @@ mod tests {
 
         assert_constant_references_eq!(
             &context,
-            vec![
+            [
                 "M1", "M2", "M3", "M4", "M5", "M6", "M7", "M8", "M9", "M10", "M11", "M12", "M13", "M14", "M15", "M16",
                 "M17", "M18", "M19", "M20", "M21", "M22",
             ]
@@ -3903,12 +3911,12 @@ mod tests {
 
         assert_diagnostics_eq!(
             &context,
-            vec!["parse-error: unexpected ... when the parent method is not forwarding (31:5-31:8)"]
+            ["parse-error: unexpected ... when the parent method is not forwarding (31:5-31:8)"]
         );
 
         assert_method_references_eq!(
             &context,
-            vec![
+            [
                 "m1", "m2", "m3", "m4", "m5", "m6", "m7", "m8", "m9", "m10", "m11", "m12", "m13", "m14", "m15", "m16",
                 "m17", "m18", "m19", "m20", "m21", "m22", "m23", "m24", "m25", "m26", "!", "m27", "m28", "m29", "m30",
                 "m31", "m32", "m33", "m34", "m35", "m36", "[]", "m37", "m38", "m39", "m40", "m41", "m42", "m43", "m44",
@@ -3931,7 +3939,7 @@ mod tests {
 
         assert_method_references_eq!(
             &context,
-            vec![
+            [
                 "m1=", "m2", "m3", "m4", "m5=", "m6", "m7", "m8", "m9=", "m10=", "m11", "m12"
             ]
         );
@@ -3955,7 +3963,7 @@ mod tests {
 
         assert_method_references_eq!(
             &context,
-            vec![
+            [
                 "m1", "m1=", "m2", "m2=", "m3", "m3=", "m4", "m4=", "m5", "m6", "m6=", "m7", "m8", "m9", "m9=", "m10",
                 "m11", "m12", "m12=", "m13",
             ]
@@ -3988,7 +3996,7 @@ mod tests {
 
         assert_diagnostics_eq!(
             &context,
-            vec![
+            [
                 "parse-warning: possibly useless use of != in void context (1:1-1:7)",
                 "parse-warning: possibly useless use of % in void context (2:1-2:6)",
                 "parse-warning: possibly useless use of & in void context (3:1-3:6)",
@@ -4006,7 +4014,7 @@ mod tests {
 
         assert_method_references_eq!(
             &context,
-            vec![
+            [
                 "!=", "%", "&", "&&", "*", "**", "+", "-", "/", "<<", "==", "===", ">>", "^", "|", "||", "<=>",
             ]
         );
@@ -4022,10 +4030,10 @@ mod tests {
 
         assert_diagnostics_eq!(
             &context,
-            vec!["parse-warning: possibly useless use of < in void context (1:1-1:6)"]
+            ["parse-warning: possibly useless use of < in void context (1:1-1:6)"]
         );
 
-        assert_method_references_eq!(&context, vec!["x", "<", "<=>", "y"]);
+        assert_method_references_eq!(&context, ["x", "<", "<=>", "y"]);
     }
 
     #[test]
@@ -4038,10 +4046,10 @@ mod tests {
 
         assert_diagnostics_eq!(
             &context,
-            vec!["parse-warning: possibly useless use of <= in void context (1:1-1:7)"]
+            ["parse-warning: possibly useless use of <= in void context (1:1-1:7)"]
         );
 
-        assert_method_references_eq!(&context, vec!["x", "<=", "<=>", "y"]);
+        assert_method_references_eq!(&context, ["x", "<=", "<=>", "y"]);
     }
 
     #[test]
@@ -4054,10 +4062,10 @@ mod tests {
 
         assert_diagnostics_eq!(
             &context,
-            vec!["parse-warning: possibly useless use of > in void context (1:1-1:6)"]
+            ["parse-warning: possibly useless use of > in void context (1:1-1:6)"]
         );
 
-        assert_method_references_eq!(&context, vec!["x", "<=>", ">", "y"]);
+        assert_method_references_eq!(&context, ["x", "<=>", ">", "y"]);
     }
 
     #[test]
@@ -4070,10 +4078,10 @@ mod tests {
 
         assert_diagnostics_eq!(
             &context,
-            vec!["parse-warning: possibly useless use of >= in void context (1:1-1:7)"]
+            ["parse-warning: possibly useless use of >= in void context (1:1-1:7)"]
         );
 
-        assert_method_references_eq!(&context, vec!["x", "<=>", ">=", "y"]);
+        assert_method_references_eq!(&context, ["x", "<=>", ">=", "y"]);
     }
 
     #[test]
@@ -4087,7 +4095,7 @@ mod tests {
         });
 
         assert_no_diagnostics!(&context);
-        assert_method_references_eq!(&context, vec!["m1()", "m2()"]);
+        assert_method_references_eq!(&context, ["m1()", "m2()"]);
     }
 
     #[test]
@@ -4179,7 +4187,7 @@ mod tests {
 
         assert_diagnostics_eq!(
             &context,
-            vec![
+            [
                 "dynamic-ancestor: Dynamic superclass (1:13-1:24)",
                 "dynamic-ancestor: Dynamic superclass (2:13-2:16)",
                 "dynamic-ancestor: Dynamic superclass (3:21-3:49)",
@@ -4234,7 +4242,7 @@ mod tests {
         assert_no_diagnostics!(&context);
 
         assert_definition_at!(&context, "1:1-4:4", Class, |def| {
-            assert_def_mixins_eq!(&context, def, Include, vec!["Baz", "Bar", "Qux"]);
+            assert_def_mixins_eq!(&context, def, Include, ["Baz", "Bar", "Qux"]);
         });
     }
 
@@ -4252,7 +4260,7 @@ mod tests {
         assert_no_diagnostics!(&context);
 
         assert_definition_at!(&context, "1:1-4:4", Module, |def| {
-            assert_def_mixins_eq!(&context, def, Include, vec!["Baz", "Bar", "Qux"]);
+            assert_def_mixins_eq!(&context, def, Include, ["Baz", "Bar", "Qux"]);
         });
     }
 
@@ -4285,7 +4293,7 @@ mod tests {
         assert_no_diagnostics!(&context);
 
         assert_definition_at!(&context, "1:1-4:4", Class, |def| {
-            assert_def_mixins_eq!(&context, def, Prepend, vec!["Baz", "Bar", "Qux"]);
+            assert_def_mixins_eq!(&context, def, Prepend, ["Baz", "Bar", "Qux"]);
         });
     }
 
@@ -4303,7 +4311,7 @@ mod tests {
         assert_no_diagnostics!(&context);
 
         assert_definition_at!(&context, "1:1-4:4", Module, |def| {
-            assert_def_mixins_eq!(&context, def, Prepend, vec!["Baz", "Bar", "Qux"]);
+            assert_def_mixins_eq!(&context, def, Prepend, ["Baz", "Bar", "Qux"]);
         });
     }
 
@@ -4321,7 +4329,7 @@ mod tests {
         assert_no_diagnostics!(&context);
 
         assert_definition_at!(&context, "1:1-4:4", Class, |class_def| {
-            assert_def_mixins_eq!(&context, class_def, Extend, vec!["Bar", "Baz"]);
+            assert_def_mixins_eq!(&context, class_def, Extend, ["Bar", "Baz"]);
         });
     }
 
@@ -4340,9 +4348,9 @@ mod tests {
         assert_no_diagnostics!(&context);
 
         assert_definition_at!(&context, "1:1-5:4", Module, |def| {
-            assert_def_mixins_eq!(&context, def, Include, vec!["Foo"]);
-            assert_def_mixins_eq!(&context, def, Prepend, vec!["Foo"]);
-            assert_def_mixins_eq!(&context, def, Extend, vec!["Foo"]);
+            assert_def_mixins_eq!(&context, def, Include, ["Foo"]);
+            assert_def_mixins_eq!(&context, def, Prepend, ["Foo"]);
+            assert_def_mixins_eq!(&context, def, Extend, ["Foo"]);
         });
     }
 
@@ -4362,7 +4370,7 @@ mod tests {
 
         assert_diagnostics_eq!(
             &context,
-            vec![
+            [
                 "dynamic-constant-reference: Dynamic constant reference (1:9-1:12)",
                 "dynamic-ancestor: Dynamic mixin argument (1:9-1:17)",
                 "dynamic-constant-reference: Dynamic constant reference (2:9-2:12)",
@@ -4389,7 +4397,7 @@ mod tests {
 
         assert_diagnostics_eq!(
             &context,
-            vec![
+            [
                 "top-level-mixin-self: Top level mixin self (1:9-1:13)",
                 "top-level-mixin-self: Top level mixin self (2:9-2:13)",
                 "top-level-mixin-self: Top level mixin self (3:8-3:12)"
@@ -5074,7 +5082,7 @@ mod tests {
             assert_definition_at!(&context, "2:3-4:6", Class, |anonymous_class| {
                 assert_eq!(foo.id(), anonymous_class.lexical_nesting_id().unwrap());
 
-                assert_def_mixins_eq!(&context, anonymous_class, Include, vec!["Bar"]);
+                assert_def_mixins_eq!(&context, anonymous_class, Include, ["Bar"]);
             });
         });
     }
@@ -5212,7 +5220,7 @@ mod tests {
             assert_name_path_eq!(&context, "Foo::Bar", *def.target_name_id());
         });
 
-        assert_constant_references_eq!(&context, vec!["Foo", "Bar"]);
+        assert_constant_references_eq!(&context, ["Foo", "Bar"]);
     }
 
     #[test]
@@ -5273,7 +5281,7 @@ mod tests {
             assert_name_path_eq!(&context, "Target", *def.target_name_id());
         });
 
-        assert_constant_references_eq!(&context, vec!["Target"]);
+        assert_constant_references_eq!(&context, ["Target"]);
     }
 
     #[test]
@@ -5356,7 +5364,7 @@ mod tests {
 
         assert_definition_at!(&context, "2:1-2:18", Class, |def| {
             assert_def_name_eq!(&context, def, "Single");
-            assert_def_comments_eq!(&context, def, vec!["# Single comment"]);
+            assert_def_comments_eq!(&context, def, ["# Single comment"]);
         });
 
         assert_definition_at!(&context, "7:1-7:18", Module, |def| {
@@ -5364,7 +5372,7 @@ mod tests {
             assert_def_comments_eq!(
                 &context,
                 def,
-                vec![
+                [
                     "# Multi-line comment 1",
                     "# Multi-line comment 2",
                     "# Multi-line comment 3"
@@ -5374,22 +5382,22 @@ mod tests {
 
         assert_definition_at!(&context, "12:1-12:28", Class, |def| {
             assert_def_name_eq!(&context, def, "EmptyCommentLine");
-            assert_def_comments_eq!(&context, def, vec!["# Comment 1", "#", "# Comment 2"]);
+            assert_def_comments_eq!(&context, def, ["# Comment 1", "#", "# Comment 2"]);
         });
 
         assert_definition_at!(&context, "15:1-15:6", Constant, |def| {
             assert_def_name_eq!(&context, def, "NoGap");
-            assert_def_comments_eq!(&context, def, vec!["# Comment directly above (no gap)"]);
+            assert_def_comments_eq!(&context, def, ["# Comment directly above (no gap)"]);
         });
 
         assert_definition_at!(&context, "19:1-19:13", Method, |def| {
             assert_def_str_eq!(&context, def, "foo()");
-            assert_def_comments_eq!(&context, def, vec!["#: ()", "#| -> void"]);
+            assert_def_comments_eq!(&context, def, ["#: ()", "#| -> void"]);
         });
 
         assert_definition_at!(&context, "23:1-23:21", Class, |def| {
             assert_def_name_eq!(&context, def, "BlankLine");
-            assert_def_comments_eq!(&context, def, vec!["# Comment with blank line"]);
+            assert_def_comments_eq!(&context, def, ["# Comment with blank line"]);
         });
 
         assert_definition_at!(&context, "28:1-28:21", Class, |def| {
@@ -5421,22 +5429,22 @@ mod tests {
 
         assert_definition_at!(&context, "2:1-12:4", Class, |def| {
             assert_def_name_eq!(&context, def, "Outer");
-            assert_def_comments_eq!(&context, def, vec!["# Outer class"]);
+            assert_def_comments_eq!(&context, def, ["# Outer class"]);
         });
 
         assert_definition_at!(&context, "4:3-7:6", Class, |def| {
             assert_def_name_eq!(&context, def, "Inner");
-            assert_def_comments_eq!(&context, def, vec!["# Inner class at 2 spaces"]);
+            assert_def_comments_eq!(&context, def, ["# Inner class at 2 spaces"]);
         });
 
         assert_definition_at!(&context, "6:5-6:20", Class, |def| {
             assert_def_name_eq!(&context, def, "Deep");
-            assert_def_comments_eq!(&context, def, vec!["# Deep class at 4 spaces"]);
+            assert_def_comments_eq!(&context, def, ["# Deep class at 4 spaces"]);
         });
 
         assert_definition_at!(&context, "11:3-11:26", Class, |def| {
             assert_def_name_eq!(&context, def, "AnotherInner");
-            assert_def_comments_eq!(&context, def, vec!["# Another inner class", "# with multiple lines"]);
+            assert_def_comments_eq!(&context, def, ["# Another inner class", "# with multiple lines"]);
         });
     }
 
@@ -5491,23 +5499,23 @@ mod tests {
         assert_no_diagnostics!(&context);
 
         assert_definition_at!(&context, "3:16-3:19", AttrReader, |def| {
-            assert_def_comments_eq!(&context, def, vec!["# Comment"]);
+            assert_def_comments_eq!(&context, def, ["# Comment"]);
         });
 
         assert_definition_at!(&context, "8:16-8:19", AttrWriter, |def| {
-            assert_def_comments_eq!(&context, def, vec!["# Comment 1", "# Comment 2", "# Comment 3"]);
+            assert_def_comments_eq!(&context, def, ["# Comment 1", "# Comment 2", "# Comment 3"]);
         });
 
         assert_definition_at!(&context, "13:18-13:21", AttrAccessor, |def| {
-            assert_def_comments_eq!(&context, def, vec!["# Comment 1", "# Comment 2", "# Comment 3"]);
+            assert_def_comments_eq!(&context, def, ["# Comment 1", "# Comment 2", "# Comment 3"]);
         });
 
         assert_definition_at!(&context, "13:24-13:27", AttrAccessor, |def| {
-            assert_def_comments_eq!(&context, def, vec!["# Comment 1", "# Comment 2", "# Comment 3"]);
+            assert_def_comments_eq!(&context, def, ["# Comment 1", "# Comment 2", "# Comment 3"]);
         });
 
         assert_definition_at!(&context, "16:9-16:13", AttrAccessor, |def| {
-            assert_def_comments_eq!(&context, def, vec!["# Comment"]);
+            assert_def_comments_eq!(&context, def, ["# Comment"]);
         });
     }
 }

--- a/rust/rubydex/src/listing.rs
+++ b/rust/rubydex/src/listing.rs
@@ -196,7 +196,7 @@ mod tests {
 
         assert_eq!(
             files,
-            vec![
+            [
                 baz.to_str().unwrap().to_string(),
                 qux.to_str().unwrap().to_string(),
                 bar.to_str().unwrap().to_string()
@@ -221,7 +221,7 @@ mod tests {
 
         assert_eq!(
             files,
-            vec![baz.to_str().unwrap().to_string(), qux.to_str().unwrap().to_string()]
+            [baz.to_str().unwrap().to_string(), qux.to_str().unwrap().to_string()]
         );
     }
 
@@ -240,7 +240,7 @@ mod tests {
 
         assert_eq!(
             errors,
-            vec![Errors::FileError(format!(
+            [Errors::FileError(format!(
                 "Path `{}` does not exist",
                 context.absolute_path_to("non_existing_path").display()
             ))]

--- a/rust/rubydex/src/model/graph.rs
+++ b/rust/rubydex/src/model/graph.rs
@@ -1165,14 +1165,14 @@ mod tests {
         let def = definitions.first().unwrap();
         assert_eq!(
             def.comments().iter().map(Comment::string).collect::<Vec<&String>>(),
-            vec!["# This is a class comment", "# Multi-line comment"]
+            ["# This is a class comment", "# Multi-line comment"]
         );
 
         let definitions = context.graph().get("CommentedModule").unwrap();
         let def = definitions.first().unwrap();
         assert_eq!(
             def.comments().iter().map(Comment::string).collect::<Vec<&String>>(),
-            vec!["# Module comment"]
+            ["# Module comment"]
         );
 
         let definitions = context.graph().get("NoCommentClass").unwrap();
@@ -1199,7 +1199,7 @@ mod tests {
         });
         context.resolve();
 
-        assert_members_eq!(context, "Foo", vec!["Bar"]);
+        assert_members_eq!(context, "Foo", ["Bar"]);
 
         // Delete `Bar`
         context.index_uri("file:///foo2.rb", {

--- a/rust/rubydex/src/query.rs
+++ b/rust/rubydex/src/query.rs
@@ -98,6 +98,6 @@ mod tests {
             "
         });
         context.resolve();
-        assert_results_eq!(context, "Fo", vec!["Foo"]);
+        assert_results_eq!(context, "Fo", ["Foo"]);
     }
 }

--- a/rust/rubydex/src/resolution.rs
+++ b/rust/rubydex/src/resolution.rs
@@ -1636,7 +1636,7 @@ mod tests {
 
         assert_no_diagnostics!(&context);
 
-        assert_members_eq!(context, "Foo", vec!["Bar", "Baz"]);
+        assert_members_eq!(context, "Foo", ["Bar", "Baz"]);
         assert_owner_eq!(context, "Foo", "Object");
 
         assert_no_members!(context, "Foo::Bar");
@@ -1662,7 +1662,7 @@ mod tests {
 
         assert_no_diagnostics!(&context);
 
-        assert_members_eq!(context, "Foo", vec!["@name", "initialize()"]);
+        assert_members_eq!(context, "Foo", ["@name", "initialize()"]);
         assert_owner_eq!(context, "Foo", "Object");
     }
 
@@ -1696,7 +1696,7 @@ mod tests {
         assert_no_members!(context, "Foo");
         assert_owner_eq!(context, "Foo", "Object");
 
-        assert_members_eq!(context, "Bar", vec!["Baz"]);
+        assert_members_eq!(context, "Bar", ["Baz"]);
         assert_owner_eq!(context, "Bar", "Object");
     }
 
@@ -1720,7 +1720,7 @@ mod tests {
         assert_no_members!(context, "Foo");
         assert_owner_eq!(context, "Foo", "Object");
 
-        assert_members_eq!(context, "Bar", vec!["Baz"]);
+        assert_members_eq!(context, "Bar", ["Baz"]);
         assert_owner_eq!(context, "Bar", "Object");
 
         assert_no_members!(context, "Bar::Baz");
@@ -1796,13 +1796,14 @@ mod tests {
         names.sort_by_key(|a| Resolver::name_depth(a, context.graph().names()));
 
         assert_eq!(
-            vec![
+            [
                 "Top", "Foo", "Qux", "Bar", "AfterTop", "Baz", "Zip", "Zap", "Zop", "Boop"
             ],
             names
                 .iter()
                 .map(|n| context.graph().strings().get(n.str()).unwrap().as_str())
                 .collect::<Vec<_>>()
+                .as_slice()
         );
     }
 
@@ -1827,7 +1828,7 @@ mod tests {
         assert_owner_eq!(context, "Foo", "Object");
         assert_singleton_class_eq!(context, "Foo", "Foo::<Foo>");
 
-        assert_members_eq!(context, "Foo::<Foo>", vec!["BAZ", "bar()"]);
+        assert_members_eq!(context, "Foo::<Foo>", ["BAZ", "bar()"]);
         assert_owner_eq!(context, "Foo::<Foo>", "Foo");
     }
 
@@ -1855,7 +1856,7 @@ mod tests {
         assert_no_members!(context, "Foo::<Foo>");
         assert_singleton_class_eq!(context, "Foo::<Foo>", "Foo::<Foo>::<<Foo>>");
 
-        assert_members_eq!(context, "Foo::<Foo>::<<Foo>>", vec!["baz()"]);
+        assert_members_eq!(context, "Foo::<Foo>::<<Foo>>", ["baz()"]);
         assert_owner_eq!(context, "Foo::<Foo>::<<Foo>>", "Foo::<Foo>");
     }
 
@@ -1885,7 +1886,7 @@ mod tests {
         assert_no_members!(context, "Bar");
         assert_owner_eq!(context, "Bar", "Object");
 
-        assert_members_eq!(context, "Foo::<Foo>", vec!["Baz", "baz()"]);
+        assert_members_eq!(context, "Foo::<Foo>", ["Baz", "baz()"]);
         assert_owner_eq!(context, "Foo::<Foo>", "Foo");
     }
 
@@ -1909,7 +1910,7 @@ mod tests {
 
         assert_no_diagnostics!(&context);
 
-        assert_members_eq!(context, "Foo", vec!["@@bar", "@@baz"]);
+        assert_members_eq!(context, "Foo", ["@@bar", "@@baz"]);
         assert_owner_eq!(context, "Foo", "Object");
     }
 
@@ -1929,7 +1930,7 @@ mod tests {
 
         assert_no_diagnostics!(&context);
 
-        assert_members_eq!(context, "Foo", vec!["@@baz", "bar()"]);
+        assert_members_eq!(context, "Foo", ["@@baz", "bar()"]);
     }
 
     #[test]
@@ -1956,7 +1957,7 @@ mod tests {
         assert_no_diagnostics!(&context);
 
         assert_no_members!(context, "Foo");
-        assert_members_eq!(context, "Bar", vec!["@@cvar1", "@@cvar2"]);
+        assert_members_eq!(context, "Bar", ["@@cvar1", "@@cvar2"]);
     }
 
     #[test]
@@ -2032,13 +2033,13 @@ mod tests {
 
         assert_no_diagnostics!(&context);
 
-        assert_members_eq!(context, "Foo::<Foo>", vec!["bar()", "baz()"]);
+        assert_members_eq!(context, "Foo::<Foo>", ["bar()", "baz()"]);
         assert_owner_eq!(context, "Foo::<Foo>", "Foo");
 
-        assert_members_eq!(context, "Foo::<Foo>::<<Foo>>", vec!["nested_bar()"]);
+        assert_members_eq!(context, "Foo::<Foo>::<<Foo>>", ["nested_bar()"]);
         assert_owner_eq!(context, "Foo::<Foo>::<<Foo>>", "Foo::<Foo>");
 
-        assert_members_eq!(context, "Bar::<Bar>", vec!["qux()"]);
+        assert_members_eq!(context, "Bar::<Bar>", ["qux()"]);
         assert_owner_eq!(context, "Bar::<Bar>", "Bar");
     }
 
@@ -2203,10 +2204,10 @@ mod tests {
 
         assert_no_diagnostics!(&context);
 
-        assert_instance_variables_eq!(context, "Foo", vec!["@bar"]);
+        assert_instance_variables_eq!(context, "Foo", ["@bar"]);
         // @qux in `class << self; def qux` - self is Foo when called, so @qux belongs to Foo's singleton class
-        assert_instance_variables_eq!(context, "Foo::<Foo>", vec!["@baz", "@foo", "@qux"]);
-        assert_instance_variables_eq!(context, "Foo::<Foo>::<<Foo>>", vec!["@nested"]);
+        assert_instance_variables_eq!(context, "Foo::<Foo>", ["@baz", "@foo", "@qux"]);
+        assert_instance_variables_eq!(context, "Foo::<Foo>::<<Foo>>", ["@nested"]);
     }
 
     #[test]
@@ -2234,8 +2235,8 @@ mod tests {
 
         assert_no_diagnostics!(&context);
 
-        assert_instance_variables_eq!(context, "Foo::<Foo>", vec!["@foo"]);
-        assert_instance_variables_eq!(context, "Bar::<Bar>", vec!["@baz"]);
+        assert_instance_variables_eq!(context, "Foo::<Foo>", ["@foo"]);
+        assert_instance_variables_eq!(context, "Bar::<Bar>", ["@baz"]);
     }
 
     #[test]
@@ -2257,7 +2258,7 @@ mod tests {
         assert_no_diagnostics!(&context);
 
         // The class is `Bar::Baz`, so its singleton class is `Bar::Baz::<Baz>`
-        assert_instance_variables_eq!(context, "Bar::Baz::<Baz>", vec!["@baz"]);
+        assert_instance_variables_eq!(context, "Bar::Baz::<Baz>", ["@baz"]);
     }
 
     #[test]
@@ -2280,8 +2281,8 @@ mod tests {
 
         assert_no_diagnostics!(&context);
 
-        assert_instance_variables_eq!(context, "Foo::<Foo>::<<Foo>>", vec!["@bar"]);
-        assert_instance_variables_eq!(context, "Foo::<Foo>::<<Foo>>::<<<Foo>>>", vec!["@baz"]);
+        assert_instance_variables_eq!(context, "Foo::<Foo>::<<Foo>>", ["@bar"]);
+        assert_instance_variables_eq!(context, "Foo::<Foo>::<<Foo>>::<<<Foo>>>", ["@baz"]);
     }
 
     #[test]
@@ -2318,7 +2319,7 @@ mod tests {
 
         assert_diagnostics_eq!(
             &context,
-            vec!["dynamic-singleton-definition: Dynamic receiver for singleton method definition (2:3-4:6)",]
+            ["dynamic-singleton-definition: Dynamic receiver for singleton method definition (2:3-4:6)",]
         );
 
         // Instance variable in method with unresolved receiver should not create a declaration
@@ -2345,7 +2346,7 @@ mod tests {
 
         assert_no_diagnostics!(&context);
 
-        assert_members_eq!(context, "Foo", vec!["bar()", "foo()"]);
+        assert_members_eq!(context, "Foo", ["bar()", "foo()"]);
     }
 
     #[test]
@@ -2361,7 +2362,7 @@ mod tests {
 
         assert_no_diagnostics!(&context);
 
-        assert_members_eq!(context, "Object", vec!["$bar", "$foo"]);
+        assert_members_eq!(context, "Object", ["$bar", "$foo"]);
     }
 
     #[test]
@@ -2676,7 +2677,7 @@ mod tests {
 
         assert_no_diagnostics!(&context);
 
-        assert_members_eq!(context, "Foo::Bar", vec!["Qux"]);
+        assert_members_eq!(context, "Foo::Bar", ["Qux"]);
         assert_owner_eq!(context, "Foo::Bar", "Foo");
 
         assert_no_members!(context, "Foo::Bar::Qux");
@@ -2927,7 +2928,7 @@ mod tests {
 
         assert_no_diagnostics!(&context);
 
-        assert_members_eq!(context, "Foo::Bar", vec!["Qux"]);
+        assert_members_eq!(context, "Foo::Bar", ["Qux"]);
         assert_owner_eq!(context, "Foo::Bar", "Foo");
 
         assert_no_members!(context, "Foo::Bar::Qux");
@@ -3327,7 +3328,7 @@ mod tests {
         assert_no_diagnostics!(&context);
 
         // Global variable aliases should still be owned by Object, regardless of where defined
-        assert_members_eq!(context, "Object", vec!["$bar", "Foo"]);
+        assert_members_eq!(context, "Object", ["$bar", "Foo"]);
     }
 
     #[test]
@@ -3347,7 +3348,7 @@ mod tests {
         assert_no_diagnostics!(&context);
 
         // inner_method should be owned by Foo, not by setup
-        assert_members_eq!(context, "Foo", vec!["inner_method()", "setup()"]);
+        assert_members_eq!(context, "Foo", ["inner_method()", "setup()"]);
     }
 
     #[test]
@@ -3368,14 +3369,10 @@ mod tests {
 
         assert_no_diagnostics!(&context);
 
-        assert_members_eq!(context, "Foo::<Foo>", vec!["setup()"]);
+        assert_members_eq!(context, "Foo::<Foo>", ["setup()"]);
 
         // All attr_* should be owned by Foo, not by setup
-        assert_members_eq!(
-            context,
-            "Foo",
-            vec!["accessor_attr()", "reader_attr()", "writer_attr()"]
-        );
+        assert_members_eq!(context, "Foo", ["accessor_attr()", "reader_attr()", "writer_attr()"]);
     }
 
     #[test]
@@ -3978,7 +3975,7 @@ mod tests {
 
         assert_no_diagnostics!(&context);
 
-        assert_members_eq!(context, "Foo", vec!["CONST"]);
+        assert_members_eq!(context, "Foo", ["CONST"]);
         assert_no_members!(context, "Bar");
     }
 
@@ -3998,7 +3995,7 @@ mod tests {
         assert_no_diagnostics!(&context);
 
         // Both entries exist as unique members
-        assert_members_eq!(context, "Foo", vec!["Array", "Array()"]);
+        assert_members_eq!(context, "Foo", ["Array", "Array()"]);
 
         // Both declarations exist with unique IDs
         assert!(
@@ -4114,6 +4111,6 @@ mod tests {
         assert_ancestors_eq!(context, "Bar::Foo", &["Bar::Foo"]);
 
         assert_no_members!(context, "Foo");
-        assert_members_eq!(context, "Bar::Foo", vec!["FOO"]);
+        assert_members_eq!(context, "Bar::Foo", ["FOO"]);
     }
 }

--- a/rust/rubydex/src/test_utils/graph_test.rs
+++ b/rust/rubydex/src/test_utils/graph_test.rs
@@ -409,7 +409,7 @@ macro_rules! assert_members_eq {
 
         actual_members.sort();
 
-        assert_eq!($expected_members, actual_members);
+        assert_eq!($expected_members, actual_members.as_slice());
     };
 }
 
@@ -417,7 +417,7 @@ macro_rules! assert_members_eq {
 #[macro_export]
 macro_rules! assert_no_members {
     ($context:expr, $declaration_id:expr) => {
-        assert_members_eq!($context, $declaration_id, vec![] as Vec<&str>);
+        assert_members_eq!($context, $declaration_id, [] as [&str; 0]);
     };
 }
 
@@ -485,7 +485,7 @@ macro_rules! assert_instance_variables_eq {
 
         actual_instance_variables.sort();
 
-        assert_eq!($expected_instance_variables, actual_instance_variables);
+        assert_eq!($expected_instance_variables, actual_instance_variables.as_slice());
     };
 }
 
@@ -493,7 +493,7 @@ macro_rules! assert_instance_variables_eq {
 #[macro_export]
 macro_rules! assert_diagnostics_eq {
     ($context:expr, $expected_diagnostics:expr) => {{
-        assert_eq!($expected_diagnostics, $context.format_diagnostics(&[]));
+        assert_eq!($expected_diagnostics, $context.format_diagnostics(&[]).as_slice());
     }};
     ($context:expr, $expected_diagnostics:expr, $ignore_rules:expr) => {{
         assert_eq!($expected_diagnostics, $context.format_diagnostics($ignore_rules));


### PR DESCRIPTION
In many cases we can make the tests slightly easier to read/write and remove unneeded `vec!` macros.