### PR TITLE
Add `workspace_path` accessor to `Graph`

### DIFF
--- a/lib/rubydex/graph.rb
+++ b/lib/rubydex/graph.rb
@@ -13,6 +13,9 @@ module Rubydex
       "tmp",
     ].freeze
 
+    #: String
+    attr_accessor :workspace_path
+
     #: (?workspace_path: String) -> void
     def initialize(workspace_path: Dir.pwd)
       @workspace_path = workspace_path

--- a/rbi/rubydex.rbi
+++ b/rbi/rubydex.rbi
@@ -192,6 +192,12 @@ module Rubydex
     sig { params(encoding: String).void }
     def encoding=(encoding); end
 
+    sig { returns(String) }
+    def workspace_path; end
+
+    sig { params(workspace_path: String).returns(String) }
+    def workspace_path=(workspace_path); end
+
     sig { returns(T::Array[String]) }
     def workspace_paths; end
 


### PR DESCRIPTION
We need to be able to configure the graph's workspace path because some language servers are spawned in a directory that doesn't match the workspace path (i.e.: `Dir.pwd != workspace_path`). This PR adds an accessor. 