### PR TITLE
Specialize declaration classes

### DIFF
--- a/ext/rubydex/declaration.h
+++ b/ext/rubydex/declaration.h
@@ -2,9 +2,21 @@
 #define RUBYDEX_DECLARATION_H
 
 #include "ruby.h"
+#include "rustbindings.h"
 
 extern VALUE cDeclaration;
+extern VALUE cNamespace;
+extern VALUE cClass;
+extern VALUE cModule;
+extern VALUE cSingletonClass;
+extern VALUE cConstant;
+extern VALUE cConstantAlias;
+extern VALUE cMethod;
+extern VALUE cGlobalVariable;
+extern VALUE cInstanceVariable;
+extern VALUE cClassVariable;
 
+VALUE rdxi_declaration_class_for_kind(CDeclarationKind kind);
 void rdxi_initialize_declaration(VALUE mRubydex);
 
 #endif // RUBYDEX_DECLARATION_H

--- a/rust/rubydex-sys/src/declaration_api.rs
+++ b/rust/rubydex-sys/src/declaration_api.rs
@@ -1,7 +1,7 @@
 //! This file provides the C API for the Graph object
 
 use libc::c_char;
-use rubydex::model::declaration::Declaration;
+use rubydex::model::declaration::{Declaration, Namespace};
 use std::ffi::CString;
 use std::ptr;
 
@@ -9,6 +9,57 @@ use crate::definition_api::{DefinitionKind, DefinitionsIter, rdx_definitions_ite
 use crate::graph_api::{GraphPointer, with_graph};
 use crate::utils;
 use rubydex::model::ids::{DeclarationId, StringId};
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub enum CDeclarationKind {
+    Class = 0,
+    Module = 1,
+    SingletonClass = 2,
+    Constant = 3,
+    ConstantAlias = 4,
+    Method = 5,
+    GlobalVariable = 6,
+    InstanceVariable = 7,
+    ClassVariable = 8,
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct CDeclaration {
+    id: u32,
+    kind: CDeclarationKind,
+}
+
+impl CDeclaration {
+    #[must_use]
+    pub fn id(&self) -> u32 {
+        self.id
+    }
+
+    #[must_use]
+    pub fn from_declaration(id: DeclarationId, decl: &Declaration) -> Self {
+        Self {
+            id: *id,
+            kind: Self::kind_from_declaration(decl),
+        }
+    }
+
+    #[must_use]
+    pub fn kind_from_declaration(decl: &Declaration) -> CDeclarationKind {
+        match decl {
+            Declaration::Namespace(Namespace::Class(_)) => CDeclarationKind::Class,
+            Declaration::Namespace(Namespace::Module(_)) => CDeclarationKind::Module,
+            Declaration::Namespace(Namespace::SingletonClass(_)) => CDeclarationKind::SingletonClass,
+            Declaration::Constant(_) => CDeclarationKind::Constant,
+            Declaration::ConstantAlias(_) => CDeclarationKind::ConstantAlias,
+            Declaration::Method(_) => CDeclarationKind::Method,
+            Declaration::GlobalVariable(_) => CDeclarationKind::GlobalVariable,
+            Declaration::InstanceVariable(_) => CDeclarationKind::InstanceVariable,
+            Declaration::ClassVariable(_) => CDeclarationKind::ClassVariable,
+        }
+    }
+}
 
 /// Returns the UTF-8 name string for a declaration id.
 /// Caller must free with `free_c_string`.
@@ -37,12 +88,16 @@ pub unsafe extern "C" fn rdx_declaration_name(pointer: GraphPointer, name_id: u3
 ///
 /// # Safety
 /// - `member` must be a valid, null-terminated UTF-8 string
+///
+/// # Panics
+///
+/// Will panic if there's inconsistent graph data
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rdx_declaration_member(
     pointer: GraphPointer,
     name_id: u32,
     member: *const c_char,
-) -> *const u32 {
+) -> *const CDeclaration {
     let Ok(member_str) = (unsafe { utils::convert_char_ptr_to_string(member) }) else {
         return ptr::null();
     };
@@ -53,7 +108,9 @@ pub unsafe extern "C" fn rdx_declaration_member(
             let member_id = StringId::from(member_str.as_str());
 
             if let Some(member_decl_id) = decl.member(&member_id) {
-                return Box::into_raw(Box::new(**member_decl_id)).cast_const();
+                let member_decl = graph.declarations().get(member_decl_id).unwrap();
+                return Box::into_raw(Box::new(CDeclaration::from_declaration(*member_decl_id, member_decl)))
+                    .cast_const();
             }
         }
 
@@ -119,7 +176,7 @@ pub unsafe extern "C" fn rdx_declaration_definitions_iter_new(
 ///
 /// Will panic if invoked on a non-existing or non-namespace declaration
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn rdx_declaration_singleton_class(pointer: GraphPointer, decl_id: u32) -> *const u32 {
+pub unsafe extern "C" fn rdx_declaration_singleton_class(pointer: GraphPointer, decl_id: u32) -> *const CDeclaration {
     with_graph(pointer, |graph| {
         let declaration = graph
             .declarations()
@@ -129,7 +186,10 @@ pub unsafe extern "C" fn rdx_declaration_singleton_class(pointer: GraphPointer, 
             .unwrap();
 
         if let Some(singleton_id) = declaration.singleton_class() {
-            Box::into_raw(Box::new(**singleton_id)).cast_const()
+            Box::into_raw(Box::new(CDeclaration::from_declaration(
+                *singleton_id,
+                graph.declarations().get(singleton_id).unwrap(),
+            )))
         } else {
             ptr::null()
         }
@@ -146,9 +206,31 @@ pub unsafe extern "C" fn rdx_declaration_singleton_class(pointer: GraphPointer, 
 ///
 /// Will panic if invoked on a non-existing or non-namespace declaration
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn rdx_declaration_owner(pointer: GraphPointer, decl_id: u32) -> *const u32 {
+pub unsafe extern "C" fn rdx_declaration_owner(pointer: GraphPointer, decl_id: u32) -> *const CDeclaration {
     with_graph(pointer, |graph| {
         let declaration = graph.declarations().get(&DeclarationId::new(decl_id)).unwrap();
-        Box::into_raw(Box::new(**declaration.owner_id())).cast_const()
+        let owner_id = *declaration.owner_id();
+        Box::into_raw(Box::new(CDeclaration::from_declaration(
+            owner_id,
+            graph.declarations().get(&owner_id).unwrap(),
+        )))
+        .cast_const()
     })
+}
+
+/// Frees a `CDeclaration` allocated on the Rust side
+///
+/// # Safety
+///
+/// - `ptr` must be a valid pointer previously returned by a function returning `*const CDeclaration`
+/// - `ptr` must not be used after being freed
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn free_c_declaration(ptr: *const CDeclaration) {
+    if ptr.is_null() {
+        return;
+    }
+
+    unsafe {
+        let _ = Box::from_raw(ptr.cast_mut());
+    }
 }

--- a/test/declaration_test.rb
+++ b/test/declaration_test.rb
@@ -23,7 +23,8 @@ class DeclarationTest < Minitest::Test
       graph.resolve
 
       declaration = graph["A"]
-      assert_instance_of(Rubydex::Declaration, declaration)
+      assert_instance_of(Rubydex::Class, declaration)
+      assert_kind_of(Rubydex::Namespace, declaration)
       assert_equal("A", declaration.name)
     end
   end
@@ -41,10 +42,10 @@ class DeclarationTest < Minitest::Test
       graph.resolve
 
       declaration = graph["A"]
-      assert_instance_of(Rubydex::Declaration, declaration)
+      assert_instance_of(Rubydex::Class, declaration)
 
       member_declaration = declaration.member("foo()")
-      assert_instance_of(Rubydex::Declaration, member_declaration)
+      assert_instance_of(Rubydex::Method, member_declaration)
       assert_equal("A#foo()", member_declaration.name)
     end
   end
@@ -150,6 +151,80 @@ class DeclarationTest < Minitest::Test
       assert_equal("Foo", graph["Foo::Bar"].owner.name)
       assert_equal("Foo::Bar", graph["Foo::Bar::<Bar>"].owner.name)
       assert_equal("Foo::Bar::<Bar>", graph["Foo::Bar::<Bar>#something()"].owner.name)
+    end
+  end
+
+  def test_declaration_kinds_return_specialized_classes
+    with_context do |context|
+      context.write!("file1.rb", <<~RUBY)
+        module Foo; end
+        class Bar
+          @@my_class_var = 1
+
+          def initialize
+            @my_instance_var = 1
+          end
+
+          class << self
+            def singleton_method; end
+          end
+
+          def instance_method; end
+        end
+
+        MY_CONSTANT = 1
+        MyAlias = Bar
+        $my_global = 1
+      RUBY
+
+      graph = Rubydex::Graph.new
+      graph.index_all(context.glob("**/*.rb"))
+      graph.resolve
+
+      # Module
+      assert_instance_of(Rubydex::Module, graph["Foo"])
+      assert_kind_of(Rubydex::Namespace, graph["Foo"])
+
+      # Class
+      assert_instance_of(Rubydex::Class, graph["Bar"])
+      assert_kind_of(Rubydex::Namespace, graph["Bar"])
+
+      # SingletonClass
+      assert_instance_of(Rubydex::SingletonClass, graph["Bar::<Bar>"])
+      assert_kind_of(Rubydex::Namespace, graph["Bar::<Bar>"])
+
+      # Method
+      assert_instance_of(Rubydex::Method, graph["Bar#instance_method()"])
+
+      # Constant
+      assert_instance_of(Rubydex::Constant, graph["MY_CONSTANT"])
+
+      # ConstantAlias
+      assert_instance_of(Rubydex::ConstantAlias, graph["MyAlias"])
+
+      # GlobalVariable
+      assert_instance_of(Rubydex::GlobalVariable, graph["$my_global"])
+
+      # InstanceVariable
+      assert_instance_of(Rubydex::InstanceVariable, graph["Bar\#@my_instance_var"])
+
+      # ClassVariable
+      assert_instance_of(Rubydex::ClassVariable, graph["Bar\#@@my_class_var"])
+
+      # All should be Declarations
+      [
+        graph["Foo"],
+        graph["Bar"],
+        graph["Bar::<Bar>"],
+        graph["Bar#instance_method()"],
+        graph["MY_CONSTANT"],
+        graph["MyAlias"],
+        graph["$my_global"],
+        graph["Bar\#@my_instance_var"],
+        graph["Bar\#@@my_class_var"],
+      ].each do |decl|
+        assert_kind_of(Rubydex::Declaration, decl, "Expected #{decl.name} to be a Declaration")
+      end
     end
   end
 end


### PR DESCRIPTION
Currently, we only have one `Declaration` Ruby class that we return for any type of declaration. This is not ideal as consumers of the API will certainly want to know what type of thing is being returned.

This PR specializes the declaration class with some sub-classes. I matched exactly the structure we have in Rust with:

```ruby
class Declaration; end
class Namespace < Declaration; end
class Class < Namespace;
class Module < Namespace; end
class SingletonClass < Namespace; end
class Constant  < Declaration; end

# and so on
```