### PR TITLE
Include `rbi` directory in published gem

### DIFF
--- a/rubydex.gemspec
+++ b/rubydex.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.files = ["README.md", "LICENSE.txt"] +
     Dir.glob("lib/**/*.rb") +
+    Dir.glob("rbi/**/*.rbi") +
     Dir.glob("ext/rubydex/**/*.{c,h}") +
     Dir.glob("rust/**/*.{rs,toml,lock,hbs}").reject { |f| f.start_with?("rust/target") }
 


### PR DESCRIPTION
Tapioca won't find our type annotations if we don't include it as part of the published gem 😅.