### PR TITLE
Simplify completion tests with assertion macro

### DIFF
--- a/rust/rubydex/src/query.rs
+++ b/rust/rubydex/src/query.rs
@@ -412,6 +412,26 @@ mod tests {
         };
     }
 
+    /// Asserts that the completion candidates match the expected list
+    macro_rules! assert_completion_eq {
+        ($context:expr, $receiver:expr, $expected:expr) => {
+            assert_eq!(
+                $expected,
+                *completion_candidates($context.graph(), CompletionContext::new($receiver))
+                    .unwrap()
+                    .iter()
+                    .map(|id| $context
+                        .graph()
+                        .declarations()
+                        .get(id)
+                        .unwrap()
+                        .name()
+                        .to_string())
+                    .collect::<Vec<_>>()
+            );
+        };
+    }
+
     #[test]
     fn fuzzy_search_returns_partial_matches() {
         let mut context = GraphTest::new();
@@ -566,17 +586,10 @@ mod tests {
         context.resolve();
 
         let name_id = Name::new(StringId::from("Child"), ParentScope::None, None).id();
-        let candidates = completion_candidates(
-            context.graph(),
-            CompletionContext::new(CompletionReceiver::Expression(name_id)),
-        )
-        .unwrap()
-        .iter()
-        .map(|id| context.graph().declarations().get(id).unwrap().name().to_string())
-        .collect::<Vec<_>>();
-
-        assert_eq!(
-            vec![
+        assert_completion_eq!(
+            context,
+            CompletionReceiver::Expression(name_id),
+            [
                 "Child",
                 "Foo",
                 "Parent",
@@ -585,8 +598,7 @@ mod tests {
                 "Foo#bar()",
                 "Parent#initialize()",
                 "Parent#@var"
-            ],
-            candidates
+            ]
         );
     }
 
@@ -615,16 +627,11 @@ mod tests {
         context.resolve();
 
         let name_id = Name::new(StringId::from("Child"), ParentScope::None, None).id();
-        let candidates = completion_candidates(
-            context.graph(),
-            CompletionContext::new(CompletionReceiver::Expression(name_id)),
-        )
-        .unwrap()
-        .iter()
-        .map(|id| context.graph().declarations().get(id).unwrap().name().to_string())
-        .collect::<Vec<_>>();
-
-        assert_eq!(vec!["Child", "Foo", "Parent", "Child#bar()"], candidates);
+        assert_completion_eq!(
+            context,
+            CompletionReceiver::Expression(name_id),
+            ["Child", "Foo", "Parent", "Child#bar()"]
+        );
     }
 
     #[test]
@@ -656,18 +663,10 @@ mod tests {
         context.resolve();
 
         let name_id = Name::new(StringId::from("Foo"), ParentScope::None, None).id();
-        let candidates = completion_candidates(
-            context.graph(),
-            CompletionContext::new(CompletionReceiver::Expression(name_id)),
-        )
-        .unwrap()
-        .iter()
-        .map(|id| context.graph().declarations().get(id).unwrap().name().to_string())
-        .collect::<Vec<_>>();
-
-        assert_eq!(
-            vec!["Baz", "Foo", "Bar", "Foo#foo_m()", "Baz#baz_m()", "Bar#bar_m()"],
-            candidates
+        assert_completion_eq!(
+            context,
+            CompletionReceiver::Expression(name_id),
+            ["Baz", "Foo", "Bar", "Foo#foo_m()", "Baz#baz_m()", "Bar#bar_m()"]
         );
     }
 
@@ -699,32 +698,18 @@ mod tests {
 
         let foo_id = Name::new(StringId::from("Foo"), ParentScope::None, None).id();
         let name_id = Name::new(StringId::from("<Foo>"), ParentScope::Attached(foo_id), None).id();
-
-        let candidates = completion_candidates(
-            context.graph(),
-            CompletionContext::new(CompletionReceiver::Expression(name_id)),
-        )
-        .unwrap()
-        .iter()
-        .map(|id| context.graph().declarations().get(id).unwrap().name().to_string())
-        .collect::<Vec<_>>();
-
-        assert_eq!(
-            vec!["Foo", "Bar", "Foo::<Foo>#do_something()", "Foo#@@foo_var"],
-            candidates
+        assert_completion_eq!(
+            context,
+            CompletionReceiver::Expression(name_id),
+            ["Foo", "Bar", "Foo::<Foo>#do_something()", "Foo#@@foo_var"]
         );
 
         let name_id = Name::new(StringId::from("Bar"), ParentScope::None, None).id();
-        let candidates = completion_candidates(
-            context.graph(),
-            CompletionContext::new(CompletionReceiver::Expression(name_id)),
-        )
-        .unwrap()
-        .iter()
-        .map(|id| context.graph().declarations().get(id).unwrap().name().to_string())
-        .collect::<Vec<_>>();
-
-        assert_eq!(vec!["Foo", "Bar", "Bar#baz()", "Foo#@@foo_var"], candidates);
+        assert_completion_eq!(
+            context,
+            CompletionReceiver::Expression(name_id),
+            ["Foo", "Bar", "Bar#baz()", "Foo#@@foo_var"]
+        );
     }
 
     #[test]
@@ -759,31 +744,18 @@ mod tests {
             Some(Name::new(StringId::from("Foo"), ParentScope::None, None).id()),
         )
         .id();
-        let candidates = completion_candidates(
-            context.graph(),
-            CompletionContext::new(CompletionReceiver::Expression(name_id)),
-        )
-        .unwrap()
-        .iter()
-        .map(|id| context.graph().declarations().get(id).unwrap().name().to_string())
-        .collect::<Vec<_>>();
-
-        assert_eq!(
-            vec!["Foo::CONST_A", "Foo", "Bar", "Bar#bar_m()", "Bar#bar_m2()"],
-            candidates
+        assert_completion_eq!(
+            context,
+            CompletionReceiver::Expression(name_id),
+            ["Foo::CONST_A", "Foo", "Bar", "Bar#bar_m()", "Bar#bar_m2()"]
         );
 
         let name_id = Name::new(StringId::from("Bar"), ParentScope::None, None).id();
-        let candidates = completion_candidates(
-            context.graph(),
-            CompletionContext::new(CompletionReceiver::Expression(name_id)),
-        )
-        .unwrap()
-        .iter()
-        .map(|id| context.graph().declarations().get(id).unwrap().name().to_string())
-        .collect::<Vec<_>>();
-
-        assert_eq!(vec!["Foo", "Bar", "Bar#bar_m()", "Bar#bar_m2()"], candidates);
+        assert_completion_eq!(
+            context,
+            CompletionReceiver::Expression(name_id),
+            ["Foo", "Bar", "Bar#bar_m()", "Bar#bar_m2()"]
+        );
     }
 
     #[test]
@@ -808,20 +780,12 @@ mod tests {
 
         let foo_id = Name::new(StringId::from("Foo"), ParentScope::None, None).id();
         let name_id = Name::new(StringId::from("Bar"), ParentScope::None, Some(foo_id)).id();
-        let candidates = completion_candidates(
-            context.graph(),
-            CompletionContext::new(CompletionReceiver::Expression(name_id)),
-        )
-        .unwrap()
-        .iter()
-        .map(|id| context.graph().declarations().get(id).unwrap().name().to_string())
-        .collect::<Vec<_>>();
-
-        // Foo::CONST is reachable from Foo::Bar through lexical scoping, so it must
-        // appear as a completion candidate when the user types the unqualified name CONST
-        assert!(
-            candidates.contains(&"Foo::CONST".to_string()),
-            "Expected Foo::CONST in candidates, got: {candidates:?}",
+        // Foo::CONST is reachable from Foo::Bar through lexical scoping, so it must appear as a completion candidate
+        // when the user types the unqualified name CONST
+        assert_completion_eq!(
+            context,
+            CompletionReceiver::Expression(name_id),
+            ["Foo::CONST", "Foo::Bar", "Foo", "Foo::Bar#baz()"]
         );
     }
 
@@ -852,16 +816,11 @@ mod tests {
             Some(Name::new(StringId::from("Foo"), ParentScope::None, None).id()),
         )
         .id();
-        let candidates = completion_candidates(
-            context.graph(),
-            CompletionContext::new(CompletionReceiver::Expression(name_id)),
-        )
-        .unwrap()
-        .iter()
-        .map(|id| context.graph().declarations().get(id).unwrap().name().to_string())
-        .collect::<Vec<_>>();
-
-        assert_eq!(vec!["Foo::Bar", "$var", "Foo", "$var2", "Foo::Bar#bar_m()"], candidates);
+        assert_completion_eq!(
+            context,
+            CompletionReceiver::Expression(name_id),
+            ["Foo::Bar", "$var", "Foo", "$var2", "Foo::Bar#bar_m()"]
+        );
     }
 
     #[test]
@@ -885,17 +844,11 @@ mod tests {
         );
         context.resolve();
 
-        let decl_id = DeclarationId::from("Foo");
-        let candidates = completion_candidates(
-            context.graph(),
-            CompletionContext::new(CompletionReceiver::NamespaceAccess(decl_id)),
-        )
-        .unwrap()
-        .iter()
-        .map(|id| context.graph().declarations().get(id).unwrap().name().to_string())
-        .collect::<Vec<_>>();
-
-        assert_eq!(vec!["Foo::CONST", "Foo::Bar", "Foo::<Foo>#class_method()"], candidates);
+        assert_completion_eq!(
+            context,
+            CompletionReceiver::NamespaceAccess(DeclarationId::from("Foo")),
+            ["Foo::CONST", "Foo::Bar", "Foo::<Foo>#class_method()"]
+        );
     }
 
     #[test]
@@ -924,24 +877,15 @@ mod tests {
         );
         context.resolve();
 
-        let decl_id = DeclarationId::from("Child");
-        let candidates = completion_candidates(
-            context.graph(),
-            CompletionContext::new(CompletionReceiver::NamespaceAccess(decl_id)),
-        )
-        .unwrap()
-        .iter()
-        .map(|id| context.graph().declarations().get(id).unwrap().name().to_string())
-        .collect::<Vec<_>>();
-
-        assert_eq!(
-            vec![
+        assert_completion_eq!(
+            context,
+            CompletionReceiver::NamespaceAccess(DeclarationId::from("Child")),
+            [
                 "Child::CHILD_CONST",
                 "Parent::PARENT_CONST",
                 "Child::<Child>#child_class_method()",
                 "Parent::<Parent>#parent_class_method()",
-            ],
-            candidates
+            ]
         );
     }
 
@@ -971,17 +915,11 @@ mod tests {
         );
         context.resolve();
 
-        let decl_id = DeclarationId::from("Child");
-        let candidates = completion_candidates(
-            context.graph(),
-            CompletionContext::new(CompletionReceiver::NamespaceAccess(decl_id)),
-        )
-        .unwrap()
-        .iter()
-        .map(|id| context.graph().declarations().get(id).unwrap().name().to_string())
-        .collect::<Vec<_>>();
-
-        assert_eq!(vec!["Child::CONST", "Child::<Child>#shared_method()",], candidates);
+        assert_completion_eq!(
+            context,
+            CompletionReceiver::NamespaceAccess(DeclarationId::from("Child")),
+            ["Child::CONST", "Child::<Child>#shared_method()"]
+        );
     }
 
     #[test]
@@ -1000,17 +938,11 @@ mod tests {
         );
         context.resolve();
 
-        let decl_id = DeclarationId::from("Foo");
-        let candidates = completion_candidates(
-            context.graph(),
-            CompletionContext::new(CompletionReceiver::NamespaceAccess(decl_id)),
-        )
-        .unwrap()
-        .iter()
-        .map(|id| context.graph().declarations().get(id).unwrap().name().to_string())
-        .collect::<Vec<_>>();
-
-        assert_eq!(vec!["Foo::CONST"], candidates);
+        assert_completion_eq!(
+            context,
+            CompletionReceiver::NamespaceAccess(DeclarationId::from("Foo")),
+            ["Foo::CONST"]
+        );
     }
 
     #[test]
@@ -1028,17 +960,11 @@ mod tests {
         );
         context.resolve();
 
-        let decl_id = DeclarationId::from("Foo");
-        let candidates = completion_candidates(
-            context.graph(),
-            CompletionContext::new(CompletionReceiver::NamespaceAccess(decl_id)),
-        )
-        .unwrap()
-        .iter()
-        .map(|id| context.graph().declarations().get(id).unwrap().name().to_string())
-        .collect::<Vec<_>>();
-
-        assert_eq!(vec!["Foo::CONST", "Foo::Bar"], candidates);
+        assert_completion_eq!(
+            context,
+            CompletionReceiver::NamespaceAccess(DeclarationId::from("Foo")),
+            ["Foo::CONST", "Foo::Bar"]
+        );
     }
 
     #[test]
@@ -1061,17 +987,11 @@ mod tests {
         );
         context.resolve();
 
-        let decl_id = DeclarationId::from("Foo");
-        let candidates = completion_candidates(
-            context.graph(),
-            CompletionContext::new(CompletionReceiver::NamespaceAccess(decl_id)),
-        )
-        .unwrap()
-        .iter()
-        .map(|id| context.graph().declarations().get(id).unwrap().name().to_string())
-        .collect::<Vec<_>>();
-
-        assert_eq!(vec!["Foo::CONST", "Foo::<Foo>#class_method()"], candidates);
+        assert_completion_eq!(
+            context,
+            CompletionReceiver::NamespaceAccess(DeclarationId::from("Foo")),
+            ["Foo::CONST", "Foo::<Foo>#class_method()"]
+        );
     }
 
     #[test]
@@ -1101,19 +1021,10 @@ mod tests {
         );
         context.resolve();
 
-        let decl_id = DeclarationId::from("Foo");
-        let candidates = completion_candidates(
-            context.graph(),
-            CompletionContext::new(CompletionReceiver::NamespaceAccess(decl_id)),
-        )
-        .unwrap()
-        .iter()
-        .map(|id| context.graph().declarations().get(id).unwrap().name().to_string())
-        .collect::<Vec<_>>();
-
-        assert_eq!(
-            vec!["Foo::FOO_CONST", "Bar::CONST", "Foo::<Foo>#foo_class_method()"],
-            candidates
+        assert_completion_eq!(
+            context,
+            CompletionReceiver::NamespaceAccess(DeclarationId::from("Foo")),
+            ["Foo::FOO_CONST", "Bar::CONST", "Foo::<Foo>#foo_class_method()"]
         );
     }
 
@@ -1138,17 +1049,11 @@ mod tests {
         );
         context.resolve();
 
-        let decl_id = DeclarationId::from("Foo");
-        let candidates = completion_candidates(
-            context.graph(),
-            CompletionContext::new(CompletionReceiver::MethodCall(decl_id)),
-        )
-        .unwrap()
-        .iter()
-        .map(|id| context.graph().declarations().get(id).unwrap().name().to_string())
-        .collect::<Vec<_>>();
-
-        assert_eq!(vec!["Foo#baz()", "Foo#bar()"], candidates);
+        assert_completion_eq!(
+            context,
+            CompletionReceiver::MethodCall(DeclarationId::from("Foo")),
+            ["Foo#baz()", "Foo#bar()"]
+        );
     }
 
     #[test]
@@ -1169,17 +1074,11 @@ mod tests {
         );
         context.resolve();
 
-        let decl_id = DeclarationId::from("Child");
-        let candidates = completion_candidates(
-            context.graph(),
-            CompletionContext::new(CompletionReceiver::MethodCall(decl_id)),
-        )
-        .unwrap()
-        .iter()
-        .map(|id| context.graph().declarations().get(id).unwrap().name().to_string())
-        .collect::<Vec<_>>();
-
-        assert_eq!(vec!["Child#child_method()", "Parent#parent_method()"], candidates);
+        assert_completion_eq!(
+            context,
+            CompletionReceiver::MethodCall(DeclarationId::from("Child")),
+            ["Child#child_method()", "Parent#parent_method()"]
+        );
     }
 
     #[test]
@@ -1202,17 +1101,11 @@ mod tests {
         );
         context.resolve();
 
-        let decl_id = DeclarationId::from("Foo");
-        let candidates = completion_candidates(
-            context.graph(),
-            CompletionContext::new(CompletionReceiver::MethodCall(decl_id)),
-        )
-        .unwrap()
-        .iter()
-        .map(|id| context.graph().declarations().get(id).unwrap().name().to_string())
-        .collect::<Vec<_>>();
-
-        assert_eq!(vec!["Foo#foo_method()", "Mixin#mixin_method()"], candidates);
+        assert_completion_eq!(
+            context,
+            CompletionReceiver::MethodCall(DeclarationId::from("Foo")),
+            ["Foo#foo_method()", "Mixin#mixin_method()"]
+        );
     }
 
     #[test]
@@ -1235,19 +1128,10 @@ mod tests {
         );
         context.resolve();
 
-        let decl_id = DeclarationId::from("Child");
-        let candidates = completion_candidates(
-            context.graph(),
-            CompletionContext::new(CompletionReceiver::MethodCall(decl_id)),
-        )
-        .unwrap()
-        .iter()
-        .map(|id| context.graph().declarations().get(id).unwrap().name().to_string())
-        .collect::<Vec<_>>();
-
-        assert_eq!(
-            vec!["Child#shared_method()", "Child#child_only()", "Parent#parent_only()"],
-            candidates
+        assert_completion_eq!(
+            context,
+            CompletionReceiver::MethodCall(DeclarationId::from("Child")),
+            ["Child#shared_method()", "Child#child_only()", "Parent#parent_only()"]
         );
     }
 
@@ -1272,17 +1156,11 @@ mod tests {
         );
         context.resolve();
 
-        let decl_id = DeclarationId::from("Foo");
-        let candidates = completion_candidates(
-            context.graph(),
-            CompletionContext::new(CompletionReceiver::MethodCall(decl_id)),
-        )
-        .unwrap()
-        .iter()
-        .map(|id| context.graph().declarations().get(id).unwrap().name().to_string())
-        .collect::<Vec<_>>();
-
-        assert_eq!(vec!["Foo#initialize()", "Foo#bar()"], candidates);
+        assert_completion_eq!(
+            context,
+            CompletionReceiver::MethodCall(DeclarationId::from("Foo")),
+            ["Foo#initialize()", "Foo#bar()"]
+        );
     }
 
     #[test]
@@ -1303,16 +1181,10 @@ mod tests {
         );
         context.resolve();
 
-        let decl_id = DeclarationId::from("Foo::<Foo>");
-        let candidates = completion_candidates(
-            context.graph(),
-            CompletionContext::new(CompletionReceiver::MethodCall(decl_id)),
-        )
-        .unwrap()
-        .iter()
-        .map(|id| context.graph().declarations().get(id).unwrap().name().to_string())
-        .collect::<Vec<_>>();
-
-        assert_eq!(vec!["Foo::<Foo>#baz()", "Foo::<Foo>#bar()"], candidates);
+        assert_completion_eq!(
+            context,
+            CompletionReceiver::MethodCall(DeclarationId::from("Foo::<Foo>")),
+            ["Foo::<Foo>#baz()", "Foo::<Foo>#bar()"]
+        );
     }
 }


### PR DESCRIPTION
Our tests were getting long, with repeated logic. This PR adds an `assert_completion_eq!` macro and simplifies all tests.