### PR TITLE
Prototype: Name-based invalidation for incremental updates

### DIFF
--- a/ext/rubydex/index_result.c
+++ b/ext/rubydex/index_result.c
@@ -1,0 +1,33 @@
+#include "index_result.h"
+#include "rustbindings.h"
+
+VALUE cIndexResult;
+
+static void index_result_free(void *ptr) {
+    if (ptr) {
+        rdx_index_result_free(ptr);
+    }
+}
+
+const rb_data_type_t index_result_type = {"IndexResult", {0, index_result_free, 0}, 0, 0, RUBY_TYPED_FREE_IMMEDIATELY};
+
+// IndexResult#definition_ids_length -> Integer
+static VALUE rdxr_index_result_definition_ids_length(VALUE self) {
+    void *index_result;
+    TypedData_Get_Struct(self, void *, &index_result_type, index_result);
+    return SIZET2NUM(rdx_index_result_definition_ids_len(index_result));
+}
+
+// IndexResult#reference_ids_length -> Integer
+static VALUE rdxr_index_result_reference_ids_length(VALUE self) {
+    void *index_result;
+    TypedData_Get_Struct(self, void *, &index_result_type, index_result);
+    return SIZET2NUM(rdx_index_result_reference_ids_len(index_result));
+}
+
+void rdxi_initialize_index_result(VALUE mRubydex) {
+    cIndexResult = rb_define_class_under(mRubydex, "IndexResult", rb_cObject);
+    rb_undef_alloc_func(cIndexResult);
+    rb_define_method(cIndexResult, "definition_ids_length", rdxr_index_result_definition_ids_length, 0);
+    rb_define_method(cIndexResult, "reference_ids_length", rdxr_index_result_reference_ids_length, 0);
+}

--- a/ext/rubydex/index_result.h
+++ b/ext/rubydex/index_result.h
@@ -1,0 +1,13 @@
+#ifndef INDEX_RESULT_H
+#define INDEX_RESULT_H
+
+#include "ruby.h"
+
+typedef void *IndexResultPointer;
+
+extern VALUE cIndexResult;
+extern const rb_data_type_t index_result_type;
+
+void rdxi_initialize_index_result(VALUE mRubydex);
+
+#endif

--- a/ext/rubydex/rubydex.c
+++ b/ext/rubydex/rubydex.c
@@ -5,6 +5,7 @@
 #include "graph.h"
 #include "location.h"
 #include "reference.h"
+#include "index_result.h"
 
 VALUE mRubydex;
 
@@ -12,6 +13,7 @@ void Init_rubydex(void) {
     rb_ext_ractor_safe(true);
 
     mRubydex = rb_define_module("Rubydex");
+    rdxi_initialize_index_result(mRubydex);
     rdxi_initialize_graph(mRubydex);
     rdxi_initialize_declaration(mRubydex);
     rdxi_initialize_document(mRubydex);

--- a/rust/rubydex-sys/src/index_result_api.rs
+++ b/rust/rubydex-sys/src/index_result_api.rs
@@ -1,0 +1,35 @@
+use libc::c_void;
+use rubydex::indexing::IndexResult;
+
+pub type IndexResultPointer = *mut c_void;
+
+#[unsafe(no_mangle)]
+pub extern "C" fn rdx_index_result_free(pointer: IndexResultPointer) {
+    if pointer.is_null() {
+        return;
+    }
+
+    unsafe {
+        let _ = Box::from_raw(pointer.cast::<IndexResult>());
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn rdx_index_result_definition_ids_len(pointer: IndexResultPointer) -> usize {
+    if pointer.is_null() {
+        return 0;
+    }
+
+    let result = unsafe { &*pointer.cast::<IndexResult>() };
+    result.definition_ids.len()
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn rdx_index_result_reference_ids_len(pointer: IndexResultPointer) -> usize {
+    if pointer.is_null() {
+        return 0;
+    }
+
+    let result = unsafe { &*pointer.cast::<IndexResult>() };
+    result.reference_ids.len()
+}

--- a/rust/rubydex-sys/src/lib.rs
+++ b/rust/rubydex-sys/src/lib.rs
@@ -3,6 +3,7 @@ pub mod definition_api;
 pub mod diagnostic_api;
 pub mod document_api;
 pub mod graph_api;
+pub mod index_result_api;
 pub mod location_api;
 pub mod name_api;
 pub mod reference_api;

--- a/rust/rubydex/examples/incremental_verify.rs
+++ b/rust/rubydex/examples/incremental_verify.rs
@@ -1,0 +1,434 @@
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::Instant;
+
+use clap::Parser;
+use rubydex::{
+    diff::{self, GraphDiff},
+    indexing::{self, IndexResult},
+    listing,
+    model::{
+        declaration::Ancestor,
+        graph::Graph,
+        identity_maps::IdentityHashSet,
+        ids::{DeclarationId, NameId},
+        name::NameRef,
+    },
+    resolution::Resolver,
+};
+use url::Url;
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "incremental_verify",
+    about = "Verify incremental resolution matches full resolution between two git refs"
+)]
+struct Args {
+    #[arg(help = "Path to git repository")]
+    path: String,
+
+    #[arg(help = "Base git ref (e.g., main, HEAD~1, abc123)")]
+    base_ref: String,
+
+    #[arg(help = "Updated git ref")]
+    updated_ref: String,
+
+    #[arg(long, short, help = "Show detailed diff output")]
+    verbose: bool,
+}
+
+fn git(path: &str, args: &[&str]) -> Result<String, String> {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(path)
+        .output()
+        .map_err(|e| format!("Failed to run git {}: {e}", args.join(" ")))?;
+
+    if !output.status.success() {
+        return Err(format!(
+            "git {} failed: {}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+fn changed_files(path: &Path, base: &str, updated: &str) -> Result<(Vec<PathBuf>, Vec<PathBuf>), String> {
+    let output = git(
+        path.to_str().unwrap(),
+        &["diff", "--relative", "--name-status", base, updated],
+    )?;
+
+    let mut modified = Vec::new();
+    let mut deleted = Vec::new();
+
+    for line in output.lines() {
+        let mut parts = line.splitn(2, '\t');
+        let Some(status) = parts.next() else {
+            continue;
+        };
+        let Some(file) = parts.next() else { continue };
+
+        if !Path::new(file)
+            .extension()
+            .is_some_and(|ext| ext.eq_ignore_ascii_case("rb"))
+        {
+            continue;
+        }
+
+        let full_path = path.join(file);
+        match status {
+            "D" => deleted.push(full_path),
+            _ => modified.push(full_path),
+        }
+    }
+
+    Ok((modified, deleted))
+}
+
+fn build_graph(path: &str) -> (Graph, std::time::Duration) {
+    let start = Instant::now();
+    let (file_paths, _) = listing::collect_file_paths(vec![path.to_string()]);
+    let mut graph = Graph::new();
+    indexing::index_files(&mut graph, file_paths);
+    let mut resolver = Resolver::new(&mut graph);
+    resolver.resolve_all();
+    (graph, start.elapsed())
+}
+
+fn file_uri(path: &Path) -> String {
+    Url::from_file_path(path)
+        .expect("Failed to build URI from path")
+        .to_string()
+}
+
+fn name_str(graph: &Graph, name_id: NameId) -> String {
+    graph
+        .names()
+        .get(&name_id)
+        .and_then(|name| graph.strings().get(name.str()))
+        .map_or_else(|| format!("{name_id}"), |s| s.to_string())
+}
+
+fn decl_name(graph: &Graph, id: DeclarationId) -> String {
+    graph
+        .declarations()
+        .get(&id)
+        .map_or("?".to_string(), |d| d.name().to_string())
+}
+
+fn describe_name(graph: &Graph, name_id: NameId) -> String {
+    let Some(name_ref) = graph.names().get(&name_id) else {
+        return "missing".to_string();
+    };
+    let str = name_str(graph, name_id);
+    let resolution = match name_ref {
+        NameRef::Resolved(resolved) => {
+            format!("resolved -> {}", decl_name(graph, *resolved.declaration_id()))
+        }
+        NameRef::Unresolved(_) => "unresolved".to_string(),
+    };
+    let deps = name_ref.dependents().len();
+    format!("\"{str}\" ({resolution}, {deps} dependents)")
+}
+
+fn describe_ancestor(graph: &Graph, ancestor: &Ancestor) -> String {
+    match ancestor {
+        Ancestor::Complete(id) => {
+            let kind = graph.declarations().get(id).map_or("?", |d| d.kind());
+            format!("{} [{}]", decl_name(graph, *id), kind)
+        }
+        Ancestor::Partial(name_id) => {
+            let str = name_str(graph, *name_id);
+            format!("{str} (partial)")
+        }
+    }
+}
+
+fn print_summary(diff: &GraphDiff) {
+    let mut parts = Vec::new();
+    let add = diff.added_declarations.len();
+    let rem = diff.removed_declarations.len();
+    let chg = diff.changed_declarations.len();
+    if add > 0 {
+        parts.push(format!("+{add} declarations"));
+    }
+    if rem > 0 {
+        parts.push(format!("-{rem} declarations"));
+    }
+    if chg > 0 {
+        parts.push(format!("~{chg} declarations"));
+    }
+
+    let add = diff.added_definitions.len();
+    let rem = diff.removed_definitions.len();
+    if add > 0 {
+        parts.push(format!("+{add} definitions"));
+    }
+    if rem > 0 {
+        parts.push(format!("-{rem} definitions"));
+    }
+
+    let add = diff.added_references.len();
+    let rem = diff.removed_references.len();
+    if add > 0 {
+        parts.push(format!("+{add} references"));
+    }
+    if rem > 0 {
+        parts.push(format!("-{rem} references"));
+    }
+
+    let add = diff.added_names.len();
+    let rem = diff.removed_names.len();
+    let chg = diff.changed_names.len();
+    if add > 0 {
+        parts.push(format!("+{add} names"));
+    }
+    if rem > 0 {
+        parts.push(format!("-{rem} names"));
+    }
+    if chg > 0 {
+        parts.push(format!("~{chg} names"));
+    }
+
+    println!("  {}", parts.join(", "));
+}
+
+#[allow(clippy::too_many_lines)]
+fn print_verbose_diff(diff: &GraphDiff, incremental: &Graph, reference: &Graph) {
+    if !diff.added_declarations.is_empty() {
+        println!(
+            "\n  Added declarations (in reference only) ({}):",
+            diff.added_declarations.len()
+        );
+        for id in &diff.added_declarations {
+            println!("    + {}", decl_name(reference, *id));
+        }
+    }
+
+    if !diff.removed_declarations.is_empty() {
+        println!(
+            "\n  Removed declarations (in incremental only) ({}):",
+            diff.removed_declarations.len()
+        );
+        for id in &diff.removed_declarations {
+            println!("    - {}", decl_name(incremental, *id));
+        }
+    }
+
+    if !diff.changed_declarations.is_empty() {
+        let mut extra_in_inc: HashMap<String, usize> = HashMap::new();
+        let mut extra_in_ref: HashMap<String, usize> = HashMap::new();
+        let mut member_changes = 0;
+        let mut descendant_changes = 0;
+        let mut singleton_changes = 0;
+
+        for id in &diff.changed_declarations {
+            let (Some(decl_a), Some(decl_b)) = (incremental.declarations().get(id), reference.declarations().get(id)) else {
+                continue;
+            };
+            let (Some(ns_a), Some(ns_b)) = (decl_a.as_namespace(), decl_b.as_namespace()) else {
+                continue;
+            };
+            if ns_a.members() != ns_b.members() {
+                member_changes += 1;
+            }
+            if ns_a.descendants() != ns_b.descendants() {
+                descendant_changes += 1;
+            }
+            if ns_a.singleton_class() != ns_b.singleton_class() {
+                singleton_changes += 1;
+            }
+
+            let anc_a: Vec<_> = ns_a.ancestors().iter().collect();
+            let anc_b: Vec<_> = ns_b.ancestors().iter().collect();
+            if anc_a != anc_b {
+                let set_a: HashSet<_> = anc_a.iter().map(|a| describe_ancestor(incremental, a)).collect();
+                let set_b: HashSet<_> = anc_b.iter().map(|a| describe_ancestor(reference, a)).collect();
+                for name in set_a.difference(&set_b) {
+                    *extra_in_inc.entry(name.clone()).or_default() += 1;
+                }
+                for name in set_b.difference(&set_a) {
+                    *extra_in_ref.entry(name.clone()).or_default() += 1;
+                }
+            }
+        }
+
+        println!("\n  Changed declarations ({}):", diff.changed_declarations.len());
+        if member_changes > 0 {
+            println!("    {member_changes} with member differences");
+        }
+        if descendant_changes > 0 {
+            println!("    {descendant_changes} with descendant differences");
+        }
+        if singleton_changes > 0 {
+            println!("    {singleton_changes} with singleton_class differences");
+        }
+
+        if !extra_in_inc.is_empty() {
+            println!("\n    Ancestors in incremental but not reference:");
+            let mut sorted: Vec<_> = extra_in_inc.into_iter().collect();
+            sorted.sort_by(|a, b| b.1.cmp(&a.1));
+            for (name, count) in &sorted {
+                println!("      {name} ({count} declarations)");
+            }
+        }
+        if !extra_in_ref.is_empty() {
+            println!("\n    Ancestors in reference but not incremental:");
+            let mut sorted: Vec<_> = extra_in_ref.into_iter().collect();
+            sorted.sort_by(|a, b| b.1.cmp(&a.1));
+            for (name, count) in &sorted {
+                println!("      {name} ({count} declarations)");
+            }
+        }
+    }
+
+    if !diff.added_definitions.is_empty() {
+        println!(
+            "\n  Added definitions (in reference only): {}",
+            diff.added_definitions.len()
+        );
+    }
+    if !diff.removed_definitions.is_empty() {
+        println!(
+            "\n  Removed definitions (in incremental only): {}",
+            diff.removed_definitions.len()
+        );
+    }
+
+    if !diff.added_references.is_empty() {
+        println!(
+            "\n  Added references (in reference only): {}",
+            diff.added_references.len()
+        );
+    }
+    if !diff.removed_references.is_empty() {
+        println!(
+            "\n  Removed references (in incremental only): {}",
+            diff.removed_references.len()
+        );
+    }
+
+    if !diff.added_names.is_empty() {
+        println!("\n  Added names (in reference only) ({}):", diff.added_names.len());
+        for id in &diff.added_names {
+            println!("    + {}", describe_name(reference, *id));
+        }
+    }
+    if !diff.removed_names.is_empty() {
+        println!(
+            "\n  Removed names (in incremental only) ({}):",
+            diff.removed_names.len()
+        );
+        for id in &diff.removed_names {
+            println!("    - {}", describe_name(incremental, *id));
+        }
+    }
+    if !diff.changed_names.is_empty() {
+        println!("\n  Changed names ({}):", diff.changed_names.len());
+        for id in &diff.changed_names {
+            println!("    incremental: {}", describe_name(incremental, *id));
+            println!("    reference:   {}", describe_name(reference, *id));
+        }
+    }
+}
+
+fn main() -> Result<(), String> {
+    let args = Args::parse();
+    let project_path = std::fs::canonicalize(&args.path).map_err(|e| format!("Failed to canonicalize path: {e}"))?;
+    let original_ref = git(&args.path, &["rev-parse", "HEAD"])?;
+
+    // Step 1: Full index at base ref
+    println!("Checking out {}...", args.base_ref);
+    git(&args.path, &["checkout", &args.base_ref])?;
+
+    println!("Building base graph...");
+    let (mut incremental_graph, base_duration) = build_graph(&args.path);
+    println!(
+        "  {} declarations, {} definitions, {} references ({:.2}s)",
+        incremental_graph.declarations().len(),
+        incremental_graph.definitions().len(),
+        incremental_graph.constant_references().len(),
+        base_duration.as_secs_f64(),
+    );
+
+    // Step 2: Checkout updated ref and do incremental update
+    let (modified_files, deleted_files) = changed_files(&project_path, &args.base_ref, &args.updated_ref)?;
+    println!(
+        "\nChecking out {}... ({} modified, {} deleted)",
+        args.updated_ref,
+        modified_files.len(),
+        deleted_files.len(),
+    );
+    git(&args.path, &["checkout", &args.updated_ref])?;
+
+    let incremental_start = Instant::now();
+
+    let mut result = IndexResult {
+        definition_ids: IdentityHashSet::default(),
+        reference_ids: IdentityHashSet::default(),
+    };
+    for path in &deleted_files {
+        let uri = file_uri(path);
+        let (def_ids, ref_ids) = incremental_graph.delete_uri(&uri);
+        result.definition_ids.extend(def_ids);
+        result.reference_ids.extend(ref_ids);
+    }
+
+    let (index_result, _) = indexing::index_files(&mut incremental_graph, modified_files);
+    result.extend(index_result);
+
+    println!(
+        "  {} definitions and {} references scheduled for resolution",
+        result.definition_ids.len(),
+        result.reference_ids.len(),
+    );
+
+    let mut resolver = Resolver::new(&mut incremental_graph);
+    resolver.resolve(&result.definition_ids, &result.reference_ids);
+
+    let incremental_duration = incremental_start.elapsed();
+    println!(
+        "  {} declarations, {} definitions, {} references ({:.2}s)",
+        incremental_graph.declarations().len(),
+        incremental_graph.definitions().len(),
+        incremental_graph.constant_references().len(),
+        incremental_duration.as_secs_f64(),
+    );
+
+    // Step 3: Full index at updated ref for comparison
+    println!("\nBuilding reference graph...");
+    let (reference_graph, reference_duration) = build_graph(&args.path);
+    println!(
+        "  {} declarations, {} definitions, {} references ({:.2}s)",
+        reference_graph.declarations().len(),
+        reference_graph.definitions().len(),
+        reference_graph.constant_references().len(),
+        reference_duration.as_secs_f64(),
+    );
+
+    // Step 4: Restore original ref
+    println!("\nRestoring {}...", &original_ref[..12]);
+    git(&args.path, &["checkout", &original_ref])?;
+
+    // Step 5: Compare
+    println!("\nComparing incremental vs reference...");
+    if let Some(diff) = diff::diff(&incremental_graph, &reference_graph) {
+        println!("MISMATCH: incremental resolution diverged from full resolution");
+        print_summary(&diff);
+        if args.verbose {
+            print_verbose_diff(&diff, &incremental_graph, &reference_graph);
+        }
+        std::process::exit(1);
+    } else {
+        println!("OK: graphs are identical");
+        println!(
+            "\nIncremental update was {:.1}x faster than full rebuild",
+            reference_duration.as_secs_f64() / incremental_duration.as_secs_f64(),
+        );
+    }
+
+    Ok(())
+}

--- a/rust/rubydex/src/diff.rs
+++ b/rust/rubydex/src/diff.rs
@@ -1,0 +1,122 @@
+use std::collections::HashSet;
+
+use crate::model::{
+    graph::Graph,
+    ids::{DeclarationId, DefinitionId, NameId, ReferenceId},
+    name::NameRef,
+};
+
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct GraphDiff {
+    pub added_declarations: HashSet<DeclarationId>,
+    pub removed_declarations: HashSet<DeclarationId>,
+    pub changed_declarations: HashSet<DeclarationId>,
+    pub added_definitions: HashSet<DefinitionId>,
+    pub removed_definitions: HashSet<DefinitionId>,
+    pub added_references: HashSet<ReferenceId>,
+    pub removed_references: HashSet<ReferenceId>,
+    pub added_names: HashSet<NameId>,
+    pub removed_names: HashSet<NameId>,
+    pub changed_names: HashSet<NameId>,
+}
+
+impl GraphDiff {
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.added_declarations.is_empty()
+            && self.removed_declarations.is_empty()
+            && self.changed_declarations.is_empty()
+            && self.added_definitions.is_empty()
+            && self.removed_definitions.is_empty()
+            && self.added_references.is_empty()
+            && self.removed_references.is_empty()
+            && self.added_names.is_empty()
+            && self.removed_names.is_empty()
+            && self.changed_names.is_empty()
+    }
+}
+
+fn declarations_equal(a: &Graph, b: &Graph, id: DeclarationId) -> bool {
+    let (Some(decl_a), Some(decl_b)) = (a.declarations().get(&id), b.declarations().get(&id)) else {
+        return false;
+    };
+
+    let Some(ns_a) = decl_a.as_namespace() else {
+        return true;
+    };
+    let Some(ns_b) = decl_b.as_namespace() else {
+        return true;
+    };
+
+    ns_a.members() == ns_b.members()
+        && ns_a.ancestors().iter().collect::<Vec<_>>() == ns_b.ancestors().iter().collect::<Vec<_>>()
+        && ns_a.descendants() == ns_b.descendants()
+        && ns_a.singleton_class() == ns_b.singleton_class()
+}
+
+fn names_equal(a: &Graph, b: &Graph, id: NameId) -> bool {
+    let (Some(name_a), Some(name_b)) = (a.names().get(&id), b.names().get(&id)) else {
+        return false;
+    };
+
+    match (name_a, name_b) {
+        (NameRef::Resolved(a), NameRef::Resolved(b)) => a.declaration_id() == b.declaration_id(),
+        (NameRef::Unresolved(_), NameRef::Unresolved(_)) => true,
+        _ => false,
+    }
+}
+
+#[must_use]
+pub fn diff(a: &Graph, b: &Graph) -> Option<GraphDiff> {
+    let mut result = GraphDiff::default();
+
+    for id in a.declarations().keys() {
+        if !b.declarations().contains_key(id) {
+            result.removed_declarations.insert(*id);
+        } else if !declarations_equal(a, b, *id) {
+            result.changed_declarations.insert(*id);
+        }
+    }
+    for id in b.declarations().keys() {
+        if !a.declarations().contains_key(id) {
+            result.added_declarations.insert(*id);
+        }
+    }
+
+    for id in a.definitions().keys() {
+        if !b.definitions().contains_key(id) {
+            result.removed_definitions.insert(*id);
+        }
+    }
+    for id in b.definitions().keys() {
+        if !a.definitions().contains_key(id) {
+            result.added_definitions.insert(*id);
+        }
+    }
+
+    for id in a.constant_references().keys() {
+        if !b.constant_references().contains_key(id) {
+            result.removed_references.insert(*id);
+        }
+    }
+    for id in b.constant_references().keys() {
+        if !a.constant_references().contains_key(id) {
+            result.added_references.insert(*id);
+        }
+    }
+
+    for id in a.names().keys() {
+        if !b.names().contains_key(id) {
+            result.removed_names.insert(*id);
+        } else if !names_equal(a, b, *id) {
+            result.changed_names.insert(*id);
+        }
+    }
+    for id in b.names().keys() {
+        if !a.names().contains_key(id) {
+            result.added_names.insert(*id);
+        }
+    }
+
+    if result.is_empty() { None } else { Some(result) }
+}

--- a/rust/rubydex/src/diff.rs
+++ b/rust/rubydex/src/diff.rs
@@ -59,11 +59,13 @@ fn names_equal(a: &Graph, b: &Graph, id: NameId) -> bool {
         return false;
     };
 
-    match (name_a, name_b) {
+    let resolution_equal = match (name_a, name_b) {
         (NameRef::Resolved(a), NameRef::Resolved(b)) => a.declaration_id() == b.declaration_id(),
         (NameRef::Unresolved(_), NameRef::Unresolved(_)) => true,
         _ => false,
-    }
+    };
+
+    resolution_equal && name_a.dependents() == name_b.dependents()
 }
 
 #[must_use]

--- a/rust/rubydex/src/indexing.rs
+++ b/rust/rubydex/src/indexing.rs
@@ -18,6 +18,13 @@ pub struct IndexResult {
     pub reference_ids: IdentityHashSet<ReferenceId>,
 }
 
+impl IndexResult {
+    pub fn extend(&mut self, other: IndexResult) {
+        self.definition_ids.extend(other.definition_ids);
+        self.reference_ids.extend(other.reference_ids);
+    }
+}
+
 /// Job that indexes a single Ruby file
 pub struct IndexingRubyFileJob {
     path: PathBuf,

--- a/rust/rubydex/src/indexing/local_graph.rs
+++ b/rust/rubydex/src/indexing/local_graph.rs
@@ -102,6 +102,10 @@ impl LocalGraph {
         &self.names
     }
 
+    pub fn names_mut(&mut self) -> &mut IdentityHashMap<NameId, NameRef> {
+        &mut self.names
+    }
+
     pub fn add_name(&mut self, name: Name) -> NameId {
         let name_id = name.id();
         let parent_scope = *name.parent_scope();

--- a/rust/rubydex/src/indexing/ruby_indexer.rs
+++ b/rust/rubydex/src/indexing/ruby_indexer.rs
@@ -836,6 +836,13 @@ impl<'a> RubyIndexer<'a> {
     ) -> Option<DefinitionId> {
         let name_id = self.index_constant_reference(name_node, also_add_reference)?;
 
+        if let Some(target_name) = self.local_graph.names_mut().get_mut(&target_name_id) {
+            target_name.add_dependent(name_id);
+        }
+        if let Some(alias_name) = self.local_graph.names_mut().get_mut(&name_id) {
+            alias_name.add_dependent(target_name_id);
+        }
+
         // Get the location for just the constant name (not including the namespace or value).
         let location = match name_node {
             ruby_prism::Node::ConstantWriteNode { .. } => name_node.as_constant_write_node().unwrap().name_loc(),

--- a/rust/rubydex/src/lib.rs
+++ b/rust/rubydex/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod compile_assertions;
 pub mod diagnostic;
+pub mod diff;
 pub mod errors;
 pub mod indexing;
 pub mod job_queue;

--- a/rust/rubydex/src/main.rs
+++ b/rust/rubydex/src/main.rs
@@ -67,7 +67,7 @@ fn main() {
     // Indexing
 
     let mut graph = Graph::new();
-    let errors = time_it!(indexing, { indexing::index_files(&mut graph, file_paths) });
+    let (_, errors) = time_it!(indexing, { indexing::index_files(&mut graph, file_paths) });
 
     for error in errors {
         eprintln!("{error}");

--- a/rust/rubydex/src/model/declaration.rs
+++ b/rust/rubydex/src/model/declaration.rs
@@ -471,6 +471,10 @@ impl Namespace {
         all_namespaces!(self, it => it.member(str_id))
     }
 
+    pub fn remove_member(&mut self, str_id: &StringId) -> Option<DeclarationId> {
+        all_namespaces!(self, it => it.remove_member(str_id))
+    }
+
     #[must_use]
     pub fn singleton_class(&self) -> Option<&DeclarationId> {
         all_namespaces!(self, it => it.singleton_class_id())

--- a/rust/rubydex/src/model/graph.rs
+++ b/rust/rubydex/src/model/graph.rs
@@ -516,10 +516,12 @@ impl Graph {
     }
 
     //// Handles the deletion of a document identified by `uri`
-    pub fn delete_uri(&mut self, uri: &str) {
+    pub fn delete_uri(&mut self, uri: &str) -> (IdentityHashSet<DefinitionId>, IdentityHashSet<ReferenceId>) {
         let uri_id = UriId::from(uri);
         self.remove_definitions_for_uri(uri_id);
         self.documents.remove(&uri_id);
+
+        (IdentityHashSet::default(), IdentityHashSet::default())
     }
 
     /// Merges everything in `other` into this Graph. This method is meant to merge all graph representations from
@@ -577,13 +579,18 @@ impl Graph {
 
     /// Updates the global representation with the information contained in `other`, handling deletions, insertions and
     /// updates to existing entries
-    pub fn update(&mut self, other: LocalGraph) {
+    pub fn update(&mut self, other: LocalGraph) -> (IdentityHashSet<DefinitionId>, IdentityHashSet<ReferenceId>) {
         // For each URI that was indexed through `other`, check what was discovered and update our current global
         // representation
         let uri_id = other.uri_id();
         self.remove_definitions_for_uri(uri_id);
 
+        let definition_ids: IdentityHashSet<DefinitionId> = other.definitions().keys().copied().collect();
+        let reference_ids: IdentityHashSet<ReferenceId> = other.constant_references().keys().copied().collect();
+
         self.extend(other);
+
+        (definition_ids, reference_ids)
     }
 
     // Removes all nodes and relationships associated to the given URI. This is used to clean up stale data when a

--- a/rust/rubydex/src/model/identity_maps.rs
+++ b/rust/rubydex/src/model/identity_maps.rs
@@ -29,7 +29,7 @@ impl Hasher for IdentityHasher {
     }
 }
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct IdentityHashBuilder;
 
 impl BuildHasher for IdentityHashBuilder {

--- a/rust/rubydex/src/resolution.rs
+++ b/rust/rubydex/src/resolution.rs
@@ -124,6 +124,7 @@ impl<'a> Resolver<'a> {
         let definition_ids: IdentityHashSet<DefinitionId> = self.graph.definitions().keys().copied().collect();
         let reference_ids: IdentityHashSet<ReferenceId> = self.graph.constant_references().keys().copied().collect();
         self.resolve(&definition_ids, &reference_ids);
+        self.graph.set_resolved();
     }
 
     /// Resolves only the specified definitions and references

--- a/test/graph_test.rb
+++ b/test/graph_test.rb
@@ -9,7 +9,7 @@ class GraphTest < Minitest::Test
   def test_indexing_empty_context
     with_context do |context|
       graph = Rubydex::Graph.new
-      assert_nil(graph.index_all(context.glob("**/*.rb")))
+      assert_instance_of(Rubydex::IndexResult, graph.index_all(context.glob("**/*.rb")))
     end
   end
 
@@ -19,7 +19,7 @@ class GraphTest < Minitest::Test
       context.write!("bar.rb", "class Bar; end")
 
       graph = Rubydex::Graph.new
-      assert_nil(graph.index_all(context.glob("**/*.rb")))
+      assert_instance_of(Rubydex::IndexResult, graph.index_all(context.glob("**/*.rb")))
     end
   end
 


### PR DESCRIPTION
This PR prototypes incremental updates via name-based invalidation.

The basic premise is that when a document is added/changed/removed we invalidate the graph for based on all names in either the old or new version of the document. We use those seed names to find dependent names and remove/invalidate everything that could possibly require re-resolution or re-linearization.

## Tracking dependent names

We are already able to traverse names upwards via nesting and parent names, but invalidation requires traversing downwards too. During indexing we can add names as dependent of one-another via a `dependents` field on the `Name`.

```rb
module Foo::Bar
  class Baz < Qux
    ABC = 1
  end
end
```

This document has 5 names:

1. `Foo` with no parent or nesting
2. `Bar` with `Foo` parent and no nesting
3. `Baz` with no parent and `Bar` nesting
4. `Qux` with no parent and `Bar` nesting
5. `ABC` with no parent and `Baz` nesting

We would add the following dependencies:

- `Foo` → `[Bar]`
- `Bar` → `[Baz, Qux]`
- `Baz` → `[ABC]`
- `Qux` → `[]`
- `ABC` → `[]`

Currently, this prototype tracks a dependency for both parent and nesting names, but I'm not sure if that's necessary. We might only need to track nesting name because we can find resolved parent/child names via the declaration members. For example, we shouldn't _need_ to track that `Bar` is a dependent of `Foo` because there will be a `Bar` member declaration in the `Foo` declaration, and we can get all the names that point to it from there.

I also experimented with tracking aliases:

```rb
A = B
```

Here we'd add `A` as a dependent of `B` and `B` as a dependent of `A`. Again, we already model the relationship in one direction via alias targets but tracking both directions here made the prototype straightforward. I wonder if target-to-aliases dependency should be tracked on the declaration, but again, this was easy.

Some form of relationship tracking is necessary here, so we can propagate invalidation in either direction when necessary.

## Invalidation

The basic algorithm for invalidating based on names is as follows:

- Enqueue all names in both old/new version of document and all dependent names
- For each name in the queue:
  - Find the declaration it resolves to
  - Enqueue all names for its definitions and references
  - Collect IDs for its definitions and references
  - Clean up the declaration
  - Do the same for each of its descendants
  - Unresolve the name
- Return the collected IDs for definitions and references merged with any IDs from the new doc

This is probably quite simplistic and missing nuance. The prototype undoubtedly has bugs, even in this simplified invalidation mechanism. However, it works for simple cases and even when testing switching branches on some smaller projects.

It *definitely* over invalidates, but the idea is that it should invalidate less than the full graph and we can incrementally work towards a solution that invalidates less and less.

## Re-resolution

The collection definition IDs and reference IDs are handed back to the resolve via the incremental updates infrastructure from #559. This list of IDs should theoretically include everything connected to an invalidated name plus the new ones. The declarations have been deleted, so the resolver will recreate them and re-resolve any unresolved names for these entities.

## Full vs incremental updates

The prototype currently has a flag to skip invalidation for the initial build. We start `resolved: false` and then after the initial resolution phase we set `resolved: true`. This is because the invalidation logic incurs a cost that we shouldn't need to pay first time.

## Verification

The prototype includes a small tool set for verifying that incremental updates are working as expected:

- The `assert_incremental_graph_intrgrity!` macro performs incremental resolution and then generates a fresh graph from the same docs. It uses the `diff` tool from #557 to compare the state of the graph—references, definitions, declarations, members, ancestry, names, resolution etc.
- The `incremental_verify` example allows us to perform the same kind of graph comparison using two references from a git project. It checks out the first reference, builds the initial graph, then switches to the second reference to perform an incremental build, then it performs a fresh full build, and finally compares the state of the incremental and fresh graphs.

For example:

```
$ cargo run --example incremental_verify --release -- /Users/thomasmarshall/src/github.com/Shopify/tapioca main main~1
```

```
Checking out main...
Building base graph...
  1837 declarations, 2252 definitions, 5127 references (0.02s)

Checking out main~1... (19 modified, 0 deleted)
  2465 definitions and 3569 references scheduled for resolution
  1837 declarations, 2252 definitions, 5127 references (0.01s)

Building reference graph...
  1837 declarations, 2252 definitions, 5127 references (0.03s)

Restoring 033d95194c4e...

Comparing incremental vs reference...
OK: graphs are identical

Incremental update was 2.2x faster than full rebuild
```

This one looks fine, but on a bigger and more complex project there are still many difference in the graph.

### Remaining challenges

There are many edge cases (and not-so-edge cases) that are not yet covered. For an example of a not-so-edge case: this prototype doesn't resolve previously resolved names that should now be.

For example:

```rb
Foo
```

This reference should be unresolved. If we add a second file:

```rb
class Foo; end
```

…the reference should become resolved. It doesn't at the moment, because we don't have a mapping of unresolved names to references—we can only get to them via declarations (resolved) or searching through the whole of `graph.constant_references`.

There are of course also many nuances to how singletons and aliases should be handled, and the prototype is, in some cases, unable to linearize complete ancestors that the fresh graph handles just fine. I wasn't yet able to track down the cause.

We also need to think about performance due to over-invalidation. This approach blows away **everything that could possibly be affected** and then builds it up again. Depending on what changes, that could be a sizable chunk of the graph. Invalidation is not free, and so there will be a point at which it's quicker to just short-cut to a full rebuild.

Another challenge will be how to index the necessary data such that we can efficiently traverse the graph for things—without massively inflating the size of the data.

I think there are some small flow/architectural things to consider here too. For one, it seems inefficient to perform invalidation on a per-document basis as we are currently doing—especially since many files will have overlapping names. Of course, once the names have been unresolved and declarations removed there will be less work to do each time, but still I think it would be preferable to collect the full set of names from all documents and process them in a single queue.

We could still implement a fast/slow path decision for incremental updates (like [this](https://github.com/Shopify/rubydex/pull/572)) on top of this approach. If 90% of key strokes don't change the set/shape of namespaces in the document then we can take a shortcut to get very fast incremental updates.

## Notes

Included in this PR are a handful of temporary commits that are unrelated to the actual prototype:

- Adding the incremental infrastructure from #559
- Adding the diff functionality from #557
- A "fix" for constant singletons that was causing noise in the graph diff