### PR TITLE
Expose keywords in the Ruby API

### DIFF
--- a/ext/rubydex/graph.c
+++ b/ext/rubydex/graph.c
@@ -648,6 +648,25 @@ static VALUE rdxr_graph_excluded_paths(VALUE self) {
     return array;
 }
 
+// Graph#keyword: (String name) -> Keyword?
+// Returns a Keyword object for the given keyword name, or nil if it is not a keyword.
+static VALUE rdxr_graph_keyword(VALUE self, VALUE name) {
+    Check_Type(name, T_STRING);
+
+    const CKeyword *kw = rdx_keyword_get(StringValueCStr(name));
+    if (kw == NULL) {
+        return Qnil;
+    }
+
+    VALUE argv[2] = {
+        rb_utf8_str_new_cstr(kw->name),
+        rb_utf8_str_new_cstr(kw->documentation),
+    };
+
+    rdx_keyword_free(kw);
+    return rb_class_new_instance(2, argv, cKeyword);
+}
+
 void rdxi_initialize_graph(VALUE moduleRubydex) {
     mRubydex = moduleRubydex;
     cGraph = rb_define_class_under(mRubydex, "Graph", rb_cObject);
@@ -678,4 +697,5 @@ void rdxi_initialize_graph(VALUE moduleRubydex) {
     rb_define_method(cGraph, "complete_method_argument", rdxr_graph_complete_method_argument, 2);
     rb_define_method(cGraph, "exclude_paths", rdxr_graph_exclude_paths, 1);
     rb_define_method(cGraph, "excluded_paths", rdxr_graph_excluded_paths, 0);
+    rb_define_method(cGraph, "keyword", rdxr_graph_keyword, 1);
 }

--- a/rust/rubydex-sys/src/graph_api.rs
+++ b/rust/rubydex-sys/src/graph_api.rs
@@ -10,6 +10,7 @@ use rubydex::indexing::LanguageId;
 use rubydex::model::encoding::Encoding;
 use rubydex::model::graph::Graph;
 use rubydex::model::ids::{DeclarationId, NameId};
+use rubydex::model::keywords;
 use rubydex::model::name::NameRef;
 use rubydex::query::{CompletionCandidate, CompletionContext, CompletionReceiver};
 use rubydex::resolution::Resolver;
@@ -868,6 +869,73 @@ pub unsafe extern "C" fn rdx_graph_complete_method_argument(
             names_to_untrack,
         )
     })
+}
+
+#[repr(C)]
+pub struct CKeyword {
+    name: *const c_char,
+    documentation: *const c_char,
+}
+
+/// Looks up a Ruby keyword by its exact name.
+/// Returns a heap-allocated `CKeyword` if found, or NULL if the name is not a keyword.
+/// Caller must free with `rdx_keyword_free`.
+///
+/// # Safety
+///
+/// - `name` must be a valid, null-terminated UTF-8 string.
+///
+/// # Panics
+///
+/// Will panic if the keyword's name or documentation contains an internal NUL byte
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rdx_keyword_get(name: *const c_char) -> *const CKeyword {
+    let Ok(name_str) = (unsafe { utils::convert_char_ptr_to_string(name) }) else {
+        return ptr::null();
+    };
+
+    match keywords::get(&name_str) {
+        Some(kw) => {
+            let c_name = CString::new(kw.name())
+                .expect("keyword name must not contain NUL")
+                .into_raw()
+                .cast_const();
+
+            let c_doc = CString::new(kw.documentation())
+                .expect("keyword documentation must not contain NUL")
+                .into_raw()
+                .cast_const();
+
+            Box::into_raw(Box::new(CKeyword {
+                name: c_name,
+                documentation: c_doc,
+            }))
+            .cast_const()
+        }
+        None => ptr::null(),
+    }
+}
+
+/// Frees a `CKeyword` previously returned by `rdx_keyword_get`.
+///
+/// # Safety
+///
+/// - `ptr` must be a valid pointer previously returned by `rdx_keyword_get`, or NULL.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rdx_keyword_free(ptr: *const CKeyword) {
+    if ptr.is_null() {
+        return;
+    }
+
+    let kw = unsafe { Box::from_raw(ptr.cast_mut()) };
+
+    if !kw.name.is_null() {
+        let _ = unsafe { CString::from_raw(kw.name.cast_mut()) };
+    }
+
+    if !kw.documentation.is_null() {
+        let _ = unsafe { CString::from_raw(kw.documentation.cast_mut()) };
+    }
 }
 
 #[cfg(test)]

--- a/test/graph_test.rb
+++ b/test/graph_test.rb
@@ -870,6 +870,30 @@ class GraphTest < Minitest::Test
     end
   end
 
+  def test_accessing_keyword_information
+    graph = Rubydex::Graph.new
+    keyword = graph.keyword("break")
+
+    assert_equal("break", keyword.name)
+    assert_equal("Exits from a loop or block, optionally returning a value. Syntax: `break` or `break value`.", keyword.documentation)
+  end
+
+  def test_keyword_returns_nil_for_non_keyword
+    graph = Rubydex::Graph.new
+    assert_nil(graph.keyword("not_a_keyword"))
+  end
+
+  def test_keyword_returns_nil_for_empty_string
+    graph = Rubydex::Graph.new
+    assert_nil(graph.keyword(""))
+  end
+
+  def test_keyword_raises_type_error_for_non_string
+    graph = Rubydex::Graph.new
+    assert_raises(TypeError) { graph.keyword(123) }
+    assert_raises(TypeError) { graph.keyword(nil) }
+  end
+
   private
 
   def assert_diagnostics(expected, actual)


### PR DESCRIPTION
Expose keyword information from the graph in the Ruby API, so that we can use it for hover.