### PR TITLE
Add require path resolution for go-to-definition

### DIFF
--- a/rust/rubydex/src/query.rs
+++ b/rust/rubydex/src/query.rs
@@ -1,7 +1,9 @@
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread;
 
 use crate::model::graph::Graph;
-use crate::model::ids::DeclarationId;
+use crate::model::ids::{DeclarationId, UriId};
 
 /// # Panics
 ///
@@ -59,8 +61,55 @@ fn match_score(query: &str, target: &str) -> usize {
     if query_chars.peek().is_some() { 0 } else { score }
 }
 
+/// Resolves a require path to its URI ID. Used for go-to-definition.
+///
+/// # Panics
+///
+/// Panics if one of the search threads panics
+#[must_use]
+pub fn resolve_require_path(graph: &Graph, require_path: &str, load_paths: &[PathBuf]) -> Option<UriId> {
+    let found = AtomicBool::new(false);
+    let found_ref = &found;
+    let normalized = require_path.trim_end_matches(".rb");
+    let num_threads = thread::available_parallelism().map(std::num::NonZero::get).unwrap_or(4);
+    let documents = graph.documents().iter().collect::<Vec<_>>();
+    let chunk_size = documents.len().div_ceil(num_threads);
+
+    if chunk_size == 0 {
+        return None;
+    }
+
+    thread::scope(|scope| {
+        let handles: Vec<_> = documents
+            .chunks(chunk_size)
+            .map(|chunk| {
+                scope.spawn(move || {
+                    for (id, document) in chunk {
+                        // Check if another thread found it
+                        if found_ref.load(Ordering::Relaxed) {
+                            return None;
+                        }
+                        if let Some(computed) = document.require_path(load_paths)
+                            && computed == normalized
+                        {
+                            found_ref.store(true, Ordering::Relaxed);
+                            return Some(**id);
+                        }
+                    }
+                    None
+                })
+            })
+            .collect();
+
+        handles.into_iter().find_map(|handle| handle.join().unwrap())
+    })
+}
+
 #[cfg(test)]
 mod tests {
+    use std::str::FromStr;
+    use url::Url;
+
     use super::*;
     use crate::test_utils::GraphTest;
 
@@ -99,5 +148,41 @@ mod tests {
         });
         context.resolve();
         assert_results_eq!(context, "Fo", ["Foo"]);
+    }
+
+    #[test]
+    fn test_resolve_require_path() {
+        let root = if cfg!(windows) {
+            PathBuf::from_str("C:\\")
+        } else {
+            PathBuf::from_str("/")
+        }
+        .unwrap();
+
+        let path = root
+            .join("lib")
+            .join("foo")
+            .join("bar.rb")
+            .to_str()
+            .unwrap()
+            .to_string();
+        let uri = Url::from_file_path(path).unwrap().to_string();
+        let load_paths = [root.join("lib")];
+
+        let mut context = GraphTest::new();
+        context.index_uri(&uri, "class Bar; end");
+
+        // finds basic path
+        let uri_id = resolve_require_path(context.graph(), "foo/bar", &load_paths);
+        assert!(uri_id.is_some());
+        let doc = context.graph().documents().get(&uri_id.unwrap()).unwrap();
+        assert_eq!(uri, doc.uri());
+
+        // handles .rb suffix
+        let uri_id_with_rb = resolve_require_path(context.graph(), "foo/bar.rb", &load_paths);
+        assert_eq!(uri_id, uri_id_with_rb);
+
+        // returns None for nonexistent
+        assert!(resolve_require_path(context.graph(), "nonexistent", &load_paths).is_none());
     }
 }


### PR DESCRIPTION
This PR is a step towards https://github.com/Shopify/rubydex/issues/411 and adds the ability to resolve require paths (`"foo/bar"`) to their corresponding file URIs by matching against load paths.

This enables go-to-definition on require statements. When a user clicks on `require "foo/bar"`, we can now find which file that maps to.

  - `Document::require_path(load_paths)` - computes the require path for a document
  - `resolve_require_path(graph, path, load_paths)` - finds the URI ID for a given require path
