### PR TITLE
Use BUNDLE_GEMFILE to determine if we need a debug build

### DIFF
--- a/ext/rubydex/extconf.rb
+++ b/ext/rubydex/extconf.rb
@@ -8,7 +8,18 @@ unless system("cargo", "--version", out: File::NULL, err: File::NULL)
 end
 
 gem_dir = Pathname.new("../..").expand_path(__dir__)
-release = ENV["RELEASE"] || !gem_dir.join(".git").exist?
+
+# Use release mode for the compilation if:
+# - The RELEASE environment variable is set
+# - We're not working on Rubydex (BUNDLE_GEMFILE doesn't point to Rubydex's own Gemfile)
+#
+# We only need debug builds when working on Rubydex itself and on CI. This approach also lets people install Rubydex
+# from the git source and get a release mode build
+
+bundle_gemfile = ENV["BUNDLE_GEMFILE"]
+developing_rubydex = bundle_gemfile && Pathname.new(bundle_gemfile).expand_path.dirname == gem_dir
+release = ENV["RELEASE"] || !developing_rubydex
+
 root_dir = gem_dir.join("rust")
 target_dir = root_dir.join("target")
 target_dir = target_dir.join("x86_64-pc-windows-gnu") if Gem.win_platform?


### PR DESCRIPTION
We were using the `.git` directory to determine if someone was working on Rubydex, so that we could decide between debug and release builds. Basically, there are two scenarios:

- When pre-compiling binaries on CI: we set the `RELEASE` flag
- When installing the gem for a platform we don't yet provide pre-compiled binaries: we fallback to this check

The issue is basically not confusing local development with the gem getting compiled in someone's machine. The `.git` directory choice is not a good one because if you install the gem from the git source, the directory will be there and then you get a slow debug build.

I think we can instead use `BUNDLE_GEMFILE`. Whenever we're working on Rubydex, Bundler is going to set the variable to point to the Rubydex Gemfile. If that is not set or if it points to something other than Rubydex's own Gemfile, then we can make release builds.