### PR TITLE
Fix crash when invoking resolve_constant with an empty constant name

### DIFF
--- a/rust/rubydex-sys/src/graph_api.rs
+++ b/rust/rubydex-sys/src/graph_api.rs
@@ -131,7 +131,10 @@ pub unsafe extern "C" fn rdx_graph_resolve_constant(
     with_mut_graph(pointer, |graph| {
         let nesting: Vec<String> = unsafe { utils::convert_double_pointer_to_vec(nesting, count).unwrap() };
         let const_name: String = unsafe { utils::convert_char_ptr_to_string(const_name).unwrap() };
-        let (name_id, names_to_untrack) = name_api::nesting_stack_to_name_id(graph, &const_name, nesting);
+
+        let Some((name_id, names_to_untrack)) = name_api::nesting_stack_to_name_id(graph, &const_name, nesting) else {
+            return ptr::null();
+        };
 
         let mut resolver = Resolver::new(graph);
 
@@ -650,8 +653,8 @@ unsafe fn completion_nesting_name_id(
     graph: &mut Graph,
     nesting: *const *const c_char,
     nesting_count: usize,
-) -> Result<(NameId, Vec<NameId>), std::str::Utf8Error> {
-    let mut nesting: Vec<String> = unsafe { utils::convert_double_pointer_to_vec(nesting, nesting_count)? };
+) -> Option<(NameId, Vec<NameId>)> {
+    let mut nesting: Vec<String> = unsafe { utils::convert_double_pointer_to_vec(nesting, nesting_count).ok()? };
 
     // When serving completion in a bare script, the self (top level) context is Object
     let self_name = if nesting.is_empty() {
@@ -660,7 +663,7 @@ unsafe fn completion_nesting_name_id(
         nesting.pop().unwrap()
     };
 
-    Ok(name_api::nesting_stack_to_name_id(graph, &self_name, nesting))
+    name_api::nesting_stack_to_name_id(graph, &self_name, nesting)
 }
 
 /// The result of a completion operation, carrying either a candidate array or an error message.
@@ -771,7 +774,7 @@ pub unsafe extern "C" fn rdx_graph_complete_expression(
     nesting_count: usize,
 ) -> CompletionResult {
     with_mut_graph(pointer, |graph| {
-        let Ok((name_id, names_to_untrack)) = (unsafe { completion_nesting_name_id(graph, nesting, nesting_count) })
+        let Some((name_id, names_to_untrack)) = (unsafe { completion_nesting_name_id(graph, nesting, nesting_count) })
         else {
             return CompletionResult::success(ptr::null_mut());
         };
@@ -853,7 +856,7 @@ pub unsafe extern "C" fn rdx_graph_complete_method_argument(
     };
 
     with_mut_graph(pointer, |graph| {
-        let Ok((self_name_id, names_to_untrack)) =
+        let Some((self_name_id, names_to_untrack)) =
             (unsafe { completion_nesting_name_id(graph, nesting, nesting_count) })
         else {
             return CompletionResult::success(ptr::null_mut());

--- a/rust/rubydex-sys/src/name_api.rs
+++ b/rust/rubydex-sys/src/name_api.rs
@@ -6,12 +6,12 @@ use rubydex::model::{
 
 /// Takes a constant name and a nesting stack (e.g.: `["Foo", "Bar::Baz", "Qux"]`) and transforms it into a `NameId`,
 /// registering each required part in the graph. Returns the `NameId` and a list of name ids that need to be untracked
-/// afterwards
-///
-/// # Panics
-///
-/// Should not panic because `const_name` will always be turned into a name
-pub fn nesting_stack_to_name_id(graph: &mut Graph, const_name: &str, nesting: Vec<String>) -> (NameId, Vec<NameId>) {
+/// afterwards. Returns `None` if the constant name contains no valid identifier parts (e.g.: `""`, `"::"`, `"Foo::"`).
+pub fn nesting_stack_to_name_id(
+    graph: &mut Graph,
+    const_name: &str,
+    nesting: Vec<String>,
+) -> Option<(NameId, Vec<NameId>)> {
     let mut current_nesting = None;
     let mut current_name = ParentScope::None;
     let mut names_to_untrack = Vec::new();
@@ -45,10 +45,11 @@ pub fn nesting_stack_to_name_id(graph: &mut Graph, const_name: &str, nesting: Ve
         current_name = ParentScope::Some(name_id);
     }
 
-    (
-        current_name.expect("The NameId cannot be None since it contains at least `const_name`"),
-        names_to_untrack,
-    )
+    let (ParentScope::Some(name_id) | ParentScope::Attached(name_id)) = current_name else {
+        return None;
+    };
+
+    Some((name_id, names_to_untrack))
 }
 
 #[cfg(test)]
@@ -65,7 +66,8 @@ mod tests {
             &mut graph,
             "Some::CONST",
             vec!["Foo".into(), "Bar::Zip".into(), "Qux".into()],
-        );
+        )
+        .unwrap();
 
         let const_name = graph.names().get(&name_id).unwrap();
         assert_eq!(StringId::from("CONST"), *const_name.str());
@@ -101,7 +103,7 @@ mod tests {
     fn top_level_reference_is_converted_to_name_id() {
         let mut graph = Graph::new();
 
-        let (name_id, _) = nesting_stack_to_name_id(&mut graph, "::CONST", vec!["Foo".into()]);
+        let (name_id, _) = nesting_stack_to_name_id(&mut graph, "::CONST", vec!["Foo".into()]).unwrap();
 
         let const_name = graph.names().get(&name_id).unwrap();
         assert_eq!(StringId::from("CONST"), *const_name.str());
@@ -117,7 +119,7 @@ mod tests {
     fn top_level_nesting_is_converted_to_name_id() {
         let mut graph = Graph::new();
 
-        let (name_id, _) = nesting_stack_to_name_id(&mut graph, "CONST", vec!["Foo".into(), "::Bar".into()]);
+        let (name_id, _) = nesting_stack_to_name_id(&mut graph, "CONST", vec!["Foo".into(), "::Bar".into()]).unwrap();
 
         let const_name = graph.names().get(&name_id).unwrap();
         assert_eq!(StringId::from("CONST"), *const_name.str());

--- a/test/graph_test.rb
+++ b/test/graph_test.rb
@@ -284,6 +284,56 @@ class GraphTest < Minitest::Test
     assert_nil(graph.resolve_constant("CONST", ["Foo", "Bar::Baz"]))
   end
 
+  def test_graph_resolve_constant_with_empty_name
+    with_context do |context|
+      context.write!("foo.rb", <<~RUBY)
+        module Bar; end
+
+        module Foo
+          CONST = 123
+
+          class Bar::Baz
+            CONST
+          end
+        end
+      RUBY
+
+      graph = Rubydex::Graph.new
+      graph.index_all(context.glob("**/*.rb"))
+      graph.resolve
+
+      assert_nil(graph.resolve_constant("", []))
+      assert_nil(graph.resolve_constant("", ["Foo"]))
+      assert_nil(graph.resolve_constant("", ["Foo", "Bar::Baz"]))
+      assert_nil(graph.resolve_constant("::", []))
+      assert_nil(graph.resolve_constant("Foo::", []))
+      assert_nil(graph.resolve_constant("Foo::Bar::", ["Baz"]))
+    end
+  end
+
+  def test_graph_resolve_constant_with_empty_nesting
+    with_context do |context|
+      context.write!("foo.rb", <<~RUBY)
+        module Bar; end
+
+        module Foo
+          CONST = 123
+
+          class Bar::Baz
+            CONST
+          end
+        end
+      RUBY
+
+      graph = Rubydex::Graph.new
+      graph.index_all(context.glob("**/*.rb"))
+      graph.resolve
+
+      assert_equal("Bar", graph.resolve_constant("Bar", []).name)
+      assert_equal("Foo", graph.resolve_constant("Foo", []).name)
+    end
+  end
+
   def test_graph_resolve_constant_alias
     with_context do |context|
       context.write!("foo.rb", <<~RUBY)


### PR DESCRIPTION
We were crashing when invoking `resolve_constant` with an empty constant name or an incomplete name like `Foo::`. This PR ensures that we don't crash.

I considered raising an error instead of returning `nil`, but I talked myself out of doing so because then we'd essentially set the expectation that the API validates the fully qualified name. For example, `""` would raise, but without extra changes `#@@<Foo>` would be accepted. Instead of trying to validate every possible input, I just went with `nil`.