### PR TITLE
Fix GH release creation

### DIFF
--- a/.github/workflows/cibuildgem.yaml
+++ b/.github/workflows/cibuildgem.yaml
@@ -103,8 +103,8 @@ jobs:
             await github.rest.repos.createRelease({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              tag_name: "${{ github.ref_name }}",
+              tag_name: "${{ github.ref }}",
               name: "${{ github.ref_name }}",
               generate_release_notes: true,
-              prerelease: "${{ github.ref_name }}".includes("-beta")
+              prerelease: "${{ github.ref_name }}".includes(".beta")
             });


### PR DESCRIPTION
There were two issues with our GH release creation:

- The tag name is supposed to be `github.ref`, which returns something like `/refs/tags/v0.1.0.beta5` instead of just `v0.1.0.beta5`
- In #599, I fixed the tag matchers, but forgot to fix the pre-release check