### PR TITLE
Install cargo-about with --features cli

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       # Verify that licenses conform to the policy in rust/about.toml
       - name: Check licenses
         run: |
-          cargo install cargo-about
+          cargo install cargo-about --features cli
           cargo about generate rust/about_templates --name about --manifest-path rust/Cargo.toml --workspace > THIRD_PARTY_LICENSES.html
   build:
     strategy:

--- a/.github/workflows/cibuildgem.yaml
+++ b/.github/workflows/cibuildgem.yaml
@@ -27,7 +27,7 @@ jobs:
           ruby-version: "3.2.9"
           bundler-cache: true
       - name: "Install cargo-about"
-        run: cargo install cargo-about
+        run: cargo install cargo-about --features cli
       - name: "Run cibuildgem"
         uses: "shopify/cibuildgem/.github/actions/cibuildgem@main"
         with:

--- a/.github/workflows/indexing_top_gems.yml
+++ b/.github/workflows/indexing_top_gems.yml
@@ -13,7 +13,6 @@ jobs:
           rustup update --no-self-update stable
           rustup default stable
           rustup component add --toolchain stable clippy rustfmt
-          cargo install cargo-about
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@0cb964fd540e0a24c900370abf38a33466142735 # v1.305.0


### PR DESCRIPTION

cargo-about 0.9.0 moved the CLI binary behind a non-default `cli` feature. Without the flag, `cargo install cargo-about` builds the library but skips the binary, so `cargo about generate` fails with `no such command: about`.


- Added `--features cli` to `cargo install cargo-about` in the workflows that invoke `cargo about generate`:
  - `.github/workflows/ci.yml`
  - `.github/workflows/cibuildgem.yaml`
- Dropped the unused `cargo install cargo-about` line from `.github/workflows/indexing_top_gems.yml`.