### PR TITLE
Only build compilation database if working on rubydex

### DIFF
--- a/ext/rubydex/extconf.rb
+++ b/ext/rubydex/extconf.rb
@@ -141,10 +141,12 @@ end
 
 File.write("Makefile", new_makefile)
 
-begin
-  require "extconf_compile_commands_json"
+if developing_rubydex
+  begin
+    require "extconf_compile_commands_json"
 
-  ExtconfCompileCommandsJson.generate!
-  ExtconfCompileCommandsJson.symlink!
-rescue LoadError # rubocop:disable Lint/SuppressedException
+    ExtconfCompileCommandsJson.generate!
+    ExtconfCompileCommandsJson.symlink!
+  rescue LoadError # rubocop:disable Lint/SuppressedException
+  end
 end


### PR DESCRIPTION
Trying to install the gem from the git source might fail when building the compilation database, but we don't need to build it unless we're working on the gem.