### PR TITLE
Expose constant alias targets in the Ruby API

### DIFF
--- a/ext/rubydex/declaration.c
+++ b/ext/rubydex/declaration.c
@@ -407,6 +407,28 @@ static VALUE rdxr_variable_declaration_references(VALUE self) {
     return rb_ary_new();
 }
 
+// ConstantAlias#target -> Declaration?
+// Returns the first resolved target declaration for this constant alias, or nil if none of its definitions resolved to
+// a target
+static VALUE rdxr_constant_alias_target(VALUE self) {
+    HandleData *data;
+    TypedData_Get_Struct(self, HandleData, &handle_type, data);
+
+    void *graph;
+    TypedData_Get_Struct(data->graph_obj, void *, &graph_type, graph);
+
+    const CDeclaration *decl = rdx_constant_alias_target(graph, data->id);
+    if (decl == NULL) {
+        return Qnil;
+    }
+
+    VALUE decl_class = rdxi_declaration_class_for_kind(decl->kind);
+    VALUE argv[] = {data->graph_obj, ULL2NUM(decl->id)};
+    free_c_declaration(decl);
+
+    return rb_class_new_instance(2, argv, decl_class);
+}
+
 void rdxi_initialize_declaration(VALUE mRubydex) {
     cDeclaration = rb_define_class_under(mRubydex, "Declaration", rb_cObject);
     cNamespace = rb_define_class_under(mRubydex, "Namespace", cDeclaration);
@@ -440,6 +462,7 @@ void rdxi_initialize_declaration(VALUE mRubydex) {
     // Constant and ConstantAlias have constant references
     rb_define_method(cConstant, "references", rdxr_constant_declaration_references, 0);
     rb_define_method(cConstantAlias, "references", rdxr_constant_declaration_references, 0);
+    rb_define_method(cConstantAlias, "target", rdxr_constant_alias_target, 0);
 
     // Method has method references
     rb_define_method(cMethod, "references", rdxr_method_declaration_references, 0);

--- a/rbi/rubydex.rbi
+++ b/rbi/rubydex.rbi
@@ -76,6 +76,9 @@ end
 class Rubydex::ConstantAlias < Rubydex::Declaration
   sig { returns(T::Enumerable[Rubydex::ConstantReference]) }
   def references; end
+
+  sig { returns(T.nilable(Rubydex::Declaration)) }
+  def target; end
 end
 
 class Rubydex::ClassVariable < Rubydex::Declaration

--- a/rust/rubydex-sys/src/declaration_api.rs
+++ b/rust/rubydex-sys/src/declaration_api.rs
@@ -424,6 +424,34 @@ pub unsafe extern "C" fn rdx_declaration_members(pointer: GraphPointer, decl_id:
     DeclarationsIter::new(declarations.into_boxed_slice())
 }
 
+/// Returns the first resolved target declaration for a constant alias declaration, or NULL if the declaration is not
+/// a constant alias or none of its definitions have a resolved target.
+///
+/// # Safety
+///
+/// Assumes that the graph pointer is valid.
+///
+/// # Panics
+///
+/// Will panic if there's inconsistent graph data
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rdx_constant_alias_target(pointer: GraphPointer, decl_id: u64) -> *const CDeclaration {
+    with_graph(pointer, |graph| {
+        let declaration_id = DeclarationId::new(decl_id);
+
+        let Some(targets) = graph.alias_targets(&declaration_id) else {
+            return ptr::null();
+        };
+
+        let Some(&target_id) = targets.first() else {
+            return ptr::null();
+        };
+
+        let target_decl = graph.declarations().get(&target_id).unwrap();
+        Box::into_raw(Box::new(CDeclaration::from_declaration(target_id, target_decl))).cast_const()
+    })
+}
+
 /// Creates a new iterator over constant references for a given declaration.
 ///
 /// # Safety

--- a/test/declaration_test.rb
+++ b/test/declaration_test.rb
@@ -608,4 +608,114 @@ class DeclarationTest < Minitest::Test
       assert_equal("Foo#initialize()", decl.name)
     end
   end
+
+  def test_following_constant_alias_targets
+    with_context do |context|
+      context.write!("file1.rb", <<~RUBY)
+        module Foo
+          class Bar
+          end
+        end
+
+        module Baz
+          Qux = Foo
+        end
+
+        ALIAS = Baz
+        # This is the same as Foo::Bar. We need to be able to follow the alias step by step
+        ALIAS::Qux::Bar
+      RUBY
+
+      graph = Rubydex::Graph.new
+      graph.index_all(context.glob("**/*.rb"))
+      graph.resolve
+
+      alias_decl = graph["ALIAS"]
+      assert_instance_of(Rubydex::ConstantAlias, alias_decl)
+
+      baz = alias_decl.target
+      assert_instance_of(Rubydex::Module, baz)
+      assert_equal("Baz", baz.name)
+
+      qux = baz.member("Qux")
+      assert_instance_of(Rubydex::ConstantAlias, qux)
+      assert_equal("Baz::Qux", qux.name)
+
+      foo = qux.target
+      assert_instance_of(Rubydex::Module, foo)
+      assert_equal("Foo", foo.name)
+
+      bar = foo.member("Bar")
+      assert_instance_of(Rubydex::Class, bar)
+      assert_equal("Foo::Bar", bar.name)
+    end
+  end
+
+  def test_unresolved_constant_alias_target_returns_nil
+    with_context do |context|
+      context.write!("file1.rb", <<~RUBY)
+        ALIAS = NonexistentConstant
+      RUBY
+
+      graph = Rubydex::Graph.new
+      graph.index_all(context.glob("**/*.rb"))
+      graph.resolve
+
+      alias_decl = graph["ALIAS"]
+      assert_instance_of(Rubydex::ConstantAlias, alias_decl)
+      assert_nil(alias_decl.target)
+    end
+  end
+
+  def test_circular_constant_alias_target
+    with_context do |context|
+      context.write!("file1.rb", <<~RUBY)
+        A = B
+        B = A
+      RUBY
+
+      graph = Rubydex::Graph.new
+      graph.index_all(context.glob("**/*.rb"))
+      graph.resolve
+
+      a = graph["A"]
+      assert_instance_of(Rubydex::ConstantAlias, a)
+
+      b = a.target
+      assert_instance_of(Rubydex::ConstantAlias, b)
+      assert_equal("B", b.name)
+
+      a_again = b.target
+      assert_instance_of(Rubydex::ConstantAlias, a_again)
+      assert_equal("A", a_again.name)
+    end
+  end
+
+  def test_constant_alias_with_multiple_definitions_returns_one_resolved_target
+    with_context do |context|
+      context.write!("file1.rb", <<~RUBY)
+        module Foo; end
+        ALIAS = Foo
+      RUBY
+
+      context.write!("file2.rb", <<~RUBY)
+        module Bar; end
+        ALIAS = Bar
+      RUBY
+
+      graph = Rubydex::Graph.new
+      graph.index_all(context.glob("**/*.rb"))
+      graph.resolve
+
+      alias_decl = graph["ALIAS"]
+      assert_instance_of(Rubydex::ConstantAlias, alias_decl)
+
+      target = alias_decl.target
+      assert_instance_of(Rubydex::Module, target)
+
+      # Since ALIAS has two definitions pointing to different targets and we just pick the first one, it could be either
+      # `Foo` or `Bar`. We check for any of them here to avoid having a flaky test
+      assert_includes(["Foo", "Bar"], target.name)
+    end
+  end
 end


### PR DESCRIPTION
Closes #689

This PR exposes constant alias targets in the Ruby API, which is necessary for correct completion in the Ruby LSP.

The implementation is pretty straight forward, we are just using existing Rust APIs.