### PR TITLE
Add `Declaration#resolve_member` to follow ancestors

### DIFF
--- a/rbi/rubydex.rbi
+++ b/rbi/rubydex.rbi
@@ -58,6 +58,9 @@ module Rubydex
     sig { params(name: String).returns(T.nilable(Declaration)) }
     def member(name); end
 
+    sig { params(name: String, only_inherited: T::Boolean).returns(T.nilable(Declaration)) }
+    def find_member(name, only_inherited: false); end
+
     sig { returns(T.nilable(SingletonClass)) }
     def singleton_class; end
   end


### PR DESCRIPTION
This PR adds `Declaration#resolve_member`, which searches the ancestors of the declaration for the given member. This is a super common operation in the LSP, so we might as well avoid so much duplication and just provide a way to do this neatly.

We need the `only_inherited` option to search only ancestors after the main namespace, which is what we use to provide go to definition for `super`.