### PR TITLE
Incremental infrastructure

### DIFF
--- a/ext/rubydex/index_result.c
+++ b/ext/rubydex/index_result.c
@@ -1,0 +1,33 @@
+#include "index_result.h"
+#include "rustbindings.h"
+
+VALUE cIndexResult;
+
+static void index_result_free(void *ptr) {
+    if (ptr) {
+        rdx_index_result_free(ptr);
+    }
+}
+
+const rb_data_type_t index_result_type = {"IndexResult", {0, index_result_free, 0}, 0, 0, RUBY_TYPED_FREE_IMMEDIATELY};
+
+// IndexResult#definition_ids_length -> Integer
+static VALUE rdxr_index_result_definition_ids_length(VALUE self) {
+    void *index_result;
+    TypedData_Get_Struct(self, void *, &index_result_type, index_result);
+    return SIZET2NUM(rdx_index_result_definition_ids_len(index_result));
+}
+
+// IndexResult#reference_ids_length -> Integer
+static VALUE rdxr_index_result_reference_ids_length(VALUE self) {
+    void *index_result;
+    TypedData_Get_Struct(self, void *, &index_result_type, index_result);
+    return SIZET2NUM(rdx_index_result_reference_ids_len(index_result));
+}
+
+void rdxi_initialize_index_result(VALUE mRubydex) {
+    cIndexResult = rb_define_class_under(mRubydex, "IndexResult", rb_cObject);
+    rb_undef_alloc_func(cIndexResult);
+    rb_define_method(cIndexResult, "definition_ids_length", rdxr_index_result_definition_ids_length, 0);
+    rb_define_method(cIndexResult, "reference_ids_length", rdxr_index_result_reference_ids_length, 0);
+}

--- a/ext/rubydex/index_result.h
+++ b/ext/rubydex/index_result.h
@@ -1,0 +1,13 @@
+#ifndef INDEX_RESULT_H
+#define INDEX_RESULT_H
+
+#include "ruby.h"
+
+typedef void *IndexResultPointer;
+
+extern VALUE cIndexResult;
+extern const rb_data_type_t index_result_type;
+
+void rdxi_initialize_index_result(VALUE mRubydex);
+
+#endif

--- a/ext/rubydex/rubydex.c
+++ b/ext/rubydex/rubydex.c
@@ -5,6 +5,7 @@
 #include "graph.h"
 #include "location.h"
 #include "reference.h"
+#include "index_result.h"
 
 VALUE mRubydex;
 
@@ -12,6 +13,7 @@ void Init_rubydex(void) {
     rb_ext_ractor_safe(true);
 
     mRubydex = rb_define_module("Rubydex");
+    rdxi_initialize_index_result(mRubydex);
     rdxi_initialize_graph(mRubydex);
     rdxi_initialize_declaration(mRubydex);
     rdxi_initialize_document(mRubydex);

--- a/rakelib/index_top_gems.rake
+++ b/rakelib/index_top_gems.rake
@@ -51,7 +51,12 @@ task index_top_gems: :compile_release do
 
             # Index the gem's files and yield errors back to the main Ractor
             graph = Rubydex::Graph.new
-            error = graph.index_all(Dir.glob("#{gem_dir}/**/*.rb"))
+            error = nil
+            begin
+              graph.index_all(Dir.glob("#{gem_dir}/**/*.rb"))
+            rescue Rubydex::IndexingError => e
+              error = e
+            end
             next unless error
 
             @mutex.synchronize { @errors << "#{gem} => #{error}" }

--- a/rust/rubydex-sys/src/index_result_api.rs
+++ b/rust/rubydex-sys/src/index_result_api.rs
@@ -1,0 +1,35 @@
+use libc::c_void;
+use rubydex::indexing::IndexResult;
+
+pub type IndexResultPointer = *mut c_void;
+
+#[unsafe(no_mangle)]
+pub extern "C" fn rdx_index_result_free(pointer: IndexResultPointer) {
+    if pointer.is_null() {
+        return;
+    }
+
+    unsafe {
+        let _ = Box::from_raw(pointer.cast::<IndexResult>());
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn rdx_index_result_definition_ids_len(pointer: IndexResultPointer) -> usize {
+    if pointer.is_null() {
+        return 0;
+    }
+
+    let result = unsafe { &*pointer.cast::<IndexResult>() };
+    result.definition_ids.len()
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn rdx_index_result_reference_ids_len(pointer: IndexResultPointer) -> usize {
+    if pointer.is_null() {
+        return 0;
+    }
+
+    let result = unsafe { &*pointer.cast::<IndexResult>() };
+    result.reference_ids.len()
+}

--- a/rust/rubydex-sys/src/lib.rs
+++ b/rust/rubydex-sys/src/lib.rs
@@ -3,6 +3,7 @@ pub mod definition_api;
 pub mod diagnostic_api;
 pub mod document_api;
 pub mod graph_api;
+pub mod index_result_api;
 pub mod location_api;
 pub mod name_api;
 pub mod reference_api;

--- a/rust/rubydex/src/main.rs
+++ b/rust/rubydex/src/main.rs
@@ -67,7 +67,7 @@ fn main() {
     // Indexing
 
     let mut graph = Graph::new();
-    let errors = time_it!(indexing, { indexing::index_files(&mut graph, file_paths) });
+    let (_, errors) = time_it!(indexing, { indexing::index_files(&mut graph, file_paths) });
 
     for error in errors {
         eprintln!("{error}");

--- a/rust/rubydex/src/model/graph.rs
+++ b/rust/rubydex/src/model/graph.rs
@@ -495,10 +495,12 @@ impl Graph {
     }
 
     //// Handles the deletion of a document identified by `uri`
-    pub fn delete_uri(&mut self, uri: &str) {
+    pub fn delete_uri(&mut self, uri: &str) -> (IdentityHashSet<DefinitionId>, IdentityHashSet<ReferenceId>) {
         let uri_id = UriId::from(uri);
         self.remove_definitions_for_uri(uri_id);
         self.documents.remove(&uri_id);
+
+        (IdentityHashSet::default(), IdentityHashSet::default())
     }
 
     /// Merges everything in `other` into this Graph. This method is meant to merge all graph representations from
@@ -535,13 +537,18 @@ impl Graph {
 
     /// Updates the global representation with the information contained in `other`, handling deletions, insertions and
     /// updates to existing entries
-    pub fn update(&mut self, other: LocalGraph) {
+    pub fn update(&mut self, other: LocalGraph) -> (IdentityHashSet<DefinitionId>, IdentityHashSet<ReferenceId>) {
         // For each URI that was indexed through `other`, check what was discovered and update our current global
         // representation
         let uri_id = other.uri_id();
         self.remove_definitions_for_uri(uri_id);
 
+        let definition_ids: IdentityHashSet<DefinitionId> = other.definitions().keys().copied().collect();
+        let reference_ids: IdentityHashSet<ReferenceId> = other.constant_references().keys().copied().collect();
+
         self.extend(other);
+
+        (definition_ids, reference_ids)
     }
 
     // Removes all nodes and relationships associated to the given URI. This is used to clean up stale data when a

--- a/rust/rubydex/src/resolution.rs
+++ b/rust/rubydex/src/resolution.rs
@@ -121,7 +121,18 @@ impl<'a> Resolver<'a> {
             );
         }
 
-        let other_ids = self.prepare_units();
+        let definition_ids: IdentityHashSet<DefinitionId> = self.graph.definitions().keys().copied().collect();
+        let reference_ids: IdentityHashSet<ReferenceId> = self.graph.constant_references().keys().copied().collect();
+        self.resolve(&definition_ids, &reference_ids);
+    }
+
+    /// Resolves only the specified definitions and references
+    pub fn resolve(
+        &mut self,
+        definition_ids: &IdentityHashSet<DefinitionId>,
+        reference_ids: &IdentityHashSet<ReferenceId>,
+    ) {
+        let other_ids = self.prepare_units(definition_ids.iter(), reference_ids.iter());
 
         loop {
             // Flag to ensure the end of the resolution loop. We go through all items in the queue based on its current
@@ -1336,13 +1347,19 @@ impl<'a> Resolver<'a> {
         parent_depth + nesting_depth + 1
     }
 
-    fn prepare_units(&mut self) -> Vec<DefinitionId> {
-        let estimated_length = self.graph.definitions().len() / 2;
-        let mut definitions = Vec::with_capacity(estimated_length);
-        let mut others = Vec::with_capacity(estimated_length);
+    fn prepare_units<'b, D, R>(&mut self, definition_ids: D, reference_ids: R) -> Vec<DefinitionId>
+    where
+        D: Iterator<Item = &'b DefinitionId>,
+        R: Iterator<Item = &'b ReferenceId>,
+    {
+        let mut definitions = Vec::new();
+        let mut others = Vec::new();
         let names = self.graph.names();
 
-        for (id, definition) in self.graph.definitions() {
+        for id in definition_ids {
+            let Some(definition) = self.graph.definitions().get(id) else {
+                continue;
+            };
             let uri = self.graph.documents().get(definition.uri_id()).unwrap().uri();
 
             match definition {
@@ -1388,19 +1405,19 @@ impl<'a> Resolver<'a> {
             (Self::name_depth(name_a, names), uri_a, offset_a).cmp(&(Self::name_depth(name_b, names), uri_b, offset_b))
         });
 
-        let mut const_refs = self
-            .graph
-            .constant_references()
-            .iter()
-            .map(|(id, constant_ref)| {
-                let uri = self.graph.documents().get(&constant_ref.uri_id()).unwrap().uri();
+        let mut const_refs = Vec::new();
 
-                (
-                    Unit::ConstantRef(*id),
-                    (names.get(constant_ref.name_id()).unwrap(), uri, constant_ref.offset()),
-                )
-            })
-            .collect::<Vec<_>>();
+        for id in reference_ids {
+            let Some(constant_ref) = self.graph.constant_references().get(id) else {
+                continue;
+            };
+            let uri = self.graph.documents().get(&constant_ref.uri_id()).unwrap().uri();
+
+            const_refs.push((
+                Unit::ConstantRef(*id),
+                (names.get(constant_ref.name_id()).unwrap(), uri, constant_ref.offset()),
+            ));
+        }
 
         // Sort constant references based on their name complexity so that simpler names are always first
         const_refs.sort_by(|(_, (name_a, uri_a, offset_a)), (_, (name_b, uri_b, offset_b))| {
@@ -1412,7 +1429,6 @@ impl<'a> Resolver<'a> {
         self.unit_queue
             .extend(const_refs.into_iter().map(|(id, _)| id).collect::<VecDeque<_>>());
 
-        others.shrink_to_fit();
         others
     }
 

--- a/test/graph_test.rb
+++ b/test/graph_test.rb
@@ -9,7 +9,7 @@ class GraphTest < Minitest::Test
   def test_indexing_empty_context
     with_context do |context|
       graph = Rubydex::Graph.new
-      assert_nil(graph.index_all(context.glob("**/*.rb")))
+      assert_instance_of(Rubydex::IndexResult, graph.index_all(context.glob("**/*.rb")))
     end
   end
 
@@ -19,7 +19,7 @@ class GraphTest < Minitest::Test
       context.write!("bar.rb", "class Bar; end")
 
       graph = Rubydex::Graph.new
-      assert_nil(graph.index_all(context.glob("**/*.rb")))
+      assert_instance_of(Rubydex::IndexResult, graph.index_all(context.glob("**/*.rb")))
     end
   end
 


### PR DESCRIPTION
This PR sets up the basic infrastructure and API for incremental updates:

```rb
result = graph.index_all(file_paths)
graph.resolve(result)
```

For now we can continue using:

```rb
graph.index_all(file_paths)
graph.resolve
```

…because `graph.resolve(nil)` will resolve everything, but we might want to switch to making the parameter required.

@vinistock suggested that we should be returning a list of units, but by returning a result struct containing two sets of IDs, it's easier to reuse the existing infrastructure for sorting and processing the units. I'm not sure I fully understood the benefit to constructing the units at index time rather than during resolution, but I'm happy to revisit if you think that would be preferable?

As of this PR, incremental updates **don't work**—we should continue using `graph.resolve(nil)` for now.

## Feedback

I'm not confident in the FFI C side of things, particularly when the result will be freed (whether we pass it into `#resolve` or not). Claude Code helped me with this and I sense-checked to the best of my current abilities. Any feedback on this would be much appreciated!