### PR TITLE
Resolve retroactive constant visibility changes

### DIFF
--- a/rust/rubydex/src/diagnostic.rs
+++ b/rust/rubydex/src/diagnostic.rs
@@ -108,4 +108,5 @@ rules! {
 
     // Resolution
     UndefinedMethodVisibilityTarget;
+    UndefinedConstantVisibilityTarget;
 }

--- a/rust/rubydex/src/model/graph.rs
+++ b/rust/rubydex/src/model/graph.rs
@@ -288,6 +288,16 @@ impl Graph {
         &self.documents
     }
 
+    /// Attaches a diagnostic to the document with the given `uri_id`. The diagnostic clears
+    /// automatically when the document is deleted or re-indexed.
+    ///
+    /// # Panics
+    ///
+    /// Panics if no document is registered for `uri_id`.
+    pub fn add_document_diagnostic(&mut self, uri_id: UriId, diagnostic: Diagnostic) {
+        self.documents.get_mut(&uri_id).unwrap().add_diagnostic(diagnostic);
+    }
+
     /// # Panics
     ///
     /// Panics if the definition is not found
@@ -602,42 +612,50 @@ impl Graph {
         &self.name_dependents
     }
 
-    /// Returns the visibility for a method declaration.
+    /// Returns the visibility for a declaration.
     ///
-    /// Scans the declaration's backing definitions from the end:
-    /// - First `MethodVisibilityDefinition` wins
-    /// - Otherwise, falls back to the latest method-like definition's indexed visibility
-    /// - Returns `None` if the declaration has no definitions with visibility
+    /// For methods, the latest definition wins. For constants, the latest
+    /// `private_constant`/`public_constant` wins, otherwise `Public`.
     #[must_use]
     pub fn visibility(&self, declaration_id: &DeclarationId) -> Option<Visibility> {
         let declaration = self.declarations.get(declaration_id)?;
         let definitions = declaration.definitions();
 
-        // Scan from the end: last visibility directive wins
-        for def_id in definitions.iter().rev() {
-            if let Some(definition) = self.definitions.get(def_id) {
-                match definition {
-                    Definition::MethodVisibility(vis) => return Some(*vis.visibility()),
-                    Definition::Method(method) => return Some(*method.visibility()),
-                    Definition::AttrAccessor(attr) => return Some(*attr.visibility()),
-                    Definition::AttrReader(attr) => return Some(*attr.visibility()),
-                    Definition::AttrWriter(attr) => return Some(*attr.visibility()),
-                    Definition::Class(_)
-                    | Definition::SingletonClass(_)
-                    | Definition::Module(_)
-                    | Definition::Constant(_)
-                    | Definition::ConstantAlias(_)
-                    | Definition::ConstantVisibility(_)
-                    | Definition::GlobalVariable(_)
-                    | Definition::InstanceVariable(_)
-                    | Definition::ClassVariable(_)
-                    | Definition::MethodAlias(_)
-                    | Definition::GlobalVariableAlias(_) => {}
+        match declaration {
+            Declaration::Namespace(Namespace::Class(_) | Namespace::Module(_))
+            | Declaration::Constant(_)
+            | Declaration::ConstantAlias(_) => {
+                for def_id in definitions.iter().rev() {
+                    if let Some(Definition::ConstantVisibility(vis)) = self.definitions.get(def_id) {
+                        return Some(*vis.visibility());
+                    }
                 }
+                Some(Visibility::Public)
             }
+            Declaration::Method(_) => {
+                for def_id in definitions.iter().rev() {
+                    let Some(definition) = self.definitions.get(def_id) else {
+                        continue;
+                    };
+                    let visibility = match definition {
+                        Definition::MethodVisibility(vis) => Some(*vis.visibility()),
+                        Definition::Method(method) => Some(*method.visibility()),
+                        Definition::AttrAccessor(attr) => Some(*attr.visibility()),
+                        Definition::AttrReader(attr) => Some(*attr.visibility()),
+                        Definition::AttrWriter(attr) => Some(*attr.visibility()),
+                        _ => None,
+                    };
+                    if visibility.is_some() {
+                        return visibility;
+                    }
+                }
+                None
+            }
+            Declaration::Namespace(Namespace::SingletonClass(_) | Namespace::Todo(_))
+            | Declaration::GlobalVariable(_)
+            | Declaration::InstanceVariable(_)
+            | Declaration::ClassVariable(_) => None,
         }
-
-        None
     }
 
     /// Drains the accumulated work items, returning them for use by the resolver.

--- a/rust/rubydex/src/resolution.rs
+++ b/rust/rubydex/src/resolution.rs
@@ -546,8 +546,63 @@ impl<'a> Resolver<'a> {
                         Declaration::GlobalVariable(Box::new(GlobalVariableDeclaration::new(name, *OBJECT_ID)))
                     });
                 }
-                Definition::ConstantVisibility(_constant_visibility) => {
-                    // TODO
+                Definition::ConstantVisibility(constant_visibility) => {
+                    // Both `private_constant` and `public_constant` can only target direct members.
+                    // Inheritance or surrounding lexical scopes are not taken into account.
+                    let receiver = *constant_visibility.receiver();
+                    let target = *constant_visibility.target();
+                    let uri_id = *constant_visibility.uri_id();
+                    let offset = constant_visibility.offset().clone();
+                    let lexical_nesting_id = *constant_visibility.lexical_nesting_id();
+                    let constant_name = self.graph.strings().get(&target).unwrap().as_str().to_string();
+
+                    let owner_id = if let Some(receiver_name_id) = receiver {
+                        let NameRef::Resolved(resolved_receiver) = self.graph.names().get(&receiver_name_id).unwrap()
+                        else {
+                            continue;
+                        };
+                        let Some(namespace_id) = self.resolve_to_namespace(*resolved_receiver.declaration_id()) else {
+                            continue;
+                        };
+                        namespace_id
+                    } else {
+                        let Some(decl_id) = self.resolve_lexical_owner(lexical_nesting_id, id) else {
+                            continue;
+                        };
+                        decl_id
+                    };
+
+                    let Some(Declaration::Namespace(namespace)) = self.graph.declarations().get(&owner_id) else {
+                        continue;
+                    };
+
+                    if let Some(member) = namespace
+                        .member(&target)
+                        .and_then(|member_id| self.graph.declarations().get(member_id))
+                        && matches!(
+                            member,
+                            Declaration::Constant(_)
+                                | Declaration::ConstantAlias(_)
+                                | Declaration::Namespace(Namespace::Class(_) | Namespace::Module(_))
+                        )
+                    {
+                        // `add_declaration` deduplicates by fully qualified name, so this appends
+                        // the visibility definition to the existing constant declaration.
+                        self.graph.add_declaration(id, member.name().to_string(), |name| {
+                            Declaration::Constant(Box::new(ConstantDeclaration::new(name, owner_id)))
+                        });
+                    } else {
+                        let diagnostic = Diagnostic::new(
+                            Rule::UndefinedConstantVisibilityTarget,
+                            uri_id,
+                            offset,
+                            format!(
+                                "undefined constant `{constant_name}` for visibility change in `{}`",
+                                namespace.name()
+                            ),
+                        );
+                        self.graph.add_document_diagnostic(uri_id, diagnostic);
+                    }
                 }
                 Definition::MethodVisibility(_) => {
                     method_visibility_ids.push(id);

--- a/rust/rubydex/src/resolution_tests.rs
+++ b/rust/rubydex/src/resolution_tests.rs
@@ -5128,4 +5128,182 @@ mod visibility_resolution_tests {
         assert_owner_eq!(context, "Child#foo()", "Child");
         assert_visibility_eq!(context, "Child#foo()", Visibility::Private);
     }
+
+    #[test]
+    fn retroactive_constant_visibility_on_direct_member() {
+        let mut context = GraphTest::new();
+        context.index_uri(
+            "file:///foo.rb",
+            r"
+            class Foo
+              BAR = 1
+              private_constant :BAR
+
+              BAZ = 2
+              public_constant :BAZ
+
+              QUX = 3
+
+              class Inner; end
+              private_constant :Inner
+
+              module InnerMod; end
+              private_constant :InnerMod
+            end
+            ",
+        );
+        context.resolve();
+
+        assert_no_diagnostics!(&context);
+        assert_visibility_eq!(context, "Foo::BAR", Visibility::Private);
+        assert_visibility_eq!(context, "Foo::BAZ", Visibility::Public);
+        assert_visibility_eq!(context, "Foo::QUX", Visibility::Public);
+        assert_visibility_eq!(context, "Foo::Inner", Visibility::Private);
+        assert_visibility_eq!(context, "Foo::InnerMod", Visibility::Private);
+    }
+
+    #[test]
+    fn retroactive_constant_visibility_via_qualified_receiver() {
+        let mut context = GraphTest::new();
+        context.index_uri(
+            "file:///foo.rb",
+            r"
+            class Foo
+              BAR = 1
+              BAZ = 2
+            end
+
+            ALIAS = Foo
+            Foo.private_constant :BAR
+            ALIAS.private_constant :BAZ
+            ",
+        );
+        context.resolve();
+
+        assert_no_diagnostics!(&context);
+        assert_visibility_eq!(context, "Foo::BAR", Visibility::Private);
+        assert_visibility_eq!(context, "Foo::BAZ", Visibility::Private);
+    }
+
+    #[test]
+    fn retroactive_constant_visibility_multi_arg_undefined_emits_per_name_diagnostic() {
+        let mut context = GraphTest::new();
+        context.index_uri(
+            "file:///foo.rb",
+            r"
+            class Foo
+              private_constant :NOPE_ONE, :NOPE_TWO
+            end
+            ",
+        );
+        context.resolve();
+
+        assert_diagnostics_eq!(
+            context,
+            &[
+                "undefined-constant-visibility-target: undefined constant `NOPE_ONE` for visibility change in `Foo` (2:21-2:29)",
+                "undefined-constant-visibility-target: undefined constant `NOPE_TWO` for visibility change in `Foo` (2:32-2:40)",
+            ]
+        );
+    }
+
+    #[test]
+    fn retroactive_constant_visibility_inherited_constant_emits_diagnostic() {
+        let mut context = GraphTest::new();
+        context.index_uri(
+            "file:///foo.rb",
+            r"
+            class Parent
+              CONST = 1
+            end
+
+            class Child < Parent
+              private_constant :CONST
+            end
+            ",
+        );
+        context.resolve();
+
+        assert_diagnostics_eq!(
+            context,
+            &[
+                "undefined-constant-visibility-target: undefined constant `CONST` for visibility change in `Child` (6:21-6:26)"
+            ]
+        );
+        assert_visibility_eq!(context, "Parent::CONST", Visibility::Public);
+    }
+
+    #[test]
+    fn retroactive_constant_visibility_clears_when_call_removed() {
+        let mut context = GraphTest::new();
+        context.index_uri(
+            "file:///foo.rb",
+            r"
+            class Foo
+              BAR = 1
+            end
+            ",
+        );
+        context.index_uri(
+            "file:///vis.rb",
+            r"
+            Foo.private_constant :BAR
+            ",
+        );
+        context.resolve();
+
+        assert_no_diagnostics!(&context);
+        assert_visibility_eq!(context, "Foo::BAR", Visibility::Private);
+
+        context.delete_uri("file:///vis.rb");
+        context.resolve();
+
+        assert_no_diagnostics!(&context);
+        assert_visibility_eq!(context, "Foo::BAR", Visibility::Public);
+    }
+
+    #[test]
+    fn retroactive_constant_visibility_inside_singleton_class_body() {
+        let mut context = GraphTest::new();
+        context.index_uri(
+            "file:///foo.rb",
+            r"
+            class Foo
+              class << self
+                BAR = 1
+                private_constant :BAR
+              end
+            end
+            ",
+        );
+        context.resolve();
+
+        assert_no_diagnostics!(&context);
+        assert_visibility_eq!(context, "Foo::<Foo>::BAR", Visibility::Private);
+    }
+
+    #[test]
+    fn retroactive_constant_visibility_persists_across_reopened_class() {
+        let mut context = GraphTest::new();
+        context.index_uri(
+            "file:///a.rb",
+            r"
+            class Foo
+              BAR = 1
+              private_constant :BAR
+            end
+            ",
+        );
+        context.index_uri(
+            "file:///b.rb",
+            r"
+            class Foo
+              BAR = 2
+            end
+            ",
+        );
+        context.resolve();
+
+        assert_visibility_eq!(context, "Foo::BAR", Visibility::Private);
+    }
 }


### PR DESCRIPTION
Continues #89 and follows #506, which indexed `ConstantVisibilityDefinition` and left the `Definition::ConstantVisibility` arm in resolution as a TODO.

This PR resolves retroactive `private_constant` and `public_constant` calls by reusing the second-pass mechanism from #738: visibility definitions are processed in `handle_remaining_definitions` after the ancestors linearization loop terminates, so we can resolve the owner and look up the named constant reliably before we apply the visibility.

Visibility is applied only to direct members of the owner. Inherited constants are rejected because both `private_constant` and `public_constant` raise `NameError` on inherited names in Ruby. When the target is missing, an `UndefinedConstantVisibilityTarget` diagnostic is emitted.

`Graph::visibility()` was changed to treat constant visibility as sticky once set: reassigning a private constant in a reopened class doesn't flip it back to public.

Note: we don't handle the case when an owner isn't yet in the graph or is indexed in a later resolve(). A follow-up PR will handle incremental resolution properly