### PR TITLE
Add method alias inside re-opened alias test

### DIFF
--- a/rust/rubydex/src/resolution.rs
+++ b/rust/rubydex/src/resolution.rs
@@ -5194,6 +5194,9 @@ mod tests {
               def initialize
                 @instance_ivar = 456
               end
+
+              def bar; end
+              alias new_bar bar
             end
             "
         });
@@ -5206,6 +5209,7 @@ mod tests {
         assert_declaration_exists!(context, "Foo#some_attr()");
         assert_declaration_exists!(context, "Foo::<Foo>#class_method()");
         assert_declaration_exists!(context, "Foo#initialize()");
+        assert_declaration_exists!(context, "Foo#new_bar()");
     }
 
     #[test]


### PR DESCRIPTION
Add the missing method alias to our test.