### PR TITLE
Expose require path resolution to Ruby API

### DIFF
--- a/test/graph_test.rb
+++ b/test/graph_test.rb
@@ -368,6 +368,21 @@ class GraphTest < Minitest::Test
     end
   end
 
+  def test_resolve_require_path
+    with_context do |context|
+      context.write!("lib/foo/bar.rb", "class Bar; end")
+
+      graph = Rubydex::Graph.new
+      graph.index_all(context.glob("**/*.rb"))
+
+      load_paths = [context.absolute_path_to("lib")]
+      document = graph.resolve_require_path("foo/bar", load_paths)
+
+      assert_instance_of(Rubydex::Document, document)
+      assert(document.uri.end_with?("lib/foo/bar.rb"))
+    end
+  end
+
   private
 
   def assert_diagnostics(expected, actual)


### PR DESCRIPTION
Follow-up to #528, and a step towards #411. 

This PR adds FFI and C bindings to expose `resolve_require_path` to Ruby, returning a `Document` that can be used directly for go-to-definition on require statements.