### PR TITLE
Improve review skill: suggest extracting repeated test setups into helpers

### DIFF
--- a/.claude/skills/review_changes/SKILL.md
+++ b/.claude/skills/review_changes/SKILL.md
@@ -17,7 +17,7 @@ Use the Rust and static analysis experts to review the code changes regarding th
 - Code quality and idiomatic patterns: does the code use idiomatic Rust? Are there opportunities to improve the code
 structure?
 - Performance: are there any performance pitfalls or opportunities for optimization?
-- Test coverage: are we missing scenarios?
+- Test coverage: are we missing scenarios? Are there repeated test setups that could be extracted into a test helper?
 - Documentation: are the key concepts clearly explained in the documentation (files under `docs` and README)?
 - Agent instructions: are there key concepts or major changes that should be reflected in AGENTS.md?
 


### PR DESCRIPTION
Adds a suggestion to the `review_changes` skill to flag repeated test setups that could be extracted into test helpers.

Inspired by feedback on #505 where several tests shared the same structure and could benefit from a shared helper.