### PR TITLE
Overlap graph merging with indexing to reduce memory usage

### DIFF
--- a/rust/rubydex/src/indexing.rs
+++ b/rust/rubydex/src/indexing.rs
@@ -119,10 +119,15 @@ pub fn index_files(graph: &mut Graph, paths: Vec<PathBuf>) -> Vec<Errors> {
     drop(local_graphs_tx);
     drop(errors_tx);
 
-    JobQueue::run(&queue);
+    let handles = JobQueue::run_without_waiting(&queue);
 
+    // Merge graphs as they arrive, overlapping with indexing work on other threads.
     while let Ok(local_graph) = local_graphs_rx.recv() {
         graph.update(local_graph);
+    }
+
+    for handle in handles {
+        handle.join().expect("Worker thread panicked");
     }
 
     errors_rx.iter().collect()

--- a/rust/rubydex/src/job_queue.rs
+++ b/rust/rubydex/src/job_queue.rs
@@ -53,10 +53,32 @@ impl JobQueue {
         Self::run_with_workers(queue, worker_count);
     }
 
+    /// Spin up worker threads and return their handles without waiting for completion.
+    ///
+    /// The caller is responsible for joining the returned handles. This allows
+    /// overlapping other work (e.g. merging results) with job processing.
+    pub fn run_without_waiting(queue: &Arc<JobQueue>) -> Vec<thread::JoinHandle<()>> {
+        let worker_count = thread::available_parallelism()
+            .map(std::num::NonZeroUsize::get)
+            .unwrap_or(4);
+
+        Self::spawn_workers(queue, worker_count)
+    }
+
     /// Spin up `worker_count` threads, each with its own local queue, and block until all threads finish.
     ///
     /// Workers steal from each other and from the global injector to keep the work balanced.
     fn run_with_workers(queue: &Arc<JobQueue>, worker_count: usize) {
+        let handles = Self::spawn_workers(queue, worker_count);
+
+        // Wait for all worker threads to finish before returning.
+        for handle in handles {
+            handle.join().expect("Worker thread panicked");
+        }
+    }
+
+    /// Spin up `worker_count` threads and return their join handles.
+    fn spawn_workers(queue: &Arc<JobQueue>, worker_count: usize) -> Vec<thread::JoinHandle<()>> {
         let mut handles = Vec::with_capacity(worker_count);
         let mut workers = Vec::with_capacity(worker_count);
         let mut stealers = Vec::with_capacity(worker_count);
@@ -77,10 +99,7 @@ impl JobQueue {
             handles.push(thread::spawn(move || queue.worker_loop(&worker, &stealers)));
         }
 
-        // Wait for all worker threads to finish before returning.
-        for handle in handles {
-            handle.join().expect("Worker thread panicked");
-        }
+        handles
     }
 
     /// Drain work for a single worker.


### PR DESCRIPTION
## Summary

- Add `JobQueue::run_without_waiting()` that returns thread handles instead of blocking
- `index_files` now merges `LocalGraph`s on the main thread as they arrive while worker threads are still indexing
- This avoids buffering all `LocalGraph`s in the channel, reducing peak memory

## Benchmark (96k files)

|              | main    | branch  | delta |
|--------------|---------|---------|-------|
| Indexing     | 10.12s  | 7.11s   | -30%  |
| Resolution   | 51.43s  | 51.12s  | ~0%   |
| Total        | 63.07s  | 59.76s  | -5%   |
| RSS          | 5531 MB | 3447 MB | -38%  |