### PR TITLE
Fix latest clippy warnings

### DIFF
--- a/rust/rubydex-mcp/src/server.rs
+++ b/rust/rubydex-mcp/src/server.rs
@@ -333,8 +333,8 @@ impl RubydexServer {
         let members: Vec<serde_json::Value> = namespace
             .map(|ns| {
                 ns.members()
-                    .iter()
-                    .filter_map(|(_, member_id)| {
+                    .values()
+                    .filter_map(|member_id| {
                         let member_decl = graph.declarations().get(member_id)?;
                         let member_def = member_decl
                             .definitions()

--- a/rust/rubydex-sys/src/graph_api.rs
+++ b/rust/rubydex-sys/src/graph_api.rs
@@ -683,9 +683,7 @@ impl CompletionResult {
     fn error(message: &str) -> Self {
         Self {
             candidates: ptr::null_mut(),
-            error: CString::new(message)
-                .map(|s| s.into_raw().cast_const())
-                .unwrap_or(ptr::null()),
+            error: CString::new(message).map_or(ptr::null(), |s| s.into_raw().cast_const()),
         }
     }
 }

--- a/rust/rubydex/src/job_queue.rs
+++ b/rust/rubydex/src/job_queue.rs
@@ -46,10 +46,7 @@ impl JobQueue {
     pub fn run(queue: &Arc<JobQueue>) {
         // Determine the number of worker threads to launch.
         // Use the number of available logical CPUs, falling back to 4 if detection fails.
-        let worker_count = thread::available_parallelism()
-            .map(std::num::NonZeroUsize::get)
-            .unwrap_or(4);
-
+        let worker_count = thread::available_parallelism().map_or(4, std::num::NonZeroUsize::get);
         Self::run_with_workers(queue, worker_count);
     }
 
@@ -58,10 +55,7 @@ impl JobQueue {
     /// The caller is responsible for joining the returned handles. This allows
     /// overlapping other work (e.g. merging results) with job processing.
     pub fn run_without_waiting(queue: &Arc<JobQueue>) -> Vec<thread::JoinHandle<()>> {
-        let worker_count = thread::available_parallelism()
-            .map(std::num::NonZeroUsize::get)
-            .unwrap_or(4);
-
+        let worker_count = thread::available_parallelism().map_or(4, std::num::NonZeroUsize::get);
         Self::spawn_workers(queue, worker_count)
     }
 

--- a/rust/rubydex/src/query.rs
+++ b/rust/rubydex/src/query.rs
@@ -30,7 +30,7 @@ pub enum MatchMode {
 ///
 /// Will panic if any of the threads panic
 pub fn declaration_search(graph: &Graph, query: &str, match_mode: &MatchMode) -> Vec<DeclarationId> {
-    let num_threads = thread::available_parallelism().map(std::num::NonZero::get).unwrap_or(4);
+    let num_threads = thread::available_parallelism().map_or(4, std::num::NonZero::get);
     let declarations = graph.declarations();
     let ids: Vec<DeclarationId> = declarations.keys().copied().collect();
     let chunk_size = ids.len().div_ceil(num_threads);
@@ -120,7 +120,7 @@ pub fn resolve_require_path(graph: &Graph, require_path: &str, load_path: &[Path
 /// Panics if one of the search threads panics
 #[must_use]
 pub fn require_paths(graph: &Graph, load_paths: &[PathBuf]) -> Vec<String> {
-    let num_threads = thread::available_parallelism().map(std::num::NonZero::get).unwrap_or(4);
+    let num_threads = thread::available_parallelism().map_or(4, std::num::NonZero::get);
     let documents = graph.documents().iter().collect::<Vec<_>>();
     let chunk_size = documents.len().div_ceil(num_threads);
 


### PR DESCRIPTION
The latest clippy has a few extra warnings. I just auto-corrected the violations, which were mostly related to using `map_or` instead of achieving it manually.

The only different one is using `values()` instead of `iter()` on a map since it's more performant when the keys are ignored.