### PR TITLE
Always rebuild rubydex MCP binary on `dev up`

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -6,8 +6,7 @@ up:
   - rust
   - custom:
       name: Install rubydex MCP server
-      met?: test -x ~/.cargo/bin/rubydex_mcp
-      meet: cargo install --path rust/rubydex-mcp
+      meet: cargo install --force --path rust/rubydex-mcp
 
 commands:
   test:


### PR DESCRIPTION
Remove the `met?` check that only verified the binary existed, which meant `dev up` would never rebuild after source changes. Using `--force` ensures `cargo install` always reinstalls from the latest source.

I'm making the change because I tried to run mcp on Core and it kept failing. It took me a while to realise I wasn't running the latest build even though I ran `dev up`. We could run a freshness check on the binary, like:

```
met?: test -x ~/.cargo/bin/rubydex_mcp && ! find rust/rubydex/src rust/rubydex-mcp/src rust/rubydex/Cargo.toml rust/rubydex-mcp/Cargo.toml -newer ~/.cargo/bin/rubydex_mcp -print -quit | grep -q .
```

But IMO it's not worth the complexity. Force rebuilding on `dev up` is easier and more robust.