### PR TITLE
Include RBS paths when indexing workspace

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem "minitest"
 gem "rubocop"
 gem "rubocop-shopify"
 gem "extconf_compile_commands_json"
+gem "rbs"
 
 # Gems that aren't supported on Windows
 platforms :ruby do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,6 +11,7 @@ GEM
     json (2.18.0)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
+    logger (1.7.0)
     mini_portile2 (2.8.9)
     minitest (6.0.1)
       prism (~> 1.5)
@@ -29,6 +30,9 @@ GEM
     rake (13.3.1)
     rake-compiler (1.3.0)
       rake
+    rbs (3.10.3)
+      logger
+      tsort
     regexp_parser (2.11.3)
     rubocop (1.81.7)
       json (~> 2.3)
@@ -49,12 +53,13 @@ GEM
     ruby-progressbar (1.13.0)
     ruby_memcheck (3.0.1)
       nokogiri
+    tsort (0.2.0)
     unicode-display_width (3.2.0)
       unicode-emoji (~> 4.1)
     unicode-emoji (4.2.0)
 
 PLATFORMS
-  arm64-darwin-23
+  arm64-darwin-24
   ruby
 
 DEPENDENCIES
@@ -62,10 +67,11 @@ DEPENDENCIES
   minitest
   rake (~> 13.3)
   rake-compiler
+  rbs
   rubocop
   rubocop-shopify
   ruby_memcheck
   rubydex!
 
 BUNDLED WITH
-  4.0.3
+  4.0.7

--- a/lib/rubydex/graph.rb
+++ b/lib/rubydex/graph.rb
@@ -45,6 +45,7 @@ module Rubydex
       end
 
       add_workspace_dependency_paths(paths)
+      add_core_rbs_definition_paths(paths)
       paths.uniq!
       paths
     end
@@ -70,6 +71,22 @@ module Rubydex
       rescue Gem::MissingSpecError
         nil
       end
+    end
+
+    # Searches for the latest installation of the `rbs` gem and adds the paths for the core and stdlib RBS definitions
+    # to the list of paths. This method does not require `rbs` to be a part of the bundle. It searches for whatever
+    # latest installation of `rbs` exists in the system and fails silently if we can't find one
+    #
+    #: (Array[String]) -> void
+    def add_core_rbs_definition_paths(paths)
+      rbs_gem_path = Gem.path
+        .flat_map { |path| Dir.glob(File.join(path, "gems", "rbs-[0-9]*/")) }
+        .max_by { |path| Gem::Version.new(File.basename(path).delete_prefix("rbs-")) }
+
+      return unless rbs_gem_path
+
+      paths << File.join(rbs_gem_path, "core")
+      paths << File.join(rbs_gem_path, "stdlib")
     end
   end
 end

--- a/test/graph_test.rb
+++ b/test/graph_test.rb
@@ -560,6 +560,35 @@ class GraphTest < Minitest::Test
     end
   end
 
+  def test_index_workspace_includes_rbs_core_definitions
+    graph = Rubydex::Graph.new
+    graph.index_workspace
+    graph.resolve
+
+    ["Kernel", "Object", "BasicObject", "Integer"].each do |core_namespace|
+      rbs_kernel = graph[core_namespace].definitions.find do |definition|
+        uri = URI(definition.location.uri)
+        File.extname(uri.path) == ".rbs"
+      end
+      assert(rbs_kernel, "Expected to find RBS definition for `#{core_namespace}` in the graph")
+    end
+  end
+
+  def test_index_workspace_includes_user_defined_rbs_files
+    with_context do |context|
+      context.write!("sig/foo.rbs", <<~RBS)
+        class Foo
+        end
+      RBS
+
+      graph = Rubydex::Graph.new(workspace_path: context.absolute_path)
+      graph.index_workspace
+      graph.resolve
+
+      assert_equal("Foo", graph["Foo"].name)
+    end
+  end
+
   private
 
   def assert_diagnostics(expected, actual)


### PR DESCRIPTION
Now that we have some RBS indexing, we can automatically include the RBS paths for `core` and `stdlib` to get the complete data when using `index_workspace`. In the future, we may want to ship with a fully indexed RBS cache, but for now let's just include the paths.

One design note: we should not require that `rbs` be on the bundle. Instead of using `Gem::Specification.find` or `Gem.find_files` (both of which are scoped to the bundle), I just searched `Gem.path` manually for the latest `rbs` installation.