### PR TITLE
Add memory size assertions

### DIFF
--- a/rust/rubydex/src/compile_assertions.rs
+++ b/rust/rubydex/src/compile_assertions.rs
@@ -1,0 +1,13 @@
+/// Asserts the memory size of a struct at compile time in bytes
+#[macro_export]
+macro_rules! assert_mem_size {
+    ($struct:ident, $size:expr) => {
+        // Check struct name on this assert! error
+        const _: () = assert!(
+            std::mem::size_of::<$struct>() == $size,
+            concat!("Incorrect size for `", stringify!($struct), "`")
+        );
+        // Check actual size on this array error
+        const _: [(); $size] = [(); std::mem::size_of::<$struct>()];
+    };
+}

--- a/rust/rubydex/src/lib.rs
+++ b/rust/rubydex/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod compile_assertions;
 pub mod diagnostic;
 pub mod errors;
 pub mod indexing;

--- a/rust/rubydex/src/model/declaration.rs
+++ b/rust/rubydex/src/model/declaration.rs
@@ -1,3 +1,4 @@
+use crate::assert_mem_size;
 use crate::diagnostic::Diagnostic;
 use crate::model::{
     identity_maps::{IdentityHashMap, IdentityHashSet},
@@ -23,6 +24,7 @@ pub enum Ancestors {
     /// A partial linearization of ancestors with some parts unresolved. This chain state always triggers retries
     Partial(Vec<Ancestor>),
 }
+assert_mem_size!(Ancestors, 32);
 
 impl Ancestors {
     pub fn iter(&self) -> std::slice::Iter<'_, Ancestor> {
@@ -248,6 +250,7 @@ pub enum Declaration {
     InstanceVariable(Box<InstanceVariableDeclaration>),
     ClassVariable(Box<ClassVariableDeclaration>),
 }
+assert_mem_size!(Declaration, 16);
 
 impl Declaration {
     #[must_use]
@@ -373,6 +376,7 @@ pub enum Namespace {
     SingletonClass(Box<SingletonClassDeclaration>),
     Module(Box<ModuleDeclaration>),
 }
+assert_mem_size!(Namespace, 16);
 
 impl Namespace {
     #[must_use]
@@ -471,14 +475,24 @@ impl Namespace {
 }
 
 namespace_declaration!(Class, ClassDeclaration);
+assert_mem_size!(ClassDeclaration, 224);
 namespace_declaration!(Module, ModuleDeclaration);
+assert_mem_size!(ModuleDeclaration, 224);
 namespace_declaration!(SingletonClass, SingletonClassDeclaration);
+assert_mem_size!(SingletonClassDeclaration, 224);
+
 simple_declaration!(ConstantDeclaration);
+assert_mem_size!(ConstantDeclaration, 112);
 simple_declaration!(MethodDeclaration);
+assert_mem_size!(MethodDeclaration, 112);
 simple_declaration!(GlobalVariableDeclaration);
+assert_mem_size!(GlobalVariableDeclaration, 112);
 simple_declaration!(InstanceVariableDeclaration);
+assert_mem_size!(InstanceVariableDeclaration, 112);
 simple_declaration!(ClassVariableDeclaration);
+assert_mem_size!(ClassVariableDeclaration, 112);
 simple_declaration!(ConstantAliasDeclaration);
+assert_mem_size!(ConstantAliasDeclaration, 112);
 
 #[cfg(test)]
 mod tests {

--- a/rust/rubydex/src/model/definitions.rs
+++ b/rust/rubydex/src/model/definitions.rs
@@ -26,10 +26,10 @@
 use bitflags::bitflags;
 
 use crate::{
+    assert_mem_size,
     model::{
         comment::Comment,
-        ids::ReferenceId,
-        ids::{DefinitionId, NameId, StringId, UriId},
+        ids::{DefinitionId, NameId, ReferenceId, StringId, UriId},
         visibility::Visibility,
     },
     offset::Offset,
@@ -66,6 +66,7 @@ pub enum Definition {
     MethodAlias(Box<MethodAliasDefinition>),
     GlobalVariableAlias(Box<GlobalVariableAliasDefinition>),
 }
+assert_mem_size!(Definition, 16);
 
 macro_rules! all_definitions {
     ($value:expr, $var:ident => $expr:expr) => {
@@ -228,6 +229,7 @@ pub struct ClassDefinition {
     superclass_ref: Option<ReferenceId>,
     mixins: Vec<Mixin>,
 }
+assert_mem_size!(ClassDefinition, 144);
 
 impl ClassDefinition {
     #[must_use]
@@ -352,6 +354,7 @@ pub struct SingletonClassDefinition {
     /// Mixins declared in this singleton class
     mixins: Vec<Mixin>,
 }
+assert_mem_size!(SingletonClassDefinition, 128);
 
 impl SingletonClassDefinition {
     #[must_use]
@@ -455,6 +458,7 @@ pub struct ModuleDefinition {
     members: Vec<DefinitionId>,
     mixins: Vec<Mixin>,
 }
+assert_mem_size!(ModuleDefinition, 128);
 
 impl ModuleDefinition {
     #[must_use]
@@ -554,6 +558,7 @@ pub struct ConstantDefinition {
     comments: Vec<Comment>,
     lexical_nesting_id: Option<DefinitionId>,
 }
+assert_mem_size!(ConstantDefinition, 72);
 
 impl ConstantDefinition {
     #[must_use]
@@ -623,6 +628,7 @@ pub struct ConstantAliasDefinition {
     alias_constant: ConstantDefinition,
     target_name_id: NameId,
 }
+assert_mem_size!(ConstantAliasDefinition, 80);
 
 impl ConstantAliasDefinition {
     #[must_use]
@@ -699,6 +705,7 @@ pub struct MethodDefinition {
     visibility: Visibility,
     receiver: Option<NameId>,
 }
+assert_mem_size!(MethodDefinition, 112);
 
 impl MethodDefinition {
     #[allow(clippy::too_many_arguments)]
@@ -796,12 +803,14 @@ pub enum Parameter {
     Forward(ParameterStruct),
     Block(ParameterStruct),
 }
+assert_mem_size!(Parameter, 24);
 
 #[derive(Debug, Clone)]
 pub struct ParameterStruct {
     offset: Offset,
     str: StringId,
 }
+assert_mem_size!(ParameterStruct, 16);
 
 impl ParameterStruct {
     #[must_use]
@@ -836,6 +845,7 @@ pub struct AttrAccessorDefinition {
     lexical_nesting_id: Option<DefinitionId>,
     visibility: Visibility,
 }
+assert_mem_size!(AttrAccessorDefinition, 72);
 
 impl AttrAccessorDefinition {
     #[must_use]
@@ -916,6 +926,7 @@ pub struct AttrReaderDefinition {
     lexical_nesting_id: Option<DefinitionId>,
     visibility: Visibility,
 }
+assert_mem_size!(AttrReaderDefinition, 72);
 
 impl AttrReaderDefinition {
     #[must_use]
@@ -996,6 +1007,7 @@ pub struct AttrWriterDefinition {
     lexical_nesting_id: Option<DefinitionId>,
     visibility: Visibility,
 }
+assert_mem_size!(AttrWriterDefinition, 72);
 
 impl AttrWriterDefinition {
     #[must_use]
@@ -1075,6 +1087,7 @@ pub struct GlobalVariableDefinition {
     comments: Vec<Comment>,
     lexical_nesting_id: Option<DefinitionId>,
 }
+assert_mem_size!(GlobalVariableDefinition, 72);
 
 impl GlobalVariableDefinition {
     #[must_use]
@@ -1147,6 +1160,7 @@ pub struct InstanceVariableDefinition {
     comments: Vec<Comment>,
     lexical_nesting_id: Option<DefinitionId>,
 }
+assert_mem_size!(InstanceVariableDefinition, 72);
 
 impl InstanceVariableDefinition {
     #[must_use]
@@ -1219,6 +1233,7 @@ pub struct ClassVariableDefinition {
     comments: Vec<Comment>,
     lexical_nesting_id: Option<DefinitionId>,
 }
+assert_mem_size!(ClassVariableDefinition, 72);
 
 impl ClassVariableDefinition {
     #[must_use]
@@ -1286,6 +1301,7 @@ pub struct MethodAliasDefinition {
     comments: Vec<Comment>,
     lexical_nesting_id: Option<DefinitionId>,
 }
+assert_mem_size!(MethodAliasDefinition, 80);
 
 impl MethodAliasDefinition {
     #[must_use]
@@ -1366,6 +1382,7 @@ pub struct GlobalVariableAliasDefinition {
     comments: Vec<Comment>,
     lexical_nesting_id: Option<DefinitionId>,
 }
+assert_mem_size!(GlobalVariableAliasDefinition, 80);
 
 impl GlobalVariableAliasDefinition {
     #[must_use]

--- a/rust/rubydex/src/model/ids.rs
+++ b/rust/rubydex/src/model/ids.rs
@@ -1,4 +1,4 @@
-use crate::model::id::Id;
+use crate::{assert_mem_size, model::id::Id};
 
 #[derive(PartialEq, Eq, Debug, Clone, Copy)]
 pub struct DeclarationMarker;
@@ -9,24 +9,29 @@ pub type DeclarationId = Id<DeclarationMarker>;
 pub struct DefinitionMarker;
 // DefinitionId represents the ID of a definition found in a specific file
 pub type DefinitionId = Id<DefinitionMarker>;
+assert_mem_size!(DefinitionId, 8);
 
 #[derive(PartialEq, Eq, Debug, Clone, Copy)]
 pub struct UriMarker;
 // UriId represents the ID of a URI, which is the unique identifier for a document
 pub type UriId = Id<UriMarker>;
+assert_mem_size!(UriId, 8);
 
 #[derive(PartialEq, Eq, Debug, Clone, Copy)]
 pub struct StringMarker;
 /// `StringId` represents an ID for an interned string value
 pub type StringId = Id<StringMarker>;
+assert_mem_size!(StringId, 8);
 
 #[derive(PartialEq, Eq, Debug, Clone, Copy)]
 pub struct ReferenceMarker;
 /// `ReferenceId` represents the ID of a reference occurrence in a file.
 /// It is built from the reference kind, `uri_id` and the reference `offset`.
 pub type ReferenceId = Id<ReferenceMarker>;
+assert_mem_size!(ReferenceId, 8);
 
 #[derive(PartialEq, Eq, Debug, Clone, Copy)]
 pub struct NameMarker;
 /// `NameId` represents an ID for any constant name that we find as part of a reference or definition
 pub type NameId = Id<NameMarker>;
+assert_mem_size!(NameId, 8);

--- a/rust/rubydex/src/model/name.rs
+++ b/rust/rubydex/src/model/name.rs
@@ -1,6 +1,9 @@
 use std::fmt::Display;
 
-use crate::model::ids::{DeclarationId, NameId, StringId};
+use crate::{
+    assert_mem_size,
+    model::ids::{DeclarationId, NameId, StringId},
+};
 
 #[derive(Debug, Clone, Copy)]
 pub enum ParentScope {
@@ -11,6 +14,7 @@ pub enum ParentScope {
     /// There's a parent scope in this reference (e.g.: `Foo::Bar`)
     Some(NameId),
 }
+assert_mem_size!(ParentScope, 16);
 
 impl ParentScope {
     pub fn map_or<F, T>(&self, default: T, f: F) -> T
@@ -80,6 +84,7 @@ pub struct Name {
     nesting: Option<NameId>,
     ref_count: usize,
 }
+assert_mem_size!(Name, 48);
 
 impl Name {
     #[must_use]


### PR DESCRIPTION
As we continue to develop and grow Rubydex, it'll be important to get a clearer picture of which critical structs are consuming a lot of memory. This PR proposes a way to do memory size assertions, so that we can keep track (I only used the assertion in a few places, but we can assert more after this is accepted).

### Alternatives

I picked compile-time assertions because it allows us to make the assertion immediately after the struct definition. I find this nice because you normally want to know the byte size when making a decision about adding more fields.

The alternative is to simply add a test verifying the memory size like this:

```rust
#[test]
fn memsize() {
  assert_eq!(16, std::mem::size_of<ParentScope>);
}
```

The disadvantage is that memory size assertions are not next to their struct definitions. The advantages is that this is not happening at compile time and thus we escape the limitations below.

### Limitations

Because these are compile time assertions, we're very limited in what we can do and how the error is presented. `assert_eq!` is not a constant function and so we can't use it, which means the error messages are a little worse.

I used a couple of tricks to display the name of the structure that failed the assertion (using stringify) and the size (using a fake array that's supposed to match the expected size).

In addition to these, the error diagnostic appears at the macro definition and not its usage, which is also a bit sub-optimal, although you can quickly see the expected in the problems tab or by going to definition on the macro.