### PR TITLE
Improve index workspace path discovery

### DIFF
--- a/lib/rubydex/graph.rb
+++ b/lib/rubydex/graph.rb
@@ -5,6 +5,14 @@ module Rubydex
   #
   # Note: this class is partially defined in C to integrate with the Rust backend
   class Graph
+    IGNORED_DIRECTORIES = [
+      ".bundle",
+      ".git",
+      ".github",
+      "node_modules",
+      "tmp",
+    ].freeze
+
     #: (?workspace_path: String) -> void
     def initialize(workspace_path: Dir.pwd)
       @workspace_path = workspace_path
@@ -13,32 +21,52 @@ module Rubydex
     # Index all files and dependencies of the workspace that exists in `@workspace_path`
     #: -> String?
     def index_workspace
-      paths = Dir.glob("#{@workspace_path}/**/*.rb")
-      paths.concat(
-        workspace_dependency_paths.flat_map do |path|
-          Dir.glob("#{path}/**/*.rb")
-        end,
-      )
-      index_all(paths)
+      index_all(workspace_paths)
+    end
+
+    # Returns all workspace paths that should be indexed, excluding directories that we don't need to descend into such
+    # as `.git`, `node_modules`. Also includes any top level Ruby files
+    #
+    #: -> Array[String]
+    def workspace_paths
+      paths = []
+
+      Dir.each_child(@workspace_path) do |entry|
+        full_path = File.join(@workspace_path, entry)
+
+        if File.directory?(full_path)
+          paths << full_path unless IGNORED_DIRECTORIES.include?(entry)
+        elsif File.extname(entry) == ".rb"
+          paths << full_path
+        end
+      end
+
+      add_workspace_dependency_paths(paths)
+      paths.uniq!
+      paths
     end
 
     private
 
     # Gathers the paths we have to index for all workspace dependencies
-    def workspace_dependency_paths
+    #: (Array[String]) -> void
+    def add_workspace_dependency_paths(paths)
       specs = Bundler.locked_gems&.specs
-      return [] unless specs
+      return unless specs
 
-      paths = specs.filter_map do |lazy_spec|
+      specs.each do |lazy_spec|
         spec = Gem::Specification.find_by_name(lazy_spec.name)
-        spec.require_paths.map { |path| File.join(spec.full_gem_path, path) }
+        spec.require_paths.each do |path|
+          # For native extensions, RubyGems inserts an absolute require path pointing to
+          # `gems/some-gem-1.0.0/extensions`. Those paths don't actually include any Ruby files inside, so we can skip
+          # descending them
+          next if File.absolute_path?(path)
+
+          paths << File.join(spec.full_gem_path, path)
+        end
       rescue Gem::MissingSpecError
         nil
       end
-
-      paths.flatten!
-      paths.uniq!
-      paths
     end
   end
 end


### PR DESCRIPTION
This PR includes a few improvements to how we list paths for indexing a workspace:

1. Excluding `/extensions/` directories. These are inserted by RubyGems as absolute paths in the gem's `require_paths`. These directories get automatically inserted for any native extension even if the directory doesn't exist. Additionally, they never contain any Ruby files
2. Ensuring paths do not contain duplicates. When indexing a gem's source code, its paths will appear both in the `workspace_path` and as part of `Bundler.locked_gems` because the gem depends on itself
3. Excluding common directories that are not relevant for Ruby projects, like `.git`, `node_modules`, `.bundle` or `tmp`. We know from the Ruby LSP that globbing these directories can consume a significant amount of time, so we can exclude them and let the Rust side descend only for relevant folders