### PR TITLE
Ensure `find_member` collects main namespace members

### DIFF
--- a/rust/rubydex-sys/src/declaration_api.rs
+++ b/rust/rubydex-sys/src/declaration_api.rs
@@ -194,13 +194,15 @@ pub unsafe extern "C" fn rdx_declaration_find_member(
             .iter()
             .find_map(|ancestor| match ancestor {
                 Ancestor::Complete(ancestor_id) => {
-                    if *ancestor_id == id {
-                        found_main_namespace = true;
-                        return None;
-                    }
-
-                    if only_inherited && !found_main_namespace {
-                        return None;
+                    // When only_inherited, skip self and prepended modules
+                    if only_inherited {
+                        let is_self = *ancestor_id == id;
+                        if is_self {
+                            found_main_namespace = true;
+                        }
+                        if is_self || !found_main_namespace {
+                            return None;
+                        }
                     }
 
                     let ancestor_decl = graph.declarations().get(ancestor_id).unwrap().as_namespace().unwrap();

--- a/test/declaration_test.rb
+++ b/test/declaration_test.rb
@@ -413,4 +413,59 @@ class DeclarationTest < Minitest::Test
       assert_equal("Parent#initialize()", decl.name)
     end
   end
+
+  def test_find_member_returns_prepended_members
+    with_context do |context|
+      context.write!("file1.rb", <<~RUBY)
+        module Prepended
+          def initialize
+            @name = "John"
+          end
+        end
+
+        class Foo
+          prepend Prepended
+        end
+      RUBY
+
+      graph = Rubydex::Graph.new
+      graph.index_all(context.glob("**/*.rb"))
+      graph.resolve
+
+      foo = graph["Foo"]
+      decl = foo.find_member("@name")
+      assert_equal("Prepended\#@name", decl.name)
+
+      decl = foo.find_member("initialize()")
+      assert_equal("Prepended#initialize()", decl.name)
+    end
+  end
+
+  def test_find_member_returns_members_in_main_namespace
+    with_context do |context|
+      context.write!("file1.rb", <<~RUBY)
+        class Foo
+          @@class_var = 1
+
+          def initialize
+            @name = "John"
+          end
+        end
+      RUBY
+
+      graph = Rubydex::Graph.new
+      graph.index_all(context.glob("**/*.rb"))
+      graph.resolve
+
+      foo = graph["Foo"]
+      decl = foo.find_member("@name")
+      assert_equal("Foo\#@name", decl.name)
+
+      decl = foo.find_member("@@class_var")
+      assert_equal("Foo\#@@class_var", decl.name)
+
+      decl = foo.find_member("initialize()")
+      assert_equal("Foo#initialize()", decl.name)
+    end
+  end
 end


### PR DESCRIPTION
There's a bug in the logic that makes `find_member` ignore the members defined in the main workspace.