### PR TITLE
Fix handling of null byte like terminators

### DIFF
--- a/ext/rubydex/graph.c
+++ b/ext/rubydex/graph.c
@@ -73,11 +73,26 @@ static VALUE rdxr_graph_index_source(VALUE self, VALUE uri, VALUE source, VALUE 
     TypedData_Get_Struct(self, void *, &graph_type, graph);
 
     const char *uri_str = StringValueCStr(uri);
-    const char *source_str = StringValueCStr(source);
     const char *language_id_str = StringValueCStr(language_id);
+    const char *source_str = RSTRING_PTR(source);
+    size_t source_len = RSTRING_LEN(source);
 
-    if (!rdx_index_source(graph, uri_str, source_str, language_id_str)) {
+    enum IndexSourceResult result = rdx_index_source(graph, uri_str, source_str, source_len, language_id_str);
+    switch (result) {
+    case IndexSourceResult_Success:
+        break;
+    case IndexSourceResult_InvalidUri:
+        rb_raise(rb_eArgError, "invalid URI (not valid UTF-8)");
+        break;
+    case IndexSourceResult_InvalidSource:
+        rb_raise(rb_eArgError, "source is not valid UTF-8");
+        break;
+    case IndexSourceResult_InvalidLanguageId:
+        rb_raise(rb_eArgError, "invalid language_id (not valid UTF-8)");
+        break;
+    case IndexSourceResult_UnsupportedLanguageId:
         rb_raise(rb_eArgError, "unsupported language_id `%s`", language_id_str);
+        break;
     }
 
     return Qnil;

--- a/test/graph_test.rb
+++ b/test/graph_test.rb
@@ -495,6 +495,21 @@ class GraphTest < Minitest::Test
     refute_nil(graph["Bar"])
   end
 
+  def test_index_source_with_invalid_source_encoding
+    graph = Rubydex::Graph.new
+    error = assert_raises(ArgumentError) do
+      graph.index_source("file:///test.rb", "\xFF\xFE".b, "ruby")
+    end
+    assert_match(/source is not valid UTF-8/, error.message)
+  end
+
+  def test_index_source_with_null_bytes_in_source
+    # Edge case supported by Prism. The `\0` cannot be confused with a string termination null byte
+    graph = Rubydex::Graph.new
+    source = "%\0abc\0"
+    graph.index_source("file:///test.rb", source, "ruby")
+  end
+
   def test_require_paths_with_invalid_arguments
     graph = Rubydex::Graph.new
 


### PR DESCRIPTION
To my surprise you can use `\0` as a string terminator in Ruby. I found out when running Ruby LSP tests against Prism fixtures, which made `index_source` crash.

To be able to handle this case correctly, we need the pointer and the length to instantiate the string on the Rust side, otherwise it considers the first `\0` as the string's terminator and we crash.

I also improved the error messages. We were always showing the same message no matter what problem happened, which isn't a nice API.