### PR TITLE
Rename `set_encoding` to `encoding=`

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ of using the Ruby API:
 # Create a new graph representing the current workspace
 graph = Rubydex::Graph.new
 # Configuring graph LSP encoding
-graph.set_encoding("utf16")
+graph.encoding = "utf16"
 # Index the entire workspace with all dependencies
 graph.index_workspace
 # Or index specific file paths

--- a/ext/rubydex/graph.c
+++ b/ext/rubydex/graph.c
@@ -325,7 +325,7 @@ static VALUE rdxr_graph_resolve(VALUE self) {
     return self;
 }
 
-// Graph#set_encoding: (String) -> void
+// Graph#encoding=: (String) -> void
 // Sets the encoding used for transforming byte offsets into LSP code unit line/column positions
 static VALUE rdxr_graph_set_encoding(VALUE self, VALUE encoding) {
     Check_Type(encoding, T_STRING);
@@ -482,7 +482,7 @@ void rdxi_initialize_graph(VALUE mRubydex) {
     rb_define_method(cGraph, "diagnostics", rdxr_graph_diagnostics, 0);
     rb_define_method(cGraph, "[]", rdxr_graph_aref, 1);
     rb_define_method(cGraph, "search", rdxr_graph_search, 1);
-    rb_define_method(cGraph, "set_encoding", rdxr_graph_set_encoding, 1);
+    rb_define_method(cGraph, "encoding=", rdxr_graph_set_encoding, 1);
     rb_define_method(cGraph, "resolve_require_path", rdxr_graph_resolve_require_path, 2);
     rb_define_method(cGraph, "require_paths", rdxr_graph_require_paths, 1);
 }

--- a/test/graph_test.rb
+++ b/test/graph_test.rb
@@ -164,7 +164,7 @@ class GraphTest < Minitest::Test
     end
   end
 
-  def test_graph_set_encoding
+  def test_graph_encoding_setter
     with_context do |context|
       context.write!("foo.rb", <<~RUBY)
         class Foo
@@ -188,7 +188,7 @@ class GraphTest < Minitest::Test
       assert_equal(17, loc.end_column)
 
       # UTF-16: code units => 1 for 1,2 byte characters, 2 for 3,4 byte characters
-      graph.set_encoding("utf16")
+      graph.encoding = "utf16"
       loc = foo.location
       assert_equal(3, loc.start_line)
       assert_equal(5, loc.start_column)
@@ -196,7 +196,7 @@ class GraphTest < Minitest::Test
       assert_equal(11, loc.end_column)
 
       # UTF-32: code units => 1 for all characters
-      graph.set_encoding("utf32")
+      graph.encoding = "utf32"
       loc = foo.location
       assert_equal(3, loc.start_line)
       assert_equal(5, loc.start_column)
@@ -205,17 +205,17 @@ class GraphTest < Minitest::Test
     end
   end
 
-  def test_graph_set_encoding_with_invalid_value
+  def test_graph_encoding_setter_with_invalid_value
     graph = Rubydex::Graph.new
 
     error = assert_raises(ArgumentError) do
-      graph.set_encoding("invalid-encoding")
+      graph.encoding = "invalid-encoding"
     end
 
     assert_match(/invalid encoding `invalid-encoding` \(should be utf8, utf16 or utf32\)/, error.message)
 
     assert_raises(TypeError) do
-      graph.set_encoding(123)
+      graph.encoding = 123
     end
   end
 


### PR DESCRIPTION
Using the `set_something` naming is not conventional Ruby and RuboCop complains about it. We should instead name setter methods with `something=`.

This PR renames `set_encoding` to `encoding=`.