### PR TITLE
Add RBS indexer scaffolding

### DIFF
--- a/rust/rubydex/src/indexing/rbs_indexer.rs
+++ b/rust/rubydex/src/indexing/rbs_indexer.rs
@@ -1,0 +1,29 @@
+//! Visit the RBS AST and create type definitions.
+
+use crate::{
+    indexing::local_graph::LocalGraph,
+    model::{document::Document, ids::UriId},
+};
+
+pub struct RBSIndexer {
+    #[allow(dead_code)]
+    uri_id: UriId,
+    local_graph: LocalGraph,
+}
+
+impl RBSIndexer {
+    #[must_use]
+    pub fn new(uri: String, source: &str) -> Self {
+        let uri_id = UriId::from(&uri);
+        let local_graph = LocalGraph::new(uri_id, Document::new(uri, source));
+
+        Self { uri_id, local_graph }
+    }
+
+    #[must_use]
+    pub fn local_graph(self) -> LocalGraph {
+        self.local_graph
+    }
+
+    pub fn index(&mut self) {}
+}


### PR DESCRIPTION
Part of https://github.com/Shopify/rubydex/issues/87

This PR introduces the basic structure for indexing RBS files. The indexer doesn't extract any definitions yet. It is intentionally minimal to establish the pattern and enable parallel development.

The `RBSIndexer` follows the same interface as `RubyIndexer`:
 - `new(uri, source)` - creates the indexer
 - `index()` - processes the file (currently no-op)
 - `local_graph()` - returns the `LocalGraph`
