### PR TITLE
Fix default parent classes

### DIFF
--- a/rust/rubydex-mcp/src/server.rs
+++ b/rust/rubydex-mcp/src/server.rs
@@ -1115,13 +1115,13 @@ mod tests {
         let s = server_with_sources(&[(&a, "class Animal; end"), (&b, "module Greetable; end")]);
         let res = parse(&s.codebase_stats());
 
-        assert_eq!(res["files"], 2);
-        assert_json_int!(res, "declarations", 5);
-        assert_json_int!(res, "definitions", 2);
+        assert_eq!(res["files"], 3);
+        assert_json_int!(res, "declarations", 7);
+        assert_json_int!(res, "definitions", 7);
 
         let breakdown = &res["breakdown_by_kind"];
-        assert_json_int!(breakdown, "Class", 4);
-        assert_json_int!(breakdown, "Module", 1);
+        assert_json_int!(breakdown, "Class", 5);
+        assert_json_int!(breakdown, "Module", 2);
     }
 
     // -- error states --

--- a/rust/rubydex-mcp/tests/mcp.rs
+++ b/rust/rubydex-mcp/tests/mcp.rs
@@ -210,7 +210,7 @@ fn mcp_server_e2e() {
         // Wait for indexing readiness before asserting semantic tool results.
         let mut request_id = 3;
         let stats = wait_for_indexing_to_complete(&mut stdin, &mut reader, &mut request_id);
-        assert_eq!(stats["files"], 1);
+        assert_eq!(stats["files"], 2);
         assert!(stats["declarations"].as_u64().unwrap() > 0);
 
         // Semantic query: search declarations.

--- a/rust/rubydex/src/indexing.rs
+++ b/rust/rubydex/src/indexing.rs
@@ -178,7 +178,7 @@ mod tests {
         let errors = index_files(&mut graph, vec![relative_to_pwd.clone()]);
 
         assert!(errors.is_empty());
-        assert_eq!(graph.documents().len(), 1);
+        assert_eq!(graph.documents().len(), 2);
     }
 
     #[test]
@@ -199,12 +199,12 @@ mod tests {
         let errors = index_files(&mut graph, vec![path]);
 
         assert!(errors.is_empty(), "Expected no errors, got: {errors:#?}");
-        assert_eq!(1, graph.definitions().len());
-        assert_eq!(1, graph.documents().len());
+        assert_eq!(6, graph.definitions().len());
+        assert_eq!(2, graph.documents().len());
 
         index_source(&mut graph, &uri, "", &LanguageId::Ruby);
 
-        assert_eq!(0, graph.definitions().len());
-        assert_eq!(1, graph.documents().len());
+        assert_eq!(5, graph.definitions().len());
+        assert_eq!(2, graph.documents().len());
     }
 }

--- a/rust/rubydex/src/integrity.rs
+++ b/rust/rubydex/src/integrity.rs
@@ -1,8 +1,9 @@
 use std::fmt;
 
 use crate::model::{
+    built_in::{BASIC_OBJECT_ID, OBJECT_ID},
     declaration::{Declaration, Namespace},
-    graph::{BASIC_OBJECT_ID, Graph, OBJECT_ID},
+    graph::Graph,
     ids::DeclarationId,
 };
 

--- a/rust/rubydex/src/model.rs
+++ b/rust/rubydex/src/model.rs
@@ -1,3 +1,4 @@
+pub mod built_in;
 pub mod comment;
 pub mod declaration;
 pub mod definitions;

--- a/rust/rubydex/src/model/built_in.rs
+++ b/rust/rubydex/src/model/built_in.rs
@@ -1,0 +1,83 @@
+use std::sync::LazyLock;
+
+use url::Url;
+
+use crate::{
+    indexing::{self, LanguageId},
+    model::{
+        declaration::{ClassDeclaration, Declaration, Namespace},
+        graph::Graph,
+        ids::DeclarationId,
+    },
+};
+
+pub static KERNEL_ID: LazyLock<DeclarationId> = LazyLock::new(|| DeclarationId::from("Kernel"));
+pub static BASIC_OBJECT_ID: LazyLock<DeclarationId> = LazyLock::new(|| DeclarationId::from("BasicObject"));
+pub static OBJECT_ID: LazyLock<DeclarationId> = LazyLock::new(|| DeclarationId::from("Object"));
+pub static MODULE_ID: LazyLock<DeclarationId> = LazyLock::new(|| DeclarationId::from("Module"));
+pub static CLASS_ID: LazyLock<DeclarationId> = LazyLock::new(|| DeclarationId::from("Class"));
+
+/// Adds core classes and modules data to the graph so that resolution can provide correct results even when not
+/// indexing the complete RBS core definitions
+///
+/// # Panics
+///
+/// Will panic if the built-in URI is invalid
+pub fn add_built_in_data(graph: &mut Graph) {
+    // We need definitions to ensure that ancestor linearization happens naturally through the algorithm. Trying to set
+    // ancestors directly on declarations doesn't work because the algorithm erases the ancestors and there are no
+    // definitions to inform it of the superclasses and mixins.
+    let uri = Url::parse("rubydex:built-in").unwrap();
+    let source = r"
+      class BasicObject
+      end
+
+      module Kernel
+      end
+
+      class Object < BasicObject
+        include Kernel
+      end
+
+      class Module < Object
+      end
+
+      class Class < Module
+      end
+    ";
+    indexing::index_source(graph, uri.as_ref(), source, &LanguageId::Rbs);
+
+    // Creating declarations eagerly is still necessary because we need to associate correct ownership data no matter in
+    // what order we discover classes and modules
+    let declarations = graph.declarations_mut();
+
+    // Built-in declarations that always exist in the Ruby object model
+    declarations.insert(
+        *BASIC_OBJECT_ID,
+        Declaration::Namespace(Namespace::Class(Box::new(ClassDeclaration::new(
+            "BasicObject".to_string(),
+            *OBJECT_ID,
+        )))),
+    );
+    declarations.insert(
+        *OBJECT_ID,
+        Declaration::Namespace(Namespace::Class(Box::new(ClassDeclaration::new(
+            "Object".to_string(),
+            *OBJECT_ID,
+        )))),
+    );
+    declarations.insert(
+        *MODULE_ID,
+        Declaration::Namespace(Namespace::Class(Box::new(ClassDeclaration::new(
+            "Module".to_string(),
+            *OBJECT_ID,
+        )))),
+    );
+    declarations.insert(
+        *CLASS_ID,
+        Declaration::Namespace(Namespace::Class(Box::new(ClassDeclaration::new(
+            "Class".to_string(),
+            *OBJECT_ID,
+        )))),
+    );
+}

--- a/rust/rubydex/src/model/graph.rs
+++ b/rust/rubydex/src/model/graph.rs
@@ -1,11 +1,11 @@
 use std::collections::HashSet;
 use std::collections::hash_map::Entry;
 use std::path::PathBuf;
-use std::sync::LazyLock;
 
 use crate::diagnostic::Diagnostic;
 use crate::indexing::local_graph::LocalGraph;
-use crate::model::declaration::{Ancestor, ClassDeclaration, Declaration, Namespace};
+use crate::model::built_in::{OBJECT_ID, add_built_in_data};
+use crate::model::declaration::{Ancestor, Declaration, Namespace};
 use crate::model::definitions::{Definition, Receiver};
 use crate::model::document::Document;
 use crate::model::encoding::Encoding;
@@ -37,11 +37,6 @@ enum InvalidationItem {
     /// Ancestor context changed — unresolve references under this name but keep the name resolved.
     References(NameId),
 }
-
-pub static BASIC_OBJECT_ID: LazyLock<DeclarationId> = LazyLock::new(|| DeclarationId::from("BasicObject"));
-pub static OBJECT_ID: LazyLock<DeclarationId> = LazyLock::new(|| DeclarationId::from("Object"));
-pub static MODULE_ID: LazyLock<DeclarationId> = LazyLock::new(|| DeclarationId::from("Module"));
-pub static CLASS_ID: LazyLock<DeclarationId> = LazyLock::new(|| DeclarationId::from("Class"));
 
 /// A work item produced by graph mutations (update/delete) that needs resolution.
 #[derive(Debug)]
@@ -92,33 +87,8 @@ pub struct Graph {
 impl Graph {
     #[must_use]
     pub fn new() -> Self {
-        let mut declarations = IdentityHashMap::default();
-
-        // Built-in declarations that always exist in the Ruby object model
-        declarations.insert(
-            *OBJECT_ID,
-            Declaration::Namespace(Namespace::Class(Box::new(ClassDeclaration::new(
-                "Object".to_string(),
-                *OBJECT_ID,
-            )))),
-        );
-        declarations.insert(
-            *MODULE_ID,
-            Declaration::Namespace(Namespace::Class(Box::new(ClassDeclaration::new(
-                "Module".to_string(),
-                *OBJECT_ID,
-            )))),
-        );
-        declarations.insert(
-            *CLASS_ID,
-            Declaration::Namespace(Namespace::Class(Box::new(ClassDeclaration::new(
-                "Class".to_string(),
-                *OBJECT_ID,
-            )))),
-        );
-
-        Self {
-            declarations,
+        let mut graph = Self {
+            declarations: IdentityHashMap::default(),
             definitions: IdentityHashMap::default(),
             documents: IdentityHashMap::default(),
             strings: IdentityHashMap::default(),
@@ -129,7 +99,10 @@ impl Graph {
             name_dependents: IdentityHashMap::default(),
             pending_work: Vec::default(),
             excluded_paths: HashSet::new(),
-        }
+        };
+
+        add_built_in_data(&mut graph);
+        graph
     }
 
     // Returns an immutable reference to the declarations map
@@ -1459,7 +1432,10 @@ mod tests {
     use crate::model::comment::Comment;
     use crate::model::declaration::Ancestors;
     use crate::test_utils::GraphTest;
-    use crate::{assert_dependents, assert_descendants, assert_members_eq, assert_no_diagnostics, assert_no_members};
+    use crate::{
+        assert_declaration_does_not_exist, assert_dependents, assert_descendants, assert_members_eq,
+        assert_no_diagnostics, assert_no_members,
+    };
 
     #[test]
     fn deleting_a_uri() {
@@ -1469,9 +1445,8 @@ mod tests {
         context.delete_uri("file:///foo.rb");
         context.resolve();
 
-        assert!(context.graph().documents.is_empty());
-        assert!(context.graph().definitions.is_empty());
-        // Object is left
+        assert!(!context.graph().documents.contains_key(&UriId::from("file:///foo.rb")));
+        assert_declaration_does_not_exist!(context, "Foo");
         assert!(
             context
                 .graph()
@@ -1536,16 +1511,15 @@ mod tests {
 
         context.index_uri("file:///foo.rb", "module Foo; end");
 
-        assert_eq!(context.graph().definitions.len(), 1);
-        assert_eq!(context.graph().documents.len(), 1);
+        let original_definition_length = context.graph().definitions.len();
+        let original_document_length = context.graph().documents.len();
 
         // Update with empty content to remove definitions but keep the URI
         context.index_uri("file:///foo.rb", "");
 
-        assert!(context.graph().definitions.is_empty());
-
         // URI remains if the file was not deleted, but definitions got erased
-        assert_eq!(context.graph().documents.len(), 1);
+        assert_eq!(original_definition_length - 1, context.graph().definitions.len());
+        assert_eq!(original_document_length, context.graph().documents.len());
     }
 
     #[test]
@@ -1555,35 +1529,31 @@ mod tests {
         context.index_uri("file:///foo.rb", "module Foo; end");
         context.resolve();
 
-        assert_eq!(context.graph().definitions.len(), 1);
-        assert_eq!(context.graph().documents.len(), 1);
+        let original_definition_length = context.graph().definitions.len();
+        let original_document_length = context.graph().documents.len();
 
-        {
-            assert!(
-                context
-                    .graph()
-                    .declarations()
-                    .get(&DeclarationId::from("Foo"))
-                    .is_some()
-            );
-        }
+        assert!(
+            context
+                .graph()
+                .declarations()
+                .get(&DeclarationId::from("Foo"))
+                .is_some()
+        );
 
         // Update with empty content to remove definitions but keep the URI
         context.index_uri("file:///foo.rb", "");
 
-        assert!(context.graph().definitions.is_empty());
         // URI remains if the file was not deleted, but definitions and declarations got erased
-        assert_eq!(context.graph().documents.len(), 1);
+        assert_eq!(original_definition_length - 1, context.graph().definitions.len());
+        assert_eq!(original_document_length, context.graph().documents.len());
 
-        {
-            assert!(
-                context
-                    .graph()
-                    .declarations()
-                    .get(&DeclarationId::from("Foo"))
-                    .is_none()
-            );
-        }
+        assert!(
+            context
+                .graph()
+                .declarations()
+                .get(&DeclarationId::from("Foo"))
+                .is_none()
+        );
     }
 
     #[test]
@@ -1601,9 +1571,9 @@ mod tests {
         );
         context.resolve();
 
-        assert_eq!(context.graph().documents.len(), 2);
+        assert_eq!(context.graph().documents.len(), 3);
         assert_eq!(context.graph().method_references.len(), 1);
-        assert_eq!(context.graph().constant_references.len(), 2);
+        assert_eq!(context.graph().constant_references.len(), 6);
         {
             let declaration = context.graph().declarations().get(&DeclarationId::from("Foo")).unwrap();
             assert_eq!(declaration.as_namespace().unwrap().references().len(), 1);
@@ -1613,9 +1583,9 @@ mod tests {
         context.index_uri("file:///references.rb", "");
 
         // URI remains if the file was not deleted, but references got erased
-        assert_eq!(context.graph().documents.len(), 2);
+        assert_eq!(context.graph().documents.len(), 3);
         assert!(context.graph().method_references.is_empty());
-        assert!(context.graph().constant_references.is_empty());
+        assert_eq!(context.graph().constant_references.len(), 4);
         {
             let declaration = context.graph().declarations().get(&DeclarationId::from("Foo")).unwrap();
             assert!(declaration.as_namespace().unwrap().references().is_empty());
@@ -1701,8 +1671,14 @@ mod tests {
         context.index_uri("file:///foo3.rb", "Foo");
         context.resolve();
 
-        assert_eq!(context.graph().names().len(), 1);
-        let name_ref = context.graph().names().values().next().unwrap();
+        assert_eq!(context.graph().names().len(), 7);
+        let foo_str_id = StringId::from("Foo");
+        let name_ref = context
+            .graph()
+            .names()
+            .values()
+            .find(|n| *n.str() == foo_str_id)
+            .unwrap();
         assert_eq!(name_ref.ref_count(), 3);
     }
 
@@ -1755,15 +1731,28 @@ mod tests {
         context.index_uri("file:///bar.rb", "Foo");
         context.resolve();
 
-        assert_eq!(context.graph().names().len(), 1);
-        assert_eq!(context.graph().names().values().next().unwrap().ref_count(), 2);
+        assert_eq!(context.graph().names().len(), 7);
+        let foo_str_id = StringId::from("Foo");
+        let foo_name = context
+            .graph()
+            .names()
+            .values()
+            .find(|n| *n.str() == foo_str_id)
+            .unwrap();
+        assert_eq!(foo_name.ref_count(), 2);
 
         context.delete_uri("file:///foo.rb");
-        assert_eq!(context.graph().names().len(), 1);
-        assert_eq!(context.graph().names().values().next().unwrap().ref_count(), 1);
+        assert_eq!(context.graph().names().len(), 7);
+        let foo_name = context
+            .graph()
+            .names()
+            .values()
+            .find(|n| *n.str() == foo_str_id)
+            .unwrap();
+        assert_eq!(foo_name.ref_count(), 1);
 
         context.delete_uri("file:///bar.rb");
-        assert!(context.graph().names().is_empty());
+        assert_eq!(context.graph().names().len(), 6);
     }
 
     #[test]
@@ -1799,7 +1788,7 @@ mod tests {
         context.index_uri("file:///foo.rb", "module Foo; end");
         context.resolve();
 
-        assert_eq!(context.graph().definitions.len(), 1);
+        assert_eq!(context.graph().definitions.len(), 6);
         let declaration = context.graph().declarations().get(&DeclarationId::from("Foo")).unwrap();
         assert_eq!(declaration.name(), "Foo");
         let document = context.graph().documents.get(&UriId::from("file:///foo.rb")).unwrap();
@@ -1817,7 +1806,7 @@ mod tests {
         context.index_uri("file:///foo.rb", "\n\n\n\n\n\nmodule Foo; end");
         context.resolve();
 
-        assert_eq!(context.graph().definitions.len(), 1);
+        assert_eq!(context.graph().definitions.len(), 6);
         let declaration = context.graph().declarations().get(&DeclarationId::from("Foo")).unwrap();
         assert_eq!(declaration.name(), "Foo");
         assert_eq!(
@@ -2236,19 +2225,19 @@ mod tests {
         ";
 
         context.index_uri("file:///foo.rb", source);
-        assert_eq!(44, context.graph().definitions.len());
-        assert_eq!(9, context.graph().constant_references.len());
+        assert_eq!(49, context.graph().definitions.len());
+        assert_eq!(13, context.graph().constant_references.len());
         assert_eq!(2, context.graph().method_references.len());
-        assert_eq!(1, context.graph().documents.len());
-        assert_eq!(13, context.graph().names.len());
-        assert_eq!(42, context.graph().strings.len());
+        assert_eq!(2, context.graph().documents.len());
+        assert_eq!(19, context.graph().names.len());
+        assert_eq!(47, context.graph().strings.len());
         context.index_uri("file:///foo.rb", source);
-        assert_eq!(44, context.graph().definitions.len());
-        assert_eq!(9, context.graph().constant_references.len());
+        assert_eq!(49, context.graph().definitions.len());
+        assert_eq!(13, context.graph().constant_references.len());
         assert_eq!(2, context.graph().method_references.len());
-        assert_eq!(1, context.graph().documents.len());
-        assert_eq!(13, context.graph().names.len());
-        assert_eq!(42, context.graph().strings.len());
+        assert_eq!(2, context.graph().documents.len());
+        assert_eq!(19, context.graph().names.len());
+        assert_eq!(47, context.graph().strings.len());
     }
 
     #[test]
@@ -2401,7 +2390,7 @@ mod incremental_resolution_tests {
         assert_ancestors_eq!(
             context,
             "Foo::Bar::Baz::Qux",
-            ["Foo::Bar::Baz::Qux", "Foo::Bar", "Object"]
+            ["Foo::Bar::Baz::Qux", "Foo::Bar", "Object", "Kernel", "BasicObject"]
         );
 
         context.index_uri(
@@ -2427,7 +2416,13 @@ mod incremental_resolution_tests {
         assert_ancestors_eq!(
             context,
             "Foo::Bar::Baz::Qux",
-            ["Foo::Bar::Baz::Qux", "Foo::Bar::Baz::Bar", "Object"]
+            [
+                "Foo::Bar::Baz::Qux",
+                "Foo::Bar::Baz::Bar",
+                "Object",
+                "Kernel",
+                "BasicObject"
+            ]
         );
     }
 
@@ -2459,7 +2454,7 @@ mod incremental_resolution_tests {
 
         assert_constant_reference_to!(context, "Foo::CONST", "file:///foo.rb:6:3-6:8");
         assert_declaration_references_count_eq!(context, "Foo::CONST", 1);
-        assert_ancestors_eq!(context, "Bar", ["Bar", "Foo", "Object"]);
+        assert_ancestors_eq!(context, "Bar", ["Bar", "Foo", "Object", "Kernel", "BasicObject"]);
 
         context.delete_uri("file:///bar.rb");
 
@@ -2471,7 +2466,7 @@ mod incremental_resolution_tests {
 
         // Bar no longer includes Foo, so CONST is unresolvable
         assert_constant_reference_unresolved!(context, "CONST");
-        assert_ancestors_eq!(context, "Bar", ["Bar", "Object"]);
+        assert_ancestors_eq!(context, "Bar", ["Bar", "Object", "Kernel", "BasicObject"]);
     }
 
     #[test]
@@ -2663,7 +2658,7 @@ mod incremental_resolution_tests {
         context.index_uri("file:///bar.rb", "class Bar; end");
         context.resolve();
 
-        assert_ancestors_eq!(context, "Foo", ["Foo", "Object"]);
+        assert_ancestors_eq!(context, "Foo", ["Foo", "Object", "Kernel", "BasicObject"]);
 
         // A new file reopens Foo with a superclass -- ancestors must be invalidated
         context.index_uri(
@@ -2678,7 +2673,7 @@ mod incremental_resolution_tests {
 
         context.resolve();
 
-        assert_ancestors_eq!(context, "Foo", ["Foo", "Bar", "Object"]);
+        assert_ancestors_eq!(context, "Foo", ["Foo", "Bar", "Object", "Kernel", "BasicObject"]);
     }
 
     #[test]
@@ -2714,8 +2709,8 @@ mod incremental_resolution_tests {
         context.resolve();
 
         assert_constant_reference_to!(context, "M::CONST", "file:///a.rb:3:3-3:8");
-        assert_ancestors_eq!(context, "A", ["A", "M", "Object"]);
-        assert_ancestors_eq!(context, "B", ["B", "M", "Object"]);
+        assert_ancestors_eq!(context, "A", ["A", "M", "Object", "Kernel", "BasicObject"]);
+        assert_ancestors_eq!(context, "B", ["B", "M", "Object", "Kernel", "BasicObject"]);
 
         context.delete_uri("file:///m.rb");
 
@@ -2725,8 +2720,8 @@ mod incremental_resolution_tests {
         context.resolve();
 
         // M is gone, but `include M` still exists in the source — M is Partial (unresolvable)
-        assert_ancestors_eq!(context, "A", ["A", Partial("M"), "Object"]);
-        assert_ancestors_eq!(context, "B", ["B", Partial("M"), "Object"]);
+        assert_ancestors_eq!(context, "A", ["A", Partial("M"), "Object", "Kernel", "BasicObject"]);
+        assert_ancestors_eq!(context, "B", ["B", Partial("M"), "Object", "Kernel", "BasicObject"]);
         assert_constant_reference_unresolved!(context, "CONST");
     }
 
@@ -2799,7 +2794,7 @@ mod incremental_resolution_tests {
         );
         context.resolve();
 
-        assert_ancestors_eq!(context, "Foo", ["Foo", "Bar", "Object"]);
+        assert_ancestors_eq!(context, "Foo", ["Foo", "Bar", "Object", "Kernel", "BasicObject"]);
         assert_constant_reference_to!(context, "Bar::CONST", "file:///ref.rb:2:3-2:8");
 
         context.index_uri(
@@ -2815,7 +2810,7 @@ mod incremental_resolution_tests {
 
         context.resolve();
 
-        assert_ancestors_eq!(context, "Foo", ["Foo", "Baz", "Object"]);
+        assert_ancestors_eq!(context, "Foo", ["Foo", "Baz", "Object", "Kernel", "BasicObject"]);
         assert_constant_reference_to!(context, "Baz::CONST", "file:///ref.rb:2:3-2:8");
     }
 
@@ -2838,7 +2833,11 @@ mod incremental_resolution_tests {
         context.resolve();
 
         assert_declaration_exists!(context, "Foo");
-        assert_members_eq!(context, "Object", ["Foo"]);
+        assert_members_eq!(
+            context,
+            "Object",
+            ["BasicObject", "Class", "Foo", "Kernel", "Module", "Object"]
+        );
     }
 
     #[test]
@@ -2874,7 +2873,7 @@ mod incremental_resolution_tests {
         );
         context.resolve();
 
-        assert_ancestors_eq!(context, "Foo", ["Foo", "M2", "M1", "Object"]);
+        assert_ancestors_eq!(context, "Foo", ["Foo", "M2", "M1", "Object", "Kernel", "BasicObject"]);
         assert_constant_reference_to!(context, "M1::CONST1", "file:///foo.rb:4:3-4:9");
         assert_constant_reference_to!(context, "M2::CONST2", "file:///foo.rb:5:3-5:9");
 
@@ -2885,7 +2884,11 @@ mod incremental_resolution_tests {
 
         context.resolve();
 
-        assert_ancestors_eq!(context, "Foo", ["Foo", Partial("M2"), Partial("M1"), "Object"]);
+        assert_ancestors_eq!(
+            context,
+            "Foo",
+            ["Foo", Partial("M2"), Partial("M1"), "Object", "Kernel", "BasicObject"]
+        );
         assert_declaration_does_not_exist!(context, "M1");
         assert_declaration_does_not_exist!(context, "M2");
         assert_constant_reference_unresolved!(context, "CONST1");
@@ -3053,7 +3056,7 @@ mod incremental_resolution_tests {
         context.resolve();
 
         assert_constant_reference_to!(context, "Foo::CONST", "file:///bar.rb:3:3-3:8");
-        assert_ancestors_eq!(context, "Bar", ["Bar", "Foo", "Object"]);
+        assert_ancestors_eq!(context, "Bar", ["Bar", "Foo", "Object", "Kernel", "BasicObject"]);
 
         context.index_uri(
             "file:///bar.rb",
@@ -3066,7 +3069,7 @@ mod incremental_resolution_tests {
         );
         context.resolve();
         assert_constant_reference_to!(context, "Foo::CONST", "file:///bar.rb:3:3-3:8");
-        assert_ancestors_eq!(context, "Bar", ["Bar", "Foo", "Object"]);
+        assert_ancestors_eq!(context, "Bar", ["Bar", "Foo", "Object", "Kernel", "BasicObject"]);
     }
 
     #[test]
@@ -3247,7 +3250,7 @@ mod incremental_resolution_tests {
         // After re-resolve, CONST should now resolve through Foo -> Bar
         context.resolve();
         assert_constant_reference_to!(context, "Bar::CONST", "file:///foo.rb:2:3-2:8");
-        assert_ancestors_eq!(context, "Foo", ["Foo", "Bar", "Object"]);
+        assert_ancestors_eq!(context, "Foo", ["Foo", "Bar", "Object", "Kernel", "BasicObject"]);
     }
 
     #[test]
@@ -3275,7 +3278,7 @@ mod incremental_resolution_tests {
         context.resolve();
 
         assert_declaration_exists!(context, "Foo::Bar");
-        assert_ancestors_eq!(context, "Foo::Bar", ["Foo::Bar", "Object"]);
+        assert_ancestors_eq!(context, "Foo::Bar", ["Foo::Bar", "Object", "Kernel", "BasicObject"]);
         assert_members_eq!(context, "Foo::Bar", ["bar()"]);
 
         context.index_uri(
@@ -3293,7 +3296,11 @@ mod incremental_resolution_tests {
         context.resolve();
 
         assert_declaration_exists!(context, "M::Foo::Bar");
-        assert_ancestors_eq!(context, "M::Foo::Bar", ["M::Foo::Bar", "Object"]);
+        assert_ancestors_eq!(
+            context,
+            "M::Foo::Bar",
+            ["M::Foo::Bar", "Object", "Kernel", "BasicObject"]
+        );
         assert_members_eq!(context, "M::Foo::Bar", ["bar()"]);
     }
 
@@ -3322,7 +3329,7 @@ mod incremental_resolution_tests {
 
         assert_declaration_exists!(context, "Foo");
         assert_declaration_exists!(context, "Foo::Bar");
-        assert_ancestors_eq!(context, "Foo::Bar", ["Foo::Bar", "Object"]);
+        assert_ancestors_eq!(context, "Foo::Bar", ["Foo::Bar", "Object", "Kernel", "BasicObject"]);
         assert_members_eq!(context, "Foo", ["Bar"]);
         assert_members_eq!(context, "Foo::Bar", ["bar()"]);
 
@@ -3341,8 +3348,8 @@ mod incremental_resolution_tests {
         context.resolve();
 
         assert_declaration_exists!(context, "Baz::Bar");
-        assert_ancestors_eq!(context, "Baz", ["Baz", "Object"]);
-        assert_ancestors_eq!(context, "Baz::Bar", ["Baz::Bar", "Object"]);
+        assert_ancestors_eq!(context, "Baz", ["Baz", "Object", "Kernel", "BasicObject"]);
+        assert_ancestors_eq!(context, "Baz::Bar", ["Baz::Bar", "Object", "Kernel", "BasicObject"]);
         assert_members_eq!(context, "Baz", ["Bar"]);
         assert_members_eq!(context, "Baz::Bar", ["bar()"]);
     }
@@ -3372,7 +3379,7 @@ mod incremental_resolution_tests {
         );
         context.resolve();
 
-        assert_ancestors_eq!(context, "Foo", ["Foo", "M1", "Object"]);
+        assert_ancestors_eq!(context, "Foo", ["Foo", "M1", "Object", "Kernel", "BasicObject"]);
         assert_constant_reference_to!(context, "M1::CONST", "file:///foo.rb:3:3-3:8");
 
         context.index_uri(
@@ -3392,7 +3399,7 @@ mod incremental_resolution_tests {
 
         context.resolve();
 
-        assert_ancestors_eq!(context, "Foo", ["Foo", "M2", "Object"]);
+        assert_ancestors_eq!(context, "Foo", ["Foo", "M2", "Object", "Kernel", "BasicObject"]);
         assert_constant_reference_to!(context, "M2::CONST", "file:///foo.rb:3:3-3:8");
     }
 
@@ -3418,7 +3425,7 @@ mod incremental_resolution_tests {
         );
         context.resolve();
 
-        assert_ancestors_eq!(context, "Foo", ["Foo", "Bar", "Object"]);
+        assert_ancestors_eq!(context, "Foo", ["Foo", "Bar", "Object", "Kernel", "BasicObject"]);
         assert_constant_reference_to!(context, "Bar::CONST", "file:///foo.rb:2:3-2:8");
 
         context.index_uri(
@@ -3436,7 +3443,7 @@ mod incremental_resolution_tests {
 
         context.resolve();
 
-        assert_ancestors_eq!(context, "Foo", ["Foo", "Object"]);
+        assert_ancestors_eq!(context, "Foo", ["Foo", "Object", "Kernel", "BasicObject"]);
         assert_constant_reference_unresolved!(context, "CONST");
     }
 
@@ -3508,7 +3515,7 @@ mod incremental_resolution_tests {
         );
         context.resolve();
 
-        assert_ancestors_eq!(context, "Foo", ["Foo", "Baz", "Bar", "Object"]);
+        assert_ancestors_eq!(context, "Foo", ["Foo", "Baz", "Bar", "Object", "Kernel", "BasicObject"]);
 
         context.index_uri(
             "file:///foo.rb",
@@ -3525,7 +3532,7 @@ mod incremental_resolution_tests {
 
         context.resolve();
 
-        assert_ancestors_eq!(context, "Foo", ["Foo", "Bar", "Baz", "Object"]);
+        assert_ancestors_eq!(context, "Foo", ["Foo", "Bar", "Baz", "Object", "Kernel", "BasicObject"]);
     }
     #[test]
     fn adding_mixin_to_multi_definition_declaration_updates_ancestors() {
@@ -3558,7 +3565,7 @@ mod incremental_resolution_tests {
         );
         context.resolve();
 
-        assert_ancestors_eq!(context, "Foo", ["Foo", "Object"]);
+        assert_ancestors_eq!(context, "Foo", ["Foo", "Object", "Kernel", "BasicObject"]);
 
         // Re-index foo2.rb to add a mixin. Foo survives (foo1.rb still defines it)
         // and enters the update path, pushing Unit::Ancestors.
@@ -3573,7 +3580,7 @@ mod incremental_resolution_tests {
         );
         context.resolve();
 
-        assert_ancestors_eq!(context, "Foo", ["Foo", "M", "Object"]);
+        assert_ancestors_eq!(context, "Foo", ["Foo", "M", "Object", "Kernel", "BasicObject"]);
     }
     /// Verifies that incremental resolution produces identical results to a fresh
     /// full resolution by building the same final state through two different paths.
@@ -3643,8 +3650,8 @@ mod incremental_resolution_tests {
         fresh.resolve();
 
         // Compare: both paths should produce identical resolved state
-        assert_ancestors_eq!(incremental, "Bar", ["Bar", "Baz", "Object"]);
-        assert_ancestors_eq!(fresh, "Bar", ["Bar", "Baz", "Object"]);
+        assert_ancestors_eq!(incremental, "Bar", ["Bar", "Baz", "Object", "Kernel", "BasicObject"]);
+        assert_ancestors_eq!(fresh, "Bar", ["Bar", "Baz", "Object", "Kernel", "BasicObject"]);
 
         assert_constant_reference_to!(incremental, "Baz::CONST", "file:///foo.rb:6:3-6:8");
         assert_constant_reference_to!(fresh, "Baz::CONST", "file:///foo.rb:6:3-6:8");

--- a/rust/rubydex/src/query.rs
+++ b/rust/rubydex/src/query.rs
@@ -5,9 +5,10 @@ use std::thread;
 
 use url::Url;
 
+use crate::model::built_in::OBJECT_ID;
 use crate::model::declaration::{Ancestor, Declaration};
 use crate::model::definitions::{Definition, Parameter};
-use crate::model::graph::{Graph, OBJECT_ID};
+use crate::model::graph::Graph;
 use crate::model::identity_maps::IdentityHashSet;
 use crate::model::ids::{DeclarationId, NameId, StringId, UriId};
 use crate::model::keywords::{self, Keyword};
@@ -762,9 +763,14 @@ mod tests {
             context,
             CompletionReceiver::Expression(name_id),
             [
+                "Class",
+                "BasicObject",
                 "Child",
-                "Foo",
                 "Parent",
+                "Kernel",
+                "Module",
+                "Foo",
+                "Object",
                 "Child#baz()",
                 "Foo::CONST",
                 "Foo#bar()",
@@ -802,7 +808,17 @@ mod tests {
         assert_declaration_completion_eq!(
             context,
             CompletionReceiver::Expression(name_id),
-            ["Child", "Foo", "Parent", "Child#bar()"]
+            [
+                "Class",
+                "BasicObject",
+                "Child",
+                "Parent",
+                "Kernel",
+                "Module",
+                "Foo",
+                "Object",
+                "Child#bar()"
+            ]
         );
     }
 
@@ -838,7 +854,19 @@ mod tests {
         assert_declaration_completion_eq!(
             context,
             CompletionReceiver::Expression(name_id),
-            ["Baz", "Foo", "Bar", "Foo#foo_m()", "Baz#baz_m()", "Bar#bar_m()"]
+            [
+                "Foo",
+                "Class",
+                "BasicObject",
+                "Object",
+                "Kernel",
+                "Module",
+                "Baz",
+                "Bar",
+                "Foo#foo_m()",
+                "Baz#baz_m()",
+                "Bar#bar_m()"
+            ]
         );
     }
 
@@ -873,14 +901,34 @@ mod tests {
         assert_declaration_completion_eq!(
             context,
             CompletionReceiver::Expression(name_id),
-            ["Foo", "Bar", "Foo::<Foo>#do_something()", "Foo#@@foo_var"]
+            [
+                "Module",
+                "Class",
+                "Object",
+                "BasicObject",
+                "Kernel",
+                "Foo",
+                "Bar",
+                "Foo::<Foo>#do_something()",
+                "Foo#@@foo_var"
+            ]
         );
 
         let name_id = Name::new(StringId::from("Bar"), ParentScope::None, None).id();
         assert_declaration_completion_eq!(
             context,
             CompletionReceiver::Expression(name_id),
-            ["Foo", "Bar", "Bar#baz()", "Foo#@@foo_var"]
+            [
+                "Module",
+                "Class",
+                "Object",
+                "BasicObject",
+                "Kernel",
+                "Foo",
+                "Bar",
+                "Bar#baz()",
+                "Foo#@@foo_var"
+            ]
         );
     }
 
@@ -919,14 +967,35 @@ mod tests {
         assert_declaration_completion_eq!(
             context,
             CompletionReceiver::Expression(name_id),
-            ["Foo::CONST_A", "Foo", "Bar", "Bar#bar_m()", "Bar#bar_m2()"]
+            [
+                "Foo::CONST_A",
+                "Module",
+                "Class",
+                "Object",
+                "BasicObject",
+                "Kernel",
+                "Foo",
+                "Bar",
+                "Bar#bar_m()",
+                "Bar#bar_m2()"
+            ]
         );
 
         let name_id = Name::new(StringId::from("Bar"), ParentScope::None, None).id();
         assert_declaration_completion_eq!(
             context,
             CompletionReceiver::Expression(name_id),
-            ["Foo", "Bar", "Bar#bar_m()", "Bar#bar_m2()"]
+            [
+                "Module",
+                "Class",
+                "Object",
+                "BasicObject",
+                "Kernel",
+                "Foo",
+                "Bar",
+                "Bar#bar_m()",
+                "Bar#bar_m2()"
+            ]
         );
     }
 
@@ -957,7 +1026,17 @@ mod tests {
         assert_declaration_completion_eq!(
             context,
             CompletionReceiver::Expression(name_id),
-            ["Foo::CONST", "Foo::Bar", "Foo", "Foo::Bar#baz()"]
+            [
+                "Foo::CONST",
+                "Foo::Bar",
+                "Class",
+                "Object",
+                "BasicObject",
+                "Kernel",
+                "Foo",
+                "Module",
+                "Foo::Bar#baz()"
+            ]
         );
     }
 
@@ -991,7 +1070,18 @@ mod tests {
         assert_declaration_completion_eq!(
             context,
             CompletionReceiver::Expression(name_id),
-            ["Foo::Bar", "$var", "Foo", "$var2", "Foo::Bar#bar_m()"]
+            [
+                "Foo::Bar",
+                "$var2",
+                "$var",
+                "BasicObject",
+                "Object",
+                "Kernel",
+                "Module",
+                "Foo",
+                "Class",
+                "Foo::Bar#bar_m()"
+            ]
         );
     }
 
@@ -1473,7 +1563,17 @@ mod tests {
                 self_name_id: name_id,
                 method_decl_id: DeclarationId::from("Foo#greet()"),
             },
-            ["Foo", "Foo#greet()", "name:", "greeting:"]
+            [
+                "Class",
+                "Object",
+                "BasicObject",
+                "Kernel",
+                "Foo",
+                "Module",
+                "Foo#greet()",
+                "name:",
+                "greeting:"
+            ]
         );
     }
 
@@ -1498,7 +1598,7 @@ mod tests {
                 self_name_id: name_id,
                 method_decl_id: DeclarationId::from("Foo#bar()"),
             },
-            ["Foo", "Foo#bar()"]
+            ["Class", "Object", "BasicObject", "Kernel", "Foo", "Module", "Foo#bar()"]
         );
     }
 
@@ -1524,7 +1624,17 @@ mod tests {
                 method_decl_id: DeclarationId::from("Foo#search()"),
             },
             // Only RequiredKeyword and OptionalKeyword, not RestKeyword (**opts)
-            ["Foo", "Foo#search()", "limit:", "offset:"]
+            [
+                "Class",
+                "Object",
+                "BasicObject",
+                "Kernel",
+                "Foo",
+                "Module",
+                "Foo#search()",
+                "limit:",
+                "offset:"
+            ]
         );
     }
 
@@ -1556,7 +1666,17 @@ mod tests {
                 self_name_id: name_id,
                 method_decl_id: DeclarationId::from("Foo#bar()"),
             },
-            ["Foo", "Foo#bar()", "first:", "second:"]
+            [
+                "Class",
+                "Object",
+                "BasicObject",
+                "Kernel",
+                "Foo",
+                "Module",
+                "Foo#bar()",
+                "first:",
+                "second:"
+            ]
         );
     }
 
@@ -1571,7 +1691,12 @@ mod tests {
             context,
             CompletionReceiver::Expression(name_id),
             [
+                "Class",
+                "Object",
+                "BasicObject",
+                "Kernel",
                 "Foo",
+                "Module",
                 "BEGIN",
                 "END",
                 "__ENCODING__",
@@ -1631,7 +1756,12 @@ mod tests {
                 method_decl_id: DeclarationId::from("Foo#bar()"),
             },
             [
+                "Class",
+                "Object",
+                "BasicObject",
+                "Kernel",
                 "Foo",
+                "Module",
                 "Foo#bar()",
                 "BEGIN",
                 "END",

--- a/rust/rubydex/src/resolution.rs
+++ b/rust/rubydex/src/resolution.rs
@@ -4,13 +4,14 @@ use std::{
 };
 
 use crate::model::{
+    built_in::{BASIC_OBJECT_ID, CLASS_ID, KERNEL_ID, MODULE_ID, OBJECT_ID},
     declaration::{
         Ancestor, Ancestors, ClassDeclaration, ClassVariableDeclaration, ConstantAliasDeclaration, ConstantDeclaration,
         Declaration, GlobalVariableDeclaration, InstanceVariableDeclaration, MethodDeclaration, ModuleDeclaration,
         Namespace, SingletonClassDeclaration, TodoDeclaration,
     },
     definitions::{Definition, Mixin, Receiver},
-    graph::{CLASS_ID, Graph, MODULE_ID, OBJECT_ID, Unit},
+    graph::{Graph, Unit},
     identity_maps::{IdentityHashBuilder, IdentityHashMap, IdentityHashSet},
     ids::{ConstantReferenceId, DeclarationId, DefinitionId, NameId, StringId},
     name::{Name, NameRef, ParentScope},
@@ -52,6 +53,14 @@ impl LinearizationContext {
             cyclic: false,
             partial: false,
         }
+    }
+
+    /// Finalize this linearization context for the given declaration. This is intended to be invoked whenever we finish
+    /// the linearization algorithm, regardless of whether we are returning a cached result or a freshly built ancestor
+    /// chain
+    fn finalize(&mut self, declaration_id: DeclarationId) {
+        self.descendants.remove(&declaration_id);
+        self.seen_ids.remove(&declaration_id);
     }
 }
 
@@ -713,7 +722,8 @@ impl<'a> Resolver<'a> {
             if declaration.as_namespace().unwrap().has_complete_ancestors() {
                 let cached = declaration.as_namespace().unwrap().clone_ancestors();
                 self.propagate_descendants(&mut context.descendants, &cached);
-                context.descendants.remove(&declaration_id);
+
+                context.finalize(declaration_id);
                 return cached;
             }
 
@@ -731,7 +741,8 @@ impl<'a> Resolver<'a> {
                     .as_namespace_mut()
                     .unwrap()
                     .set_ancestors(estimated_ancestors.clone());
-                context.descendants.remove(&declaration_id);
+
+                context.finalize(declaration_id);
                 return estimated_ancestors;
             }
 
@@ -795,6 +806,7 @@ impl<'a> Resolver<'a> {
         } else {
             Ancestors::Complete(ancestors)
         };
+
         self.graph
             .declarations_mut()
             .get_mut(&declaration_id)
@@ -803,7 +815,7 @@ impl<'a> Resolver<'a> {
             .unwrap()
             .set_ancestors(result.clone());
 
-        context.descendants.remove(&declaration_id);
+        context.finalize(declaration_id);
         result
     }
 
@@ -812,7 +824,7 @@ impl<'a> Resolver<'a> {
         declaration_id: DeclarationId,
         context: &mut LinearizationContext,
     ) -> Option<Vec<Ancestor>> {
-        if declaration_id == *OBJECT_ID {
+        if declaration_id == *BASIC_OBJECT_ID {
             return None;
         }
 
@@ -1601,7 +1613,7 @@ impl<'a> Resolver<'a> {
         let mut others = Vec::with_capacity(estimated);
         let mut singleton_methods = Vec::new();
         let mut const_refs = Vec::new();
-        let mut ancestors = Vec::new();
+        let mut ancestors = vec![*BASIC_OBJECT_ID, *KERNEL_ID, *OBJECT_ID, *MODULE_ID, *CLASS_ID];
         let names = self.graph.names();
         let depths = Self::compute_name_depths(names);
 
@@ -1703,8 +1715,8 @@ impl<'a> Resolver<'a> {
     /// - Class: parent is the singleton class of the original parent class
     /// - Singleton class: recurse as many times as necessary to wrap the original attached object's parent class
     fn singleton_parent_id(&mut self, attached_id: DeclarationId) -> (DeclarationId, bool) {
-        // Base case: if we reached `Object`, then the parent is `Class`
-        if attached_id == *OBJECT_ID {
+        // Base case: if we reached `BasicObject`, then the parent is `Class`
+        if attached_id == *BASIC_OBJECT_ID {
             return (*CLASS_ID, false);
         }
 
@@ -1806,11 +1818,11 @@ mod tests {
     use crate::test_utils::GraphTest;
     use crate::{
         assert_alias_targets_contain, assert_ancestors_eq, assert_constant_alias_target_eq,
-        assert_constant_reference_to, assert_declaration_definitions_count_eq, assert_declaration_does_not_exist,
-        assert_declaration_exists, assert_declaration_kind_eq, assert_declaration_references_count_eq,
-        assert_descendants, assert_diagnostics_eq, assert_instance_variables_eq, assert_members_eq,
-        assert_no_constant_alias_target, assert_no_diagnostics, assert_no_members, assert_owner_eq,
-        assert_singleton_class_eq,
+        assert_constant_reference_to, assert_constant_reference_unresolved, assert_declaration_definitions_count_eq,
+        assert_declaration_does_not_exist, assert_declaration_exists, assert_declaration_kind_eq,
+        assert_declaration_references_count_eq, assert_descendants, assert_diagnostics_eq,
+        assert_instance_variables_eq, assert_members_eq, assert_no_constant_alias_target, assert_no_diagnostics,
+        assert_no_members, assert_owner_eq, assert_singleton_class_eq,
     };
 
     #[test]
@@ -1912,13 +1924,7 @@ mod tests {
         context.resolve();
 
         assert_no_diagnostics!(&context, &[Rule::ParseWarning]);
-
-        let reference = context.graph().constant_references().values().next().unwrap();
-
-        match context.graph().names().get(reference.name_id()) {
-            Some(NameRef::Unresolved(_)) => {}
-            _ => panic!("expected unresolved constant reference"),
-        }
+        assert_constant_reference_unresolved!(context, "Foo");
     }
 
     #[test]
@@ -2057,14 +2063,22 @@ mod tests {
         });
 
         let depths = Resolver::compute_name_depths(context.graph().names());
-        let mut names = context.graph().names().iter().collect::<Vec<_>>();
+        let mut names = context
+            .graph()
+            .names()
+            .iter()
+            .filter(|(_, n)| {
+                !["Kernel", "BasicObject", "Object", "Module", "Class"]
+                    .contains(&context.graph().strings().get(n.str()).unwrap().as_str())
+            })
+            .collect::<Vec<_>>();
         assert_eq!(10, names.len());
 
         names.sort_by_key(|(id, _)| depths.get(id).unwrap());
 
         assert_eq!(
             [
-                "Top", "Foo", "Qux", "AfterTop", "Bar", "Baz", "Zip", "Zap", "Zop", "Boop"
+                "Top", "Foo", "Bar", "Qux", "AfterTop", "Baz", "Zip", "Zap", "Zop", "Boop"
             ],
             names
                 .iter()
@@ -2354,7 +2368,11 @@ mod tests {
 
         assert_no_diagnostics!(&context);
 
-        assert_ancestors_eq!(context, "Qux", ["Qux", "Baz", "Bar", "Foo", "Object"]);
+        assert_ancestors_eq!(
+            context,
+            "Qux",
+            ["Qux", "Baz", "Bar", "Foo", "Object", "Kernel", "BasicObject"]
+        );
     }
 
     #[test]
@@ -2768,7 +2786,11 @@ mod tests {
 
         assert_no_diagnostics!(&context);
 
-        assert_members_eq!(context, "Object", ["$bar", "$foo"]);
+        assert_members_eq!(
+            context,
+            "Object",
+            ["$bar", "$foo", "BasicObject", "Class", "Kernel", "Module", "Object"]
+        );
     }
 
     #[test]
@@ -2788,7 +2810,7 @@ mod tests {
 
         assert_no_diagnostics!(&context);
 
-        assert_ancestors_eq!(context, "Baz", ["Baz", "Foo::Bar", "Object"]);
+        assert_ancestors_eq!(context, "Baz", ["Baz", "Foo::Bar", "Object", "Kernel", "BasicObject"]);
     }
 
     #[test]
@@ -2833,7 +2855,11 @@ mod tests {
 
         assert_no_diagnostics!(&context);
 
-        assert_ancestors_eq!(context, "Baz", ["Foo::Bar", "Foo", "Baz", "Object"]);
+        assert_ancestors_eq!(
+            context,
+            "Baz",
+            ["Foo::Bar", "Foo", "Baz", "Object", "Kernel", "BasicObject"]
+        );
     }
 
     #[test]
@@ -2857,7 +2883,11 @@ mod tests {
 
         assert_ancestors_eq!(context, "Foo", ["Foo"]);
         assert_ancestors_eq!(context, "Bar", ["Foo", "Bar"]);
-        assert_ancestors_eq!(context, "Qux", ["Qux", "Foo", "Bar", "Baz", "Object"]);
+        assert_ancestors_eq!(
+            context,
+            "Qux",
+            ["Qux", "Foo", "Bar", "Baz", "Object", "Kernel", "BasicObject"]
+        );
     }
 
     #[test]
@@ -2886,7 +2916,7 @@ mod tests {
         assert_ancestors_eq!(context, "B", ["B"]);
         // TODO: this is a temporary hack to avoid crashing on `Struct.new`, `Class.new` and `Module.new`
         //assert_ancestors_eq!(context, "A", Vec::<&str>::new());
-        assert_ancestors_eq!(context, "C", ["B", "C", "Object"]);
+        assert_ancestors_eq!(context, "C", ["B", "C", "Object", "Kernel", "BasicObject"]);
         assert_ancestors_eq!(context, "D", ["B", "D"]);
     }
 
@@ -2998,7 +3028,7 @@ mod tests {
 
         assert_no_diagnostics!(&context);
 
-        assert_ancestors_eq!(context, "Foo", ["A", "B", "Foo", "Object"]);
+        assert_ancestors_eq!(context, "Foo", ["A", "B", "Foo", "Object", "Kernel", "BasicObject"]);
     }
 
     #[test]
@@ -3059,7 +3089,11 @@ mod tests {
 
         assert_no_diagnostics!(&context);
 
-        assert_ancestors_eq!(context, "Child", ["A", "B", "Child", "A", "B", "Parent", "Object"]);
+        assert_ancestors_eq!(
+            context,
+            "Child",
+            ["A", "B", "Child", "A", "B", "Parent", "Object", "Kernel", "BasicObject"]
+        );
     }
 
     #[test]
@@ -3126,7 +3160,11 @@ mod tests {
 
         assert_no_diagnostics!(&context);
 
-        assert_ancestors_eq!(context, "Baz", ["Baz", "Foo::Bar", "Foo", "Object"]);
+        assert_ancestors_eq!(
+            context,
+            "Baz",
+            ["Baz", "Foo::Bar", "Foo", "Object", "Kernel", "BasicObject"]
+        );
     }
 
     #[test]
@@ -3150,7 +3188,11 @@ mod tests {
 
         assert_ancestors_eq!(context, "Foo", ["Foo"]);
         assert_ancestors_eq!(context, "Bar", ["Foo", "Bar"]);
-        assert_ancestors_eq!(context, "Qux", ["Qux", "Foo", "Bar", "Baz", "Object"]);
+        assert_ancestors_eq!(
+            context,
+            "Qux",
+            ["Qux", "Foo", "Bar", "Baz", "Object", "Kernel", "BasicObject"]
+        );
     }
 
     #[test]
@@ -3179,7 +3221,7 @@ mod tests {
         assert_ancestors_eq!(context, "B", ["B"]);
         // TODO: this is a temporary hack to avoid crashing on `Struct.new`, `Class.new` and `Module.new`
         //assert_ancestors_eq!(context, "A", Vec::<&str>::new());
-        assert_ancestors_eq!(context, "C", ["C", "B", "Object"]);
+        assert_ancestors_eq!(context, "C", ["C", "B", "Object", "Kernel", "BasicObject"]);
         assert_ancestors_eq!(context, "D", ["D", "B"]);
     }
 
@@ -3310,7 +3352,11 @@ mod tests {
 
         assert_no_diagnostics!(&context);
 
-        assert_ancestors_eq!(context, "Child", ["Child", "Parent", "B", "A", "Object"]);
+        assert_ancestors_eq!(
+            context,
+            "Child",
+            ["Child", "Parent", "B", "A", "Object", "Kernel", "BasicObject"]
+        );
     }
 
     #[test]
@@ -3386,8 +3432,8 @@ mod tests {
 
         assert_no_diagnostics!(&context);
 
-        assert_ancestors_eq!(context, "Foo", ["A", "Foo", "Object"]);
-        assert_ancestors_eq!(context, "Bar", ["A", "Bar", "A", "Object"]);
+        assert_ancestors_eq!(context, "Foo", ["A", "Foo", "Object", "Kernel", "BasicObject"]);
+        assert_ancestors_eq!(context, "Bar", ["A", "Bar", "A", "Object", "Kernel", "BasicObject"]);
     }
 
     #[test]
@@ -3432,10 +3478,26 @@ mod tests {
 
         assert_no_diagnostics!(&context);
 
-        assert_ancestors_eq!(context, "Foo", ["B", "A", "Foo", "A", "C", "Object"]);
-        assert_ancestors_eq!(context, "Bar", ["B", "A", "Bar", "C", "A", "Object"]);
-        assert_ancestors_eq!(context, "Baz", ["B", "A", "Baz", "C", "Object"]);
-        assert_ancestors_eq!(context, "Qux", ["B", "A", "Qux", "C", "Object"]);
+        assert_ancestors_eq!(
+            context,
+            "Foo",
+            ["B", "A", "Foo", "A", "C", "Object", "Kernel", "BasicObject"]
+        );
+        assert_ancestors_eq!(
+            context,
+            "Bar",
+            ["B", "A", "Bar", "C", "A", "Object", "Kernel", "BasicObject"]
+        );
+        assert_ancestors_eq!(
+            context,
+            "Baz",
+            ["B", "A", "Baz", "C", "Object", "Kernel", "BasicObject"]
+        );
+        assert_ancestors_eq!(
+            context,
+            "Qux",
+            ["B", "A", "Qux", "C", "Object", "Kernel", "BasicObject"]
+        );
     }
 
     #[test]
@@ -3462,8 +3524,16 @@ mod tests {
 
         assert_no_diagnostics!(&context);
 
-        assert_ancestors_eq!(context, "Foo", ["A", "Foo", "Parent", "A", "Object"]);
-        assert_ancestors_eq!(context, "Bar", ["Bar", "Parent", "A", "Object"]);
+        assert_ancestors_eq!(
+            context,
+            "Foo",
+            ["A", "Foo", "Parent", "A", "Object", "Kernel", "BasicObject"]
+        );
+        assert_ancestors_eq!(
+            context,
+            "Bar",
+            ["Bar", "Parent", "A", "Object", "Kernel", "BasicObject"]
+        );
     }
 
     #[test]
@@ -3483,7 +3553,7 @@ mod tests {
 
         assert_no_diagnostics!(&context);
 
-        assert_ancestors_eq!(context, "Foo", ["Foo", "A", "B", "Object"]);
+        assert_ancestors_eq!(context, "Foo", ["Foo", "A", "B", "Object", "Kernel", "BasicObject"]);
     }
 
     #[test]
@@ -3535,7 +3605,6 @@ mod tests {
 
         assert_no_diagnostics!(&context);
 
-        // Note: the commented out parts require RBS indexing
         assert_ancestors_eq!(
             context,
             "Baz::<Baz>",
@@ -3545,12 +3614,12 @@ mod tests {
                 "Foo",
                 "Bar::<Bar>",
                 "Object::<Object>",
-                // "BasicObject::<BasicObject>",
+                "BasicObject::<BasicObject>",
                 "Class",
-                // "Module",
+                "Module",
                 "Object",
-                // "Kernel",
-                // "BasicObject"
+                "Kernel",
+                "BasicObject"
             ]
         );
 
@@ -3562,16 +3631,16 @@ mod tests {
                 "Zip",
                 "Bar::<Bar>::<<Bar>>",
                 "Object::<Object>::<<Object>>",
-                // "BasicObject::<BasicObject>::<<BasicObject>>",
+                "BasicObject::<BasicObject>::<<BasicObject>>",
                 "Class::<Class>",
-                // "Module::<Module>",
+                "Module::<Module>",
                 "Object::<Object>",
-                // "BasicObject::<BasicObject>",
+                "BasicObject::<BasicObject>",
                 "Class",
-                // "Module",
+                "Module",
                 "Object",
-                // "Kernel",
-                // "BasicObject"
+                "Kernel",
+                "BasicObject"
             ]
         );
     }
@@ -3603,19 +3672,10 @@ mod tests {
 
         assert_no_diagnostics!(&context);
 
-        // Note: the commented out parts require RBS indexing
         assert_ancestors_eq!(
             context,
             "Baz::<Baz>",
-            [
-                "Baz::<Baz>",
-                "Qux",
-                "Foo",
-                "Module",
-                "Object",
-                // "Kernel",
-                // "BasicObject"
-            ]
+            ["Baz::<Baz>", "Qux", "Foo", "Module", "Object", "Kernel", "BasicObject"]
         );
         assert_ancestors_eq!(
             context,
@@ -3625,12 +3685,12 @@ mod tests {
                 "Zip",
                 "Module::<Module>",
                 "Object::<Object>",
-                // "BasicObject::<BasicObject>",
+                "BasicObject::<BasicObject>",
                 "Class",
-                // "Module",
+                "Module",
                 "Object",
-                // "Kernel",
-                // "BasicObject"
+                "Kernel",
+                "BasicObject"
             ]
         );
     }
@@ -3661,7 +3721,6 @@ mod tests {
 
         assert_no_diagnostics!(&context);
 
-        // TODO: the commented out parts require RBS indexing
         assert_ancestors_eq!(
             context,
             "Bar::<Bar>",
@@ -3670,12 +3729,12 @@ mod tests {
                 "Bar::<Bar>",
                 "Foo",
                 "Object::<Object>",
-                // "BasicObject::<BasicObject>",
+                "BasicObject::<BasicObject>",
                 "Class",
-                // "Module",
+                "Module",
                 "Object",
-                // "Kernel",
-                // "BasicObject"
+                "Kernel",
+                "BasicObject"
             ]
         );
 
@@ -3688,12 +3747,12 @@ mod tests {
                 "Bar::<Bar>",
                 "Foo",
                 "Object::<Object>",
-                // "BasicObject::<BasicObject>",
+                "BasicObject::<BasicObject>",
                 "Class",
-                // "Module",
+                "Module",
                 "Object",
-                // "Kernel",
-                // "BasicObject"
+                "Kernel",
+                "BasicObject"
             ]
         );
         assert_ancestors_eq!(
@@ -3703,16 +3762,16 @@ mod tests {
                 "Baz::<Baz>::<<Baz>>",
                 "Bar::<Bar>::<<Bar>>",
                 "Object::<Object>::<<Object>>",
-                // "BasicObject::<BasicObject>::<<BasicObject>>",
+                "BasicObject::<BasicObject>::<<BasicObject>>",
                 "Class::<Class>",
-                // "Module::<Module>",
+                "Module::<Module>",
                 "Object::<Object>",
-                // "BasicObject::<BasicObject>",
+                "BasicObject::<BasicObject>",
                 "Class",
-                // "Module",
+                "Module",
                 "Object",
-                // "Kernel",
-                // "BasicObject"
+                "Kernel",
+                "BasicObject"
             ]
         );
     }
@@ -3734,7 +3793,11 @@ mod tests {
         assert_no_diagnostics!(&context);
 
         // Global variable aliases should still be owned by Object, regardless of where defined
-        assert_members_eq!(context, "Object", ["$bar", "Foo"]);
+        assert_members_eq!(
+            context,
+            "Object",
+            ["$bar", "BasicObject", "Class", "Foo", "Kernel", "Module", "Object"]
+        );
     }
 
     #[test]
@@ -4504,7 +4567,7 @@ mod tests {
 
         assert_no_diagnostics!(&context);
 
-        assert_ancestors_eq!(context, "C", ["C", "A", "B", "Object"]);
+        assert_ancestors_eq!(context, "C", ["C", "A", "B", "Object", "Kernel", "BasicObject"]);
         assert_constant_reference_to!(context, "A::X", "file:///1.rb:8:3-8:4");
     }
 
@@ -4538,7 +4601,7 @@ mod tests {
 
         assert_no_diagnostics!(&context);
 
-        assert_ancestors_eq!(context, "C", ["C", "O::A", "B", "Object"]);
+        assert_ancestors_eq!(context, "C", ["C", "O::A", "B", "Object", "Kernel", "BasicObject"]);
         assert_constant_reference_to!(context, "O::A::X", "file:///1.rb:7:3-7:4");
     }
 
@@ -4560,7 +4623,16 @@ mod tests {
         assert_ancestors_eq!(
             context,
             "Foo::<Foo>",
-            &["Foo::<Foo>", "Object::<Object>", "Class", "Object"]
+            [
+                "Foo::<Foo>",
+                "Object::<Object>",
+                "BasicObject::<BasicObject>",
+                "Class",
+                "Module",
+                "Object",
+                "Kernel",
+                "BasicObject"
+            ]
         );
     }
 
@@ -4582,15 +4654,23 @@ mod tests {
         assert_ancestors_eq!(
             context,
             "Foo::<Foo>::<<Foo>>::<<<Foo>>>",
-            &[
+            [
                 "Foo::<Foo>::<<Foo>>::<<<Foo>>>",
                 "Object::<Object>::<<Object>>::<<<Object>>>",
+                "BasicObject::<BasicObject>::<<BasicObject>>::<<<BasicObject>>>",
                 "Class::<Class>::<<Class>>",
+                "Module::<Module>::<<Module>>",
                 "Object::<Object>::<<Object>>",
+                "BasicObject::<BasicObject>::<<BasicObject>>",
                 "Class::<Class>",
+                "Module::<Module>",
                 "Object::<Object>",
+                "BasicObject::<BasicObject>",
                 "Class",
-                "Object"
+                "Module",
+                "Object",
+                "Kernel",
+                "BasicObject"
             ]
         );
     }
@@ -4615,13 +4695,19 @@ mod tests {
         assert_ancestors_eq!(
             context,
             "Foo::Bar::<Bar>::<<Bar>>",
-            &[
+            [
                 "Foo::Bar::<Bar>::<<Bar>>",
                 "Object::<Object>::<<Object>>",
+                "BasicObject::<BasicObject>::<<BasicObject>>",
                 "Class::<Class>",
+                "Module::<Module>",
                 "Object::<Object>",
+                "BasicObject::<BasicObject>",
                 "Class",
-                "Object"
+                "Module",
+                "Object",
+                "Kernel",
+                "BasicObject"
             ]
         );
     }
@@ -4647,13 +4733,19 @@ mod tests {
         assert_ancestors_eq!(
             context,
             "Foo::<Foo>::<<Foo>>",
-            &[
+            [
                 "Foo::<Foo>::<<Foo>>",
                 "Object::<Object>::<<Object>>",
+                "BasicObject::<BasicObject>::<<BasicObject>>",
                 "Class::<Class>",
+                "Module::<Module>",
                 "Object::<Object>",
+                "BasicObject::<BasicObject>",
                 "Class",
-                "Object"
+                "Module",
+                "Object",
+                "Kernel",
+                "BasicObject"
             ]
         );
     }
@@ -4793,8 +4885,12 @@ mod tests {
 
         assert_no_diagnostics!(&context);
 
-        assert_ancestors_eq!(context, "Bar", ["Bar", "Foo", "Object"]);
-        assert_ancestors_eq!(context, "Baz::Child", ["Baz::Child", "Baz::Base", "Object"]);
+        assert_ancestors_eq!(context, "Bar", ["Bar", "Foo", "Object", "Kernel", "BasicObject"]);
+        assert_ancestors_eq!(
+            context,
+            "Baz::Child",
+            ["Baz::Child", "Baz::Base", "Object", "Kernel", "BasicObject"]
+        );
     }
 
     #[test]
@@ -4836,7 +4932,11 @@ mod tests {
 
         assert_no_diagnostics!(&context);
 
-        assert_members_eq!(context, "Object", ["$foo"]);
+        assert_members_eq!(
+            context,
+            "Object",
+            ["$foo", "BasicObject", "Class", "Kernel", "Module", "Object"]
+        );
     }
 
     #[test]
@@ -4860,7 +4960,7 @@ mod tests {
 
         assert_no_diagnostics!(&context);
 
-        assert_ancestors_eq!(context, "Foo", ["Foo", "Baz", "Bar", "Object"]);
+        assert_ancestors_eq!(context, "Foo", ["Foo", "Baz", "Bar", "Object", "Kernel", "BasicObject"]);
     }
 
     #[test]
@@ -4926,7 +5026,7 @@ mod tests {
 
         context.resolve();
         assert_no_diagnostics!(&context);
-        assert_ancestors_eq!(context, "Bar", ["Bar", "Baz", "Object"]);
+        assert_ancestors_eq!(context, "Bar", ["Bar", "Baz", "Object", "Kernel", "BasicObject"]);
     }
 
     #[test]
@@ -4956,7 +5056,7 @@ mod tests {
 
         context.resolve();
         assert_no_diagnostics!(&context);
-        assert_ancestors_eq!(context, "Bar", ["Bar", "Object"]);
+        assert_ancestors_eq!(context, "Bar", ["Bar", "Object", "Kernel", "BasicObject"]);
     }
 
     #[test]
@@ -4973,7 +5073,7 @@ mod tests {
 
         context.resolve();
         assert_no_diagnostics!(&context);
-        assert_ancestors_eq!(context, "Bar", ["Bar", "Object"]);
+        assert_ancestors_eq!(context, "Bar", ["Bar", "Object", "Kernel", "BasicObject"]);
     }
 
     #[test]
@@ -4990,7 +5090,7 @@ mod tests {
 
         context.resolve();
         assert_no_diagnostics!(&context);
-        assert_ancestors_eq!(context, "Bar", ["Bar", "Object"]);
+        assert_ancestors_eq!(context, "Bar", ["Bar", "Object", "Kernel", "BasicObject"]);
     }
 
     #[test]
@@ -5016,12 +5116,12 @@ mod tests {
             [
                 "Bar::<Bar>",
                 "Object::<Object>",
-                // "BasicObject::<BasicObject>",
+                "BasicObject::<BasicObject>",
                 "Class",
-                // "Module",
+                "Module",
                 "Object",
-                // "Kernel",
-                // "BasicObject"
+                "Kernel",
+                "BasicObject"
             ]
         );
     }
@@ -5076,7 +5176,7 @@ mod tests {
 
         context.resolve();
         assert_no_diagnostics!(&context);
-        assert_ancestors_eq!(context, "Bar", ["Bar", "Baz", "Object"]);
+        assert_ancestors_eq!(context, "Bar", ["Bar", "Baz", "Object", "Kernel", "BasicObject"]);
     }
 
     #[test]
@@ -5351,7 +5451,7 @@ mod tests {
         });
         context.resolve();
         assert_no_diagnostics!(&context);
-        assert_ancestors_eq!(context, "Foo", ["Foo", "Base", "Object"]);
+        assert_ancestors_eq!(context, "Foo", ["Foo", "Base", "Object", "Kernel", "BasicObject"]);
     }
 
     #[test]
@@ -5368,7 +5468,7 @@ mod tests {
         });
         context.resolve();
         assert_no_diagnostics!(&context);
-        assert_ancestors_eq!(context, "Foo", ["Foo", "M", "Object"]);
+        assert_ancestors_eq!(context, "Foo", ["Foo", "M", "Object", "Kernel", "BasicObject"]);
     }
 
     #[test]
@@ -5439,7 +5539,7 @@ mod tests {
         });
 
         context.resolve();
-        assert_ancestors_eq!(context, "Baz", ["Baz", "Object"]);
+        assert_ancestors_eq!(context, "Baz", ["Baz", "Object", "Kernel", "BasicObject"]);
     }
 
     #[test]
@@ -5619,10 +5719,82 @@ mod tests {
                 "Bar::<Bar>",
                 "Foo::<Foo>",
                 "Object::<Object>",
+                "BasicObject::<BasicObject>",
                 "Class",
-                "Object"
+                "Module",
+                "Object",
+                "Kernel",
+                "BasicObject"
             ]
         );
+    }
+
+    #[test]
+    fn ancestors_with_missing_core() {
+        let mut context = GraphTest::new();
+        context.index_uri(
+            "file:///foo.rb",
+            "
+            module Bar; end
+
+            class Foo
+              include Bar
+            end
+            ",
+        );
+        context.resolve();
+
+        assert_ancestors_eq!(context, "Foo", ["Foo", "Bar", "Object", "Kernel", "BasicObject"]);
+        assert_descendants!(context, "Bar", ["Foo"]);
+    }
+
+    #[test]
+    fn ancestor_patches_to_object_are_correctly_processed() {
+        let mut context = GraphTest::new();
+        context.index_uri(
+            "file:///foo.rb",
+            "
+            module Foo; end
+
+            module Kernel
+              include Foo
+            end
+            ",
+        );
+        context.resolve();
+
+        assert_ancestors_eq!(context, "Object", ["Object", "Kernel", "Foo", "BasicObject"]);
+    }
+
+    #[test]
+    fn basic_object_ancestors() {
+        let mut context = GraphTest::new();
+        context.index_uri(
+            "file:///foo.rb",
+            "
+            class Foo < BasicObject
+            end
+            ",
+        );
+        context.resolve();
+
+        assert_ancestors_eq!(context, "Foo", ["Foo", "BasicObject"]);
+    }
+
+    #[test]
+    fn basic_object_ancestors_including_kernel() {
+        let mut context = GraphTest::new();
+        context.index_uri(
+            "file:///foo.rb",
+            "
+            class Foo < BasicObject
+              include Kernel
+            end
+            ",
+        );
+        context.resolve();
+
+        assert_ancestors_eq!(context, "Foo", ["Foo", "Kernel", "BasicObject"]);
     }
 }
 
@@ -5651,7 +5823,11 @@ mod todo_tests {
 
         assert_declaration_kind_eq!(context, "Foo", "<TODO>");
 
-        assert_members_eq!(context, "Object", vec!["Foo"]);
+        assert_members_eq!(
+            context,
+            "Object",
+            vec!["BasicObject", "Class", "Foo", "Kernel", "Module", "Object"]
+        );
         assert_members_eq!(context, "Foo", vec!["Bar"]);
         assert_members_eq!(context, "Foo::Bar", vec!["Baz"]);
         assert_no_members!(context, "Foo::Bar::Baz");
@@ -5679,7 +5855,11 @@ mod todo_tests {
 
         assert_declaration_kind_eq!(context, "Foo", "<TODO>");
 
-        assert_members_eq!(context, "Object", vec!["Foo"]);
+        assert_members_eq!(
+            context,
+            "Object",
+            vec!["BasicObject", "Class", "Foo", "Kernel", "Module", "Object"]
+        );
         assert_members_eq!(context, "Foo", vec!["Bar", "Baz"]);
         assert_members_eq!(context, "Foo::Bar", vec!["bar()"]);
         assert_members_eq!(context, "Foo::Baz", vec!["baz()"]);
@@ -5740,7 +5920,11 @@ mod todo_tests {
         // Foo was initially created as a Todo (from class Foo::Bar), then promoted to Class
         assert_declaration_kind_eq!(context, "Foo", "Class");
 
-        assert_members_eq!(context, "Object", vec!["Foo"]);
+        assert_members_eq!(
+            context,
+            "Object",
+            vec!["BasicObject", "Class", "Foo", "Kernel", "Module", "Object"]
+        );
         assert_members_eq!(context, "Foo", vec!["Bar", "foo()"]);
         assert_members_eq!(context, "Foo::Bar", vec!["bar()"]);
     }
@@ -5774,7 +5958,11 @@ mod todo_tests {
         // Foo was promoted from Todo to Class after the second resolution
         assert_declaration_kind_eq!(context, "Foo", "Class");
 
-        assert_members_eq!(context, "Object", vec!["Foo"]);
+        assert_members_eq!(
+            context,
+            "Object",
+            vec!["BasicObject", "Class", "Foo", "Kernel", "Module", "Object"]
+        );
         assert_members_eq!(context, "Foo", vec!["Bar", "foo()"]);
         assert_members_eq!(context, "Foo::Bar", vec!["bar()"]);
     }
@@ -5795,7 +5983,11 @@ mod todo_tests {
         assert_declaration_kind_eq!(context, "A", "<TODO>");
         assert_declaration_kind_eq!(context, "A::B", "<TODO>");
         assert_declaration_kind_eq!(context, "A::B::C", "Class");
-        assert_members_eq!(context, "Object", vec!["A"]);
+        assert_members_eq!(
+            context,
+            "Object",
+            vec!["A", "BasicObject", "Class", "Kernel", "Module", "Object"]
+        );
         assert_members_eq!(context, "A", vec!["B"]);
         assert_members_eq!(context, "A::B", vec!["C"]);
         assert_members_eq!(context, "A::B::C", vec!["foo()"]);
@@ -5818,7 +6010,11 @@ mod todo_tests {
         assert_declaration_kind_eq!(context, "A::B", "<TODO>");
         assert_declaration_kind_eq!(context, "A::B::C", "<TODO>");
         assert_declaration_kind_eq!(context, "A::B::C::D", "Class");
-        assert_members_eq!(context, "Object", vec!["A"]);
+        assert_members_eq!(
+            context,
+            "Object",
+            vec!["A", "BasicObject", "Class", "Kernel", "Module", "Object"]
+        );
         assert_members_eq!(context, "A", vec!["B"]);
         assert_members_eq!(context, "A::B", vec!["C"]);
         assert_members_eq!(context, "A::B::C", vec!["D"]);
@@ -5869,7 +6065,11 @@ mod todo_tests {
         assert_declaration_kind_eq!(context, "A::B", "<TODO>");
         assert_declaration_kind_eq!(context, "A::B::C", "Class");
         assert_declaration_kind_eq!(context, "A::B::D", "Class");
-        assert_members_eq!(context, "Object", vec!["A"]);
+        assert_members_eq!(
+            context,
+            "Object",
+            vec!["A", "BasicObject", "Class", "Kernel", "Module", "Object"]
+        );
         assert_members_eq!(context, "A", vec!["B"]);
         assert_members_eq!(context, "A::B", vec!["C", "D"]);
         assert_members_eq!(context, "A::B::C", vec!["c_method()"]);

--- a/rust/rubydex/src/visualization/dot.rs
+++ b/rust/rubydex/src/visualization/dot.rs
@@ -109,7 +109,7 @@ fn write_document_nodes(output: &mut String, graph: &Graph) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_utils::GraphTest;
+    use crate::{model::ids::DeclarationId, test_utils::GraphTest};
 
     fn create_test_graph() -> GraphTest {
         let mut graph_test = GraphTest::new();
@@ -127,45 +127,61 @@ mod tests {
         graph_test
     }
 
+    /// Finds the first definition ID for the declaration with the given name.
+    fn def_id_for(graph: &Graph, name: &str) -> String {
+        let decl = graph.declarations().get(&DeclarationId::from(name)).unwrap();
+        decl.definitions().first().unwrap().to_string()
+    }
+
     #[test]
     fn test_dot_generation() {
         let context = create_test_graph();
         let dot_output = generate(context.graph());
 
-        let class_def_id = context
-            .graph()
-            .definitions()
-            .iter()
-            .find(|(_, def)| matches!(def, crate::model::definitions::Definition::Class(_)))
-            .map(|(id, _)| id.to_string())
-            .unwrap();
-
-        let module_def_id = context
-            .graph()
-            .definitions()
-            .iter()
-            .find(|(_, def)| matches!(def, crate::model::definitions::Definition::Module(_)))
-            .map(|(id, _)| id.to_string())
-            .unwrap();
+        let basic_object_def = def_id_for(context.graph(), "BasicObject");
+        let class_def = def_id_for(context.graph(), "Class");
+        let kernel_def = def_id_for(context.graph(), "Kernel");
+        let module_def = def_id_for(context.graph(), "Module");
+        let object_def = def_id_for(context.graph(), "Object");
+        let test_class_def = def_id_for(context.graph(), "TestClass");
+        let test_module_def = def_id_for(context.graph(), "TestModule");
 
         let expected = format!(
             r#"digraph {{
     rankdir=TB;
 
+    "Name:BasicObject" [label="BasicObject",shape=hexagon];
+    "Name:BasicObject" -> "def_{basic_object_def}" [dir=both];
     "Name:Class" [label="Class",shape=hexagon];
+    "Name:Class" -> "def_{class_def}" [dir=both];
+    "Name:Kernel" [label="Kernel",shape=hexagon];
+    "Name:Kernel" -> "def_{kernel_def}" [dir=both];
     "Name:Module" [label="Module",shape=hexagon];
+    "Name:Module" -> "def_{module_def}" [dir=both];
     "Name:Object" [label="Object",shape=hexagon];
+    "Name:Object" -> "def_{object_def}" [dir=both];
     "Name:TestClass" [label="TestClass",shape=hexagon];
-    "Name:TestClass" -> "def_{class_def_id}" [dir=both];
+    "Name:TestClass" -> "def_{test_class_def}" [dir=both];
     "Name:TestModule" [label="TestModule",shape=hexagon];
-    "Name:TestModule" -> "def_{module_def_id}" [dir=both];
+    "Name:TestModule" -> "def_{test_module_def}" [dir=both];
 
-    "def_{class_def_id}" [label="Class(TestClass)",shape=ellipse];
-    "def_{module_def_id}" [label="Module(TestModule)",shape=ellipse];
+    "def_{basic_object_def}" [label="Class(BasicObject)",shape=ellipse];
+    "def_{class_def}" [label="Class(Class)",shape=ellipse];
+    "def_{module_def}" [label="Class(Module)",shape=ellipse];
+    "def_{object_def}" [label="Class(Object)",shape=ellipse];
+    "def_{test_class_def}" [label="Class(TestClass)",shape=ellipse];
+    "def_{kernel_def}" [label="Module(Kernel)",shape=ellipse];
+    "def_{test_module_def}" [label="Module(TestModule)",shape=ellipse];
 
     "file:///test.rb" [label="test.rb",shape=box];
-    "def_{class_def_id}" -> "file:///test.rb";
-    "def_{module_def_id}" -> "file:///test.rb";
+    "def_{test_class_def}" -> "file:///test.rb";
+    "def_{test_module_def}" -> "file:///test.rb";
+    "rubydex:built-in" [label="rubydex:built-in",shape=box];
+    "def_{basic_object_def}" -> "rubydex:built-in";
+    "def_{kernel_def}" -> "rubydex:built-in";
+    "def_{object_def}" -> "rubydex:built-in";
+    "def_{module_def}" -> "rubydex:built-in";
+    "def_{class_def}" -> "rubydex:built-in";
 
 }}
 "#

--- a/rust/rubydex/tests/cli.rs
+++ b/rust/rubydex/tests/cli.rs
@@ -30,12 +30,12 @@ fn paths_argument_variants() {
     rdx(&[])
         .success()
         .stderr(predicate::str::is_empty())
-        .stdout(predicate::str::contains("Indexed 0 files"));
+        .stdout(predicate::str::contains("Indexed 1 files"));
 
     rdx(&["."])
         .success()
         .stderr(predicate::str::is_empty())
-        .stdout(predicate::str::contains("Indexed 0 files"));
+        .stdout(predicate::str::contains("Indexed 1 files"));
 
     with_context(|context| {
         context.write("dir1/file1.rb", "class Class1\nend\n");
@@ -49,7 +49,7 @@ fn paths_argument_variants() {
         ])
         .success()
         .stderr(predicate::str::is_empty())
-        .stdout(predicate::str::contains("Indexed 3 files"));
+        .stdout(predicate::str::contains("Indexed 4 files"));
     });
 }
 
@@ -62,9 +62,9 @@ fn prints_index_metrics() {
         rdx(&[context.absolute_path().to_str().unwrap()])
             .success()
             .stderr(predicate::str::is_empty())
-            .stdout(predicate::str::contains("Indexed 2 files"))
-            .stdout(predicate::str::contains("Found 5 names"))
-            .stdout(predicate::str::contains("Found 2 definitions"));
+            .stdout(predicate::str::contains("Indexed 3 files"))
+            .stdout(predicate::str::contains("Found 7 names"))
+            .stdout(predicate::str::contains("Found 7 definitions"));
     });
 }
 
@@ -95,16 +95,34 @@ fn visualize_simple_class() {
             digraph {
                 rankdir=TB;
 
+                "Name:BasicObject" [label="BasicObject",shape=hexagon];
+                "Name:BasicObject" -> "def_<ID>" [dir=both];
                 "Name:Class" [label="Class",shape=hexagon];
+                "Name:Class" -> "def_<ID>" [dir=both];
+                "Name:Kernel" [label="Kernel",shape=hexagon];
+                "Name:Kernel" -> "def_<ID>" [dir=both];
                 "Name:Module" [label="Module",shape=hexagon];
+                "Name:Module" -> "def_<ID>" [dir=both];
                 "Name:Object" [label="Object",shape=hexagon];
+                "Name:Object" -> "def_<ID>" [dir=both];
                 "Name:SimpleClass" [label="SimpleClass",shape=hexagon];
                 "Name:SimpleClass" -> "def_<ID>" [dir=both];
 
+                "def_<ID>" [label="Class(BasicObject)",shape=ellipse];
+                "def_<ID>" [label="Class(Class)",shape=ellipse];
+                "def_<ID>" [label="Class(Module)",shape=ellipse];
+                "def_<ID>" [label="Class(Object)",shape=ellipse];
                 "def_<ID>" [label="Class(SimpleClass)",shape=ellipse];
+                "def_<ID>" [label="Module(Kernel)",shape=ellipse];
 
                 "file://<PATH>/simple.rb" [label="simple.rb",shape=box];
                 "def_<ID>" -> "file://<PATH>/simple.rb";
+                "rubydex:built-in" [label="rubydex:built-in",shape=box];
+                "def_<ID>" -> "rubydex:built-in";
+                "def_<ID>" -> "rubydex:built-in";
+                "def_<ID>" -> "rubydex:built-in";
+                "def_<ID>" -> "rubydex:built-in";
+                "def_<ID>" -> "rubydex:built-in";
 
             }
 

--- a/test/declaration_test.rb
+++ b/test/declaration_test.rb
@@ -301,7 +301,7 @@ class DeclarationTest < Minitest::Test
       graph.resolve
 
       child = graph["Child"]
-      assert_equal(["Bar", "Child", "Foo", "Parent", "Object"], child.ancestors.map(&:name))
+      assert_equal(["Bar", "Child", "Foo", "Parent", "Object", "Kernel", "BasicObject"], child.ancestors.map(&:name))
     end
   end
 

--- a/test/definition_test.rb
+++ b/test/definition_test.rb
@@ -82,7 +82,7 @@ class DefinitionTest < Minitest::Test
       graph = Rubydex::Graph.new
       graph.index_all(context.glob("**/*.rb"))
 
-      def_a = graph.documents.first.definitions.find { |d| d.name == "A" }
+      def_a = graph.documents.find { |d| d.uri == context.uri_to("file1.rb") }.definitions.find { |d| d.name == "A" }
       refute_nil(def_a)
       location = def_a.location.to_display
       refute_nil(location)
@@ -93,7 +93,7 @@ class DefinitionTest < Minitest::Test
       assert_equal(3, location.end_line)
       assert_equal(4, location.end_column)
 
-      def_foo = graph.documents.first.definitions.find { |d| d.name == "foo()" }
+      def_foo = graph.documents.find { |d| d.uri == context.uri_to("file1.rb") }.definitions.find { |d| d.name == "foo()" }
       refute_nil(def_foo)
       location = def_foo.location.to_display
       refute_nil(location)
@@ -120,7 +120,7 @@ class DefinitionTest < Minitest::Test
       graph = Rubydex::Graph.new
       graph.index_all(context.glob("**/*.rb"))
 
-      foo_comments = graph.documents.first.definitions.find { |d| d.name == "Foo" }.comments
+      foo_comments = graph.documents.find { |d| d.uri == context.uri_to("file1.rb") }.definitions.find { |d| d.name == "Foo" }.comments
       assert_equal(
         [
           "# This is a class comment (#{context.absolute_path_to("file1.rb")}:1:1-1:26)",
@@ -129,7 +129,7 @@ class DefinitionTest < Minitest::Test
         foo_comments.map { |c| "#{c.string} (#{normalized_comment_location(c)})" },
       )
 
-      bar_comments = graph.documents.first.definitions.find { |d| d.name == "bar()" }.comments
+      bar_comments = graph.documents.find { |d| d.uri == context.uri_to("file1.rb") }.definitions.find { |d| d.name == "bar()" }.comments
       assert_equal(
         ["# Method comment (#{context.absolute_path_to("file1.rb")}:4:3-4:19)"],
         bar_comments.map { |c| "#{c.string} (#{normalized_comment_location(c)})" },
@@ -160,11 +160,14 @@ class DefinitionTest < Minitest::Test
       graph = Rubydex::Graph.new
       graph.index_all(context.glob("**/*.rb"))
 
-      assert(graph.documents.first.definitions.find { |d| d.name == "Deprecated" }.deprecated?)
-      refute(graph.documents.first.definitions.find { |d| d.name == "NotDeprecated" }.deprecated?)
-      assert(graph.documents.first.definitions.find { |d| d.name == "deprecated_method()" }.deprecated?)
-      assert(graph.documents.first.definitions.find { |d| d.name == "also_deprecated_method()" }.deprecated?)
-      refute(graph.documents.first.definitions.find { |d| d.name == "not_deprecated_method()" }.deprecated?)
+      document = graph.documents.find { |d| d.uri == context.uri_to("file1.rb") }
+      definitions = document.definitions
+
+      assert(definitions.find { |d| d.name == "Deprecated" }.deprecated?)
+      refute(definitions.find { |d| d.name == "NotDeprecated" }.deprecated?)
+      assert(definitions.find { |d| d.name == "deprecated_method()" }.deprecated?)
+      assert(definitions.find { |d| d.name == "also_deprecated_method()" }.deprecated?)
+      refute(definitions.find { |d| d.name == "not_deprecated_method()" }.deprecated?)
     end
   end
 
@@ -196,11 +199,14 @@ class DefinitionTest < Minitest::Test
       graph = Rubydex::Graph.new
       graph.index_all(context.glob("**/*.rb"))
 
-      assert(graph.documents.first.definitions.find { |d| d.name == "DeprecatedWithBlank" }.deprecated?)
-      assert(graph.documents.first.definitions.find { |d| d.name == "DeprecatedWithMessage" }.deprecated?)
-      assert(graph.documents.first.definitions.find { |d| d.name == "deprecated_method()" }.deprecated?)
-      assert(graph.documents.first.definitions.find { |d| d.name == "also_deprecated_method()" }.deprecated?)
-      refute(graph.documents.first.definitions.find { |d| d.name == "NotDeprecated" }.deprecated?)
+      document = graph.documents.find { |d| d.uri == context.uri_to("file1.rb") }
+      definitions = document.definitions
+
+      assert(definitions.find { |d| d.name == "DeprecatedWithBlank" }.deprecated?)
+      assert(definitions.find { |d| d.name == "DeprecatedWithMessage" }.deprecated?)
+      assert(definitions.find { |d| d.name == "deprecated_method()" }.deprecated?)
+      assert(definitions.find { |d| d.name == "also_deprecated_method()" }.deprecated?)
+      refute(definitions.find { |d| d.name == "NotDeprecated" }.deprecated?)
     end
   end
 
@@ -215,7 +221,7 @@ class DefinitionTest < Minitest::Test
       graph = Rubydex::Graph.new
       graph.index_all(context.glob("**/*.rb"))
 
-      defs = graph.documents.first.definitions
+      defs = graph.documents.find { |d| d.uri == context.uri_to("file1.rb") }.definitions
 
       # Before resolution, the superclass should be an unresolved constant reference
       child_def = defs.find { |d| d.name == "Child" }
@@ -253,7 +259,7 @@ class DefinitionTest < Minitest::Test
       graph = Rubydex::Graph.new
       graph.index_all(context.glob("**/*.rb"))
 
-      defs = graph.documents.first.definitions
+      defs = graph.documents.find { |d| d.uri == context.uri_to("file1.rb") }.definitions
 
       # No mixins returns empty array
       no_mixins_def = defs.find { |d| d.name == "NoMixins" }
@@ -304,7 +310,7 @@ class DefinitionTest < Minitest::Test
       graph.index_all(context.glob("**/*.rb"))
       graph.resolve
 
-      defs = graph.documents.first.definitions
+      defs = graph.documents.find { |d| d.uri == context.uri_to("file1.rb") }.definitions
       mod_def = defs.find { |d| d.name == "WithMixins" }
       mixins = mod_def.mixins
 
@@ -326,7 +332,7 @@ class DefinitionTest < Minitest::Test
       graph.index_all(context.glob("**/*.rb"))
       graph.resolve
 
-      defs = graph.documents.first.definitions
+      defs = graph.documents.find { |d| d.uri == context.uri_to("file1.rb") }.definitions
       mod_def = defs.find { |d| d.is_a?(Rubydex::ModuleDefinition) }
       refute_nil(mod_def)
       mixins = mod_def.mixins
@@ -353,7 +359,7 @@ class DefinitionTest < Minitest::Test
       graph.index_all(context.glob("**/*.rb"))
       graph.resolve
 
-      defs = graph.documents.first.definitions
+      defs = graph.documents.find { |d| d.uri == context.uri_to("file1.rb") }.definitions
       singleton_def = defs.find { |d| d.is_a?(Rubydex::SingletonClassDefinition) }
       refute_nil(singleton_def)
       mixins = singleton_def.mixins

--- a/test/document_test.rb
+++ b/test/document_test.rb
@@ -21,7 +21,7 @@ class DocumentTest < Minitest::Test
       graph = Rubydex::Graph.new
       graph.index_all(context.glob("**/*.rb"))
 
-      document = graph.documents.first
+      document = graph.documents.find { |d| d.uri == context.uri_to("file1.rb") }
       assert_instance_of(Rubydex::Document, document)
       assert_equal(context.uri_to("file1.rb"), document.uri)
     end
@@ -37,7 +37,7 @@ class DocumentTest < Minitest::Test
       graph = Rubydex::Graph.new
       graph.index_all(context.glob("**/*.rb"))
 
-      document = graph.documents.first
+      document = graph.documents.find { |d| d.uri == context.uri_to("file1.rb") }
       refute_nil(document)
 
       enumerator = document.definitions
@@ -57,7 +57,7 @@ class DocumentTest < Minitest::Test
       graph = Rubydex::Graph.new
       graph.index_all(context.glob("**/*.rb"))
 
-      document = graph.documents.first
+      document = graph.documents.find { |d| d.uri == context.uri_to("file1.rb") }
       refute_nil(document)
 
       definitions = []

--- a/test/graph_test.rb
+++ b/test/graph_test.rb
@@ -92,10 +92,10 @@ class GraphTest < Minitest::Test
 
       enumerator = graph.declarations
 
-      # Object, Class, Module + the indexed files
-      assert_equal(5, enumerator.size)
-      assert_equal(5, enumerator.count)
-      assert_equal(5, enumerator.to_a.size)
+      # Object, Class, Module, BasicObject, Kernel + the indexed files
+      assert_equal(7, enumerator.size)
+      assert_equal(7, enumerator.count)
+      assert_equal(7, enumerator.to_a.size)
     end
   end
 
@@ -113,7 +113,7 @@ class GraphTest < Minitest::Test
         declarations << declaration
       end
 
-      assert_equal(5, declarations.size)
+      assert_equal(7, declarations.size)
     end
   end
 
@@ -127,9 +127,9 @@ class GraphTest < Minitest::Test
 
       enumerator = graph.documents
 
-      assert_equal(2, enumerator.size)
-      assert_equal(2, enumerator.count)
-      assert_equal(2, enumerator.to_a.size)
+      assert_equal(3, enumerator.size)
+      assert_equal(3, enumerator.count)
+      assert_equal(3, enumerator.to_a.size)
     end
   end
 
@@ -146,7 +146,7 @@ class GraphTest < Minitest::Test
         documents << document
       end
 
-      assert_equal(2, documents.size)
+      assert_equal(3, documents.size)
     end
   end
 
@@ -430,7 +430,7 @@ class GraphTest < Minitest::Test
       graph.index_all(context.glob("**/*.rb"))
       graph.resolve
 
-      assert_equal(2, graph.documents.count)
+      assert_equal(3, graph.documents.count)
       foo = graph["Foo"]
 
       deleted = graph.delete_document(context.uri_to("foo.rb"))
@@ -440,8 +440,9 @@ class GraphTest < Minitest::Test
       assert_empty(foo.definitions.to_a)
       assert_nil(graph["Foo"])
 
-      assert_equal(1, graph.documents.count)
-      assert_equal("Bar", graph.documents.first.definitions.first.name)
+      assert_equal(2, graph.documents.count)
+      bar_doc = graph.documents.find { |d| d.uri == context.uri_to("bar.rb") }
+      assert_equal("Bar", bar_doc.definitions.first.name)
     end
   end
 
@@ -463,7 +464,7 @@ class GraphTest < Minitest::Test
     graph.index_source("file:///foo.rb", "class Foo; end", "ruby")
     graph.resolve
 
-    assert_equal(1, graph.documents.count)
+    assert_equal(2, graph.documents.count)
     refute_nil(graph["Foo"])
   end
 
@@ -471,7 +472,7 @@ class GraphTest < Minitest::Test
     graph = Rubydex::Graph.new
     graph.index_source("file:///foo.rbs", "class Foo\nend", "rbs")
 
-    assert_equal(1, graph.documents.count)
+    assert_equal(2, graph.documents.count)
   end
 
   def test_index_source_with_unknown_language_id
@@ -511,7 +512,7 @@ class GraphTest < Minitest::Test
     graph.index_source("file:///foo.rb", "class Bar; end", "ruby")
     graph.resolve
 
-    assert_equal(1, graph.documents.count)
+    assert_equal(2, graph.documents.count)
     assert_nil(graph["Foo"])
     refute_nil(graph["Bar"])
   end

--- a/test/references_test.rb
+++ b/test/references_test.rb
@@ -22,9 +22,9 @@ class ReferencesTest < Minitest::Test
 
       enumerator = graph.constant_references
 
-      assert_equal(2, enumerator.size)
-      assert_equal(2, enumerator.count)
-      assert_equal(2, enumerator.to_a.size)
+      assert_equal(6, enumerator.size)
+      assert_equal(6, enumerator.count)
+      assert_equal(6, enumerator.to_a.size)
     end
   end
 
@@ -46,7 +46,7 @@ class ReferencesTest < Minitest::Test
       graph.constant_references do |unresolved_reference|
         references << unresolved_reference
       end
-      assert_equal(2, references.size)
+      assert_equal(6, references.size)
 
       references.sort_by!(&:location)
 
@@ -79,7 +79,10 @@ class ReferencesTest < Minitest::Test
       graph.index_all(context.glob("**/*.rb"))
       graph.resolve
 
-      references = graph.constant_references.to_a.sort_by(&:location)
+      file_uri = context.uri_to("file1.rb")
+      references = graph.constant_references.to_a
+        .select { |r| r.location.uri == file_uri }
+        .sort_by(&:location)
       assert_equal(2, references.size)
 
       ref1, ref2 = references
@@ -132,14 +135,15 @@ class ReferencesTest < Minitest::Test
       graph.index_all(context.glob("**/*.rb"))
       graph.resolve
 
-      refs = graph.constant_references.to_a
+      b_uri = context.uri_to("b.rb")
+      refs = graph.constant_references.to_a.select { |r| r.location.uri == b_uri }
       assert_equal(1, refs.size)
       assert_kind_of(Rubydex::ResolvedConstantReference, refs.first)
 
       graph.delete_document(context.uri_to("a.rb"))
       graph.resolve
 
-      refs = graph.constant_references.to_a
+      refs = graph.constant_references.to_a.select { |r| r.location.uri == b_uri }
       assert_equal(1, refs.size)
       assert_kind_of(Rubydex::UnresolvedConstantReference, refs.first)
       assert_equal("A", refs.first.name)
@@ -161,7 +165,10 @@ class ReferencesTest < Minitest::Test
       graph.index_all(context.glob("**/*.rb"))
       graph.resolve
 
-      references = graph.constant_references.to_a.sort_by(&:location)
+      file_uri = context.uri_to("file1.rb")
+      references = graph.constant_references.to_a
+        .select { |r| r.location.uri == file_uri }
+        .sort_by(&:location)
 
       resolved = references.select { |r| r.is_a?(Rubydex::ResolvedConstantReference) }
       unresolved = references.select { |r| r.is_a?(Rubydex::UnresolvedConstantReference) }


### PR DESCRIPTION
We had originally considered `Object` to be the final possible class in ancestor chains, which was a temporary measure to get resolution working. This PR changes this to ensure it's actually `BasicObject`, which is the correct final ancestor.

The PR looks large, but there are basically only 3 actual fixes outside of test updates:

1. I created a `built_in` file with information about the basic core modules and classes. It adds definitions and declarations. I documented in a comment why it is necessary
2. Changed the final class checks from `OBJECT_ID` to `BASIC_OBJECT_ID`
3. Started finalizing the linearization context when we are done with a declaration. This is important because otherwise the `seen_ids` information can leak across recursive calls and that results in incorrect results