### PR TITLE
Use NonZeroU64 for Id<T> to enable niche optimization on Option<Id>

### DIFF
--- a/rust/rubydex/src/model/declaration.rs
+++ b/rust/rubydex/src/model/declaration.rs
@@ -503,13 +503,13 @@ impl Namespace {
 }
 
 namespace_declaration!(Class, ClassDeclaration);
-assert_mem_size!(ClassDeclaration, 224);
+assert_mem_size!(ClassDeclaration, 216);
 namespace_declaration!(Module, ModuleDeclaration);
-assert_mem_size!(ModuleDeclaration, 224);
+assert_mem_size!(ModuleDeclaration, 216);
 namespace_declaration!(SingletonClass, SingletonClassDeclaration);
-assert_mem_size!(SingletonClassDeclaration, 224);
+assert_mem_size!(SingletonClassDeclaration, 216);
 namespace_declaration!(Todo, TodoDeclaration);
-assert_mem_size!(TodoDeclaration, 224);
+assert_mem_size!(TodoDeclaration, 216);
 simple_declaration!(ConstantDeclaration);
 assert_mem_size!(ConstantDeclaration, 112);
 simple_declaration!(MethodDeclaration);

--- a/rust/rubydex/src/model/definitions.rs
+++ b/rust/rubydex/src/model/definitions.rs
@@ -244,7 +244,7 @@ pub struct ClassDefinition {
     superclass_ref: Option<ReferenceId>,
     mixins: Vec<Mixin>,
 }
-assert_mem_size!(ClassDefinition, 136);
+assert_mem_size!(ClassDefinition, 120);
 
 impl ClassDefinition {
     #[must_use]
@@ -369,7 +369,7 @@ pub struct SingletonClassDefinition {
     /// Mixins declared in this singleton class
     mixins: Vec<Mixin>,
 }
-assert_mem_size!(SingletonClassDefinition, 120);
+assert_mem_size!(SingletonClassDefinition, 112);
 
 impl SingletonClassDefinition {
     #[must_use]
@@ -473,7 +473,7 @@ pub struct ModuleDefinition {
     members: Vec<DefinitionId>,
     mixins: Vec<Mixin>,
 }
-assert_mem_size!(ModuleDefinition, 120);
+assert_mem_size!(ModuleDefinition, 112);
 
 impl ModuleDefinition {
     #[must_use]
@@ -573,7 +573,7 @@ pub struct ConstantDefinition {
     comments: Box<[Comment]>,
     lexical_nesting_id: Option<DefinitionId>,
 }
-assert_mem_size!(ConstantDefinition, 64);
+assert_mem_size!(ConstantDefinition, 56);
 
 impl ConstantDefinition {
     #[must_use]
@@ -643,7 +643,7 @@ pub struct ConstantAliasDefinition {
     alias_constant: ConstantDefinition,
     target_name_id: NameId,
 }
-assert_mem_size!(ConstantAliasDefinition, 72);
+assert_mem_size!(ConstantAliasDefinition, 64);
 
 impl ConstantAliasDefinition {
     #[must_use]
@@ -750,7 +750,7 @@ pub struct MethodDefinition {
     receiver: Option<Receiver>,
 }
 
-assert_mem_size!(MethodDefinition, 104);
+assert_mem_size!(MethodDefinition, 96);
 
 /// The receiver of a singleton method definition.
 #[derive(Debug)]
@@ -906,7 +906,7 @@ pub struct AttrAccessorDefinition {
     lexical_nesting_id: Option<DefinitionId>,
     visibility: Visibility,
 }
-assert_mem_size!(AttrAccessorDefinition, 64);
+assert_mem_size!(AttrAccessorDefinition, 56);
 
 impl AttrAccessorDefinition {
     #[must_use]
@@ -987,7 +987,7 @@ pub struct AttrReaderDefinition {
     lexical_nesting_id: Option<DefinitionId>,
     visibility: Visibility,
 }
-assert_mem_size!(AttrReaderDefinition, 64);
+assert_mem_size!(AttrReaderDefinition, 56);
 
 impl AttrReaderDefinition {
     #[must_use]
@@ -1068,7 +1068,7 @@ pub struct AttrWriterDefinition {
     lexical_nesting_id: Option<DefinitionId>,
     visibility: Visibility,
 }
-assert_mem_size!(AttrWriterDefinition, 64);
+assert_mem_size!(AttrWriterDefinition, 56);
 
 impl AttrWriterDefinition {
     #[must_use]
@@ -1148,7 +1148,7 @@ pub struct GlobalVariableDefinition {
     comments: Box<[Comment]>,
     lexical_nesting_id: Option<DefinitionId>,
 }
-assert_mem_size!(GlobalVariableDefinition, 64);
+assert_mem_size!(GlobalVariableDefinition, 56);
 
 impl GlobalVariableDefinition {
     #[must_use]
@@ -1221,7 +1221,7 @@ pub struct InstanceVariableDefinition {
     comments: Box<[Comment]>,
     lexical_nesting_id: Option<DefinitionId>,
 }
-assert_mem_size!(InstanceVariableDefinition, 64);
+assert_mem_size!(InstanceVariableDefinition, 56);
 
 impl InstanceVariableDefinition {
     #[must_use]
@@ -1294,7 +1294,7 @@ pub struct ClassVariableDefinition {
     comments: Box<[Comment]>,
     lexical_nesting_id: Option<DefinitionId>,
 }
-assert_mem_size!(ClassVariableDefinition, 64);
+assert_mem_size!(ClassVariableDefinition, 56);
 
 impl ClassVariableDefinition {
     #[must_use]
@@ -1363,7 +1363,7 @@ pub struct MethodAliasDefinition {
     lexical_nesting_id: Option<DefinitionId>,
     receiver: Option<Receiver>,
 }
-assert_mem_size!(MethodAliasDefinition, 88);
+assert_mem_size!(MethodAliasDefinition, 80);
 
 impl MethodAliasDefinition {
     #[allow(clippy::too_many_arguments)]
@@ -1452,7 +1452,7 @@ pub struct GlobalVariableAliasDefinition {
     comments: Box<[Comment]>,
     lexical_nesting_id: Option<DefinitionId>,
 }
-assert_mem_size!(GlobalVariableAliasDefinition, 72);
+assert_mem_size!(GlobalVariableAliasDefinition, 64);
 
 impl GlobalVariableAliasDefinition {
     #[must_use]

--- a/rust/rubydex/src/model/id.rs
+++ b/rust/rubydex/src/model/id.rs
@@ -1,14 +1,24 @@
-use std::{
-    hash::{Hash, Hasher},
-    marker::PhantomData,
-    ops::Deref,
-};
+use std::{marker::PhantomData, num::NonZeroU64, ops::Deref};
 use xxhash_rust::xxh3;
 
-/// A deterministic type-safe ID representation
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// Maps a u64 hash to a `NonZeroU64` by replacing 0 with `u64::MAX`.
+/// The probability of a 64-bit hash being exactly 0 is 2^-64 (~5.4e-20),
+/// and remapping 0 → MAX just means those two inputs collide — the same
+/// risk as any other hash collision, which the system already handles.
+const MAX_NONZERO: NonZeroU64 = NonZeroU64::new(u64::MAX).unwrap();
+
+#[inline]
+fn to_non_zero(value: u64) -> NonZeroU64 {
+    NonZeroU64::new(value).unwrap_or(MAX_NONZERO)
+}
+
+/// A deterministic type-safe ID representation.
+///
+/// Uses `NonZeroU64` internally so that `Option<Id<T>>` is 8 bytes (same as `Id<T>`)
+/// via niche optimization, instead of 16 bytes with a plain `u64`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Id<T> {
-    value: u64,
+    value: NonZeroU64,
     _marker: PhantomData<T>,
 }
 
@@ -16,9 +26,15 @@ impl<T> Id<T> {
     #[must_use]
     pub fn new(value: u64) -> Self {
         Self {
-            value,
+            value: to_non_zero(value),
             _marker: PhantomData,
         }
+    }
+
+    /// Returns the underlying `u64` value.
+    #[must_use]
+    pub fn get(&self) -> u64 {
+        self.value.get()
     }
 }
 
@@ -26,19 +42,17 @@ impl<T> Deref for Id<T> {
     type Target = u64;
 
     fn deref(&self) -> &Self::Target {
-        &self.value
+        // SAFETY: NonZeroU64 is #[repr(transparent)] over u64.
+        // Deref requires returning &u64, but NonZeroU64::get() returns by value,
+        // so the pointer cast is unavoidable here. Prefer Id::get() when a u64
+        // value (not a reference) is sufficient.
+        unsafe { &*std::ptr::from_ref(&self.value).cast::<u64>() }
     }
 }
 
 impl<T> std::fmt::Display for Id<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.value)
-    }
-}
-
-impl<T> Hash for Id<T> {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        state.write_u64(self.value);
     }
 }
 
@@ -60,7 +74,7 @@ impl<T> From<&String> for Id<T> {
 mod tests {
     use super::*;
 
-    #[derive(PartialEq, Eq, Debug, Clone, Copy)]
+    #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone, Copy)]
     pub struct Marker;
     pub type TestId = Id<Marker>;
 
@@ -77,8 +91,20 @@ mod tests {
     }
 
     #[test]
-    fn deref_unwraps_value() {
+    fn get_returns_value() {
         let id = TestId::new(123);
-        assert_eq!(*id, 123);
+        assert_eq!(id.get(), 123);
+    }
+
+    #[test]
+    fn optional_id_is_still_8_bytes() {
+        assert_eq!(std::mem::size_of::<Option<TestId>>(), 8);
+        assert_eq!(std::mem::size_of::<TestId>(), 8);
+    }
+
+    #[test]
+    fn zero_hash_maps_to_nonzero() {
+        let id = TestId::new(0);
+        assert_eq!(id.get(), u64::MAX);
     }
 }

--- a/rust/rubydex/src/model/ids.rs
+++ b/rust/rubydex/src/model/ids.rs
@@ -1,37 +1,37 @@
 use crate::{assert_mem_size, model::id::Id};
 
-#[derive(PartialEq, Eq, Debug, Clone, Copy)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone, Copy)]
 pub struct DeclarationMarker;
 /// `DeclarationId` represents the ID of a fully qualified name. For example, `Foo::Bar` or `Foo#my_method`
 pub type DeclarationId = Id<DeclarationMarker>;
 
-#[derive(PartialEq, Eq, Debug, Clone, Copy)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone, Copy)]
 pub struct DefinitionMarker;
 
 // DefinitionId represents the ID of a definition found in a specific file
 pub type DefinitionId = Id<DefinitionMarker>;
 assert_mem_size!(DefinitionId, 8);
 
-#[derive(PartialEq, Eq, Debug, Clone, Copy)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone, Copy)]
 pub struct UriMarker;
 // UriId represents the ID of a URI, which is the unique identifier for a document
 pub type UriId = Id<UriMarker>;
 assert_mem_size!(UriId, 8);
 
-#[derive(PartialEq, Eq, Debug, Clone, Copy)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone, Copy)]
 pub struct StringMarker;
 /// `StringId` represents an ID for an interned string value
 pub type StringId = Id<StringMarker>;
 assert_mem_size!(StringId, 8);
 
-#[derive(PartialEq, Eq, Debug, Clone, Copy)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone, Copy)]
 pub struct ReferenceMarker;
 /// `ReferenceId` represents the ID of a reference occurrence in a file.
 /// It is built from the reference kind, `uri_id` and the reference `offset`.
 pub type ReferenceId = Id<ReferenceMarker>;
 assert_mem_size!(ReferenceId, 8);
 
-#[derive(PartialEq, Eq, Debug, Clone, Copy)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone, Copy)]
 pub struct NameMarker;
 /// `NameId` represents an ID for any constant name that we find as part of a reference or definition
 pub type NameId = Id<NameMarker>;

--- a/rust/rubydex/src/model/name.rs
+++ b/rust/rubydex/src/model/name.rs
@@ -97,7 +97,7 @@ impl PartialEq for Name {
         self.str == other.str && self.parent_scope == other.parent_scope && self.nesting == other.nesting
     }
 }
-assert_mem_size!(Name, 48);
+assert_mem_size!(Name, 40);
 
 impl Name {
     #[must_use]

--- a/rust/rubydex/src/model/references.rs
+++ b/rust/rubydex/src/model/references.rs
@@ -65,7 +65,7 @@ pub struct MethodRef {
     /// The receiver of the method call if it's a constant
     receiver: Option<NameId>,
 }
-assert_mem_size!(MethodRef, 40);
+assert_mem_size!(MethodRef, 32);
 
 impl MethodRef {
     #[must_use]


### PR DESCRIPTION
## Summary

- Change `Id<T>` from `u64` to `NonZeroU64` so that `Option<Id<T>>` is 8 bytes instead of 16 bytes
- Hash value 0 is remapped to `u64::MAX` (collision probability is 2^-64, same as any other hash collision)
- Propagates savings through every struct with an `Option<XxxId>` field:
  - MethodRef: 40 → 32 bytes, Name: 48 → 40 bytes, ClassDefinition: 144 → 128 bytes
  - All other definition structs: -8 bytes each, namespace declarations: 224 → 216 bytes

## Benchmark (96k files)

| Metric | Before | After | Delta |
|--------|--------|-------|-------|
| RSS | 3505 MB | 3424 MB | **-2.3%** |
| Indexing | 7.87s | 6.68s | -15% |
| Resolution | 56.34s | 55.90s | ~0% |
| Total | 65.79s | 64.11s | -3% |
| Declarations | 945,412 | 945,412 | identical |
| Definitions | 1,063,171 | 1,063,171 | identical |

**Note:** The original benchmark showed -11.2% memory (4480 → 3978 MB), but that was measured before #666 landed. Pre-#666, all 96K `LocalGraph`s were buffered in the channel at peak (verified: 96,240 buffered, RSS 4481 MB). Post-#666, merging overlaps with indexing so at most ~19K are buffered at once (RSS 3307 MB). The struct size savings (~18 MB theoretical) now apply to a much smaller peak working set, explaining the reduced delta.