### PR TITLE
Unlink Rust shared shared object before copying

### DIFF
--- a/ext/rubydex/extconf.rb
+++ b/ext/rubydex/extconf.rb
@@ -86,11 +86,15 @@ copy_dylib_commands = if Gem.win_platform?
   ""
 elsif RUBY_PLATFORM.include?("darwin")
   src_dylib = target_dir.join("librubydex_sys.dylib")
-  "\t$(COPY) #{src_dylib} #{lib_dir}"
+  dst_dylib = lib_dir.join("librubydex_sys.dylib")
+  # Unlink before copy so the new dylib gets a fresh inode. Overwriting in place while another process
+  # (e.g. the Ruby LSP) has the old dylib mmap'd triggers a macOS code-signing SIGKILL on its next page fault.
+  "\t$(Q)$(RM) #{dst_dylib}\n\t$(COPY) #{src_dylib} #{lib_dir}"
 else
   # Linux
   src_dylib = target_dir.join("librubydex_sys.so")
-  "\t$(COPY) #{src_dylib} #{lib_dir}"
+  dst_dylib = lib_dir.join("librubydex_sys.so")
+  "\t$(Q)$(RM) #{dst_dylib}\n\t$(COPY) #{src_dylib} #{lib_dir}"
 end
 
 rust_srcs = Dir.glob("#{root_dir}/**/*.rs").reject { |path| path.include?("rust/target") }


### PR DESCRIPTION
I believe this fixes the SIGKILL issues we've been getting when developing. My understanding of the problem is:

1. The Ruby LSP launches using the development version of Rubydex in the repo, which loads the `librubydex_sys.dylib`
2. As we're working on Rubydex, we re-compile and the dylib gets overridden
3. The problem is that we're not unlinking (rm) and then creating the new one, but just copying straight away, which macOS flags as insecure and interrupts with a SIGKILL

I tested this a bit and it seems that the issue indeed goes away.