### PR TITLE
Specify target CPU for sanitizers

### DIFF
--- a/ext/rubydex/extconf.rb
+++ b/ext/rubydex/extconf.rb
@@ -56,7 +56,7 @@ end
 create_makefile("rubydex/rubydex")
 
 cargo_command = if ENV["SANITIZER"]
-  ENV["RUSTFLAGS"] = "-Zsanitizer=#{ENV["SANITIZER"]}"
+  ENV["RUSTFLAGS"] = "-Zsanitizer=#{ENV["SANITIZER"]} -C target-cpu=x86-64-v3"
   "cargo +nightly build -Zbuild-std #{cargo_args.join(" ")}".strip
 else
   "cargo build #{cargo_args.join(" ")}".strip


### PR DESCRIPTION
Based on my investigation, the flaky memleak checks could be due to a specific Ubuntu architecture that we sometimes get on CI, which includes instructions that Valgrind doesn't support yet.

Specifying the target CPU _should_ stop it from failing even when running on these workers.