### PR TITLE
Add method call with receiver completion

### DIFF
--- a/rust/rubydex/src/query.rs
+++ b/rust/rubydex/src/query.rs
@@ -145,6 +145,10 @@ pub enum CompletionReceiver {
     /// Completion requested after a namespace access operator (e.g.: `Foo::`)
     /// Includes: all constants and singleton methods for the namespace and its ancestors
     NamespaceAccess(DeclarationId),
+    /// Completion requested after a method call operator (e.g.: `foo.`, `@bar.`, `@@baz.`, `Qux.`).
+    /// In the case of singleton completion (e.g.: `Foo.`), the declaration ID should be for the singleton class (i.e.: `Foo::<Foo>`)
+    /// Includes: all methods that exist on the type of the receiver and its ancestors
+    MethodCall(DeclarationId),
 }
 
 pub struct CompletionContext<'a> {
@@ -215,6 +219,7 @@ pub fn completion_candidates<'a>(
     match context.completion_receiver {
         CompletionReceiver::Expression(self_name_id) => expression_completion(graph, self_name_id, context),
         CompletionReceiver::NamespaceAccess(decl_id) => namespace_access_completion(graph, decl_id, context),
+        CompletionReceiver::MethodCall(decl_id) => method_call_completion(graph, decl_id, context),
     }
 }
 
@@ -260,6 +265,27 @@ fn namespace_access_completion<'a>(
                 let ancestor_decl = graph.declarations().get(ancestor_id).unwrap().as_namespace().unwrap();
                 collect_candidates!(graph, &ancestor_decl, context, candidates, Declaration::Method(_));
             }
+        }
+    }
+
+    Ok(candidates)
+}
+
+/// Collect completion for a method call (e.g.: `foo.`, `@bar.`, `Baz.`)
+fn method_call_completion<'a>(
+    graph: &'a Graph,
+    receiver_decl_id: DeclarationId,
+    mut context: CompletionContext<'a>,
+) -> Result<Vec<DeclarationId>, Box<dyn Error>> {
+    let Some(Declaration::Namespace(namespace)) = graph.declarations().get(&receiver_decl_id) else {
+        return Err(format!("Expected declaration {receiver_decl_id:?} to be a namespace").into());
+    };
+    let mut candidates = Vec::new();
+
+    for ancestor in namespace.ancestors() {
+        if let Ancestor::Complete(ancestor_id) = ancestor {
+            let ancestor_decl = graph.declarations().get(ancestor_id).unwrap().as_namespace().unwrap();
+            collect_candidates!(graph, &ancestor_decl, context, candidates, Declaration::Method(_));
         }
     }
 
@@ -1089,5 +1115,204 @@ mod tests {
             vec!["Foo::FOO_CONST", "Bar::CONST", "Foo::<Foo>#foo_class_method()"],
             candidates
         );
+    }
+
+    #[test]
+    fn method_call_completion_collects_instance_methods() {
+        let mut context = GraphTest::new();
+
+        context.index_uri(
+            "file:///foo.rb",
+            "
+            class Foo
+              CONST = 1
+
+              def bar; end
+              def baz; end
+
+              class << self
+                def class_method; end
+              end
+            end
+            ",
+        );
+        context.resolve();
+
+        let decl_id = DeclarationId::from("Foo");
+        let candidates = completion_candidates(
+            context.graph(),
+            CompletionContext::new(CompletionReceiver::MethodCall(decl_id)),
+        )
+        .unwrap()
+        .iter()
+        .map(|id| context.graph().declarations().get(id).unwrap().name().to_string())
+        .collect::<Vec<_>>();
+
+        assert_eq!(vec!["Foo#baz()", "Foo#bar()"], candidates);
+    }
+
+    #[test]
+    fn method_call_completion_includes_inherited_methods() {
+        let mut context = GraphTest::new();
+
+        context.index_uri(
+            "file:///foo.rb",
+            "
+            class Parent
+              def parent_method; end
+            end
+
+            class Child < Parent
+              def child_method; end
+            end
+            ",
+        );
+        context.resolve();
+
+        let decl_id = DeclarationId::from("Child");
+        let candidates = completion_candidates(
+            context.graph(),
+            CompletionContext::new(CompletionReceiver::MethodCall(decl_id)),
+        )
+        .unwrap()
+        .iter()
+        .map(|id| context.graph().declarations().get(id).unwrap().name().to_string())
+        .collect::<Vec<_>>();
+
+        assert_eq!(vec!["Child#child_method()", "Parent#parent_method()"], candidates);
+    }
+
+    #[test]
+    fn method_call_completion_includes_methods_from_included_modules() {
+        let mut context = GraphTest::new();
+
+        context.index_uri(
+            "file:///foo.rb",
+            "
+            module Mixin
+              def mixin_method; end
+            end
+
+            class Foo
+              include Mixin
+
+              def foo_method; end
+            end
+            ",
+        );
+        context.resolve();
+
+        let decl_id = DeclarationId::from("Foo");
+        let candidates = completion_candidates(
+            context.graph(),
+            CompletionContext::new(CompletionReceiver::MethodCall(decl_id)),
+        )
+        .unwrap()
+        .iter()
+        .map(|id| context.graph().declarations().get(id).unwrap().name().to_string())
+        .collect::<Vec<_>>();
+
+        assert_eq!(vec!["Foo#foo_method()", "Mixin#mixin_method()"], candidates);
+    }
+
+    #[test]
+    fn method_call_completion_deduplicates_overridden_methods() {
+        let mut context = GraphTest::new();
+
+        context.index_uri(
+            "file:///foo.rb",
+            "
+            class Parent
+              def shared_method; end
+              def parent_only; end
+            end
+
+            class Child < Parent
+              def shared_method; end
+              def child_only; end
+            end
+            ",
+        );
+        context.resolve();
+
+        let decl_id = DeclarationId::from("Child");
+        let candidates = completion_candidates(
+            context.graph(),
+            CompletionContext::new(CompletionReceiver::MethodCall(decl_id)),
+        )
+        .unwrap()
+        .iter()
+        .map(|id| context.graph().declarations().get(id).unwrap().name().to_string())
+        .collect::<Vec<_>>();
+
+        assert_eq!(
+            vec!["Child#shared_method()", "Child#child_only()", "Parent#parent_only()"],
+            candidates
+        );
+    }
+
+    #[test]
+    fn method_call_completion_excludes_non_method_members() {
+        let mut context = GraphTest::new();
+
+        context.index_uri(
+            "file:///foo.rb",
+            "
+            class Foo
+              CONST = 1
+              @@class_var = 2
+
+              def initialize
+                @ivar = 3
+              end
+
+              def bar; end
+            end
+            ",
+        );
+        context.resolve();
+
+        let decl_id = DeclarationId::from("Foo");
+        let candidates = completion_candidates(
+            context.graph(),
+            CompletionContext::new(CompletionReceiver::MethodCall(decl_id)),
+        )
+        .unwrap()
+        .iter()
+        .map(|id| context.graph().declarations().get(id).unwrap().name().to_string())
+        .collect::<Vec<_>>();
+
+        assert_eq!(vec!["Foo#initialize()", "Foo#bar()"], candidates);
+    }
+
+    #[test]
+    fn method_call_completion_at_singleton_level() {
+        let mut context = GraphTest::new();
+
+        context.index_uri(
+            "file:///foo.rb",
+            "
+            class Foo
+              def self.bar; end
+
+              class << self
+                def baz; end
+              end
+            end
+            ",
+        );
+        context.resolve();
+
+        let decl_id = DeclarationId::from("Foo::<Foo>");
+        let candidates = completion_candidates(
+            context.graph(),
+            CompletionContext::new(CompletionReceiver::MethodCall(decl_id)),
+        )
+        .unwrap()
+        .iter()
+        .map(|id| context.graph().declarations().get(id).unwrap().name().to_string())
+        .collect::<Vec<_>>();
+
+        assert_eq!(vec!["Foo::<Foo>#baz()", "Foo::<Foo>#bar()"], candidates);
     }
 }


### PR DESCRIPTION
This PR adds completion for method calls with a receiver. We can only provide this type of completion if we know what's the type of the receiver, so this scenario expects a declaration ID.

If the receiver is of an unknown type, there's no way to provide any completion.