### PR TITLE
Add receiver to method references

### DIFF
--- a/rust/rubydex/src/model/references.rs
+++ b/rust/rubydex/src/model/references.rs
@@ -1,4 +1,5 @@
 use crate::{
+    assert_mem_size,
     model::ids::{NameId, ReferenceId, StringId, UriId},
     offset::Offset,
 };
@@ -13,6 +14,7 @@ pub struct ConstantReference {
     /// The offsets inside of the document where we found the reference
     offset: Offset,
 }
+assert_mem_size!(ConstantReference, 24);
 
 impl ConstantReference {
     #[must_use]
@@ -62,12 +64,20 @@ pub struct MethodRef {
     uri_id: UriId,
     /// The offsets inside of the document where we found the reference
     offset: Offset,
+    /// The receiver of the method call if it's a constant
+    receiver: Option<NameId>,
 }
+assert_mem_size!(MethodRef, 40);
 
 impl MethodRef {
     #[must_use]
-    pub fn new(str: StringId, uri_id: UriId, offset: Offset) -> Self {
-        Self { str, uri_id, offset }
+    pub fn new(str: StringId, uri_id: UriId, offset: Offset, receiver: Option<NameId>) -> Self {
+        Self {
+            str,
+            uri_id,
+            offset,
+            receiver,
+        }
     }
 
     #[must_use]
@@ -83,6 +93,11 @@ impl MethodRef {
     #[must_use]
     pub fn offset(&self) -> &Offset {
         &self.offset
+    }
+
+    #[must_use]
+    pub fn receiver(&self) -> Option<NameId> {
+        self.receiver
     }
 
     #[must_use]


### PR DESCRIPTION
To avoid exposing a mutable version of the graph to the Ruby API, we need to ensure that resolution will create the necessary singleton classes and linearize their ancestors.

As a way to achieve this, we can add a receiver to method references that we can resolve to correctly create the expected declarations.

In the future, I would expect method references to be collected during an inference loop since we have to check the type of the receiver. For the time being, we only support constant receivers that we can detect between indexing and resolving.

### Trade offs

This PR stack will eliminate the need to mutate the graph after resolution, but memory usage increases in Core by 1.5 GB.