### PR TITLE
Make locations zero based with `to_display` method

### DIFF
--- a/lib/rubydex/location.rb
+++ b/lib/rubydex/location.rb
@@ -39,6 +39,19 @@ module Rubydex
       a <=> b
     end
 
+    # Turns this zero based location into a one based location for display purposes.
+    #
+    #: () -> Location
+    def to_display
+      self.class.new(
+        uri: @uri,
+        start_line: @start_line + 1,
+        end_line: @end_line + 1,
+        start_column: @start_column + 1,
+        end_column: @end_column + 1,
+      )
+    end
+
     #: -> String
     def to_s
       "#{path}:#{@start_line}:#{@start_column}-#{@end_line}:#{@end_column}"

--- a/rust/rubydex-sys/src/location_api.rs
+++ b/rust/rubydex-sys/src/location_api.rs
@@ -37,18 +37,18 @@ pub(crate) fn create_location_for_uri_and_offset(graph: &Graph, document: &Docum
 
         Location {
             uri: CString::new(document.uri()).unwrap().into_raw().cast_const(),
-            start_line: wide_start_pos.line + 1,
-            end_line: wide_end_pos.line + 1,
-            start_column: wide_start_pos.col + 1,
-            end_column: wide_end_pos.col + 1,
+            start_line: wide_start_pos.line,
+            end_line: wide_end_pos.line,
+            start_column: wide_start_pos.col,
+            end_column: wide_end_pos.col,
         }
     } else {
         Location {
             uri: CString::new(document.uri()).unwrap().into_raw().cast_const(),
-            start_line: start_pos.line + 1,
-            end_line: end_pos.line + 1,
-            start_column: start_pos.col + 1,
-            end_column: end_pos.col + 1,
+            start_line: start_pos.line,
+            end_line: end_pos.line,
+            start_column: start_pos.col,
+            end_column: end_pos.col,
         }
     };
 

--- a/test/definition_test.rb
+++ b/test/definition_test.rb
@@ -84,7 +84,7 @@ class DefinitionTest < Minitest::Test
 
       def_a = graph.documents.first.definitions.find { |d| d.name == "A" }
       refute_nil(def_a)
-      location = def_a.location
+      location = def_a.location.to_display
       refute_nil(location)
       assert_equal(context.uri_to("file1.rb"), location.uri)
       assert_equal(context.absolute_path_to("file1.rb"), location.path)
@@ -95,7 +95,7 @@ class DefinitionTest < Minitest::Test
 
       def_foo = graph.documents.first.definitions.find { |d| d.name == "foo()" }
       refute_nil(def_foo)
-      location = def_foo.location
+      location = def_foo.location.to_display
       refute_nil(location)
       assert_equal(context.uri_to("file1.rb"), location.uri)
       assert_equal(context.absolute_path_to("file1.rb"), location.path)
@@ -209,7 +209,7 @@ class DefinitionTest < Minitest::Test
   # Comment locations on Windows include the carriage return. This means that the end column is off by one when compared
   # to Unix locations. This method creates a fake adjusted location for Windows so that we can assert locations once
   def normalized_comment_location(comment)
-    loc = comment.location
+    loc = comment.location.to_display
     return loc unless Gem.win_platform?
 
     Rubydex::Location.new(

--- a/test/graph_test.rb
+++ b/test/graph_test.rb
@@ -181,7 +181,7 @@ class GraphTest < Minitest::Test
       foo = graph["Foo\#@叫聲😍x"].definitions.first
 
       # UTF-8: code units => number of bytes
-      loc = foo.location
+      loc = foo.location.to_display
       assert_equal(3, loc.start_line)
       assert_equal(5, loc.start_column)
       assert_equal(3, loc.end_line)
@@ -189,7 +189,7 @@ class GraphTest < Minitest::Test
 
       # UTF-16: code units => 1 for 1,2 byte characters, 2 for 3,4 byte characters
       graph.encoding = "utf16"
-      loc = foo.location
+      loc = foo.location.to_display
       assert_equal(3, loc.start_line)
       assert_equal(5, loc.start_column)
       assert_equal(3, loc.end_line)
@@ -197,7 +197,7 @@ class GraphTest < Minitest::Test
 
       # UTF-32: code units => 1 for all characters
       graph.encoding = "utf32"
-      loc = foo.location
+      loc = foo.location.to_display
       assert_equal(3, loc.start_line)
       assert_equal(5, loc.start_column)
       assert_equal(3, loc.end_line)

--- a/test/references_test.rb
+++ b/test/references_test.rb
@@ -54,11 +54,11 @@ class ReferencesTest < Minitest::Test
 
       assert_kind_of(Rubydex::ConstantReference, ref1)
       assert_equal("A", ref1.name)
-      assert_equal("#{context.absolute_path_to("file1.rb")}:2:11-2:12", ref1.location.to_s)
+      assert_equal("#{context.absolute_path_to("file1.rb")}:2:11-2:12", ref1.location.to_display.to_s)
 
       assert_kind_of(Rubydex::ConstantReference, ref2)
       assert_equal("B", ref2.name)
-      assert_equal("#{context.absolute_path_to("file1.rb")}:4:10-4:11", ref2.location.to_s)
+      assert_equal("#{context.absolute_path_to("file1.rb")}:4:10-4:11", ref2.location.to_display.to_s)
     end
   end
 
@@ -109,7 +109,7 @@ class ReferencesTest < Minitest::Test
       ref1 = references[0]
       assert_kind_of(Rubydex::MethodReference, ref1)
       assert_equal("puts", ref1.name)
-      assert_equal("#{context.absolute_path_to("file1.rb")}:4:5-4:9", ref1.location.to_s)
+      assert_equal("#{context.absolute_path_to("file1.rb")}:4:5-4:9", ref1.location.to_display.to_s)
     end
   end
 end


### PR DESCRIPTION
While trying to adopt Rubydex in the LSP, I noticed that all of the location objects are adding `+1` to all location values, which would require the LSP to then `-1` all of them back.

This PR makes locations zero based and instead provides a `to_display` method which returns a one based version of them. That way, tools that need display location can still get it easily.