### PR TITLE
Revert ID sizes back to 64 bits

### DIFF
--- a/ext/rubydex/declaration.c
+++ b/ext/rubydex/declaration.c
@@ -89,10 +89,10 @@ static VALUE declaration_definitions_yield(VALUE args) {
     HandleData *data;
     TypedData_Get_Struct(self, HandleData, &handle_type, data);
 
-    uint32_t id = 0;
+    uint64_t id = 0;
     DefinitionKind kind;
     while (rdx_definitions_iter_next(iter, &id, &kind)) {
-        VALUE argv[] = {data->graph_obj, UINT2NUM(id)};
+        VALUE argv[] = {data->graph_obj, ULL2NUM(id)};
         VALUE defn_class = rdxi_definition_class_for_kind(kind);
         VALUE handle = rb_class_new_instance(2, argv, defn_class);
         rb_yield(handle);
@@ -163,7 +163,7 @@ static VALUE rdxr_declaration_member(VALUE self, VALUE name) {
     }
 
     VALUE decl_class = rdxi_declaration_class_for_kind(decl->kind);
-    VALUE argv[] = {data->graph_obj, UINT2NUM(decl->id)};
+    VALUE argv[] = {data->graph_obj, ULL2NUM(decl->id)};
     free_c_declaration(decl);
 
     return rb_class_new_instance(2, argv, decl_class);
@@ -183,7 +183,7 @@ static VALUE rdxr_declaration_singleton_class(VALUE self) {
     }
 
     VALUE decl_class = rdxi_declaration_class_for_kind(decl->kind);
-    VALUE argv[] = {data->graph_obj, UINT2NUM(decl->id)};
+    VALUE argv[] = {data->graph_obj, ULL2NUM(decl->id)};
     free_c_declaration(decl);
 
     return rb_class_new_instance(2, argv, decl_class);
@@ -203,7 +203,7 @@ static VALUE rdxr_declaration_owner(VALUE self) {
     }
 
     VALUE decl_class = rdxi_declaration_class_for_kind(decl->kind);
-    VALUE argv[] = {data->graph_obj, UINT2NUM(decl->id)};
+    VALUE argv[] = {data->graph_obj, ULL2NUM(decl->id)};
     free_c_declaration(decl);
 
     return rb_class_new_instance(2, argv, decl_class);

--- a/ext/rubydex/document.c
+++ b/ext/rubydex/document.c
@@ -33,10 +33,10 @@ static VALUE document_definitions_yield(VALUE args) {
     HandleData *data;
     TypedData_Get_Struct(self, HandleData, &handle_type, data);
 
-    uint32_t id = 0;
+    uint64_t id = 0;
     DefinitionKind kind;
     while (rdx_definitions_iter_next(iter, &id, &kind)) {
-        VALUE argv[] = {data->graph_obj, UINT2NUM(id)};
+        VALUE argv[] = {data->graph_obj, ULL2NUM(id)};
         VALUE defn_class = rdxi_definition_class_for_kind(kind);
         VALUE handle = rb_class_new_instance(2, argv, defn_class);
         rb_yield(handle);

--- a/ext/rubydex/graph.c
+++ b/ext/rubydex/graph.c
@@ -118,9 +118,9 @@ static VALUE graph_documents_yield(VALUE args) {
     VALUE self = rb_ary_entry(args, 0);
     void *iter = (void *)(uintptr_t)NUM2ULL(rb_ary_entry(args, 1));
 
-    uint32_t id = 0;
+    uint64_t id = 0;
     while (rdx_graph_documents_iter_next(iter, &id)) {
-        VALUE argv[] = {self, UINT2NUM(id)};
+        VALUE argv[] = {self, ULL2NUM(id)};
         VALUE handle = rb_class_new_instance(2, argv, cDocument);
         rb_yield(handle);
     }
@@ -181,7 +181,7 @@ static VALUE rdxr_graph_aref(VALUE self, VALUE key) {
     }
 
     VALUE decl_class = rdxi_declaration_class_for_kind(decl->kind);
-    VALUE argv[] = {self, UINT2NUM(decl->id)};
+    VALUE argv[] = {self, ULL2NUM(decl->id)};
     free_c_declaration(decl);
 
     return rb_class_new_instance(2, argv, decl_class);
@@ -192,11 +192,11 @@ static VALUE graph_references_yield(VALUE args) {
     VALUE self = rb_ary_entry(args, 0);
     void *iter = (void *)(uintptr_t)NUM2ULL(rb_ary_entry(args, 1));
 
-    uint32_t id = 0;
+    uint64_t id = 0;
     ReferenceKind kind;
     while (rdx_references_iter_next(iter, &id, &kind)) {
         VALUE ref_class = rdxi_reference_class_for_kind(kind);
-        VALUE argv[] = {self, UINT2NUM(id)};
+        VALUE argv[] = {self, ULL2NUM(id)};
         VALUE obj = rb_class_new_instance(2, argv, ref_class);
         rb_yield(obj);
     }
@@ -323,7 +323,7 @@ static VALUE rdxr_graph_resolve_constant(VALUE self, VALUE const_name, VALUE nes
     }
 
     VALUE decl_class = rdxi_declaration_class_for_kind(decl->kind);
-    VALUE argv[] = {self, UINT2NUM(decl->id)};
+    VALUE argv[] = {self, ULL2NUM(decl->id)};
     free_c_declaration(decl);
 
     return rb_class_new_instance(2, argv, decl_class);
@@ -342,7 +342,7 @@ static VALUE rdxr_graph_resolve_require_path(VALUE self, VALUE require_path, VAL
     size_t paths_len = RARRAY_LEN(load_paths);
     char **converted_paths = rdxi_str_array_to_char(load_paths, paths_len);
 
-    const uint32_t *uri_id = rdx_resolve_require_path(graph, path_str, (const char **)converted_paths, paths_len);
+    const uint64_t *uri_id = rdx_resolve_require_path(graph, path_str, (const char **)converted_paths, paths_len);
 
     for (size_t i = 0; i < paths_len; i++) {
         free(converted_paths[i]);
@@ -353,8 +353,8 @@ static VALUE rdxr_graph_resolve_require_path(VALUE self, VALUE require_path, VAL
         return Qnil;
     }
 
-    VALUE argv[] = {self, UINT2NUM(*uri_id)};
-    free_u32(uri_id);
+    VALUE argv[] = {self, ULL2NUM(*uri_id)};
+    free_u64(uri_id);
     return rb_class_new_instance(2, argv, cDocument);
 }
 

--- a/ext/rubydex/handle.h
+++ b/ext/rubydex/handle.h
@@ -5,7 +5,7 @@
 
 typedef struct {
     VALUE graph_obj; // Ruby Graph object to keep it alive
-    uint32_t id;     // Canonical ID mapping to a DeclarationId, DefinitionId, UriId, etc. See `ids.rs`.
+    uint64_t id;     // Canonical ID mapping to a DeclarationId, DefinitionId, UriId, etc. See `ids.rs`.
 } HandleData;
 
 static void handle_mark(void *ptr) {
@@ -36,7 +36,7 @@ static VALUE rdxr_handle_initialize(VALUE self, VALUE graph_obj, VALUE id_val) {
     HandleData *data;
     TypedData_Get_Struct(self, HandleData, &handle_type, data);
     data->graph_obj = graph_obj;
-    data->id = NUM2UINT(id_val);
+    data->id = NUM2ULL(id_val);
 
     return self;
 }

--- a/ext/rubydex/utils.c
+++ b/ext/rubydex/utils.c
@@ -36,7 +36,7 @@ VALUE rdxi_declarations_yield(VALUE args) {
     CDeclaration decl;
     while (rdx_graph_declarations_iter_next(iter, &decl)) {
         VALUE decl_class = rdxi_declaration_class_for_kind(decl.kind);
-        VALUE argv[] = {self, UINT2NUM(decl.id)};
+        VALUE argv[] = {self, ULL2NUM(decl.id)};
         VALUE handle = rb_class_new_instance(2, argv, decl_class);
         rb_yield(handle);
     }

--- a/rust/rubydex-sys/src/declaration_api.rs
+++ b/rust/rubydex-sys/src/declaration_api.rs
@@ -5,7 +5,7 @@ use rubydex::model::declaration::{Ancestor, Declaration, Namespace};
 use std::ffi::CString;
 use std::ptr;
 
-use crate::definition_api::{DefinitionKind, DefinitionsIter, rdx_definitions_iter_new_from_ids};
+use crate::definition_api::{DefinitionsIter, rdx_definitions_iter_new_from_ids};
 use crate::graph_api::{GraphPointer, with_graph};
 use crate::utils;
 use rubydex::model::ids::{DeclarationId, StringId};
@@ -27,13 +27,13 @@ pub enum CDeclarationKind {
 #[repr(C)]
 #[derive(Debug, Clone, Copy)]
 pub struct CDeclaration {
-    id: u32,
+    id: u64,
     kind: CDeclarationKind,
 }
 
 impl CDeclaration {
     #[must_use]
-    pub fn id(&self) -> u32 {
+    pub fn id(&self) -> u64 {
         self.id
     }
 
@@ -115,7 +115,7 @@ impl DeclarationsIter {
 ///
 /// This function will panic if the name pointer is invalid.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn rdx_declaration_name(pointer: GraphPointer, name_id: u32) -> *const c_char {
+pub unsafe extern "C" fn rdx_declaration_name(pointer: GraphPointer, name_id: u64) -> *const c_char {
     with_graph(pointer, |graph| {
         let name_id = DeclarationId::new(name_id);
         if let Some(decl) = graph.declarations().get(&name_id) {
@@ -138,7 +138,7 @@ pub unsafe extern "C" fn rdx_declaration_name(pointer: GraphPointer, name_id: u3
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rdx_declaration_member(
     pointer: GraphPointer,
-    name_id: u32,
+    name_id: u64,
     member: *const c_char,
 ) -> *const CDeclaration {
     let Ok(member_str) = (unsafe { utils::convert_char_ptr_to_string(member) }) else {
@@ -172,7 +172,7 @@ pub unsafe extern "C" fn rdx_declaration_member(
 ///
 /// This function will panic if the name pointer is invalid.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn rdx_declaration_unqualified_name(pointer: GraphPointer, name_id: u32) -> *const c_char {
+pub unsafe extern "C" fn rdx_declaration_unqualified_name(pointer: GraphPointer, name_id: u64) -> *const c_char {
     with_graph(pointer, |graph| {
         let name_id = DeclarationId::new(name_id);
         if let Some(decl) = graph.declarations().get(&name_id) {
@@ -196,7 +196,7 @@ pub unsafe extern "C" fn rdx_declaration_unqualified_name(pointer: GraphPointer,
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rdx_declaration_definitions_iter_new(
     pointer: GraphPointer,
-    decl_id: u32,
+    decl_id: u64,
 ) -> *mut DefinitionsIter {
     // Snapshot the IDs and kinds at iterator creation to avoid borrowing across FFI calls
     with_graph(pointer, |graph| {
@@ -204,7 +204,7 @@ pub unsafe extern "C" fn rdx_declaration_definitions_iter_new(
         if let Some(decl) = graph.declarations().get(&decl_id) {
             rdx_definitions_iter_new_from_ids(graph, decl.definitions())
         } else {
-            DefinitionsIter::new(Vec::<(u32, DefinitionKind)>::new().into_boxed_slice())
+            DefinitionsIter::new(Vec::<_>::new().into_boxed_slice())
         }
     })
 }
@@ -219,7 +219,7 @@ pub unsafe extern "C" fn rdx_declaration_definitions_iter_new(
 ///
 /// Will panic if invoked on a non-existing or non-namespace declaration
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn rdx_declaration_singleton_class(pointer: GraphPointer, decl_id: u32) -> *const CDeclaration {
+pub unsafe extern "C" fn rdx_declaration_singleton_class(pointer: GraphPointer, decl_id: u64) -> *const CDeclaration {
     with_graph(pointer, |graph| {
         let declaration = graph
             .declarations()
@@ -249,7 +249,7 @@ pub unsafe extern "C" fn rdx_declaration_singleton_class(pointer: GraphPointer, 
 ///
 /// Will panic if invoked on a non-existing or non-namespace declaration
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn rdx_declaration_owner(pointer: GraphPointer, decl_id: u32) -> *const CDeclaration {
+pub unsafe extern "C" fn rdx_declaration_owner(pointer: GraphPointer, decl_id: u64) -> *const CDeclaration {
     with_graph(pointer, |graph| {
         let declaration = graph.declarations().get(&DeclarationId::new(decl_id)).unwrap();
         let owner_id = *declaration.owner_id();
@@ -288,7 +288,7 @@ pub unsafe extern "C" fn free_c_declaration(ptr: *const CDeclaration) {
 ///
 /// Will panic if there's inconsistent graph data
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn rdx_declaration_ancestors(pointer: GraphPointer, decl_id: u32) -> *mut DeclarationsIter {
+pub unsafe extern "C" fn rdx_declaration_ancestors(pointer: GraphPointer, decl_id: u64) -> *mut DeclarationsIter {
     let declarations = with_graph(pointer, |graph| {
         let declaration_id = DeclarationId::new(decl_id);
 
@@ -322,7 +322,7 @@ pub unsafe extern "C" fn rdx_declaration_ancestors(pointer: GraphPointer, decl_i
 ///
 /// Will panic if there's inconsistent graph data
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn rdx_declaration_descendants(pointer: GraphPointer, decl_id: u32) -> *mut DeclarationsIter {
+pub unsafe extern "C" fn rdx_declaration_descendants(pointer: GraphPointer, decl_id: u64) -> *mut DeclarationsIter {
     let declarations = with_graph(pointer, |graph| {
         let declaration_id = DeclarationId::new(decl_id);
 

--- a/rust/rubydex-sys/src/definition_api.rs
+++ b/rust/rubydex-sys/src/definition_api.rs
@@ -57,7 +57,7 @@ pub(crate) fn map_definition_to_kind(defn: &Definition) -> DefinitionKind {
 ///
 /// This function will panic if the definition cannot be found.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn rdx_definition_kind(pointer: GraphPointer, definition_id: u32) -> DefinitionKind {
+pub unsafe extern "C" fn rdx_definition_kind(pointer: GraphPointer, definition_id: u64) -> DefinitionKind {
     with_graph(pointer, |graph| {
         let definition_id = DefinitionId::new(definition_id);
         if let Some(defn) = graph.definitions().get(&definition_id) {
@@ -79,7 +79,7 @@ pub unsafe extern "C" fn rdx_definition_kind(pointer: GraphPointer, definition_i
 ///
 /// This function will panic if the definition cannot be found.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn rdx_definition_name(pointer: GraphPointer, definition_id: u32) -> *const c_char {
+pub unsafe extern "C" fn rdx_definition_name(pointer: GraphPointer, definition_id: u64) -> *const c_char {
     with_graph(pointer, |graph| {
         let def_id = DefinitionId::new(definition_id);
         if let Some(defn) = graph.definitions().get(&def_id) {
@@ -99,13 +99,13 @@ pub unsafe extern "C" fn rdx_definition_name(pointer: GraphPointer, definition_i
 /// Shared iterator over definition (id, kind) pairs
 #[derive(Debug)]
 pub struct DefinitionsIter {
-    pub entries: Box<[(u32, DefinitionKind)]>,
+    pub entries: Box<[(u64, DefinitionKind)]>,
     pub index: usize,
 }
 
 impl DefinitionsIter {
     #[must_use]
-    pub fn new(entries: Box<[(u32, DefinitionKind)]>) -> *mut DefinitionsIter {
+    pub fn new(entries: Box<[(u64, DefinitionKind)]>) -> *mut DefinitionsIter {
         Box::into_raw(Box::new(DefinitionsIter { entries, index: 0 }))
     }
 }
@@ -131,7 +131,7 @@ pub unsafe extern "C" fn rdx_definitions_iter_len(iter: *const DefinitionsIter) 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rdx_definitions_iter_next(
     iter: *mut DefinitionsIter,
-    out_id: *mut u32,
+    out_id: *mut u64,
     out_kind: *mut DefinitionKind,
 ) -> bool {
     if iter.is_null() || out_id.is_null() || out_kind.is_null() {
@@ -191,7 +191,7 @@ pub struct CommentArray {
 /// # Panics
 /// This function will panic if a definition or document cannot be found.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn rdx_definition_comments(pointer: GraphPointer, definition_id: u32) -> *mut CommentArray {
+pub unsafe extern "C" fn rdx_definition_comments(pointer: GraphPointer, definition_id: u64) -> *mut CommentArray {
     with_graph(pointer, |graph| {
         let def_id = DefinitionId::new(definition_id);
         let Some(defn) = graph.definitions().get(&def_id) else {
@@ -265,7 +265,7 @@ pub unsafe extern "C" fn rdx_definition_comments_free(ptr: *mut CommentArray) {
 ///
 /// This function will panic if a definition or document cannot be found.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn rdx_definition_location(pointer: GraphPointer, definition_id: u32) -> *mut Location {
+pub unsafe extern "C" fn rdx_definition_location(pointer: GraphPointer, definition_id: u64) -> *mut Location {
     with_graph(pointer, |graph| {
         let def_id = DefinitionId::new(definition_id);
         let Some(defn) = graph.definitions().get(&def_id) else {
@@ -299,7 +299,7 @@ where
                 .map_or_else(|| panic!("Definition not found: {id:?}"), map_definition_to_kind);
             (id, kind)
         })
-        .collect::<Vec<(u32, DefinitionKind)>>()
+        .collect::<Vec<_>>()
         .into_boxed_slice();
 
     DefinitionsIter::new(entries)
@@ -314,7 +314,7 @@ where
 /// # Panics
 /// This function will panic if a definition cannot be found.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn rdx_definition_is_deprecated(pointer: GraphPointer, definition_id: u32) -> bool {
+pub unsafe extern "C" fn rdx_definition_is_deprecated(pointer: GraphPointer, definition_id: u64) -> bool {
     with_graph(pointer, |graph| {
         let def_id = DefinitionId::new(definition_id);
         let defn = graph.definitions().get(&def_id).expect("definition not found");
@@ -335,7 +335,7 @@ pub unsafe extern "C" fn rdx_definition_is_deprecated(pointer: GraphPointer, def
 /// # Panics
 /// Panics if the definition's document does not exist in the graph.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn rdx_definition_name_location(pointer: GraphPointer, definition_id: u32) -> *mut Location {
+pub unsafe extern "C" fn rdx_definition_name_location(pointer: GraphPointer, definition_id: u64) -> *mut Location {
     with_graph(pointer, |graph| {
         let def_id = DefinitionId::new(definition_id);
         let Some(defn) = graph.definitions().get(&def_id) else {

--- a/rust/rubydex-sys/src/document_api.rs
+++ b/rust/rubydex-sys/src/document_api.rs
@@ -4,7 +4,7 @@ use libc::c_char;
 use std::ffi::CString;
 use std::ptr;
 
-use crate::definition_api::{DefinitionKind, DefinitionsIter, rdx_definitions_iter_new_from_ids};
+use crate::definition_api::{DefinitionsIter, rdx_definitions_iter_new_from_ids};
 use crate::graph_api::{GraphPointer, with_graph};
 use rubydex::model::ids::UriId;
 
@@ -19,7 +19,7 @@ use rubydex::model::ids::UriId;
 ///
 /// This function will panic if the URI pointer is invalid.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn rdx_document_uri(pointer: GraphPointer, uri_id: u32) -> *const c_char {
+pub unsafe extern "C" fn rdx_document_uri(pointer: GraphPointer, uri_id: u64) -> *const c_char {
     with_graph(pointer, |graph| {
         let uri_id = UriId::new(uri_id);
         if let Some(doc) = graph.documents().get(&uri_id) {
@@ -41,14 +41,14 @@ pub unsafe extern "C" fn rdx_document_uri(pointer: GraphPointer, uri_id: u32) ->
 /// - `pointer` must be a valid `GraphPointer` previously returned by this crate.
 /// - The returned pointer must be freed with `rdx_document_definitions_iter_free`.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn rdx_document_definitions_iter_new(pointer: GraphPointer, uri_id: u32) -> *mut DefinitionsIter {
+pub unsafe extern "C" fn rdx_document_definitions_iter_new(pointer: GraphPointer, uri_id: u64) -> *mut DefinitionsIter {
     // Snapshot the IDs and kinds at iterator creation to avoid borrowing across FFI calls
     with_graph(pointer, |graph| {
         let uri_id = UriId::new(uri_id);
         if let Some(doc) = graph.documents().get(&uri_id) {
             rdx_definitions_iter_new_from_ids(graph, doc.definitions())
         } else {
-            DefinitionsIter::new(Vec::<(u32, DefinitionKind)>::new().into_boxed_slice())
+            DefinitionsIter::new(Vec::<_>::new().into_boxed_slice())
         }
     })
 }

--- a/rust/rubydex-sys/src/graph_api.rs
+++ b/rust/rubydex-sys/src/graph_api.rs
@@ -275,7 +275,7 @@ pub unsafe extern "C" fn rdx_graph_declarations_iter_free(iter: *mut Declaration
 #[derive(Debug)]
 pub struct DocumentsIter {
     /// The snapshot of document (URI) IDs
-    ids: Box<[u32]>,
+    ids: Box<[u64]>,
     /// The current index of the iterator
     index: usize,
 }
@@ -294,7 +294,7 @@ pub unsafe extern "C" fn rdx_graph_documents_iter_new(pointer: GraphPointer) -> 
             .documents()
             .keys()
             .map(|uri_id| **uri_id)
-            .collect::<Vec<u32>>()
+            .collect::<Vec<_>>()
             .into_boxed_slice()
     });
 
@@ -323,7 +323,7 @@ pub unsafe extern "C" fn rdx_graph_documents_iter_len(iter: *const DocumentsIter
 /// - `iter` must be a valid pointer previously returned by `rdx_graph_documents_iter_new`.
 /// - `out_id` must be a valid, writable pointer.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn rdx_graph_documents_iter_next(iter: *mut DocumentsIter, out_id: *mut u32) -> bool {
+pub unsafe extern "C" fn rdx_graph_documents_iter_next(iter: *mut DocumentsIter, out_id: *mut u64) -> bool {
     if iter.is_null() || out_id.is_null() {
         return false;
     }
@@ -387,7 +387,7 @@ pub unsafe extern "C" fn rdx_graph_get_declaration(pointer: GraphPointer, name: 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rdx_graph_constant_references_iter_new(pointer: GraphPointer) -> *mut ReferencesIter {
     with_graph(pointer, |graph| {
-        let refs: Vec<(u32, ReferenceKind)> = graph
+        let refs: Vec<_> = graph
             .constant_references()
             .keys()
             .map(|id| (**id, ReferenceKind::Constant))
@@ -404,7 +404,7 @@ pub unsafe extern "C" fn rdx_graph_constant_references_iter_new(pointer: GraphPo
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rdx_graph_method_references_iter_new(pointer: GraphPointer) -> *mut ReferencesIter {
     with_graph(pointer, |graph| {
-        let refs: Vec<(u32, ReferenceKind)> = graph
+        let refs: Vec<_> = graph
             .method_references()
             .keys()
             .map(|id| (**id, ReferenceKind::Method))
@@ -416,7 +416,7 @@ pub unsafe extern "C" fn rdx_graph_method_references_iter_new(pointer: GraphPoin
 
 /// Resolves a require path to its document URI ID.
 /// Returns a pointer to the URI ID if found, or NULL if not found.
-/// Caller must free with `free_u32`.
+/// Caller must free with the returned pointer.
 ///
 /// # Safety
 /// - `pointer` must be a valid `GraphPointer` previously returned by this crate.
@@ -428,7 +428,7 @@ pub unsafe extern "C" fn rdx_resolve_require_path(
     require_path: *const c_char,
     load_paths: *const *const c_char,
     load_paths_count: usize,
-) -> *const u32 {
+) -> *const u64 {
     let Ok(path_str) = (unsafe { utils::convert_char_ptr_to_string(require_path) }) else {
         return ptr::null();
     };

--- a/rust/rubydex-sys/src/reference_api.rs
+++ b/rust/rubydex-sys/src/reference_api.rs
@@ -18,13 +18,13 @@ pub enum ReferenceKind {
 /// Shared iterator over reference (id, kind) pairs
 #[derive(Debug)]
 pub struct ReferencesIter {
-    pub entries: Box<[(u32, ReferenceKind)]>,
+    pub entries: Box<[(u64, ReferenceKind)]>,
     pub index: usize,
 }
 
 impl ReferencesIter {
     #[must_use]
-    pub fn new(entries: Box<[(u32, ReferenceKind)]>) -> *mut ReferencesIter {
+    pub fn new(entries: Box<[(u64, ReferenceKind)]>) -> *mut ReferencesIter {
         Box::into_raw(Box::new(ReferencesIter { entries, index: 0 }))
     }
 }
@@ -54,7 +54,7 @@ pub unsafe extern "C" fn rdx_references_iter_len(iter: *const ReferencesIter) ->
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rdx_references_iter_next(
     iter: *mut ReferencesIter,
-    out_id: *mut u32,
+    out_id: *mut u64,
     out_kind: *mut ReferenceKind,
 ) -> bool {
     if iter.is_null() || out_id.is_null() || out_kind.is_null() {
@@ -101,7 +101,7 @@ pub unsafe extern "C" fn rdx_references_iter_free(iter: *mut ReferencesIter) {
 ///
 /// This function will panic if the reference cannot be found.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn rdx_constant_reference_name(pointer: GraphPointer, reference_id: u32) -> *const c_char {
+pub unsafe extern "C" fn rdx_constant_reference_name(pointer: GraphPointer, reference_id: u64) -> *const c_char {
     with_graph(pointer, |graph| {
         let ref_id = ReferenceId::new(reference_id);
         let reference = graph.constant_references().get(&ref_id).expect("Reference not found");
@@ -127,7 +127,7 @@ pub unsafe extern "C" fn rdx_constant_reference_name(pointer: GraphPointer, refe
 ///
 /// This function will panic if the reference cannot be found.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn rdx_method_reference_name(pointer: GraphPointer, reference_id: u32) -> *const c_char {
+pub unsafe extern "C" fn rdx_method_reference_name(pointer: GraphPointer, reference_id: u64) -> *const c_char {
     with_graph(pointer, |graph| {
         let ref_id = ReferenceId::new(reference_id);
         let reference = graph.method_references().get(&ref_id).expect("Reference not found");
@@ -152,7 +152,7 @@ pub unsafe extern "C" fn rdx_method_reference_name(pointer: GraphPointer, refere
 ///
 /// This function will panic if a reference or document cannot be found.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn rdx_constant_reference_location(pointer: GraphPointer, reference_id: u32) -> *mut Location {
+pub unsafe extern "C" fn rdx_constant_reference_location(pointer: GraphPointer, reference_id: u64) -> *mut Location {
     with_graph(pointer, |graph| {
         let ref_id = ReferenceId::new(reference_id);
         let reference = graph.constant_references().get(&ref_id).expect("Reference not found");
@@ -177,7 +177,7 @@ pub unsafe extern "C" fn rdx_constant_reference_location(pointer: GraphPointer, 
 ///
 /// This function will panic if a reference or document cannot be found.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn rdx_method_reference_location(pointer: GraphPointer, reference_id: u32) -> *mut Location {
+pub unsafe extern "C" fn rdx_method_reference_location(pointer: GraphPointer, reference_id: u64) -> *mut Location {
     with_graph(pointer, |graph| {
         let ref_id = ReferenceId::new(reference_id);
         let reference = graph.method_references().get(&ref_id).expect("Reference not found");

--- a/rust/rubydex-sys/src/utils.rs
+++ b/rust/rubydex-sys/src/utils.rs
@@ -41,9 +41,9 @@ pub extern "C" fn free_c_string(ptr: *const c_char) {
     }
 }
 
-/// Frees a boxed u32 allocated on the Rust side
+/// Frees a boxed u64 allocated on the Rust side
 #[unsafe(no_mangle)]
-pub extern "C" fn free_u32(ptr: *const u32) {
+pub extern "C" fn free_u64(ptr: *const u64) {
     unsafe {
         let _ = Box::from_raw(ptr.cast_mut());
     }

--- a/rust/rubydex/Cargo.toml
+++ b/rust/rubydex/Cargo.toml
@@ -19,7 +19,7 @@ test_utils = ["dep:tempfile"]
 ruby-prism = "1.9.0"
 ruby-rbs = "0.1"
 url = "2.5.4"
-xxhash-rust = { version = "0.8.15", features = ["xxh32"] }
+xxhash-rust = { version = "0.8.15", features = ["xxh3"] }
 clap = { version = "4.5.16", features = ["derive"] }
 glob = "0.3.2"
 bitflags = "2.9"

--- a/rust/rubydex/src/model/declaration.rs
+++ b/rust/rubydex/src/model/declaration.rs
@@ -482,11 +482,11 @@ impl Namespace {
 }
 
 namespace_declaration!(Class, ClassDeclaration);
-assert_mem_size!(ClassDeclaration, 216);
+assert_mem_size!(ClassDeclaration, 224);
 namespace_declaration!(Module, ModuleDeclaration);
-assert_mem_size!(ModuleDeclaration, 216);
+assert_mem_size!(ModuleDeclaration, 224);
 namespace_declaration!(SingletonClass, SingletonClassDeclaration);
-assert_mem_size!(SingletonClassDeclaration, 216);
+assert_mem_size!(SingletonClassDeclaration, 224);
 
 simple_declaration!(ConstantDeclaration);
 assert_mem_size!(ConstantDeclaration, 112);

--- a/rust/rubydex/src/model/definitions.rs
+++ b/rust/rubydex/src/model/definitions.rs
@@ -49,53 +49,6 @@ impl DefinitionFlags {
     }
 }
 
-#[repr(u8)]
-#[derive(PartialEq, Debug)]
-pub enum DefinitionKind {
-    Class = 0,
-    SingletonClass = 1,
-    Module = 2,
-    Constant = 3,
-    ConstantAlias = 4,
-    Method = 5,
-    AttrAccessor = 6,
-    AttrReader = 7,
-    AttrWriter = 8,
-    GlobalVariable = 9,
-    InstanceVariable = 10,
-    ClassVariable = 11,
-    MethodAlias = 12,
-    GlobalVariableAlias = 13,
-}
-
-impl From<u8> for DefinitionKind {
-    fn from(value: u8) -> Self {
-        match value {
-            0 => DefinitionKind::Class,
-            1 => DefinitionKind::SingletonClass,
-            2 => DefinitionKind::Module,
-            3 => DefinitionKind::Constant,
-            4 => DefinitionKind::ConstantAlias,
-            5 => DefinitionKind::Method,
-            6 => DefinitionKind::AttrAccessor,
-            7 => DefinitionKind::AttrReader,
-            8 => DefinitionKind::AttrWriter,
-            9 => DefinitionKind::GlobalVariable,
-            10 => DefinitionKind::InstanceVariable,
-            11 => DefinitionKind::ClassVariable,
-            12 => DefinitionKind::MethodAlias,
-            13 => DefinitionKind::GlobalVariableAlias,
-            _ => panic!("Invalid DefinitionKind value: {value}"),
-        }
-    }
-}
-
-impl From<DefinitionKind> for u8 {
-    fn from(kind: DefinitionKind) -> Self {
-        kind as u8
-    }
-}
-
 #[derive(Debug)]
 pub enum Definition {
     Class(Box<ClassDefinition>),
@@ -276,7 +229,7 @@ pub struct ClassDefinition {
     superclass_ref: Option<ReferenceId>,
     mixins: Vec<Mixin>,
 }
-assert_mem_size!(ClassDefinition, 120);
+assert_mem_size!(ClassDefinition, 144);
 
 impl ClassDefinition {
     #[must_use]
@@ -307,9 +260,7 @@ impl ClassDefinition {
 
     #[must_use]
     pub fn id(&self) -> DefinitionId {
-        let mut id = DefinitionId::from(&format!("{}{}{}", *self.uri_id, self.offset.start(), *self.name_id));
-        id.tag_kind(DefinitionKind::Class);
-        id
+        DefinitionId::from(&format!("{}{}{}", *self.uri_id, self.offset.start(), *self.name_id))
     }
 
     #[must_use]
@@ -403,7 +354,7 @@ pub struct SingletonClassDefinition {
     /// Mixins declared in this singleton class
     mixins: Vec<Mixin>,
 }
-assert_mem_size!(SingletonClassDefinition, 112);
+assert_mem_size!(SingletonClassDefinition, 128);
 
 impl SingletonClassDefinition {
     #[must_use]
@@ -431,9 +382,7 @@ impl SingletonClassDefinition {
 
     #[must_use]
     pub fn id(&self) -> DefinitionId {
-        let mut id = DefinitionId::from(&format!("{}{}{}", *self.uri_id, self.offset.start(), *self.name_id));
-        id.tag_kind(DefinitionKind::SingletonClass);
-        id
+        DefinitionId::from(&format!("{}{}{}", *self.uri_id, self.offset.start(), *self.name_id))
     }
 
     #[must_use]
@@ -509,7 +458,7 @@ pub struct ModuleDefinition {
     members: Vec<DefinitionId>,
     mixins: Vec<Mixin>,
 }
-assert_mem_size!(ModuleDefinition, 112);
+assert_mem_size!(ModuleDefinition, 128);
 
 impl ModuleDefinition {
     #[must_use]
@@ -537,9 +486,7 @@ impl ModuleDefinition {
 
     #[must_use]
     pub fn id(&self) -> DefinitionId {
-        let mut id = DefinitionId::from(&format!("{}{}{}", *self.uri_id, self.offset.start(), *self.name_id));
-        id.tag_kind(DefinitionKind::Module);
-        id
+        DefinitionId::from(&format!("{}{}{}", *self.uri_id, self.offset.start(), *self.name_id))
     }
 
     #[must_use]
@@ -611,7 +558,7 @@ pub struct ConstantDefinition {
     comments: Vec<Comment>,
     lexical_nesting_id: Option<DefinitionId>,
 }
-assert_mem_size!(ConstantDefinition, 56);
+assert_mem_size!(ConstantDefinition, 72);
 
 impl ConstantDefinition {
     #[must_use]
@@ -635,9 +582,7 @@ impl ConstantDefinition {
 
     #[must_use]
     pub fn id(&self) -> DefinitionId {
-        let mut id = DefinitionId::from(&format!("{}{}{}", *self.uri_id, self.offset.start(), *self.name_id));
-        id.tag_kind(DefinitionKind::Constant);
-        id
+        DefinitionId::from(&format!("{}{}{}", *self.uri_id, self.offset.start(), *self.name_id))
     }
 
     #[must_use]
@@ -683,7 +628,7 @@ pub struct ConstantAliasDefinition {
     alias_constant: ConstantDefinition,
     target_name_id: NameId,
 }
-assert_mem_size!(ConstantAliasDefinition, 64);
+assert_mem_size!(ConstantAliasDefinition, 80);
 
 impl ConstantAliasDefinition {
     #[must_use]
@@ -696,15 +641,13 @@ impl ConstantAliasDefinition {
 
     #[must_use]
     pub fn id(&self) -> DefinitionId {
-        let mut id = DefinitionId::from(&format!(
+        DefinitionId::from(&format!(
             "{}{}{}{}",
             *self.alias_constant.uri_id(),
             self.alias_constant.offset().start(),
             *self.alias_constant.name_id(),
             *self.target_name_id,
-        ));
-        id.tag_kind(DefinitionKind::ConstantAlias);
-        id
+        ))
     }
 
     #[must_use]
@@ -762,7 +705,7 @@ pub struct MethodDefinition {
     visibility: Visibility,
     receiver: Option<NameId>,
 }
-assert_mem_size!(MethodDefinition, 88);
+assert_mem_size!(MethodDefinition, 112);
 
 impl MethodDefinition {
     #[allow(clippy::too_many_arguments)]
@@ -799,9 +742,7 @@ impl MethodDefinition {
             formatted_id.push_str(&receiver.to_string());
         }
 
-        let mut id = DefinitionId::from(&formatted_id);
-        id.tag_kind(DefinitionKind::Method);
-        id
+        DefinitionId::from(&formatted_id)
     }
 
     #[must_use]
@@ -862,14 +803,14 @@ pub enum Parameter {
     Forward(ParameterStruct),
     Block(ParameterStruct),
 }
-assert_mem_size!(Parameter, 16);
+assert_mem_size!(Parameter, 24);
 
 #[derive(Debug, Clone)]
 pub struct ParameterStruct {
     offset: Offset,
     str: StringId,
 }
-assert_mem_size!(ParameterStruct, 12);
+assert_mem_size!(ParameterStruct, 16);
 
 impl ParameterStruct {
     #[must_use]
@@ -904,7 +845,7 @@ pub struct AttrAccessorDefinition {
     lexical_nesting_id: Option<DefinitionId>,
     visibility: Visibility,
 }
-assert_mem_size!(AttrAccessorDefinition, 56);
+assert_mem_size!(AttrAccessorDefinition, 72);
 
 impl AttrAccessorDefinition {
     #[must_use]
@@ -930,9 +871,7 @@ impl AttrAccessorDefinition {
 
     #[must_use]
     pub fn id(&self) -> DefinitionId {
-        let mut id = DefinitionId::from(&format!("{}{}{}", *self.uri_id, self.offset.start(), *self.str_id));
-        id.tag_kind(DefinitionKind::AttrAccessor);
-        id
+        DefinitionId::from(&format!("{}{}{}", *self.uri_id, self.offset.start(), *self.str_id))
     }
 
     #[must_use]
@@ -987,7 +926,7 @@ pub struct AttrReaderDefinition {
     lexical_nesting_id: Option<DefinitionId>,
     visibility: Visibility,
 }
-assert_mem_size!(AttrReaderDefinition, 56);
+assert_mem_size!(AttrReaderDefinition, 72);
 
 impl AttrReaderDefinition {
     #[must_use]
@@ -1013,9 +952,7 @@ impl AttrReaderDefinition {
 
     #[must_use]
     pub fn id(&self) -> DefinitionId {
-        let mut id = DefinitionId::from(&format!("{}{}{}", *self.uri_id, self.offset.start(), *self.str_id));
-        id.tag_kind(DefinitionKind::AttrReader);
-        id
+        DefinitionId::from(&format!("{}{}{}", *self.uri_id, self.offset.start(), *self.str_id))
     }
 
     #[must_use]
@@ -1070,7 +1007,7 @@ pub struct AttrWriterDefinition {
     lexical_nesting_id: Option<DefinitionId>,
     visibility: Visibility,
 }
-assert_mem_size!(AttrWriterDefinition, 56);
+assert_mem_size!(AttrWriterDefinition, 72);
 
 impl AttrWriterDefinition {
     #[must_use]
@@ -1096,9 +1033,7 @@ impl AttrWriterDefinition {
 
     #[must_use]
     pub fn id(&self) -> DefinitionId {
-        let mut id = DefinitionId::from(&format!("{}{}{}", *self.uri_id, self.offset.start(), *self.str_id));
-        id.tag_kind(DefinitionKind::AttrWriter);
-        id
+        DefinitionId::from(&format!("{}{}{}", *self.uri_id, self.offset.start(), *self.str_id))
     }
 
     #[must_use]
@@ -1152,7 +1087,7 @@ pub struct GlobalVariableDefinition {
     comments: Vec<Comment>,
     lexical_nesting_id: Option<DefinitionId>,
 }
-assert_mem_size!(GlobalVariableDefinition, 56);
+assert_mem_size!(GlobalVariableDefinition, 72);
 
 impl GlobalVariableDefinition {
     #[must_use]
@@ -1176,9 +1111,7 @@ impl GlobalVariableDefinition {
 
     #[must_use]
     pub fn id(&self) -> DefinitionId {
-        let mut id = DefinitionId::from(&format!("{}{}{}", *self.uri_id, self.offset.start(), *self.str_id));
-        id.tag_kind(DefinitionKind::GlobalVariable);
-        id
+        DefinitionId::from(&format!("{}{}{}", *self.uri_id, self.offset.start(), *self.str_id))
     }
 
     #[must_use]
@@ -1227,7 +1160,7 @@ pub struct InstanceVariableDefinition {
     comments: Vec<Comment>,
     lexical_nesting_id: Option<DefinitionId>,
 }
-assert_mem_size!(InstanceVariableDefinition, 56);
+assert_mem_size!(InstanceVariableDefinition, 72);
 
 impl InstanceVariableDefinition {
     #[must_use]
@@ -1251,9 +1184,7 @@ impl InstanceVariableDefinition {
 
     #[must_use]
     pub fn id(&self) -> DefinitionId {
-        let mut id = DefinitionId::from(&format!("{}{}{}", *self.uri_id, self.offset.start(), *self.str_id));
-        id.tag_kind(DefinitionKind::InstanceVariable);
-        id
+        DefinitionId::from(&format!("{}{}{}", *self.uri_id, self.offset.start(), *self.str_id))
     }
 
     #[must_use]
@@ -1302,7 +1233,7 @@ pub struct ClassVariableDefinition {
     comments: Vec<Comment>,
     lexical_nesting_id: Option<DefinitionId>,
 }
-assert_mem_size!(ClassVariableDefinition, 56);
+assert_mem_size!(ClassVariableDefinition, 72);
 
 impl ClassVariableDefinition {
     #[must_use]
@@ -1326,9 +1257,7 @@ impl ClassVariableDefinition {
 
     #[must_use]
     pub fn id(&self) -> DefinitionId {
-        let mut id = DefinitionId::from(&format!("{}{}{}", *self.uri_id, self.offset.start(), *self.str_id));
-        id.tag_kind(DefinitionKind::ClassVariable);
-        id
+        DefinitionId::from(&format!("{}{}{}", *self.uri_id, self.offset.start(), *self.str_id))
     }
 
     #[must_use]
@@ -1372,7 +1301,7 @@ pub struct MethodAliasDefinition {
     comments: Vec<Comment>,
     lexical_nesting_id: Option<DefinitionId>,
 }
-assert_mem_size!(MethodAliasDefinition, 56);
+assert_mem_size!(MethodAliasDefinition, 80);
 
 impl MethodAliasDefinition {
     #[must_use]
@@ -1398,15 +1327,13 @@ impl MethodAliasDefinition {
 
     #[must_use]
     pub fn id(&self) -> DefinitionId {
-        let mut id = DefinitionId::from(&format!(
+        DefinitionId::from(&format!(
             "{}{}{}{}",
             *self.uri_id,
             self.offset.start(),
             *self.new_name_str_id,
             *self.old_name_str_id,
-        ));
-        id.tag_kind(DefinitionKind::MethodAlias);
-        id
+        ))
     }
 
     #[must_use]
@@ -1455,7 +1382,7 @@ pub struct GlobalVariableAliasDefinition {
     comments: Vec<Comment>,
     lexical_nesting_id: Option<DefinitionId>,
 }
-assert_mem_size!(GlobalVariableAliasDefinition, 56);
+assert_mem_size!(GlobalVariableAliasDefinition, 80);
 
 impl GlobalVariableAliasDefinition {
     #[must_use]
@@ -1481,15 +1408,13 @@ impl GlobalVariableAliasDefinition {
 
     #[must_use]
     pub fn id(&self) -> DefinitionId {
-        let mut id = DefinitionId::from(&format!(
+        DefinitionId::from(&format!(
             "{}{}{}{}",
             *self.uri_id,
             self.offset.start(),
             *self.new_name_str_id,
             *self.old_name_str_id,
-        ));
-        id.tag_kind(DefinitionKind::GlobalVariableAlias);
-        id
+        ))
     }
 
     #[must_use]

--- a/rust/rubydex/src/model/ids.rs
+++ b/rust/rubydex/src/model/ids.rs
@@ -1,11 +1,4 @@
-use crate::{
-    assert_mem_size,
-    model::{
-        definitions::DefinitionKind,
-        id::{Id, Taggable},
-        references::ReferenceKind,
-    },
-};
+use crate::{assert_mem_size, model::id::Id};
 
 #[derive(PartialEq, Eq, Debug, Clone, Copy)]
 pub struct DeclarationMarker;
@@ -14,57 +7,32 @@ pub type DeclarationId = Id<DeclarationMarker>;
 
 #[derive(PartialEq, Eq, Debug, Clone, Copy)]
 pub struct DefinitionMarker;
-impl Taggable for DefinitionMarker {
-    type Kind = DefinitionKind;
-}
 
 // DefinitionId represents the ID of a definition found in a specific file
 pub type DefinitionId = Id<DefinitionMarker>;
-assert_mem_size!(DefinitionId, 4);
+assert_mem_size!(DefinitionId, 8);
 
 #[derive(PartialEq, Eq, Debug, Clone, Copy)]
 pub struct UriMarker;
 // UriId represents the ID of a URI, which is the unique identifier for a document
 pub type UriId = Id<UriMarker>;
-assert_mem_size!(UriId, 4);
+assert_mem_size!(UriId, 8);
 
 #[derive(PartialEq, Eq, Debug, Clone, Copy)]
 pub struct StringMarker;
 /// `StringId` represents an ID for an interned string value
 pub type StringId = Id<StringMarker>;
-assert_mem_size!(StringId, 4);
+assert_mem_size!(StringId, 8);
 
 #[derive(PartialEq, Eq, Debug, Clone, Copy)]
 pub struct ReferenceMarker;
-impl Taggable for ReferenceMarker {
-    type Kind = ReferenceKind;
-}
 /// `ReferenceId` represents the ID of a reference occurrence in a file.
 /// It is built from the reference kind, `uri_id` and the reference `offset`.
 pub type ReferenceId = Id<ReferenceMarker>;
-assert_mem_size!(ReferenceId, 4);
+assert_mem_size!(ReferenceId, 8);
 
 #[derive(PartialEq, Eq, Debug, Clone, Copy)]
 pub struct NameMarker;
 /// `NameId` represents an ID for any constant name that we find as part of a reference or definition
 pub type NameId = Id<NameMarker>;
-assert_mem_size!(NameId, 4);
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn definition_ids_can_be_tagged() {
-        let mut id = DefinitionId::from("some_input");
-        id.tag_kind(DefinitionKind::Class);
-        assert_eq!(DefinitionKind::Class, id.kind());
-    }
-
-    #[test]
-    fn reference_ids_can_be_tagged() {
-        let mut id = ReferenceId::from("some_input");
-        id.tag_kind(ReferenceKind::Constant);
-        assert_eq!(ReferenceKind::Constant, id.kind());
-    }
-}
+assert_mem_size!(NameId, 8);

--- a/rust/rubydex/src/model/name.rs
+++ b/rust/rubydex/src/model/name.rs
@@ -20,7 +20,7 @@ pub enum ParentScope {
     ///        ^ Attached for <<Foo>>
     Attached(NameId),
 }
-assert_mem_size!(ParentScope, 8);
+assert_mem_size!(ParentScope, 16);
 
 impl ParentScope {
     pub fn map_or<F, T>(&self, default: T, f: F) -> T
@@ -91,7 +91,7 @@ pub struct Name {
     nesting: Option<NameId>,
     ref_count: u32,
 }
-assert_mem_size!(Name, 24);
+assert_mem_size!(Name, 48);
 
 impl Name {
     #[must_use]

--- a/rust/rubydex/src/model/references.rs
+++ b/rust/rubydex/src/model/references.rs
@@ -4,29 +4,6 @@ use crate::{
     offset::Offset,
 };
 
-#[repr(u8)]
-#[derive(PartialEq, Debug)]
-pub enum ReferenceKind {
-    Constant = 0,
-    Method = 1,
-}
-
-impl From<u8> for ReferenceKind {
-    fn from(value: u8) -> Self {
-        match value {
-            0 => ReferenceKind::Constant,
-            1 => ReferenceKind::Method,
-            _ => panic!("Invalid ReferenceKind value: {value}"),
-        }
-    }
-}
-
-impl From<ReferenceKind> for u8 {
-    fn from(kind: ReferenceKind) -> Self {
-        kind as u8
-    }
-}
-
 /// A reference to a constant
 #[derive(Debug)]
 pub struct ConstantReference {
@@ -37,7 +14,7 @@ pub struct ConstantReference {
     /// The offsets inside of the document where we found the reference
     offset: Offset,
 }
-assert_mem_size!(ConstantReference, 16);
+assert_mem_size!(ConstantReference, 24);
 
 impl ConstantReference {
     #[must_use]
@@ -66,15 +43,13 @@ impl ConstantReference {
 
     #[must_use]
     pub fn id(&self) -> ReferenceId {
-        let mut id = ReferenceId::from(&format!(
+        ReferenceId::from(&format!(
             "{}:{}:{}-{}",
             self.name_id,
             self.uri_id,
             self.offset.start(),
             self.offset.end()
-        ));
-        id.tag_kind(ReferenceKind::Constant);
-        id
+        ))
     }
 }
 
@@ -90,7 +65,7 @@ pub struct MethodRef {
     /// The receiver of the method call if it's a constant
     receiver: Option<NameId>,
 }
-assert_mem_size!(MethodRef, 24);
+assert_mem_size!(MethodRef, 40);
 
 impl MethodRef {
     #[must_use]
@@ -125,14 +100,12 @@ impl MethodRef {
 
     #[must_use]
     pub fn id(&self) -> ReferenceId {
-        let mut id = ReferenceId::from(&format!(
+        ReferenceId::from(&format!(
             "{}:{}:{}-{}",
             self.str,
             self.uri_id,
             self.offset.start(),
             self.offset.end()
-        ));
-        id.tag_kind(ReferenceKind::Method);
-        id
+        ))
     }
 }

--- a/rust/rubydex/src/resolution.rs
+++ b/rust/rubydex/src/resolution.rs
@@ -1792,7 +1792,7 @@ mod tests {
 
         assert_eq!(
             [
-                "Top", "Foo", "Bar", "AfterTop", "Qux", "Baz", "Zip", "Zap", "Zop", "Boop"
+                "Top", "Foo", "Qux", "AfterTop", "Bar", "Baz", "Zip", "Zap", "Zop", "Boop"
             ],
             names
                 .iter()


### PR DESCRIPTION
Unfortunately, u32 is clearly not enough to avoid collisions in a codebase as large as Core. This PR reverts the ID sizes back to 64 bits and removes tagging.

Here are the unsuccessful things I tried to avoid collision with u32:

- Switching our ID hashing from strings to bytes (this does have better performance as it avoids string allocations, but doesn't help with collisions)
- Partitioning parts of the IDs with more bits for data that better differentiates entities. For example, URI + offset is much higher relevance for constant references than name since you cannot put two references in the same exact spot in the code (only exception is hidden singleton references)
- Hashing the ID parts separately and then combining them
- Kind tagging

### Idea

The only ID that actually fits in u32 is `UriId`. One idea I had is that we could partition `DefinitionId` and `ReferenceId` to store the URI in it. That way, we don't pay the price of also storing the UriId in these structs and still avoid collisions. That's an experiment for a different PR though. Let's eliminate the collisions first.