### PR TITLE
Expose Declaration#owner to Ruby API

### DIFF
--- a/ext/rubydex/declaration.c
+++ b/ext/rubydex/declaration.c
@@ -152,6 +152,26 @@ static VALUE rdxr_declaration_singleton_class(VALUE self) {
     return rb_class_new_instance(2, argv, cDeclaration);
 }
 
+// Declaration#owner -> Declaration
+static VALUE rdxr_declaration_owner(VALUE self) {
+    HandleData *data;
+    TypedData_Get_Struct(self, HandleData, &handle_type, data);
+
+    void *graph;
+    TypedData_Get_Struct(data->graph_obj, void *, &graph_type, graph);
+    const uint32_t *owner_id = rdx_declaration_owner(graph, data->id);
+
+    if (owner_id == NULL) {
+        rb_raise(rb_eRuntimeError, "owner can never be nil for any declarations");
+    }
+
+    uint32_t id = *owner_id;
+    free_u32(owner_id);
+    VALUE argv[] = {data->graph_obj, UINT2NUM(id)};
+
+    return rb_class_new_instance(2, argv, cDeclaration);
+}
+
 void rdxi_initialize_declaration(VALUE mRubydex) {
     cDeclaration = rb_define_class_under(mRubydex, "Declaration", rb_cObject);
 
@@ -162,6 +182,7 @@ void rdxi_initialize_declaration(VALUE mRubydex) {
     rb_define_method(cDeclaration, "definitions", rdxr_declaration_definitions, 0);
     rb_define_method(cDeclaration, "member", rdxr_declaration_member, 1);
     rb_define_method(cDeclaration, "singleton_class", rdxr_declaration_singleton_class, 0);
+    rb_define_method(cDeclaration, "owner", rdxr_declaration_owner, 0);
 
     rb_funcall(rb_singleton_class(cDeclaration), rb_intern("private"), 1, ID2SYM(rb_intern("new")));
 }

--- a/rust/rubydex-sys/src/declaration_api.rs
+++ b/rust/rubydex-sys/src/declaration_api.rs
@@ -135,3 +135,20 @@ pub unsafe extern "C" fn rdx_declaration_singleton_class(pointer: GraphPointer, 
         }
     })
 }
+
+/// Returns the owner of the declaration (attached object in the case of singleton classes)
+///
+/// # Safety
+///
+/// Assumes pointer is valid
+///
+/// # Panics
+///
+/// Will panic if invoked on a non-existing or non-namespace declaration
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rdx_declaration_owner(pointer: GraphPointer, decl_id: u32) -> *const u32 {
+    with_graph(pointer, |graph| {
+        let declaration = graph.declarations().get(&DeclarationId::new(decl_id)).unwrap();
+        Box::into_raw(Box::new(**declaration.owner_id())).cast_const()
+    })
+}

--- a/test/declaration_test.rb
+++ b/test/declaration_test.rb
@@ -129,4 +129,27 @@ class DeclarationTest < Minitest::Test
       assert_equal("Foo::Bar::<Bar>", bar.singleton_class.name)
     end
   end
+
+  def test_declaration_owner
+    with_context do |context|
+      context.write!("file1.rb", <<~RUBY)
+        module Foo
+          class Bar
+            class << self
+              def something; end
+            end
+          end
+        end
+      RUBY
+
+      graph = Rubydex::Graph.new
+      graph.index_all(context.glob("**/*.rb"))
+      graph.resolve
+
+      assert_equal("Object", graph["Foo"].owner.name)
+      assert_equal("Foo", graph["Foo::Bar"].owner.name)
+      assert_equal("Foo::Bar", graph["Foo::Bar::<Bar>"].owner.name)
+      assert_equal("Foo::Bar::<Bar>", graph["Foo::Bar::<Bar>#something()"].owner.name)
+    end
+  end
 end


### PR DESCRIPTION
Similar to exposing a declaration's singleton class, consumers of the API should be able to read the owner.

Just a note: for all declarations, owner means what namespace owns that declaration, except for singleton classes where owner means the attached object. There's no implementation difference or multiple code paths. It's just a conceptual difference where the same field represents slightly different things to avoid extra memory cost.