### PR TITLE
Expose Declaration#descendants to Ruby API

### DIFF
--- a/rust/rubydex-sys/src/declaration_api.rs
+++ b/rust/rubydex-sys/src/declaration_api.rs
@@ -311,3 +311,31 @@ pub unsafe extern "C" fn rdx_declaration_ancestors(pointer: GraphPointer, decl_i
 
     Box::into_raw(Box::new(DeclarationsIter::new(declarations.into_boxed_slice())))
 }
+
+/// Returns an iterator over the descendant declarations of a given declaration
+///
+/// # Safety
+///
+/// Assumes that the graph and member pointers are valid
+///
+/// # Panics
+///
+/// Will panic if there's inconsistent graph data
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rdx_declaration_descendants(pointer: GraphPointer, decl_id: u32) -> *mut DeclarationsIter {
+    let declarations = with_graph(pointer, |graph| {
+        let declaration_id = DeclarationId::new(decl_id);
+
+        let Some(Declaration::Namespace(declaration)) = graph.declarations().get(&declaration_id) else {
+            return Vec::new();
+        };
+
+        declaration
+            .descendants()
+            .iter()
+            .map(|id| CDeclaration::from_declaration(*id, graph.declarations().get(id).unwrap()))
+            .collect::<Vec<_>>()
+    });
+
+    Box::into_raw(Box::new(DeclarationsIter::new(declarations.into_boxed_slice())))
+}

--- a/rust/rubydex/src/model/declaration.rs
+++ b/rust/rubydex/src/model/declaration.rs
@@ -431,6 +431,11 @@ impl Namespace {
         all_namespaces!(self, it => it.has_complete_ancestors())
     }
 
+    #[must_use]
+    pub fn descendants(&self) -> &IdentityHashSet<DeclarationId> {
+        all_namespaces!(self, it => it.descendants())
+    }
+
     pub fn add_descendant(&mut self, descendant_id: DeclarationId) {
         all_namespaces!(self, it => it.add_descendant(descendant_id));
     }

--- a/test/declaration_test.rb
+++ b/test/declaration_test.rb
@@ -228,6 +228,29 @@ class DeclarationTest < Minitest::Test
     end
   end
 
+  def test_descendants
+    with_context do |context|
+      context.write!("file1.rb", <<~RUBY)
+        module Foo; end
+        module Bar; end
+
+        class Parent; end
+        class Child < Parent
+          include Foo
+          prepend Bar
+        end
+      RUBY
+
+      graph = Rubydex::Graph.new
+      graph.index_all(context.glob("**/*.rb"))
+      graph.resolve
+
+      assert_equal(["Child", "Parent"], graph["Parent"].descendants.map(&:name))
+      assert_equal(["Child", "Foo"], graph["Foo"].descendants.map(&:name))
+      assert_equal(["Child", "Bar"], graph["Bar"].descendants.map(&:name))
+    end
+  end
+
   def test_ancestors
     with_context do |context|
       context.write!("file1.rb", <<~RUBY)


### PR DESCRIPTION
Expose the descendants information to the Ruby API, which will allow the Ruby LSP to finally implement the sub-types feature.