### PR TITLE
Add API to index in-memory sources

### DIFF
--- a/ext/rubydex/graph.c
+++ b/ext/rubydex/graph.c
@@ -61,6 +61,28 @@ static VALUE rdxr_graph_index_all(VALUE self, VALUE file_paths) {
     return array;
 }
 
+// Indexes a single source string in memory, dispatching to the appropriate indexer based on language_id
+//
+// Graph#index_source: (String uri, String source, String language_id) -> void
+static VALUE rdxr_graph_index_source(VALUE self, VALUE uri, VALUE source, VALUE language_id) {
+    Check_Type(uri, T_STRING);
+    Check_Type(source, T_STRING);
+    Check_Type(language_id, T_STRING);
+
+    void *graph;
+    TypedData_Get_Struct(self, void *, &graph_type, graph);
+
+    const char *uri_str = StringValueCStr(uri);
+    const char *source_str = StringValueCStr(source);
+    const char *language_id_str = StringValueCStr(language_id);
+
+    if (!rdx_index_source(graph, uri_str, source_str, language_id_str)) {
+        rb_raise(rb_eArgError, "unsupported language_id `%s`", language_id_str);
+    }
+
+    return Qnil;
+}
+
 // Size function for the declarations enumerator
 static VALUE graph_declarations_size(VALUE self, VALUE _args, VALUE _eobj) {
     void *graph;
@@ -449,6 +471,7 @@ void rdxi_initialize_graph(VALUE mRubydex) {
     cGraph = rb_define_class_under(mRubydex, "Graph", rb_cObject);
     rb_define_alloc_func(cGraph, rdxr_graph_alloc);
     rb_define_method(cGraph, "index_all", rdxr_graph_index_all, 1);
+    rb_define_method(cGraph, "index_source", rdxr_graph_index_source, 3);
     rb_define_method(cGraph, "delete_document", rdxr_graph_delete_document, 1);
     rb_define_method(cGraph, "resolve", rdxr_graph_resolve, 0);
     rb_define_method(cGraph, "resolve_constant", rdxr_graph_resolve_constant, 2);

--- a/rust/rubydex/src/test_utils/graph_test.rs
+++ b/rust/rubydex/src/test_utils/graph_test.rs
@@ -1,8 +1,7 @@
 use super::normalize_indentation;
 #[cfg(test)]
 use crate::diagnostic::Rule;
-use crate::indexing::local_graph::LocalGraph;
-use crate::indexing::ruby_indexer::RubyIndexer;
+use crate::indexing::{self, LanguageId};
 use crate::model::graph::Graph;
 use crate::resolution::Resolver;
 
@@ -22,17 +21,10 @@ impl GraphTest {
         &self.graph
     }
 
-    #[must_use]
-    fn index_source(uri: &str, source: &str) -> LocalGraph {
-        let mut indexer = RubyIndexer::new(uri.to_string(), source);
-        indexer.index();
-        indexer.local_graph()
-    }
-
+    /// Indexes a Ruby source
     pub fn index_uri(&mut self, uri: &str, source: &str) {
         let source = normalize_indentation(source);
-        let local_index = Self::index_source(uri, &source);
-        self.graph.update(local_index);
+        indexing::index_source(&mut self.graph, uri, &source, &LanguageId::Ruby);
     }
 
     pub fn delete_uri(&mut self, uri: &str) {


### PR DESCRIPTION
This PR allows us to index documents that are stored in-memory (like unsaved files) rather than on disk.

I was starting the work on the Ruby LSP adoption and realized that all of our tests need to be able to index in-memory sources. Rather than re-writing the entire test suite, I figured we ought to add this API already since we need it for the regular LSP operations anyway.

My proposal is that we create a separate API for in-memory sources that is disconnected from indexing all files from disk. The reason is because we have these scenarios:

- Boot: we need to index everything from disk based on the workspace path + dependency paths
- Watched files change notifications: these notifications are received when a file modification was committed to disk and we always receive a list of modifications. Using the existing `index_all` API, which accepts an array and runs in parallel is the adequate choice
- Regular file modifications: these are the only ones that happen in-memory and they are always sent to the LSP one by one