### PR TITLE
Clean up require path code

### DIFF
--- a/rust/rubydex/src/model/document.rs
+++ b/rust/rubydex/src/model/document.rs
@@ -129,8 +129,8 @@ impl Document {
         if url.scheme() != "file" {
             return None;
         }
-        let file_path = url.to_file_path().ok()?;
 
+        let file_path = url.to_file_path().ok()?;
         if file_path.extension().is_none_or(|ext| ext != "rb") {
             return None;
         }
@@ -161,14 +161,8 @@ mod tests {
     use super::*;
 
     fn test_root() -> PathBuf {
-        let root = if cfg!(windows) {
-            PathBuf::from_str("C:\\")
-        } else {
-            PathBuf::from_str("/")
-        }
-        .unwrap();
-
-        root.join("test")
+        let root = if cfg!(windows) { "C:\\" } else { "/" };
+        PathBuf::from_str(root).unwrap()
     }
 
     #[test]
@@ -227,19 +221,19 @@ mod tests {
 
         // non-file URI
         let document = Document::new("untitled:Untitled-1".to_string(), "");
-        assert_eq!(None, document.require_path(&load_paths));
+        assert!(document.require_path(&load_paths).is_none());
 
         // non-.rb extension
         let path = root.join("lib").join("foo.so");
         let uri = Url::from_file_path(path).unwrap().to_string();
         let document = Document::new(uri, "");
-        assert_eq!(None, document.require_path(&load_paths));
+        assert!(document.require_path(&load_paths).is_none());
 
         // /libfoo is not under /lib - should not match due to partial directory name
         let path = root.join("libfoo").join("bar.rb");
         let uri = Url::from_file_path(path).unwrap().to_string();
         let document = Document::new(uri, "");
-        assert_eq!(None, document.require_path(&load_paths));
+        assert!(document.require_path(&load_paths).is_none());
     }
 
     #[test]

--- a/rust/rubydex/src/query.rs
+++ b/rust/rubydex/src/query.rs
@@ -69,8 +69,7 @@ fn match_score(query: &str, target: &str) -> usize {
 /// Panics if one of the search threads panics
 #[must_use]
 pub fn resolve_require_path(graph: &Graph, require_path: &str, load_paths: &[PathBuf]) -> Option<UriId> {
-    let found = AtomicBool::new(false);
-    let found_ref = &found;
+    let found_ref = &AtomicBool::new(false);
     let normalized = require_path.trim_end_matches(".rb");
     let num_threads = thread::available_parallelism().map(std::num::NonZero::get).unwrap_or(4);
     let documents = graph.documents().iter().collect::<Vec<_>>();
@@ -200,14 +199,8 @@ mod tests {
     }
 
     fn test_root() -> PathBuf {
-        let root = if cfg!(windows) {
-            PathBuf::from_str("C:\\")
-        } else {
-            PathBuf::from_str("/")
-        }
-        .unwrap();
-
-        root.join("test")
+        let root = if cfg!(windows) { "C:\\" } else { "/" };
+        PathBuf::from_str(root).unwrap()
     }
 
     #[test]


### PR DESCRIPTION
This PR addresses the post-merge review feedback on #528:

Simplify test helpers, tighten assertion style, and inline an unnecessary intermediate variable.