### PR TITLE
Create Todo declarations for multi-level compact namespaces

### DIFF
--- a/rust/rubydex/src/resolution.rs
+++ b/rust/rubydex/src/resolution.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{HashSet, VecDeque},
+    collections::{HashSet, VecDeque, hash_map::Entry},
     hash::BuildHasher,
 };
 
@@ -1131,14 +1131,13 @@ impl<'a> Resolver<'a> {
 
         let parent_name = self.graph.names().get(&parent_scope).unwrap();
         let parent_str_id = *parent_name.str();
-        let parent_has_explicit_prefix = parent_name.parent_scope().as_ref().is_some();
-        // NLL: borrow of parent_name ends here
+        let parent_has_parent_scope = parent_name.parent_scope().as_ref().is_some();
+        // Non-Lexical Lifetimes: borrow of parent_name ends here
 
-        // For bare names (no explicit `::` prefix), always use OBJECT_ID as the owner.
-        // Using nesting here would create "Nesting::Bar" instead of "Bar" for a bare `Bar`
-        // reference, which is incorrect: if `Bar` can't be found anywhere, the placeholder
-        // should live at the top level so it can be promoted when `module Bar` appears later.
-        let parent_owner_id = if parent_has_explicit_prefix {
+        // For `class A::B::C` where `A` is bare (no `::` prefix), place the Todo under
+        // Object so it becomes top-level `A`. This way `module A; end` appearing later
+        // promotes it correctly. Using nesting would incorrectly create `SomeModule::A`.
+        let parent_owner_id = if parent_has_parent_scope {
             match self.name_owner_id(parent_scope) {
                 Outcome::Resolved(id, _) => id,
                 Outcome::Unresolved(None) => self.create_todo_for_parent(parent_scope),
@@ -1160,7 +1159,7 @@ impl<'a> Resolver<'a> {
 
         let declaration_id = DeclarationId::from(&fully_qualified_name);
 
-        if let std::collections::hash_map::Entry::Vacant(e) = self.graph.declarations_mut().entry(declaration_id) {
+        if let Entry::Vacant(e) = self.graph.declarations_mut().entry(declaration_id) {
             e.insert(Declaration::Namespace(Namespace::Todo(Box::new(TodoDeclaration::new(
                 fully_qualified_name,
                 parent_owner_id,
@@ -5824,5 +5823,39 @@ mod todo_tests {
         assert_declaration_kind_eq!(context, "Bar::Baz::Qux", "Class");
         assert_members_eq!(context, "Bar", vec!["Baz"]);
         assert_members_eq!(context, "Bar::Baz", vec!["Qux"]);
+    }
+
+    #[test]
+    fn no_todo_when_parent_is_reachable_through_include() {
+        // Baz::Qux inside Foo, where Baz comes from included Bar module.
+        // Baz::Qux should resolve through inheritance to Bar::Baz::Qux, not create
+        // a top-level Baz Todo.
+        let mut context = GraphTest::new();
+        context.index_uri("file:///file1.rb", {
+            r"
+            module Foo
+              include Bar
+
+              class Baz::Qux; end
+            end
+            "
+        });
+        context.index_uri("file:///file2.rb", {
+            r"
+            module Bar
+              module Baz; end
+            end
+            "
+        });
+        context.resolve();
+
+        assert_declaration_exists!(context, "Bar::Baz");
+        assert_declaration_exists!(context, "Bar::Baz::Qux");
+        assert_members_eq!(context, "Bar::Baz", vec!["Qux"]);
+        assert_declaration_does_not_exist!(context, "Foo::Baz");
+        // No spurious top-level Baz Todo should be created
+        assert_declaration_does_not_exist!(context, "Baz");
+        // Baz::Qux should NOT exist at top level
+        assert_declaration_does_not_exist!(context, "Baz::Qux");
     }
 }


### PR DESCRIPTION
## Problem

`class A::B::C` where `A` is unknown panics when the class body contains `def self.foo` with instance variables:

```
thread panicked at rubydex/src/resolution.rs:386:42:
SelfReceiver definition should have a declaration
```

The panic occurs in `handle_remaining_definitions` because `C`'s definition never gets a declaration — the resolution loop retries indefinitely and then gives up.

Fixes #663

## Root cause

The Todo mechanism from #529 only handles **one level** of unknown parent in compact notation. For `class Foo::Bar` where `Foo` is unknown, `resolve_constant_internal(Foo)` returns `Unresolved(None)`, which triggers Todo creation in `name_owner_id`.

For multi-level paths like `class A::B::C`, the flow differs:

1. `name_owner_id(C)` calls `resolve_constant_internal(B)`
2. `B` has parent scope `A` — checks if `A`'s name is resolved
3. `A` is unresolved → returns `Retry(None)`
4. `name_owner_id` passes `Retry(None)` through unchanged — **never reaches the Todo creation branch**
5. The unit is re-enqueued, but nothing ever resolves `A`, so the loop stalls

## Fix

Two changes:

### 1. `name_owner_id` returns `Unresolved(None)` for unknown parent scopes

In the parent scope branch, both `Retry(None)` and `Unresolved(None)` from `resolve_constant_internal` now return `Unresolved(None)`. This distinguishes "parent is genuinely unknown" from other failure modes (circular aliases return `Retry(None)` via `resolve_to_primary_namespace`, nesting issues return `Retry(None)` from the nesting branch).

### 2. `handle_constant_declaration` creates Todos when it receives `Unresolved(None)`

The **reason** to create Todos comes from the caller — it has a definition that needs an owner. Todo creation is extracted into `create_todo_for_parent`, which recursively walks the parent chain creating placeholders. If real definitions appear later, the existing promotion mechanism upgrades Todos in place.

### 3. Todo tests moved to dedicated module

All tests asserting `<TODO>` behavior are now in `resolution::todo_tests`.