### PR TITLE
Add project name to dev

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -1,3 +1,4 @@
+name: rubydex
 nix: true
 up:
   - ruby


### PR DESCRIPTION
When using worktrees to run multiple Claude code sessions on the codebase, you need to `dev up` to set up the Nix environment ahead of time.

However, dev is very particular about the naming convention it accepts, so if you created your worktree with an underscore, that's already enough to not have it work.

Let's specify the name in `dev.yml`, so that we don't have to worry about the worktree names when running parallel sessions.