### PR TITLE
Merge LocalGraphs concurrently with indexing workers

### DIFF
--- a/rust/rubydex/src/indexing.rs
+++ b/rust/rubydex/src/indexing.rs
@@ -119,11 +119,24 @@ pub fn index_files(graph: &mut Graph, paths: Vec<PathBuf>) -> Vec<Errors> {
     drop(local_graphs_tx);
     drop(errors_tx);
 
-    JobQueue::run(&queue);
+    // Run workers and merge loop concurrently. The scoped thread can borrow
+    // `graph` because `std::thread::scope` guarantees all threads join before
+    // the scope exits.
+    std::thread::scope(|s| {
+        // Merge local graphs on a dedicated thread as workers produce them.
+        // This avoids buffering all LocalGraphs in the channel at once.
+        let merge_handle = s.spawn(|| {
+            while let Ok(local_graph) = local_graphs_rx.recv() {
+                graph.update(local_graph);
+            }
+        });
 
-    while let Ok(local_graph) = local_graphs_rx.recv() {
-        graph.update(local_graph);
-    }
+        // Run the worker pool (blocks until all jobs complete, then senders drop)
+        JobQueue::run(&queue);
+
+        // Wait for merge thread to finish consuming remaining buffered graphs
+        merge_handle.join().expect("Merge thread panicked");
+    });
 
     errors_rx.iter().collect()
 }


### PR DESCRIPTION
## Summary

- Previously, all indexing workers completed before any LocalGraphs were merged into the global Graph
- With an unbounded channel, this buffered all ~96K LocalGraphs simultaneously — hundreds of MB of temporary data
- Now a dedicated merge thread consumes LocalGraphs as workers produce them via `std::thread::scope`, keeping only a small number buffered at any time
- Also improves indexing throughput by overlapping merge work with parsing

## Benchmark

| Metric | Before | After | Delta |
|--------|--------|-------|-------|
| Memory (peak footprint) | 4480 MB | 3497 MB | **-21.9%** |
| Declarations | 895,844 | 895,844 | identical |
| Definitions | 1,063,171 | 1,063,171 | identical |