### PR TITLE
Resolve retroactive method visibility changes

### DIFF
--- a/rust/rubydex/src/diagnostic.rs
+++ b/rust/rubydex/src/diagnostic.rs
@@ -107,4 +107,5 @@ rules! {
     InvalidMethodVisibility;
 
     // Resolution
+    UndefinedMethodVisibilityTarget;
 }

--- a/rust/rubydex/src/model/graph.rs
+++ b/rust/rubydex/src/model/graph.rs
@@ -14,6 +14,7 @@ use crate::model::ids::{ConstantReferenceId, DeclarationId, DefinitionId, Method
 use crate::model::name::{Name, NameRef, ParentScope, ResolvedName};
 use crate::model::references::{ConstantReference, MethodRef};
 use crate::model::string_ref::StringRef;
+use crate::model::visibility::Visibility;
 use crate::stats;
 
 /// An entity whose validity depends on a particular `NameId`.
@@ -599,6 +600,44 @@ impl Graph {
     #[must_use]
     pub fn name_dependents(&self) -> &IdentityHashMap<NameId, Vec<NameDependent>> {
         &self.name_dependents
+    }
+
+    /// Returns the visibility for a method declaration.
+    ///
+    /// Scans the declaration's backing definitions from the end:
+    /// - First `MethodVisibilityDefinition` wins
+    /// - Otherwise, falls back to the latest method-like definition's indexed visibility
+    /// - Returns `None` if the declaration has no definitions with visibility
+    #[must_use]
+    pub fn visibility(&self, declaration_id: &DeclarationId) -> Option<Visibility> {
+        let declaration = self.declarations.get(declaration_id)?;
+        let definitions = declaration.definitions();
+
+        // Scan from the end: last visibility directive wins
+        for def_id in definitions.iter().rev() {
+            if let Some(definition) = self.definitions.get(def_id) {
+                match definition {
+                    Definition::MethodVisibility(vis) => return Some(*vis.visibility()),
+                    Definition::Method(method) => return Some(*method.visibility()),
+                    Definition::AttrAccessor(attr) => return Some(*attr.visibility()),
+                    Definition::AttrReader(attr) => return Some(*attr.visibility()),
+                    Definition::AttrWriter(attr) => return Some(*attr.visibility()),
+                    Definition::Class(_)
+                    | Definition::SingletonClass(_)
+                    | Definition::Module(_)
+                    | Definition::Constant(_)
+                    | Definition::ConstantAlias(_)
+                    | Definition::ConstantVisibility(_)
+                    | Definition::GlobalVariable(_)
+                    | Definition::InstanceVariable(_)
+                    | Definition::ClassVariable(_)
+                    | Definition::MethodAlias(_)
+                    | Definition::GlobalVariableAlias(_) => {}
+                }
+            }
+        }
+
+        None
     }
 
     /// Drains the accumulated work items, returning them for use by the resolver.

--- a/rust/rubydex/src/resolution.rs
+++ b/rust/rubydex/src/resolution.rs
@@ -3,6 +3,7 @@ use std::{
     hash::BuildHasher,
 };
 
+use crate::diagnostic::{Diagnostic, Rule};
 use crate::model::{
     built_in::{BASIC_OBJECT_ID, CLASS_ID, KERNEL_ID, MODULE_ID, OBJECT_ID},
     declaration::{
@@ -272,6 +273,8 @@ impl<'a> Resolver<'a> {
     /// Handle other definitions that don't require resolution, but need to have their declarations and membership created
     #[allow(clippy::too_many_lines)]
     fn handle_remaining_definitions(&mut self, other_ids: Vec<DefinitionId>) {
+        let mut method_visibility_ids = Vec::new();
+
         for id in other_ids {
             match self.graph.definitions().get(&id).unwrap() {
                 Definition::Method(method_definition) => {
@@ -538,8 +541,8 @@ impl<'a> Resolver<'a> {
                 Definition::ConstantVisibility(_constant_visibility) => {
                     // TODO
                 }
-                Definition::MethodVisibility(_method_visibility) => {
-                    // TODO
+                Definition::MethodVisibility(_) => {
+                    method_visibility_ids.push(id);
                 }
                 Definition::Class(_)
                 | Definition::SingletonClass(_)
@@ -550,6 +553,91 @@ impl<'a> Resolver<'a> {
                 }
             }
         }
+
+        self.resolve_method_visibilities(method_visibility_ids);
+    }
+
+    /// Resolves retroactive method visibility changes (`private :foo`, `protected :foo`, `public :foo`).
+    ///
+    /// Runs as a second pass after all methods/attrs are declared, so `private :bar` works
+    /// regardless of whether `def bar` appeared before or after it in source.
+    fn resolve_method_visibilities(&mut self, visibility_ids: Vec<DefinitionId>) {
+        let mut pending_work = Vec::new();
+
+        for id in visibility_ids {
+            let Definition::MethodVisibility(method_visibility) = self.graph.definitions().get(&id).unwrap() else {
+                unreachable!()
+            };
+
+            let str_id = *method_visibility.str_id();
+            let uri_id = *method_visibility.uri_id();
+            let offset = method_visibility.offset().clone();
+            let lexical_nesting_id = *method_visibility.lexical_nesting_id();
+
+            let Some(owner_id) = self.resolve_lexical_owner(lexical_nesting_id) else {
+                continue;
+            };
+
+            let Some(Declaration::Namespace(namespace)) = self.graph.declarations().get(&owner_id) else {
+                continue;
+            };
+
+            let mut visibility_applied = false;
+            let mut has_partial = false;
+
+            for ancestor in namespace.ancestors() {
+                match ancestor {
+                    Ancestor::Complete(ancestor_id) => {
+                        let has_member = self
+                            .graph
+                            .declarations()
+                            .get(ancestor_id)
+                            .and_then(|decl| decl.as_namespace())
+                            .and_then(|ns| ns.member(&str_id))
+                            .is_some();
+
+                        if has_member {
+                            // Direct member: `create_declaration`'s fully qualified name dedup attaches
+                            // this visibility definition to the existing method declaration.
+                            // Inherited: a new child-owned declaration is created.
+                            self.create_declaration(str_id, id, owner_id, |name| {
+                                Declaration::Method(Box::new(MethodDeclaration::new(name, owner_id)))
+                            });
+                            visibility_applied = true;
+                            break;
+                        }
+                    }
+                    Ancestor::Partial(_) => has_partial = true,
+                }
+            }
+
+            if visibility_applied {
+                continue;
+            }
+
+            if has_partial {
+                // Method might exist on an unresolved ancestor — requeue for retry.
+                pending_work.push(Unit::Definition(id));
+            } else {
+                // Ancestors are fully resolved — method definitively doesn't exist.
+                let method_name = self.graph.strings().get(&str_id).unwrap().as_str().to_string();
+                let owner_name = self.graph.declarations().get(&owner_id).unwrap().name().to_string();
+                let diagnostic = Diagnostic::new(
+                    Rule::UndefinedMethodVisibilityTarget,
+                    uri_id,
+                    offset,
+                    format!("undefined method `{method_name}` for visibility change in `{owner_name}`"),
+                );
+                self.graph
+                    .declarations_mut()
+                    .get_mut(&owner_id)
+                    .unwrap()
+                    .add_diagnostic(diagnostic);
+            }
+        }
+
+        // Must extend work here so incremental resolution can resolve previously unresolved visibility operations
+        self.graph.extend_work(pending_work);
     }
 
     fn create_declaration<F>(

--- a/rust/rubydex/src/resolution_tests.rs
+++ b/rust/rubydex/src/resolution_tests.rs
@@ -4699,3 +4699,226 @@ mod todo_tests {
         assert_members_eq!(context, "Foo::<Foo>", ["bar()", "baz()"]);
     }
 }
+
+mod visibility_resolution_tests {
+    use super::*;
+    use crate::model::visibility::Visibility;
+
+    macro_rules! assert_visibility_eq {
+        ($context:expr, $declaration_name:expr, $expected_visibility:expr) => {
+            let decl_id = crate::model::ids::DeclarationId::from($declaration_name);
+            let actual = $context
+                .graph()
+                .visibility(&decl_id)
+                .unwrap_or_else(|| panic!("No visibility found for `{}`", $declaration_name));
+            assert_eq!(
+                actual, $expected_visibility,
+                "Expected `{}` to have visibility {}, got {}",
+                $declaration_name, $expected_visibility, actual
+            );
+        };
+    }
+
+    #[test]
+    fn retroactive_visibility_on_direct_method() {
+        let mut context = GraphTest::new();
+        context.index_uri(
+            "file:///foo.rb",
+            r"
+            class Foo
+              def bar; end
+              private :bar
+
+              def baz; end
+              protected :baz
+
+              private def qux; end
+              public :qux
+            end
+            ",
+        );
+        context.resolve();
+
+        assert_no_diagnostics!(&context);
+        assert_visibility_eq!(context, "Foo#bar()", Visibility::Private);
+        assert_visibility_eq!(context, "Foo#baz()", Visibility::Protected);
+        assert_visibility_eq!(context, "Foo#qux()", Visibility::Public);
+    }
+
+    #[test]
+    fn retroactive_visibility_on_attr_methods() {
+        let mut context = GraphTest::new();
+        context.index_uri(
+            "file:///foo.rb",
+            r"
+            class Foo
+              attr_reader :reader_method
+              private :reader_method
+
+              attr_writer :writer_method
+              protected :writer_method
+
+              attr_accessor :accessor_method
+              private :accessor_method
+            end
+            ",
+        );
+        context.resolve();
+
+        assert_no_diagnostics!(&context);
+        assert_visibility_eq!(context, "Foo#reader_method()", Visibility::Private);
+        assert_visibility_eq!(context, "Foo#writer_method()", Visibility::Protected);
+        assert_visibility_eq!(context, "Foo#accessor_method()", Visibility::Private);
+    }
+
+    #[test]
+    fn retroactive_visibility_on_inherited_method() {
+        let mut context = GraphTest::new();
+        context.index_uri(
+            "file:///foo.rb",
+            r"
+            class Parent
+              def foo; end
+            end
+
+            class Child < Parent
+              private :foo
+            end
+            ",
+        );
+        context.resolve();
+
+        assert_no_diagnostics!(&context);
+        assert_declaration_exists!(context, "Child#foo()");
+        assert_members_eq!(context, "Child", ["foo()"]);
+        assert_owner_eq!(context, "Child#foo()", "Child");
+        assert_visibility_eq!(context, "Child#foo()", Visibility::Private);
+        assert_visibility_eq!(context, "Parent#foo()", Visibility::Public);
+    }
+
+    #[test]
+    fn retroactive_visibility_on_grandparent_method() {
+        let mut context = GraphTest::new();
+        context.index_uri(
+            "file:///foo.rb",
+            r"
+            class GrandParent
+              def greet; end
+            end
+
+            class Parent < GrandParent; end
+
+            class Child < Parent
+              private :greet
+            end
+            ",
+        );
+        context.resolve();
+
+        assert_no_diagnostics!(&context);
+        assert_owner_eq!(context, "Child#greet()", "Child");
+        assert_visibility_eq!(context, "Child#greet()", Visibility::Private);
+    }
+
+    #[test]
+    fn retroactive_visibility_on_included_module_method() {
+        let mut context = GraphTest::new();
+        context.index_uri(
+            "file:///foo.rb",
+            r"
+            module Greetable
+              def greet; end
+            end
+
+            class Foo
+              include Greetable
+              private :greet
+            end
+            ",
+        );
+        context.resolve();
+
+        assert_no_diagnostics!(&context);
+        assert_owner_eq!(context, "Foo#greet()", "Foo");
+        assert_visibility_eq!(context, "Foo#greet()", Visibility::Private);
+    }
+
+    #[test]
+    fn retroactive_visibility_on_undefined_method_emits_diagnostic() {
+        let mut context = GraphTest::new();
+        context.index_uri(
+            "file:///foo.rb",
+            r"
+            class Foo
+              private :nonexistent
+            end
+            ",
+        );
+        context.resolve();
+
+        assert_diagnostics_eq!(
+            context,
+            &[
+                "undefined-method-visibility-target: undefined method `nonexistent()` for visibility change in `Foo` (2:12-2:23)"
+            ]
+        );
+    }
+
+    #[test]
+    fn retroactive_visibility_across_reopened_class() {
+        let mut context = GraphTest::new();
+        context.index_uri(
+            "file:///a.rb",
+            r"
+            class Foo
+              def bar; end
+            end
+            ",
+        );
+        context.index_uri(
+            "file:///b.rb",
+            r"
+            class Foo
+              private :bar
+            end
+            ",
+        );
+        context.resolve();
+
+        assert_no_diagnostics!(&context);
+        assert_visibility_eq!(context, "Foo#bar()", Visibility::Private);
+    }
+
+    #[test]
+    fn retroactive_visibility_resolves_when_ancestor_discovered_incrementally() {
+        let mut context = GraphTest::new();
+        context.index_uri(
+            "file:///child.rb",
+            r"
+            class Child
+              include M
+              private :foo
+            end
+            ",
+        );
+        context.resolve();
+
+        assert_no_diagnostics!(&context);
+        assert_declaration_does_not_exist!(context, "Child#foo()");
+
+        context.index_uri(
+            "file:///module.rb",
+            r"
+            module M
+              def foo; end
+            end
+            ",
+        );
+        context.resolve();
+
+        assert_no_diagnostics!(&context);
+        assert_declaration_exists!(context, "Child#foo()");
+        assert_owner_eq!(context, "Child#foo()", "Child");
+        assert_visibility_eq!(context, "Child#foo()", Visibility::Private);
+    }
+}


### PR DESCRIPTION
This PR continues the work in #89 and follows #695, which added indexing for `MethodVisibilityDefinition` and left the `Definition::MethodVisibility` arm in resolution as a TODO.

This change resolves retroactive `private`, `protected`, and `public` visibility changes by deferring visibility definitions to a second pass inside `handle_remaining_definitions`, so methods and attrs are always declared before visibility is applied.

For inherited targets such as `private :foo` where `foo` comes from a parent class or included module, the resolver creates a child-owned `MethodDeclaration`, matching CRuby's behaviour where `Child.instance_method(:foo).owner` is `Child`. When ancestor resolution is partial, unresolved visibility changes are requeued for a later resolve pass.

We also add diagnostics for undefined visibility targets and introduce `Graph::visibility()` as a helper for querying a method declaration's resolved visibility.

Note: This PR intentionally covers retroactive `private`, `protected`, and `public` resolution only. `module_function` will come in a follow-up PR because its dual instance/singleton behaviour needs separate handling.