### PR TITLE
Return array of IO errors from indexing

### DIFF
--- a/lib/rubydex/graph.rb
+++ b/lib/rubydex/graph.rb
@@ -19,7 +19,7 @@ module Rubydex
     end
 
     # Index all files and dependencies of the workspace that exists in `@workspace_path`
-    #: -> String?
+    #: -> Array[String]
     def index_workspace
       index_all(workspace_paths)
     end

--- a/rakelib/index_top_gems.rake
+++ b/rakelib/index_top_gems.rake
@@ -51,10 +51,10 @@ task index_top_gems: :compile_release do
 
             # Index the gem's files and yield errors back to the main Ractor
             graph = Rubydex::Graph.new
-            error = graph.index_all(Dir.glob("#{gem_dir}/**/*.rb"))
-            next unless error
+            errors = graph.index_all(Dir.glob("#{gem_dir}/**/*.rb"))
+            next if errors.empty?
 
-            @mutex.synchronize { @errors << "#{gem} => #{error}" }
+            @mutex.synchronize { @errors << "#{gem} => #{errors.join(", ")}" }
           end
         end
       end

--- a/test/graph_test.rb
+++ b/test/graph_test.rb
@@ -9,7 +9,7 @@ class GraphTest < Minitest::Test
   def test_indexing_empty_context
     with_context do |context|
       graph = Rubydex::Graph.new
-      assert_nil(graph.index_all(context.glob("**/*.rb")))
+      assert_empty(graph.index_all(context.glob("**/*.rb")))
     end
   end
 
@@ -19,19 +19,17 @@ class GraphTest < Minitest::Test
       context.write!("bar.rb", "class Bar; end")
 
       graph = Rubydex::Graph.new
-      assert_nil(graph.index_all(context.glob("**/*.rb")))
+      assert_empty(graph.index_all(context.glob("**/*.rb")))
     end
   end
 
   def test_indexing_invalid_file_paths
     graph = Rubydex::Graph.new
 
-    error = assert_raises(Rubydex::IndexingError) do
-      graph.index_all(["not_found.rb"])
-    end
+    errors = graph.index_all(["not_found.rb"])
 
-    assert_kind_of(Rubydex::Error, error)
-    assert_match(/FileError: Path `.*not_found.rb` does not exist/, error.message)
+    assert_equal(1, errors.length)
+    assert_match(/FileError: Path `.*not_found.rb` does not exist/, errors.first)
   end
 
   def test_indexing_with_parse_errors


### PR DESCRIPTION
This PR changes the return of `Graph#index_all` so that we return an array of error messages rather than raising.

Raising is weird for this API because indexing didn't actually fail completely. It just encountered some IO errors (like file permission problems), but likely succeeded in indexing everything else in the codebase.