### PR TITLE
Hyphenate compound adjectives in project descriptions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ Use the available subagents to help the user accomplish the requested task:
 
 ## Project Overview
 
-This Ruby gem and companion Rust crate provide a modern, high performance and low memory usage code indexing and
+This Ruby gem and companion Rust crate provide a modern, high-performance and low-memory-usage code indexing and
 static analysis tools for hyper scale Ruby projects. The Rust crate is a library that implements all of the indexing
 and static analysis logic. The Ruby gem is a native extension written in C that connects to that Rust library and
 exposes a Ruby level API to interact with the logic.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Rubydex
 
-This project is a high performance static analysis toolkit for the Ruby language. The goal is to be a solid
+This project is a high-performance static analysis toolkit for the Ruby language. The goal is to be a solid
 foundation to power a variety of tools, such as type checkers, linters, language servers and more.
 
 ## Usage

--- a/rubydex.gemspec
+++ b/rubydex.gemspec
@@ -9,8 +9,8 @@ Gem::Specification.new do |spec|
   spec.email = ["ruby@shopify.com"]
   spec.licenses = ["MIT"]
 
-  spec.summary = "A high performance static analysis suite for Ruby"
-  spec.description = "A high performance static analysis suite for Ruby, built in Rust with Ruby APIs"
+  spec.summary = "A high-performance static analysis suite for Ruby"
+  spec.description = "A high-performance static analysis suite for Ruby, built in Rust with Ruby APIs"
   spec.homepage = "https://github.com/Shopify/rubydex"
   spec.required_ruby_version = ">= 3.2.0"
   spec.required_rubygems_version = ">= 3.3.11"


### PR DESCRIPTION
## Summary

* Fix "high performance" → "high-performance" when used as a compound adjective before a noun
* Applied consistently across gemspec, README.md, and AGENTS.md