### PR TITLE
Separate sanitizers from valgrind check

### DIFF
--- a/.github/workflows/memleak.yml
+++ b/.github/workflows/memleak.yml
@@ -13,7 +13,7 @@ on:
       - "ext/**"
 
 jobs:
-  memleak:
+  valgrind:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -29,13 +29,30 @@ jobs:
         run: |
           rustup update --no-self-update stable
           rustup default stable
+
+      - name: Run tests under Valgrind
+        run: bundle exec rake ruby_test:valgrind
+
+  sanitizer:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        sanitizer: [memory, leak, thread]
+    name: ${{ matrix.sanitizer }} sanitizer
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@09a7688d3b55cf0e976497ff046b70949eeaccfd # v1.288.0
+        with:
+          bundler-cache: true
+
+      - name: Install Rust tools
+        run: |
+          rustup update --no-self-update stable
+          rustup default stable
           rustup component add rust-src --toolchain nightly-x86_64-unknown-linux-gnu
 
-      - name: Run tests capturing leaks with `memory` sanitizer
-        run: SANITIZER=memory bundle exec rake ruby_test:valgrind
-
-      - name: Run tests capturing leaks with `leak` sanitizer
-        run: SANITIZER=leak bundle exec rake ruby_test:valgrind
-
-      - name: Run tests capturing leaks with `thread` sanitizer
-        run: SANITIZER=thread bundle exec rake ruby_test:valgrind
+      - name: Run tests with ${{ matrix.sanitizer }} sanitizer
+        run: SANITIZER=${{ matrix.sanitizer }} bundle exec rake ruby_test

--- a/ext/rubydex/extconf.rb
+++ b/ext/rubydex/extconf.rb
@@ -56,7 +56,7 @@ end
 create_makefile("rubydex/rubydex")
 
 cargo_command = if ENV["SANITIZER"]
-  ENV["RUSTFLAGS"] = "-Zsanitizer=#{ENV["SANITIZER"]} -C target-cpu=x86-64-v3"
+  ENV["RUSTFLAGS"] = "-Zsanitizer=#{ENV["SANITIZER"]}"
   "cargo +nightly build -Zbuild-std #{cargo_args.join(" ")}".strip
 else
   "cargo build #{cargo_args.join(" ")}".strip


### PR DESCRIPTION
The changes in #533 didn't really fix the flakiness in CI. I think we can try to separate the Rust sanitizers form the Valgrind check, which may be conflicting and causing the occasional failures. 