### PR TITLE
Resolve constants against enclosing lexical scope in `class << self`

### DIFF
--- a/rust/rubydex-sys/src/name_api.rs
+++ b/rust/rubydex-sys/src/name_api.rs
@@ -44,9 +44,10 @@ pub fn nesting_stack_to_name_id(
 }
 
 /// Processes a qualified name (e.g., `"Foo::Bar"` or `"<Foo>"`) by splitting on `"::"` and registering each part in the
-/// graph. Singleton class names (starting with `<`) use `ParentScope::Attached` and `nesting=None`, matching how the
-/// indexer creates them. When a singleton is the first part (i.e., `current_name` has no parent), `current_nesting` is
-/// used as the attachment point.
+/// graph. Singleton class names (starting with `<`) use `ParentScope::Attached` and a `nesting` equal to the attached
+/// target, matching how the indexer creates them (`class << self` always sits lexically inside its attached class).
+/// When a singleton is the first part (i.e., `current_name` has no parent), `current_nesting` is used as the attachment
+/// point.
 fn process_qualified_name(
     graph: &mut Graph,
     qualified_name: &str,
@@ -61,12 +62,13 @@ fn process_qualified_name(
         }
 
         let (parent_scope, nesting_for_part) = if part.starts_with('<') {
-            let attached = match *current_name {
-                ParentScope::Some(id) | ParentScope::Attached(id) => ParentScope::Attached(id),
-                _ => current_nesting.map_or(ParentScope::None, ParentScope::Attached),
+            let attached_id = match *current_name {
+                ParentScope::Some(id) | ParentScope::Attached(id) => Some(id),
+                _ => *current_nesting,
             };
 
-            (attached, None)
+            let attached = attached_id.map_or(ParentScope::None, ParentScope::Attached);
+            (attached, attached_id)
         } else {
             (*current_name, *current_nesting)
         };

--- a/rust/rubydex/src/indexing/ruby_indexer.rs
+++ b/rust/rubydex/src/indexing/ruby_indexer.rs
@@ -1507,9 +1507,10 @@ impl Visit<'_> for RubyIndexer<'_> {
         };
 
         let string_id = self.local_graph.intern_string(singleton_class_name);
+        let nesting = self.current_lexical_scope_name_id();
         let name_id = self
             .local_graph
-            .add_name(Name::new(string_id, ParentScope::Attached(attached_target), None));
+            .add_name(Name::new(string_id, ParentScope::Attached(attached_target), nesting));
 
         let definition = Definition::SingletonClass(Box::new(SingletonClassDefinition::new(
             name_id,

--- a/rust/rubydex/src/model/graph.rs
+++ b/rust/rubydex/src/model/graph.rs
@@ -2273,14 +2273,14 @@ mod tests {
         assert_eq!(13, context.graph().constant_references.len());
         assert_eq!(2, context.graph().method_references.len());
         assert_eq!(2, context.graph().documents.len());
-        assert_eq!(19, context.graph().names.len());
+        assert_eq!(20, context.graph().names.len());
         assert_eq!(47, context.graph().strings.len());
         context.index_uri("file:///foo.rb", source);
         assert_eq!(49, context.graph().definitions.len());
         assert_eq!(13, context.graph().constant_references.len());
         assert_eq!(2, context.graph().method_references.len());
         assert_eq!(2, context.graph().documents.len());
-        assert_eq!(19, context.graph().names.len());
+        assert_eq!(20, context.graph().names.len());
         assert_eq!(47, context.graph().strings.len());
     }
 

--- a/rust/rubydex/src/query.rs
+++ b/rust/rubydex/src/query.rs
@@ -897,7 +897,7 @@ mod tests {
         context.resolve();
 
         let foo_id = Name::new(StringId::from("Foo"), ParentScope::None, None).id();
-        let name_id = Name::new(StringId::from("<Foo>"), ParentScope::Attached(foo_id), None).id();
+        let name_id = Name::new(StringId::from("<Foo>"), ParentScope::Attached(foo_id), Some(foo_id)).id();
         assert_declaration_completion_eq!(
             context,
             CompletionReceiver::Expression(name_id),

--- a/rust/rubydex/src/resolution_tests.rs
+++ b/rust/rubydex/src/resolution_tests.rs
@@ -357,6 +357,146 @@ fn resolution_for_singleton_class_of_external_constant() {
 }
 
 #[test]
+fn resolves_sibling_constant_inside_singleton_class_method_body() {
+    // Constant referenced from inside a method defined in `class << self` must resolve against
+    // the lexical scope that encloses the singleton class block, not stop at the singleton class.
+    let mut context = GraphTest::new();
+    context.index_uri("file:///foo.rb", {
+        r"
+        module A
+          module B
+            class Sibling; end
+
+            class Main
+              class << self
+                def does_not_resolve_here
+                  Sibling
+                end
+              end
+            end
+          end
+        end
+        "
+    });
+    context.resolve();
+
+    assert_no_diagnostics!(&context);
+    assert_constant_reference_to!(context, "A::B::Sibling", "file:///foo.rb:8:11-8:18");
+}
+
+#[test]
+fn resolves_sibling_constant_inside_nested_singleton_class() {
+    // Nested `class << self` inside a nested class: lookup must still walk outward through
+    // every enclosing lexical scope to find a sibling defined far above.
+    let mut context = GraphTest::new();
+    context.index_uri("file:///foo.rb", {
+        r"
+        module A
+          module B
+            class Sibling; end
+
+            class Main
+              class Inner
+                class << self
+                  def m
+                    Sibling
+                  end
+                end
+              end
+            end
+          end
+        end
+        "
+    });
+    context.resolve();
+
+    assert_no_diagnostics!(&context);
+    assert_constant_reference_to!(context, "A::B::Sibling", "file:///foo.rb:9:13-9:20");
+}
+
+#[test]
+fn resolves_sibling_constant_directly_in_singleton_class_body() {
+    // Constant referenced directly in the `class << self` body (not inside a method) — e.g.
+    // passed as an argument to a class-level DSL call — must also resolve lexically.
+    let mut context = GraphTest::new();
+    context.index_uri("file:///foo.rb", {
+        r"
+        module A
+          module B
+            class Sibling; end
+
+            class Main
+              class << self
+                Sibling
+              end
+            end
+          end
+        end
+        "
+    });
+    context.resolve();
+
+    assert_no_diagnostics!(&context);
+    assert_constant_reference_to!(context, "A::B::Sibling", "file:///foo.rb:7:9-7:16");
+}
+
+#[test]
+fn singleton_class_lexical_scope_still_resolves_sibling_from_other_scopes() {
+    // Sanity / non-regression: a sibling constant must continue to resolve from every other
+    // scope where it already worked (instance method body, class body, top level).
+    let mut context = GraphTest::new();
+    context.index_uri("file:///foo.rb", {
+        r"
+        module A
+          module B
+            class Sibling; end
+
+            class Main
+              Sibling
+
+              def instance_method
+                Sibling
+              end
+            end
+
+            Sibling
+          end
+        end
+        "
+    });
+    context.resolve();
+
+    assert_no_diagnostics!(&context, &[Rule::ParseWarning]);
+    assert_constant_reference_to!(context, "A::B::Sibling", "file:///foo.rb:6:7-6:14");
+    assert_constant_reference_to!(context, "A::B::Sibling", "file:///foo.rb:9:9-9:16");
+    assert_constant_reference_to!(context, "A::B::Sibling", "file:///foo.rb:13:5-13:12");
+}
+
+#[test]
+fn singleton_class_scope_does_not_over_resolve_unknown_constant() {
+    // Sanity: a constant that genuinely does not exist must remain unresolved even with the
+    // fix in place — the fix must not invent resolutions by walking too far.
+    let mut context = GraphTest::new();
+    context.index_uri("file:///foo.rb", {
+        r"
+        module A
+          class Main
+            class << self
+              def m
+                NotDefined
+              end
+            end
+          end
+        end
+        "
+    });
+    context.resolve();
+
+    assert_no_diagnostics!(&context, &[Rule::ParseWarning]);
+    assert_constant_reference_unresolved!(context, "NotDefined", "file:///foo.rb:5:9-5:19");
+}
+
+#[test]
 fn resolution_for_class_variable_in_nested_singleton_class() {
     let mut context = GraphTest::new();
     context.index_uri("file:///foo.rb", {


### PR DESCRIPTION
## Summary

Fixes a constant-resolution bug in `class << self` bodies. Constants referenced from inside a singleton class block (or from methods defined inside one) were not resolving against the enclosing lexical scope. For example:

```ruby
module A
  module B
    class Sibling; end

    class Main
      class << self
        def m
          Sibling   # was left unresolved
        end
      end
    end
  end
end
```

## Root cause

The resolution algorithm already walks lexical scopes correctly; it follows the `nesting` linked list on each `Name`. The bug was in the indexer: when the singleton class `Name` was created, its `nesting` was set to `None`, so the walk terminated at the singleton class frame and never reached `A::B` or `A`.

## Fix

One-line change in `RubyIndexer::visit_singleton_class_node`: populate the singleton class `Name`'s `nesting` with the current lexical scope at the point of the `class << self` block, matching how regular classes and modules are indexed.

Two existing tests are updated to reflect the new `Name` identity: `<Foo>` with a nesting interns to a different `Name` than `<Foo>` without one.

## Tests

Added 5 tests covering:

- `Sibling` used inside a method in `class << self`
- `Sibling` used inside `class << self` nested under an outer class
- `Sibling` used directly in the `class << self` body (not inside a method)
- Non-regression: sibling still resolves from instance method / class body / top level
- Does not over-resolve unknown constants

All 528 rubydex tests pass; clippy and fmt are clean.