### PR TITLE
Add MCP server for AI-assisted Ruby code intelligence

### DIFF
--- a/.claude/skills/rubydex-mcp-benchmark/SKILL.md
+++ b/.claude/skills/rubydex-mcp-benchmark/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: rubydex-mcp-benchmark
+description: Use when benchmarking rubydex MCP against plain Grep/Glob for Ruby code tasks. Guides A/B comparison setup, candidate selection, and metrics collection.
+---
+
+# Rubydex MCP Benchmark
+
+Compare rubydex MCP-assisted development vs standard Grep/Glob for Ruby code tasks.
+
+## Prerequisites
+
+Ensure the `rubydex_mcp` binary is installed:
+
+```bash
+# From the rubydex repo root
+cargo install --path rust/rubydex-mcp
+```
+
+This places `rubydex_mcp` in `~/.cargo/bin/`. Verify: `rubydex_mcp --help`
+
+## Step 1: Find a Good Benchmark Candidate
+
+Use rubydex MCP tools to find a class or module suitable for testing:
+
+1. Run `codebase_stats` to get an overview of the target project
+2. Run `search_declarations` with kind "Class" or "Module" to list candidates
+3. For each candidate, run `find_constant_references` and count references
+4. Pick a target with **10-30 references across 4+ files** that has test coverage
+
+Good candidates are:
+- Self-contained (not deeply entangled with the whole codebase)
+- Referenced in both lib and test directories
+- Have a dedicated test file
+
+## Step 2: Set Up the Experiment
+
+Create two git worktrees for the target Ruby project:
+
+```bash
+cd /path/to/target-project
+git worktree add ../project-with-mcp -b bench-with-mcp HEAD
+git worktree add ../project-without-mcp -b bench-without-mcp HEAD
+```
+
+Add `.mcp.json` to the with-mcp worktree only:
+
+```bash
+cat > ../project-with-mcp/.mcp.json << 'EOF'
+{
+  "mcpServers": {
+    "rubydex": {
+      "command": "${HOME}/.cargo/bin/rubydex_mcp"
+    }
+  }
+}
+EOF
+```
+
+## Step 3: Generate Commands for the Developer
+
+Pick a testing prompt based on the scenario. Keep prompts **vague and natural** - like a lazy developer would type. Don't specify full namespaces, file paths, or implementation details. Let the agent figure it out. This tests the MCP advantage fairly since the MCP agent can resolve ambiguity semantically while the non-MCP agent has to grep around.
+
+**Guidelines for writing prompts:**
+- Use short class names, not fully qualified (`Context` not `IRB::Context`)
+- Don't specify file locations or paths
+- Don't tell the agent how to do it, just what to do
+- Always end with how to run tests
+
+**Examples:**
+
+Rename:
+```
+Rename Locale to LocaleManager in IRB. All existing tests must continue to pass. Run tests with: bundle exec rake test
+```
+
+Extract module:
+```
+Extract all history-related methods from Context into a new module Context::HistoryManager. All existing tests must continue to pass. Run tests with: bundle exec rake test
+```
+
+Then generate two ready-to-copy commands and present them to the developer:
+
+**With MCP** (run in terminal 1):
+```bash
+cd /path/to/project-with-mcp && claude "<testing prompt>" --dangerously-skip-permissions
+```
+
+**Without MCP** (run in terminal 2):
+```bash
+cd /path/to/project-without-mcp && claude "<testing prompt>" --dangerously-skip-permissions
+```
+
+Tell the developer to copy and run these commands in separate terminals simultaneously.
+
+## Step 4: Compare Results
+
+After both sessions complete, compare:
+
+| Metric | With MCP | Without MCP |
+|--------|----------|-------------|
+| Duration | (from session) | (from session) |
+| Tokens | (from session stats) | (from session stats) |
+| Files changed | `git diff --stat` in with-mcp worktree | `git diff --stat` in without-mcp worktree |
+| Tests | pass/fail | pass/fail |
+
+Run `git diff --stat` in each worktree to compare the changes made.
+
+## Step 5: Cleanup
+
+```bash
+cd /path/to/target-project
+git worktree remove ../project-with-mcp
+git worktree remove ../project-without-mcp
+git branch -D bench-with-mcp bench-without-mcp
+```
+
+## Reference: Our Benchmark Results
+
+| Scenario | Metric | With MCP | Without MCP | MCP Advantage |
+|----------|--------|----------|-------------|---------------|
+| Rename (IRB::Locale, 16 refs) | Tokens | 22k | 31.8k | 30% fewer |
+| Rename (IRB::Locale, 16 refs) | Time | 2m 9s | 2m 44s | 25% faster |
+| Extract module (IRB::Context) | Tokens | 33.2k | 63.0k | 47% fewer |
+| Extract module (IRB::Context) | Time | 1m 49s | 2m 39s | 31% faster |

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,7 @@
+{
+  "mcpServers": {
+    "rubydex": {
+      "command": "${HOME}/.cargo/bin/rubydex_mcp"
+    }
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,10 +57,12 @@ When necessary, commands can be executed for the Ruby code.
 
 ## Rust workspace
 
-The Rust workspace under the `rust` directory contains two crates:
+The Rust workspace under the `rust` directory contains three crates:
 
 - `rubydex`: this crate implements the entire indexing and static analysis logic. The implementation aims to be optimized
 to achieve maximum performance in super large codebases while maintaining memory usage to a minimum
+- `rubydex-mcp`: an MCP (Model Context Protocol) server that exposes rubydex's code intelligence as tools for AI
+assistants. Communicates over stdio using JSON-RPC
 - `rubydex-sys`: this crate provides bindings for C, so that the logic from `rubydex` can be called through FFI
 
 The workspace's goal is to provide all indexing and static analysis capabilities to power tools such as language servers,
@@ -85,9 +87,11 @@ When necessary, commands can be executed for the Rust code.
 - `cargo run -- <directory> --stats`: runs the indexer with detailed performance breakdown
 - `cargo run -- <directory> --stop-after <stage>`: stops after the specified stage (Listing, Indexing, or Resolution)
 - `cargo run -- <directory> --visualize`: generates a DOT visualization of the graph
-- `cargo test`: runs Rust tests
+- `cargo test`: runs Rust tests (all workspace crates)
+- `cargo test -p rubydex-mcp`: runs MCP server tests only
 - `cargo test test_name`: runs a specific tests example
 - `cargo fmt`: auto formats the Rust code
 - `cargo clippy`: lints the Rust code
+- `cargo install --path rust/rubydex-mcp`: installs the MCP server binary
 - `bundle exec rake lint_rust`: lints the Rust code
 - `bundle exec rake format_rust`: auto formats the Rust code

--- a/README.md
+++ b/README.md
@@ -77,6 +77,49 @@ diagnostic.message
 diagnostic.location
 ```
 
+## MCP Server (Experimental)
+
+Rubydex can run as an MCP (Model Context Protocol) server, enabling AI assistants
+like Claude to semantically query your Ruby codebase.
+
+### Setup
+
+1. Install the binary:
+   ```bash
+   cargo install --path rust/rubydex-mcp
+   ```
+
+2. Add rubydex to the Ruby project you want to index:
+   ```bash
+   claude mcp add --scope project rubydex "\${HOME}/.cargo/bin/rubydex_mcp"
+   ```
+
+   Or manually create a `.mcp.json` in the project root:
+   ```json
+   {
+     "mcpServers": {
+       "rubydex": {
+         "command": "${HOME}/.cargo/bin/rubydex_mcp"
+       }
+     }
+   }
+   ```
+
+3. Start Claude Code from that project directory. The MCP server indexes
+   the project at startup and provides semantic code intelligence tools.
+   Verify with `/mcp` in the session.
+
+### Available MCP Tools
+
+| Tool | Description |
+|------|-------------|
+| `search_declarations` | Fuzzy search for classes, modules, methods, constants |
+| `get_declaration` | Full details by fully qualified name with docs, ancestors, members |
+| `get_descendants` | What classes/modules inherit from or include this one |
+| `find_constant_references` | All precise, resolved constant references across the codebase |
+| `get_file_declarations` | List declarations defined in a specific file |
+| `codebase_stats` | High-level statistics about the indexed codebase |
+
 ## Contributing
 
 See [the contributing documentation](CONTRIBUTING.md).

--- a/dev.yml
+++ b/dev.yml
@@ -4,6 +4,10 @@ up:
   - ruby
   - bundler
   - rust
+  - custom:
+      name: Install rubydex MCP server
+      met?: test -x ~/.cargo/bin/rubydex_mcp
+      meet: cargo install --path rust/rubydex-mcp
 
 commands:
   test:

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -12,6 +12,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -78,10 +87,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bindgen"
@@ -121,10 +147,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+
+[[package]]
 name = "bytecount"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
+
+[[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cbindgen"
@@ -168,6 +206,20 @@ name = "cfg-if"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+
+[[package]]
+name = "chrono"
+version = "0.4.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "serde",
+ "wasm-bindgen",
+ "windows-link 0.2.1",
+]
 
 [[package]]
 name = "clang-sys"
@@ -227,6 +279,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -261,6 +319,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -282,6 +374,12 @@ name = "doc-comment"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
@@ -330,6 +428,95 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+
+[[package]]
+name = "futures-task"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+
+[[package]]
+name = "futures-util"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -358,6 +545,30 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "icu_collections"
@@ -446,6 +657,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -496,6 +713,16 @@ name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "js-sys"
+version = "0.3.85"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "libc"
@@ -597,10 +824,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
+name = "pastey"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "potential_utf"
@@ -676,6 +921,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "regex"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -703,6 +968,41 @@ name = "regex-syntax"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+
+[[package]]
+name = "rmcp"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bef41ebc9ebed2c1b1d90203e9d1756091e8a00bbc3107676151f39868ca0ee"
+dependencies = [
+ "async-trait",
+ "base64",
+ "chrono",
+ "futures",
+ "pastey",
+ "pin-project-lite",
+ "rmcp-macros",
+ "schemars",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "rmcp-macros"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e88ad84b8b6237a934534a62b379a5be6388915663c0cc598ceb9b3292bbbfe"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn",
+]
 
 [[package]]
 name = "ruby-prism"
@@ -771,6 +1071,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "rubydex-mcp"
+version = "0.1.0"
+dependencies = [
+ "assert_cmd",
+ "clap",
+ "rmcp",
+ "rubydex",
+ "schemars",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
+]
+
+[[package]]
 name = "rubydex-sys"
 version = "0.1.0"
 dependencies = [
@@ -801,10 +1116,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
 name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "chrono",
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn",
+]
 
 [[package]]
 name = "serde"
@@ -820,6 +1167,17 @@ name = "serde_derive"
 version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -865,6 +1223,12 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
@@ -932,6 +1296,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f18aa187839b2bdb1ad2fa35ead8c4c2976b64e4363c386d45ac0f7ee85c9233"
 
 [[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -939,6 +1323,41 @@ checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tokio"
+version = "1.49.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
+dependencies = [
+ "bytes",
+ "pin-project-lite",
+ "tokio-macros",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -981,6 +1400,37 @@ name = "toml_write"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
 
 [[package]]
 name = "unicode-ident"
@@ -1036,10 +1486,114 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen"
+version = "0.2.108"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.108"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.108"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.108"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.2.1",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link 0.2.1",
+]
 
 [[package]]
 name = "windows-sys"
@@ -1081,7 +1635,7 @@ version = "0.53.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
  "windows_i686_gnu 0.53.0",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
   "rubydex",
+  "rubydex-mcp",
   "rubydex-sys",
 ]
 

--- a/rust/rubydex-mcp/Cargo.toml
+++ b/rust/rubydex-mcp/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "rubydex-mcp"
+version = "0.1.0"
+edition = "2024"
+rust-version = "1.89.0"
+license = "MIT"
+
+[[bin]]
+name = "rubydex_mcp"
+path = "src/main.rs"
+
+[dependencies]
+rubydex = { path = "../rubydex" }
+clap = { version = "4.5.16", features = ["derive"] }
+rmcp = { version = "0.15", features = ["server", "macros", "transport-io", "schemars"] }
+tokio = { version = "1", features = ["macros", "rt", "io-std"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+schemars = "1"
+url = "2"
+
+[dev-dependencies]
+rubydex = { path = "../rubydex", features = ["test_utils"] }
+assert_cmd = "2.0"
+serde_json = "1"
+
+[lints]
+workspace = true

--- a/rust/rubydex-mcp/src/main.rs
+++ b/rust/rubydex-mcp/src/main.rs
@@ -1,0 +1,48 @@
+use clap::Parser;
+
+mod server;
+mod tools;
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "rubydex_mcp",
+    about = "Rubydex MCP server for AI-assisted Ruby code intelligence",
+    version
+)]
+struct Args {
+    #[arg(value_name = "PATH", default_value = ".")]
+    path: String,
+}
+
+fn main() {
+    let args = Args::parse();
+
+    let root = match std::fs::canonicalize(&args.path) {
+        Ok(p) => p
+            .into_os_string()
+            .into_string()
+            .expect("Project path is not valid UTF-8"),
+        Err(e) => {
+            eprintln!("Warning: failed to canonicalize '{}': {e}", args.path);
+            args.path
+        }
+    };
+
+    // Create the server and start indexing in the background.
+    let server = server::RubydexServer::new(root.clone());
+    server.spawn_indexer(root);
+
+    // Serve MCP over stdio immediately while indexing runs.
+    // We need to do this because Claude Code's default MCP server timeout is 30 seconds,
+    // And in big codebases it's possible to exceed that and Claude Code would just consider
+    // the server fail to connect.
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("Failed to build tokio runtime");
+
+    if let Err(e) = rt.block_on(server.serve()) {
+        eprintln!("MCP server error: {e}");
+        std::process::exit(1);
+    }
+}

--- a/rust/rubydex-mcp/src/server.rs
+++ b/rust/rubydex-mcp/src/server.rs
@@ -1,0 +1,533 @@
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, RwLock};
+
+use crate::tools::{
+    FindConstantReferencesParams, GetDeclarationParams, GetDescendantsParams, GetFileDeclarationsParams,
+    SearchDeclarationsParams,
+};
+use rmcp::{
+    ServerHandler,
+    handler::server::{router::tool::ToolRouter, wrapper::Parameters},
+    model::{ServerCapabilities, ServerInfo},
+    tool, tool_handler, tool_router,
+    transport::io::stdio,
+};
+use rubydex::model::ids::{DeclarationId, UriId};
+use rubydex::model::{
+    declaration::{Ancestor, Ancestors},
+    graph::Graph,
+};
+use url::Url;
+
+struct ServerState {
+    graph: Option<Graph>,
+    error: Option<String>,
+}
+
+pub struct RubydexServer {
+    state: Arc<RwLock<ServerState>>,
+    root_path: PathBuf,
+    tool_router: ToolRouter<Self>,
+}
+
+impl RubydexServer {
+    pub fn new(root: String) -> Self {
+        Self {
+            state: Arc::new(RwLock::new(ServerState {
+                graph: None,
+                error: None,
+            })),
+            root_path: PathBuf::from(root),
+            tool_router: Self::tool_router(),
+        }
+    }
+
+    /// Spawns a background thread that indexes the codebase and marks the server as ready.
+    pub fn spawn_indexer(&self, path: String) {
+        let state = Arc::clone(&self.state);
+        std::thread::spawn(move || {
+            let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                let (file_paths, errors) = rubydex::listing::collect_file_paths(vec![path]);
+                for error in &errors {
+                    eprintln!("Listing error: {error}");
+                }
+
+                let mut graph = Graph::new();
+                let errors = rubydex::indexing::index_files(&mut graph, file_paths);
+                for error in &errors {
+                    eprintln!("Indexing error: {error}");
+                }
+
+                let mut resolver = rubydex::resolution::Resolver::new(&mut graph);
+                resolver.resolve_all();
+
+                eprintln!(
+                    "Rubydex indexed {} files, {} declarations",
+                    graph.documents().len(),
+                    graph.declarations().len()
+                );
+                graph
+            }));
+
+            let mut state = state.write().expect("state lock poisoned");
+            match result {
+                Ok(graph) => {
+                    state.graph = Some(graph);
+                }
+                Err(panic) => {
+                    let msg = panic
+                        .downcast_ref::<String>()
+                        .map(String::as_str)
+                        .or_else(|| panic.downcast_ref::<&str>().copied())
+                        .unwrap_or("unknown error");
+                    eprintln!("Rubydex indexing failed: {msg}");
+                    state.error = Some(msg.to_string());
+                }
+            }
+        });
+    }
+
+    pub async fn serve(self) -> Result<(), Box<dyn std::error::Error>> {
+        let service = rmcp::ServiceExt::serve(self, stdio()).await?;
+        service.waiting().await?;
+        Ok(())
+    }
+}
+
+/// Returns a structured JSON error string with a machine-readable type, message, and suggestion.
+fn error_json(error_type: &str, message: &str, suggestion: &str) -> String {
+    serde_json::to_string(&serde_json::json!({
+        "error": error_type,
+        "message": message,
+        "suggestion": suggestion,
+    }))
+    .unwrap_or_else(|_| "{}".to_string())
+}
+
+/// Acquires the read lock and returns a guard with the graph if ready.
+/// Returns early with a JSON error if still indexing or if indexing failed.
+macro_rules! ensure_graph_ready {
+    ($self:expr) => {{
+        let state = $self.state.read().expect("state lock poisoned");
+        if let Some(err) = &state.error {
+            return error_json(
+                "indexing_failed",
+                &format!("Rubydex indexing failed: {err}"),
+                "Check server logs for details. The MCP server needs to be restarted.",
+            );
+        }
+        if state.graph.is_none() {
+            return error_json(
+                "indexing",
+                "Rubydex is still indexing the codebase",
+                "The server is starting up. Please retry in a few seconds.",
+            );
+        }
+        state
+    }};
+}
+
+/// Looks up a declaration by name, returning an error JSON string from the caller if not found.
+macro_rules! lookup_declaration {
+    ($graph:expr, $name:expr) => {{
+        let declaration_id = DeclarationId::from($name);
+        match $graph.declarations().get(&declaration_id) {
+            Some(decl) => (declaration_id, decl),
+            None => {
+                return error_json(
+                    "not_found",
+                    &format!("Declaration '{}' not found", $name),
+                    "Try search_declarations with a partial name to find the correct FQN",
+                );
+            }
+        }
+    }};
+}
+
+/// Narrows a declaration to a namespace, returning an error JSON string if it's not a class or module.
+macro_rules! require_namespace {
+    ($decl:expr, $name:expr, $tool_name:literal) => {
+        match $decl.as_namespace() {
+            Some(ns) => ns,
+            None => {
+                return error_json(
+                    "invalid_kind",
+                    &format!("'{}' is not a class or module (it is a {})", $name, $decl.kind()),
+                    concat!(
+                        $tool_name,
+                        " only works on classes and modules, not methods or constants"
+                    ),
+                );
+            }
+        }
+    };
+}
+
+/// Parses a file URI into a platform-native absolute path.
+fn uri_to_path(uri: &str) -> Option<PathBuf> {
+    Url::parse(uri).ok()?.to_file_path().ok()
+}
+
+/// Converts a file URI to a path relative to `root` when possible.
+/// Falls back to an absolute display path if it cannot be relativized.
+fn format_path(uri: &str, root: &Path) -> String {
+    let Some(path) = uri_to_path(uri) else {
+        return uri.to_string();
+    };
+
+    path.strip_prefix(root)
+        .map_or_else(|_| path.display().to_string(), |rel| rel.display().to_string())
+}
+
+/// Formats an ancestor chain into a JSON array of `{"name": ..., "kind": ...}` objects.
+fn format_ancestors(graph: &Graph, ancestors: &Ancestors) -> Vec<serde_json::Value> {
+    ancestors
+        .iter()
+        .filter_map(|ancestor| match ancestor {
+            Ancestor::Complete(id) => {
+                let ancestor_decl = graph.declarations().get(id)?;
+                Some(serde_json::json!({
+                    "name": ancestor_decl.name(),
+                    "kind": ancestor_decl.kind(),
+                }))
+            }
+            Ancestor::Partial(name_id) => {
+                let name_ref = graph.names().get(name_id)?;
+                Some(serde_json::json!({
+                    "name": format!("{name_ref:?}"),
+                    "kind": "Unresolved",
+                }))
+            }
+        })
+        .collect()
+}
+
+#[tool_router]
+impl RubydexServer {
+    #[tool(
+        description = "Search for Ruby classes, modules, methods, or constants by name. Use this INSTEAD OF Grep when you know part of a Ruby identifier name and want to find its definition. Returns fully qualified names, kinds, and file locations. Use the `kind` filter (\"Class\", \"Module\", \"Method\", \"Constant\") to narrow results."
+    )]
+    fn search_declarations(&self, Parameters(params): Parameters<SearchDeclarationsParams>) -> String {
+        let state = ensure_graph_ready!(self);
+        let graph = state.graph.as_ref().unwrap();
+        let ids = rubydex::query::declaration_search(graph, &params.query);
+
+        let limit = params.limit.unwrap_or(25).min(100);
+        let kind_filter = params.kind.as_deref();
+
+        let mut results: Vec<serde_json::Value> = Vec::new();
+        for id in ids {
+            if results.len() >= limit {
+                break;
+            }
+
+            let Some(decl) = graph.declarations().get(&id) else {
+                continue;
+            };
+
+            if let Some(kind) = kind_filter
+                && !decl.kind().eq_ignore_ascii_case(kind)
+            {
+                continue;
+            }
+
+            let locations: Vec<serde_json::Value> = decl
+                .definitions()
+                .iter()
+                .filter_map(|def_id| {
+                    let def = graph.definitions().get(def_id)?;
+                    let doc = graph.documents().get(def.uri_id())?;
+                    let loc = def.offset().to_location(doc).to_presentation();
+                    Some(serde_json::json!({
+                        "path": format_path(doc.uri(), &self.root_path),
+                        "line": loc.start_line(),
+                    }))
+                })
+                .collect();
+
+            results.push(serde_json::json!({
+                "name": decl.name(),
+                "kind": decl.kind(),
+                "locations": locations,
+            }));
+        }
+
+        serde_json::to_string(&results).unwrap_or_else(|_| "[]".to_string())
+    }
+
+    #[tool(
+        description = "Get complete information about a Ruby class, module, method, or constant by its exact fully qualified name. Returns file locations, documentation comments, ancestor chain, and members with locations. FQN format: \"Foo::Bar\" for classes/modules/constants, \"Foo::Bar#method_name\" for instance methods."
+    )]
+    fn get_declaration(&self, Parameters(params): Parameters<GetDeclarationParams>) -> String {
+        let state = ensure_graph_ready!(self);
+        let graph = state.graph.as_ref().unwrap();
+        let (_, decl) = lookup_declaration!(graph, &params.name);
+
+        let definitions: Vec<serde_json::Value> = decl
+            .definitions()
+            .iter()
+            .filter_map(|def_id| {
+                let def = graph.definitions().get(def_id)?;
+                let doc = graph.documents().get(def.uri_id())?;
+                let loc = def.offset().to_location(doc).to_presentation();
+                let path = format_path(doc.uri(), &self.root_path);
+                let comments: Vec<String> = def
+                    .comments()
+                    .iter()
+                    .map(|c| {
+                        c.string()
+                            .as_str()
+                            .strip_prefix("# ")
+                            .unwrap_or(c.string().as_str())
+                            .to_string()
+                    })
+                    .collect();
+
+                Some(serde_json::json!({
+                    "path": path,
+                    "line": loc.start_line(),
+                    "comments": comments,
+                }))
+            })
+            .collect();
+
+        let namespace = decl.as_namespace();
+        let ancestors = namespace
+            .map(|ns| format_ancestors(graph, ns.ancestors()))
+            .unwrap_or_default();
+
+        let members: Vec<serde_json::Value> = namespace
+            .map(|ns| {
+                ns.members()
+                    .iter()
+                    .filter_map(|(_, member_id)| {
+                        let member_decl = graph.declarations().get(member_id)?;
+                        let member_def = member_decl
+                            .definitions()
+                            .first()
+                            .and_then(|def_id| graph.definitions().get(def_id));
+
+                        let mut member = serde_json::json!({
+                            "name": member_decl.name(),
+                            "kind": member_decl.kind(),
+                        });
+
+                        if let Some(def) = member_def
+                            && let Some(doc) = graph.documents().get(def.uri_id())
+                        {
+                            let loc = def.offset().to_location(doc).to_presentation();
+                            member["location"] = serde_json::json!({
+                                "path": format_path(doc.uri(), &self.root_path),
+                                "line": loc.start_line(),
+                            });
+                        }
+
+                        Some(member)
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        let result = serde_json::json!({
+            "name": decl.name(),
+            "kind": decl.kind(),
+            "definitions": definitions,
+            "ancestors": ancestors,
+            "members": members,
+        });
+
+        serde_json::to_string(&result).unwrap_or_else(|_| "{}".to_string())
+    }
+
+    #[tool(
+        description = "Find all classes and modules that inherit from or include a given class/module. Returns known descendants, including transitive relationships, for impact analysis before modifying a base class or module."
+    )]
+    fn get_descendants(&self, Parameters(params): Parameters<GetDescendantsParams>) -> String {
+        let state = ensure_graph_ready!(self);
+        let graph = state.graph.as_ref().unwrap();
+        let (_, decl) = lookup_declaration!(graph, &params.name);
+        let namespace = require_namespace!(decl, &params.name, "get_descendants");
+
+        let descendants: Vec<serde_json::Value> = namespace
+            .descendants()
+            .iter()
+            .filter_map(|desc_id| {
+                let desc_decl = graph.declarations().get(desc_id)?;
+                Some(serde_json::json!({
+                    "name": desc_decl.name(),
+                    "kind": desc_decl.kind(),
+                }))
+            })
+            .collect();
+
+        let result = serde_json::json!({
+            "name": decl.name(),
+            "descendants": descendants,
+        });
+
+        serde_json::to_string(&result).unwrap_or_else(|_| "{}".to_string())
+    }
+
+    #[tool(
+        description = "Find all resolved references to a Ruby class, module, or constant across the codebase. Returns file paths, line numbers, and columns for each usage."
+    )]
+    fn find_constant_references(&self, Parameters(params): Parameters<FindConstantReferencesParams>) -> String {
+        let state = ensure_graph_ready!(self);
+        let graph = state.graph.as_ref().unwrap();
+        let (_, decl) = lookup_declaration!(graph, &params.name);
+
+        let limit = params.limit.unwrap_or(50).min(200);
+        let mut references: Vec<serde_json::Value> = Vec::with_capacity(limit.min(decl.references().len()));
+        let mut truncated = false;
+
+        for ref_id in decl.references() {
+            if references.len() >= limit {
+                truncated = true;
+                break;
+            }
+
+            let Some(const_ref) = graph.constant_references().get(ref_id) else {
+                continue;
+            };
+
+            let Some(doc) = graph.documents().get(&const_ref.uri_id()) else {
+                continue;
+            };
+            let loc = const_ref.offset().to_location(doc).to_presentation();
+            references.push(serde_json::json!({
+                "path": format_path(doc.uri(), &self.root_path),
+                "line": loc.start_line(),
+                "column": loc.start_col(),
+            }));
+        }
+
+        let mut result = serde_json::json!({
+            "name": params.name,
+            "references": references,
+        });
+        if truncated {
+            result["truncated"] = serde_json::Value::Bool(true);
+        }
+
+        serde_json::to_string(&result).unwrap_or_else(|_| "{}".to_string())
+    }
+
+    #[tool(
+        description = "List all Ruby classes, modules, methods, and constants defined in a specific file. Returns a structural overview with names, kinds, and line numbers. Use this to understand a file's structure before reading it, or to see what a file contributes to the codebase. Accepts relative or absolute paths."
+    )]
+    fn get_file_declarations(&self, Parameters(params): Parameters<GetFileDeclarationsParams>) -> String {
+        let state = ensure_graph_ready!(self);
+        let graph = state.graph.as_ref().unwrap();
+
+        let absolute_target = if Path::new(&params.file_path).is_absolute() {
+            PathBuf::from(&params.file_path)
+        } else {
+            self.root_path.join(&params.file_path)
+        };
+        let canonical_target = std::fs::canonicalize(&absolute_target).unwrap_or(absolute_target);
+
+        let Ok(uri) = Url::from_file_path(&canonical_target) else {
+            return error_json(
+                "invalid_path",
+                &format!("Cannot convert '{}' to a file URI", params.file_path),
+                "Use a relative path like 'app/models/user.rb' or an absolute path",
+            );
+        };
+
+        let uri_id = UriId::from(uri.as_str());
+        let Some(doc) = graph.documents().get(&uri_id) else {
+            return error_json(
+                "not_found",
+                &format!("File '{}' not found in the index", params.file_path),
+                "Use a relative path like 'app/models/user.rb' or an absolute path matching the indexed project",
+            );
+        };
+
+        let mut declarations: Vec<serde_json::Value> = Vec::new();
+
+        for def_id in doc.definitions() {
+            let Some(def) = graph.definitions().get(def_id) else {
+                continue;
+            };
+
+            let loc = def.offset().to_location(doc).to_presentation();
+
+            let decl_name = graph
+                .definition_id_to_declaration_id(*def_id)
+                .and_then(|decl_id| graph.declarations().get(decl_id))
+                .map(|decl| (decl.name().to_string(), decl.kind()));
+
+            if let Some((name, kind)) = decl_name {
+                declarations.push(serde_json::json!({
+                    "name": name,
+                    "kind": kind,
+                    "line": loc.start_line(),
+                }));
+            }
+        }
+
+        let result = serde_json::json!({
+            "file": format_path(doc.uri(), &self.root_path),
+            "declarations": declarations,
+        });
+
+        serde_json::to_string(&result).unwrap_or_else(|_| "{}".to_string())
+    }
+
+    #[tool(
+        description = "Get an overview of the indexed Ruby codebase: total file count, declaration counts, and breakdown by kind (classes, modules, methods, constants). Use this to understand codebase size and composition, or to verify that indexing completed successfully."
+    )]
+    fn codebase_stats(&self) -> String {
+        let state = ensure_graph_ready!(self);
+        let graph = state.graph.as_ref().unwrap();
+
+        let mut breakdown: HashMap<&str, usize> = HashMap::new();
+        for decl in graph.declarations().values() {
+            *breakdown.entry(decl.kind()).or_default() += 1;
+        }
+
+        let breakdown_json: serde_json::Value = breakdown
+            .iter()
+            .map(|(k, v)| (k.to_string(), serde_json::json!(v)))
+            .collect();
+
+        let result = serde_json::json!({
+            "files": graph.documents().len(),
+            "declarations": graph.declarations().len(),
+            "definitions": graph.definitions().len(),
+            "constant_references": graph.constant_references().len(),
+            "method_references": graph.method_references().len(),
+            "breakdown_by_kind": breakdown_json,
+        });
+
+        serde_json::to_string(&result).unwrap_or_else(|_| "{}".to_string())
+    }
+}
+
+const SERVER_INSTRUCTIONS: &str = r#"Rubydex provides semantic Ruby code intelligence. Use these tools INSTEAD OF Grep when working with Ruby code structure.
+
+Decision guide:
+- Know a name? -> search_declarations (fuzzy search by name)
+- Have an exact fully qualified name? -> get_declaration (full details with docs, ancestors, members)
+- Need reverse hierarchy? -> get_descendants (what inherits from this class/module)
+- Refactoring a class/module/constant? -> find_constant_references (all precise usages across codebase)
+- Exploring a file? -> get_file_declarations (structural overview)
+- Want general statistics? -> codebase_stats (size and composition)
+
+Typical workflow: search_declarations -> get_declaration -> find_constant_references.
+
+Fully qualified name format: "Foo::Bar" for classes/modules/constants, "Foo::Bar#method_name" for instance methods.
+
+Use Grep instead for: literal string search, log messages, comments, non-Ruby files, or content search rather than structural queries."#;
+
+#[tool_handler]
+impl ServerHandler for RubydexServer {
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo {
+            instructions: Some(SERVER_INSTRUCTIONS.into()),
+            capabilities: ServerCapabilities::builder().enable_tools().build(),
+            ..Default::default()
+        }
+    }
+}

--- a/rust/rubydex-mcp/src/tools.rs
+++ b/rust/rubydex-mcp/src/tools.rs
@@ -1,0 +1,37 @@
+use schemars::JsonSchema;
+
+#[derive(Debug, serde::Deserialize, JsonSchema)]
+pub struct SearchDeclarationsParams {
+    #[schemars(description = "Search query to fuzzy match against declaration names")]
+    pub query: String,
+    #[schemars(description = "Filter by declaration kind: Class, Module, Method, Constant, etc.")]
+    pub kind: Option<String>,
+    #[schemars(description = "Maximum number of results to return (default 25, max 100)")]
+    pub limit: Option<usize>,
+}
+
+#[derive(Debug, serde::Deserialize, JsonSchema)]
+pub struct GetDeclarationParams {
+    #[schemars(description = "Fully qualified name of the declaration (e.g. 'Foo::Bar', 'Foo::Bar#baz')")]
+    pub name: String,
+}
+
+#[derive(Debug, serde::Deserialize, JsonSchema)]
+pub struct GetDescendantsParams {
+    #[schemars(description = "Fully qualified name of the class or module")]
+    pub name: String,
+}
+
+#[derive(Debug, serde::Deserialize, JsonSchema)]
+pub struct FindConstantReferencesParams {
+    #[schemars(description = "Fully qualified name of the class, module, or constant to find references for")]
+    pub name: String,
+    #[schemars(description = "Maximum number of references to return (default 50, max 200)")]
+    pub limit: Option<usize>,
+}
+
+#[derive(Debug, serde::Deserialize, JsonSchema)]
+pub struct GetFileDeclarationsParams {
+    #[schemars(description = "File path (relative or absolute) to list declarations for")]
+    pub file_path: String,
+}

--- a/rust/rubydex-mcp/tests/mcp.rs
+++ b/rust/rubydex-mcp/tests/mcp.rs
@@ -1,0 +1,299 @@
+use assert_cmd::prelude::*;
+use rubydex::test_utils::with_context;
+use serde_json::{Value, json};
+use std::io::{BufRead, BufReader, Read, Write};
+use std::process::{Command, Stdio};
+
+const MAX_INDEXING_RETRIES: u64 = 60;
+
+/// Send a JSON-RPC message followed by a newline to the process stdin.
+fn send_message(stdin: &mut impl Write, msg: &Value) {
+    let payload = serde_json::to_string(msg).unwrap();
+    writeln!(stdin, "{payload}").unwrap();
+    stdin.flush().unwrap();
+}
+
+/// Read a single JSON-RPC response line from the process stdout.
+fn read_response(reader: &mut BufReader<impl std::io::Read>) -> Value {
+    let mut line = String::new();
+    reader.read_line(&mut line).unwrap();
+    serde_json::from_str(line.trim()).unwrap()
+}
+
+fn send_request(stdin: &mut impl Write, id: u64, method: &str, params: &Value) {
+    send_message(
+        stdin,
+        &json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": method,
+            "params": params,
+        }),
+    );
+}
+
+fn read_response_for_id(reader: &mut BufReader<impl Read>, expected_id: u64) -> Value {
+    let response = read_response(reader);
+    assert_eq!(response["id"], expected_id);
+    response
+}
+
+fn call_tool(
+    stdin: &mut impl Write,
+    reader: &mut BufReader<impl Read>,
+    request_id: u64,
+    tool_name: &str,
+    arguments: &Value,
+) -> Value {
+    send_request(
+        stdin,
+        request_id,
+        "tools/call",
+        &json!({
+            "name": tool_name,
+            "arguments": arguments,
+        }),
+    );
+
+    let response = read_response_for_id(reader, request_id);
+    let content_text = response["result"]["content"][0]["text"].as_str().unwrap();
+    serde_json::from_str(content_text).unwrap()
+}
+
+fn call_next_tool(
+    stdin: &mut impl Write,
+    reader: &mut BufReader<impl Read>,
+    request_id: &mut u64,
+    tool_name: &str,
+    arguments: &Value,
+) -> Value {
+    *request_id += 1;
+    call_tool(stdin, reader, *request_id, tool_name, arguments)
+}
+
+fn names_from_entries(entries: &[Value]) -> Vec<String> {
+    entries
+        .iter()
+        .filter_map(|entry| entry["name"].as_str().map(ToOwned::to_owned))
+        .collect()
+}
+
+fn assert_has_name(names: &[String], expected_name: &str, context: &str) {
+    assert!(
+        names.iter().any(|name| name == expected_name),
+        "Expected {context} to include {expected_name}, got: {names:?}"
+    );
+}
+
+fn initialize_session(stdin: &mut impl Write, reader: &mut BufReader<impl Read>) {
+    send_request(
+        stdin,
+        1,
+        "initialize",
+        &json!({
+            "protocolVersion": "2025-03-26",
+            "capabilities": {},
+            "clientInfo": { "name": "test-client", "version": "0.1.0" }
+        }),
+    );
+
+    let response = read_response_for_id(reader, 1);
+    assert!(response["result"]["capabilities"]["tools"].is_object());
+
+    send_message(
+        stdin,
+        &json!({
+            "jsonrpc": "2.0",
+            "method": "notifications/initialized"
+        }),
+    );
+}
+
+fn assert_tools_are_registered(stdin: &mut impl Write, reader: &mut BufReader<impl Read>) {
+    send_request(stdin, 2, "tools/list", &json!({}));
+
+    let response = read_response_for_id(reader, 2);
+    let tools = response["result"]["tools"].as_array().unwrap();
+    let tool_names: Vec<&str> = tools.iter().map(|tool| tool["name"].as_str().unwrap()).collect();
+
+    assert!(
+        tool_names.contains(&"search_declarations"),
+        "Missing search_declarations tool"
+    );
+    assert!(tool_names.contains(&"get_declaration"), "Missing get_declaration tool");
+    assert!(tool_names.contains(&"get_descendants"), "Missing get_descendants tool");
+    assert!(
+        tool_names.contains(&"find_constant_references"),
+        "Missing find_constant_references tool"
+    );
+    assert!(
+        tool_names.contains(&"get_file_declarations"),
+        "Missing get_file_declarations tool"
+    );
+    assert!(tool_names.contains(&"codebase_stats"), "Missing codebase_stats tool");
+    assert_eq!(tool_names.len(), 6, "Expected exactly 6 tools");
+}
+
+fn wait_for_indexing_to_complete(
+    stdin: &mut impl Write,
+    reader: &mut BufReader<impl Read>,
+    request_id: &mut u64,
+) -> Value {
+    for _ in 0..MAX_INDEXING_RETRIES {
+        let parsed = call_tool(stdin, reader, *request_id, "codebase_stats", &json!({}));
+        if parsed.get("error").is_none() {
+            return parsed;
+        }
+
+        assert_eq!(
+            parsed["error"].as_str(),
+            Some("indexing"),
+            "Expected transient indexing error while booting, got: {parsed}"
+        );
+
+        *request_id += 1;
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+
+    panic!("Timed out waiting for indexing to complete");
+}
+
+#[test]
+#[allow(clippy::too_many_lines)]
+fn mcp_server_e2e() {
+    with_context(|context| {
+        context.write(
+            "app.rb",
+            r#"
+                class Animal
+                  def speak
+                    "..."
+                  end
+                end
+
+                class Dog < Animal
+                  def speak
+                    "Woof!"
+                  end
+                end
+
+                module Greetable
+                  def greet
+                    "Hello"
+                  end
+                end
+
+                class Kennel
+                  def build
+                    Animal.new
+                  end
+                end
+            "#,
+        );
+
+        let mut child = Command::cargo_bin("rubydex_mcp")
+            .unwrap()
+            .args([context.absolute_path().to_str().unwrap()])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .unwrap();
+
+        let mut stdin = child.stdin.take().unwrap();
+        let stdout = child.stdout.take().unwrap();
+        let mut reader = BufReader::new(stdout);
+
+        initialize_session(&mut stdin, &mut reader);
+        assert_tools_are_registered(&mut stdin, &mut reader);
+
+        // Wait for indexing readiness before asserting semantic tool results.
+        let mut request_id = 3;
+        let stats = wait_for_indexing_to_complete(&mut stdin, &mut reader, &mut request_id);
+        assert_eq!(stats["files"], 1);
+        assert!(stats["declarations"].as_u64().unwrap() > 0);
+
+        // Semantic query: search declarations.
+        let results: Vec<Value> = serde_json::from_value(call_next_tool(
+            &mut stdin,
+            &mut reader,
+            &mut request_id,
+            "search_declarations",
+            &json!({ "query": "Dog" }),
+        ))
+        .unwrap();
+        let result_names = names_from_entries(&results);
+        assert_has_name(&result_names, "Dog", "search results");
+
+        // Semantic query: inspect declaration details.
+        let decl = call_next_tool(
+            &mut stdin,
+            &mut reader,
+            &mut request_id,
+            "get_declaration",
+            &json!({ "name": "Dog" }),
+        );
+        assert_eq!(decl["name"], "Dog");
+        assert_eq!(decl["kind"], "Class");
+        assert!(!decl["definitions"].as_array().unwrap().is_empty());
+
+        // Verify ancestors are included in get_declaration response
+        let ancestor_entries = decl["ancestors"].as_array().unwrap();
+        let ancestor_names = names_from_entries(ancestor_entries);
+        assert_has_name(&ancestor_names, "Animal", "Dog ancestors");
+
+        // Semantic query: descendants.
+        let descendants = call_next_tool(
+            &mut stdin,
+            &mut reader,
+            &mut request_id,
+            "get_descendants",
+            &json!({ "name": "Animal" }),
+        );
+        let descendant_entries = descendants["descendants"].as_array().unwrap();
+        let descendant_names = names_from_entries(descendant_entries);
+        assert_has_name(&descendant_names, "Dog", "Animal descendants");
+
+        // Semantic query: resolved constant references.
+        let references = call_next_tool(
+            &mut stdin,
+            &mut reader,
+            &mut request_id,
+            "find_constant_references",
+            &json!({ "name": "Animal" }),
+        );
+        let refs = references["references"].as_array().unwrap();
+        assert!(
+            !refs.is_empty(),
+            "Expected at least one reference to Animal, got: {references}"
+        );
+        assert!(
+            refs.iter().all(|entry| entry["path"].as_str().is_some()),
+            "Expected references to include file paths, got: {references}"
+        );
+
+        // Semantic query: file declarations.
+        let file_declarations = call_next_tool(
+            &mut stdin,
+            &mut reader,
+            &mut request_id,
+            "get_file_declarations",
+            &json!({ "file_path": "app.rb" }),
+        );
+        assert!(
+            file_declarations["file"]
+                .as_str()
+                .is_some_and(|path| path.ends_with("app.rb")),
+            "Expected file path to end with app.rb, got: {file_declarations}"
+        );
+        let declaration_entries = file_declarations["declarations"].as_array().unwrap();
+        let declaration_names = names_from_entries(declaration_entries);
+        assert_has_name(&declaration_names, "Animal", "file declarations");
+        assert_has_name(&declaration_names, "Dog", "file declarations");
+        assert_has_name(&declaration_names, "Greetable", "file declarations");
+
+        // Clean up: drop stdin to signal EOF, then wait for the process to exit
+        drop(stdin);
+        let _ = child.wait().unwrap();
+    });
+}

--- a/rust/rubydex/src/offset.rs
+++ b/rust/rubydex/src/offset.rs
@@ -60,9 +60,71 @@ impl Offset {
     /// Converts an offset to a display range like `1:1-1:5`
     #[must_use]
     pub fn to_display_range(&self, document: &Document) -> String {
+        let loc = self.to_location(document).to_presentation();
+        format!(
+            "{}:{}-{}:{}",
+            loc.start_line(),
+            loc.start_col(),
+            loc.end_line(),
+            loc.end_col()
+        )
+    }
+
+    /// Converts this offset to a 0-indexed [`Location`] with start and end line/column numbers.
+    #[must_use]
+    pub fn to_location(&self, document: &Document) -> Location {
         let line_index = document.line_index();
         let start = line_index.line_col(self.start().into());
         let end = line_index.line_col(self.end().into());
-        format!("{}:{}-{}:{}", start.line + 1, start.col + 1, end.line + 1, end.col + 1)
+        Location {
+            start_line: start.line,
+            start_col: start.col,
+            end_line: end.line,
+            end_col: end.col,
+        }
+    }
+}
+
+/// A resolved location within a file, with start and end line/column positions.
+/// Values are 0-indexed by default. Use [`to_presentation`](Location::to_presentation)
+/// for 1-indexed values suitable for display.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Location {
+    start_line: u32,
+    start_col: u32,
+    end_line: u32,
+    end_col: u32,
+}
+
+impl Location {
+    #[must_use]
+    pub fn start_line(&self) -> u32 {
+        self.start_line
+    }
+
+    #[must_use]
+    pub fn start_col(&self) -> u32 {
+        self.start_col
+    }
+
+    #[must_use]
+    pub fn end_line(&self) -> u32 {
+        self.end_line
+    }
+
+    #[must_use]
+    pub fn end_col(&self) -> u32 {
+        self.end_col
+    }
+
+    /// Returns a new `Location` with 1-indexed values for display purposes.
+    #[must_use]
+    pub fn to_presentation(&self) -> Self {
+        Self {
+            start_line: self.start_line + 1,
+            start_col: self.start_col + 1,
+            end_line: self.end_line + 1,
+            end_col: self.end_col + 1,
+        }
     }
 }


### PR DESCRIPTION
## Summary

Adds an MCP (Model Context Protocol) server to rubydex as a separate workspace crate (`rubydex-mcp`), allowing AI assistants like Claude Code to semantically query indexed Ruby programs. This is a prototype/experiment exploring how code intelligence can improve AI agent effectiveness compared to plain grep-based approaches.

**What it does:** When launched with `rubydex_mcp <path>`, the binary indexes the Ruby project and serves semantic queries over JSON-RPC stdio. AI agents can then use these tools instead of grep for structural Ruby queries.

### 6 MCP tools

| Tool | What it does |
|------|-------------|
| `search_declarations` | Fuzzy search for classes, modules, methods, constants |
| `get_declaration` | Full details by fully qualified name with docs, ancestors, members |
| `get_descendants` | What classes/modules inherit from or include this one |
| `find_constant_references` | All precise, resolved constant references across the codebase |
| `get_file_declarations` | Structural overview of a file's declarations |
| `codebase_stats` | Indexed codebase statistics |

### Key design decisions

- **Separate crate** — `rubydex-mcp` is its own workspace crate to keep MCP dependencies (42 unique crates: rmcp, tokio, schemars, etc.) out of the rubydex library consumed by rubydex-sys
- **Read-only at runtime** — the server owns the `Graph` directly (no `Arc`, no locks); all tools are pure reads
- **Precise references only** — `find_constant_references` returns only resolved constant references, not fuzzy name matches; agents use Grep for method call sites
- **Structured JSON errors** — all error responses include machine-readable error type, message, and recovery suggestion
- **Result limits** — `find_constant_references` defaults to 50 results (max 200) with a `truncated` flag to prevent context window blowout
- **No source embedding** — tools return file paths and line numbers; agents use their built-in Read tool to fetch source when needed

### Also in this PR

- `Location` struct added to `rubydex::offset` for reusable offset-to-line/col conversion
- `.mcp.json` committed to repo root for zero-config setup
- `dev up` step to auto-install the MCP binary
- Benchmarking skill (`.claude/skills/rubydex-mcp-benchmark/`) for A/B comparing MCP-assisted vs grep-based development

### Early benchmark results (IRB project)

| Scenario | Metric | With MCP | Without MCP |
|----------|--------|----------|-------------|
| Rename (IRB::Locale, 16 refs) | Tokens | 22k | 31.8k |
| Extract module (IRB::Context) | Tokens | 33.2k | 63.0k |

## Usage

The `.mcp.json` is committed to the repo root. Install the binary:

```bash
cargo install --path rust/rubydex-mcp
```

Or just run `dev up` — it installs automatically.

To use rubydex MCP in other Ruby projects, add a `.mcp.json` to that project's root:

```json
{
  "mcpServers": {
    "rubydex": {
      "command": "${HOME}/.cargo/bin/rubydex_mcp"
    }
  }
}
```

Then start Claude Code from that project directory. Verify with `/mcp` in the session.