### PR TITLE
Rewrite assert_def_superclass_ref_eq! to support full paths

### DIFF
--- a/rust/rubydex/src/indexing/rbs_indexer.rs
+++ b/rust/rubydex/src/indexing/rbs_indexer.rs
@@ -342,7 +342,6 @@ mod tests {
 
         assert_definition_at!(&context, "1:1-2:4", Class, |def| {
             assert_def_name_eq!(&context, def, "Foo");
-            assert!(def.superclass_ref().is_some());
             assert_def_superclass_ref_eq!(&context, def, "Bar");
         });
     }

--- a/rust/rubydex/src/indexing/ruby_indexer.rs
+++ b/rust/rubydex/src/indexing/ruby_indexer.rs
@@ -4478,7 +4478,7 @@ mod tests {
         refs.sort_by_key(|a| (a.offset().start(), a.offset().end()));
 
         assert_definition_at!(&context, "1:1-1:26", Class, |def| {
-            assert_def_superclass_ref_eq!(&context, def, "Baz");
+            assert_def_superclass_ref_eq!(&context, def, "Bar::Baz");
             assert_def_name_offset_eq!(&context, def, "1:7-1:10");
         });
     }

--- a/rust/rubydex/src/test_utils/local_graph_test.rs
+++ b/rust/rubydex/src/test_utils/local_graph_test.rs
@@ -254,36 +254,18 @@ macro_rules! assert_def_name_eq {
 /// Asserts that a definition's superclass reference matches the expected name.
 ///
 /// Usage:
-/// - `assert_def_superclass_ref_eq!(ctx, def, "Bar::Baz")`
+/// - `assert_def_superclass_ref_eq!(ctx, def, "Bar::Baz")` - asserts the full path `Bar::Baz`
 #[cfg(test)]
 #[macro_export]
 macro_rules! assert_def_superclass_ref_eq {
     ($context:expr, $def:expr, $expected_name:expr) => {{
-        let name = $context
+        let name_id = *$context
             .graph()
-            .strings()
-            .get(
-                $context
-                    .graph()
-                    .names()
-                    .get(
-                        $context
-                            .graph()
-                            .constant_references()
-                            .get($def.superclass_ref().unwrap())
-                            .unwrap()
-                            .name_id(),
-                    )
-                    .unwrap()
-                    .str(),
-            )
+            .constant_references()
+            .get($def.superclass_ref().unwrap())
             .unwrap()
-            .as_str();
-        assert_eq!(
-            $expected_name, name,
-            "superclass reference mismatch: expected `{}`, got `{name}`",
-            $expected_name,
-        );
+            .name_id();
+        $crate::assert_name_path_eq!($context, $expected_name, name_id);
     }};
 }
 


### PR DESCRIPTION
Rewriting `assert_def_superclass_ref_eq!` to support full paths, as per post-merge review https://github.com/Shopify/rubydex/pull/606#discussion_r2859884569

Also using this opportunity to remove the redundant `assert!(def.superclass_ref().is_some())`.