### PR TITLE
Add completion for expressions

### DIFF
--- a/rust/rubydex/src/model/declaration.rs
+++ b/rust/rubydex/src/model/declaration.rs
@@ -479,6 +479,11 @@ impl Namespace {
     pub fn set_singleton_class_id(&mut self, declaration_id: DeclarationId) {
         all_namespaces!(self, it => it.set_singleton_class_id(declaration_id));
     }
+
+    #[must_use]
+    pub fn owner_id(&self) -> &DeclarationId {
+        all_namespaces!(self, it => &it.owner_id)
+    }
 }
 
 namespace_declaration!(Class, ClassDeclaration);

--- a/rust/rubydex/src/model/graph.rs
+++ b/rust/rubydex/src/model/graph.rs
@@ -320,6 +320,31 @@ impl Graph {
         name_id
     }
 
+    /// Searches for the initial attached object for an arbitrarily nested singleton class.
+    /// Walks up the owner chain until finding a non-singleton namespace.
+    ///
+    /// # Example
+    /// For `Foo::<Foo>::<<Foo>>`, returns `Foo`
+    ///
+    /// # Panics
+    ///
+    /// Panics if we attached a singleton class to something that isn't a namespace
+    #[must_use]
+    pub fn attached_object<'a>(&'a self, maybe_singleton: &'a Namespace) -> &'a Namespace {
+        let mut attached_object = maybe_singleton;
+
+        while matches!(attached_object, Namespace::SingletonClass(_)) {
+            attached_object = self
+                .declarations
+                .get(attached_object.owner_id())
+                .unwrap()
+                .as_namespace()
+                .unwrap();
+        }
+
+        attached_object
+    }
+
     #[must_use]
     pub fn get(&self, name: &str) -> Option<Vec<&Definition>> {
         let declaration_id = DeclarationId::from(name);

--- a/rust/rubydex/src/model/name.rs
+++ b/rust/rubydex/src/model/name.rs
@@ -157,6 +157,11 @@ impl ResolvedName {
     pub fn declaration_id(&self) -> &DeclarationId {
         &self.declaration_id
     }
+
+    #[must_use]
+    pub fn nesting(&self) -> &Option<NameId> {
+        self.name.nesting()
+    }
 }
 
 /// A usage of a constant name. This could be a constant reference or a definition like a class or module


### PR DESCRIPTION
First step for #59

This PR adds a completion API with support for expression completion. That means, completion when there's nothing before the cursor.

The idea of the implementation is to have an enum to describe all of the possible contexts we may see completion being triggered since they all collect slightly different declarations. I tried to document all scenarios, despite having only implemented expression.

**Notes**

The expression completion is currently missing keywords. I'll propose something for those in a different PR.