### PR TITLE
Take self type into account for completion

### DIFF
--- a/ext/rubydex/graph.c
+++ b/ext/rubydex/graph.c
@@ -13,6 +13,9 @@ static VALUE mRubydex;
 static VALUE cKeyword;
 static VALUE cKeywordParameter;
 
+// Interned once in `rdxi_initialize_graph` to avoid repeated symbol-table lookups on hot completion paths.
+static ID id_self_receiver;
+
 // Free function for the custom Graph allocator. We always have to call into Rust to free data allocated by it
 static void graph_free(void *ptr) {
     if (ptr) {
@@ -546,11 +549,29 @@ static VALUE completion_result_to_ruby_array(struct CompletionResult result, VAL
     return ruby_array;
 }
 
-// Graph#complete_expression: (Array[String] nesting) -> Array[Declaration | Keyword]
+// Graph#complete_expression: (Array[String] nesting, self_receiver: nil) -> Array[Declaration | Keyword]
 // Returns completion candidates for an expression context.
-// The nesting array represents the lexical scope stack
-static VALUE rdxr_graph_complete_expression(VALUE self, VALUE nesting) {
+// The nesting array represents the lexical scope stack. The optional self_receiver keyword argument
+// overrides the self-type (e.g., "Foo::<Foo>" for `def Foo.bar`); when nil, self is derived from
+// the innermost nesting element.
+static VALUE rdxr_graph_complete_expression(int argc, VALUE *argv, VALUE self) {
+    VALUE nesting, opts;
+    rb_scan_args(argc, argv, "1:", &nesting, &opts);
     rdxi_check_array_of_strings(nesting);
+
+    const char *self_receiver = NULL;
+    if (!NIL_P(opts)) {
+        VALUE kwarg_val;
+        rb_get_kwargs(opts, &id_self_receiver, 0, 1, &kwarg_val);
+
+        if (kwarg_val != Qundef && !NIL_P(kwarg_val)) {
+            Check_Type(kwarg_val, T_STRING);
+            if (RSTRING_LEN(kwarg_val) == 0) {
+                rb_raise(rb_eArgError, "self_receiver cannot be empty");
+            }
+            self_receiver = StringValueCStr(kwarg_val);
+        }
+    }
 
     void *graph;
     TypedData_Get_Struct(self, void *, &graph_type, graph);
@@ -559,7 +580,7 @@ static VALUE rdxr_graph_complete_expression(VALUE self, VALUE nesting) {
     char **converted_nesting = rdxi_str_array_to_char(nesting, nesting_count);
 
     struct CompletionResult result =
-        rdx_graph_complete_expression(graph, (const char *const *)converted_nesting, nesting_count);
+        rdx_graph_complete_expression(graph, (const char *const *)converted_nesting, nesting_count, self_receiver);
 
     rdxi_free_str_array(converted_nesting, nesting_count);
     return completion_result_to_ruby_array(result, self);
@@ -589,11 +610,29 @@ static VALUE rdxr_graph_complete_method_call(VALUE self, VALUE name) {
     return completion_result_to_ruby_array(result, self);
 }
 
-// Graph#complete_method_argument: (String name, Array[String] nesting) -> Array[Declaration | Keyword | KeywordParameter]
+// Graph#complete_method_argument: (String name, Array[String] nesting, self_receiver: nil) -> Array[Declaration | Keyword | KeywordParameter]
 // Returns completion candidates inside a method call's argument list (e.g., `foo.bar(|)`).
-static VALUE rdxr_graph_complete_method_argument(VALUE self, VALUE name, VALUE nesting) {
+// See complete_expression for semantics of self_receiver.
+static VALUE rdxr_graph_complete_method_argument(int argc, VALUE *argv, VALUE self) {
+    VALUE name, nesting, opts;
+    rb_scan_args(argc, argv, "2:", &name, &nesting, &opts);
+
     Check_Type(name, T_STRING);
     rdxi_check_array_of_strings(nesting);
+
+    const char *self_receiver = NULL;
+    if (!NIL_P(opts)) {
+        VALUE kwarg_val;
+        rb_get_kwargs(opts, &id_self_receiver, 0, 1, &kwarg_val);
+
+        if (kwarg_val != Qundef && !NIL_P(kwarg_val)) {
+            Check_Type(kwarg_val, T_STRING);
+            if (RSTRING_LEN(kwarg_val) == 0) {
+                rb_raise(rb_eArgError, "self_receiver cannot be empty");
+            }
+            self_receiver = StringValueCStr(kwarg_val);
+        }
+    }
 
     void *graph;
     TypedData_Get_Struct(self, void *, &graph_type, graph);
@@ -602,7 +641,7 @@ static VALUE rdxr_graph_complete_method_argument(VALUE self, VALUE name, VALUE n
     char **converted_nesting = rdxi_str_array_to_char(nesting, nesting_count);
 
     struct CompletionResult result = rdx_graph_complete_method_argument(
-        graph, StringValueCStr(name), (const char *const *)converted_nesting, nesting_count);
+        graph, StringValueCStr(name), (const char *const *)converted_nesting, nesting_count, self_receiver);
 
     rdxi_free_str_array(converted_nesting, nesting_count);
     return completion_result_to_ruby_array(result, self);
@@ -673,6 +712,8 @@ void rdxi_initialize_graph(VALUE moduleRubydex) {
     cKeyword = rb_define_class_under(mRubydex, "Keyword", rb_cObject);
     cKeywordParameter = rb_define_class_under(mRubydex, "KeywordParameter", rb_cObject);
 
+    id_self_receiver = rb_intern("self_receiver");
+
     rb_define_alloc_func(cGraph, rdxr_graph_alloc);
     rb_define_method(cGraph, "index_all", rdxr_graph_index_all, 1);
     rb_define_method(cGraph, "index_source", rdxr_graph_index_source, 3);
@@ -691,10 +732,10 @@ void rdxi_initialize_graph(VALUE moduleRubydex) {
     rb_define_method(cGraph, "encoding=", rdxr_graph_set_encoding, 1);
     rb_define_method(cGraph, "resolve_require_path", rdxr_graph_resolve_require_path, 2);
     rb_define_method(cGraph, "require_paths", rdxr_graph_require_paths, 1);
-    rb_define_method(cGraph, "complete_expression", rdxr_graph_complete_expression, 1);
+    rb_define_method(cGraph, "complete_expression", rdxr_graph_complete_expression, -1);
     rb_define_method(cGraph, "complete_namespace_access", rdxr_graph_complete_namespace_access, 1);
     rb_define_method(cGraph, "complete_method_call", rdxr_graph_complete_method_call, 1);
-    rb_define_method(cGraph, "complete_method_argument", rdxr_graph_complete_method_argument, 2);
+    rb_define_method(cGraph, "complete_method_argument", rdxr_graph_complete_method_argument, -1);
     rb_define_method(cGraph, "exclude_paths", rdxr_graph_exclude_paths, 1);
     rb_define_method(cGraph, "excluded_paths", rdxr_graph_excluded_paths, 0);
     rb_define_method(cGraph, "keyword", rdxr_graph_keyword, 1);

--- a/rbi/rubydex.rbi
+++ b/rbi/rubydex.rbi
@@ -152,6 +152,7 @@ class Rubydex::GlobalVariableDefinition < Rubydex::Definition; end
 class Rubydex::InstanceVariableDefinition < Rubydex::Definition; end
 class Rubydex::MethodAliasDefinition < Rubydex::Definition; end
 class Rubydex::MethodDefinition < Rubydex::Definition; end
+
 class Rubydex::ModuleDefinition < Rubydex::Definition
   sig { returns(T::Array[Rubydex::Mixin]) }
   def mixins; end
@@ -314,10 +315,17 @@ class Rubydex::Graph
   # Returns completion candidates for an expression context. This includes all keywords, constants, methods, instance
   # variables, class variables and global variables reachable from the current lexical scope and self type.
   #
-  # The nesting array represents the lexical scope stack, where the last element is the self type. An empty array
-  # defaults to `Object` as the self type (top-level context).
-  sig { params(nesting: T::Array[String]).returns(T::Array[T.any(Rubydex::Declaration, Rubydex::Keyword)]) }
-  def complete_expression(nesting); end
+  # The nesting array represents the lexical scope stack. The optional `self_receiver` keyword argument overrides the
+  # self type independently of the lexical scope (e.g., `"Foo::<Foo>"` for `def Foo.bar`). This distinction is important
+  # because constants and class variables are always attached to the lexical scope. Meanwhile, methods and instance
+  # variables are attached to the type of `self` and those don't always match.
+  sig do
+    params(
+      nesting: T::Array[String],
+      self_receiver: T.nilable(String),
+    ).returns(T::Array[T.any(Rubydex::Declaration, Rubydex::Keyword)])
+  end
+  def complete_expression(nesting, self_receiver: nil); end
 
   # Returns completion candidates after a namespace access operator (e.g., `Foo::`). This includes all constants and
   # singleton methods for the namespace and its ancestors.
@@ -332,9 +340,15 @@ class Rubydex::Graph
   # Returns completion candidates inside a method call's argument list (e.g., `foo.bar(|)`). This includes everything
   # that expression completion provides plus keyword argument names of the method being called.
   #
-  # The nesting array represents the lexical scope stack, where the last element is the self type.
-  sig { params(name: String, nesting: T::Array[String]).returns(T::Array[T.any(Rubydex::Declaration, Rubydex::Keyword, Rubydex::KeywordParameter)]) }
-  def complete_method_argument(name, nesting); end
+  # See `complete_expression` for the semantics of `nesting` and `self_receiver`.
+  sig do
+    params(
+      name: String,
+      nesting: T::Array[String],
+      self_receiver: T.nilable(String),
+    ).returns(T::Array[T.any(Rubydex::Declaration, Rubydex::Keyword, Rubydex::KeywordParameter)])
+  end
+  def complete_method_argument(name, nesting, self_receiver: nil); end
 
   private
 

--- a/rust/rubydex-sys/src/declaration_api.rs
+++ b/rust/rubydex-sys/src/declaration_api.rs
@@ -64,6 +64,25 @@ impl CDeclaration {
     }
 }
 
+/// Convert a nullable C string to `Option<DeclarationId>`.
+/// Null, empty, or non-UTF-8 input yields `None`.
+///
+/// # Safety
+///
+/// If non-null, `ptr` must point to a valid, NUL-terminated C string that remains valid for the
+/// duration of the call. The contents do not need to be UTF-8 — non-UTF-8 input is handled by returning
+/// `None`.
+pub(crate) unsafe fn decl_id_from_char_ptr(ptr: *const c_char) -> Option<DeclarationId> {
+    if ptr.is_null() {
+        return None;
+    }
+    let s = unsafe { utils::convert_char_ptr_to_string(ptr) }.ok()?;
+    if s.is_empty() {
+        return None;
+    }
+    Some(DeclarationId::from(s.as_str()))
+}
+
 /// An iterator over declaration IDs
 ///
 /// We snapshot the IDs at iterator creation so if the graph is modified, the iterator will not see the changes

--- a/rust/rubydex-sys/src/graph_api.rs
+++ b/rust/rubydex-sys/src/graph_api.rs
@@ -2,6 +2,7 @@
 
 use crate::declaration_api::CDeclaration;
 use crate::declaration_api::DeclarationsIter;
+use crate::declaration_api::decl_id_from_char_ptr;
 use crate::document_api::DocumentsIter;
 use crate::reference_api::{CConstantReference, CMethodReference, ConstantReferencesIter, MethodReferencesIter};
 use crate::{name_api, utils};
@@ -768,11 +769,15 @@ fn run_and_finalize_completion(
 ///
 /// - `pointer` must be a valid `GraphPointer` previously returned by this crate.
 /// - `nesting` must point to `nesting_count` valid, null-terminated UTF-8 strings.
+/// - `self_receiver` must be null or a valid, null-terminated UTF-8 string. When non-null, it
+///   overrides the self-type (e.g., `"Foo::<Foo>"` for completion inside `def Foo.bar`), while
+///   the lexical nesting still comes from `nesting`.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rdx_graph_complete_expression(
     pointer: GraphPointer,
     nesting: *const *const c_char,
     nesting_count: usize,
+    self_receiver: *const c_char,
 ) -> CompletionResult {
     with_mut_graph(pointer, |graph| {
         let Some((name_id, names_to_untrack)) = (unsafe { completion_nesting_name_id(graph, nesting, nesting_count) })
@@ -780,7 +785,16 @@ pub unsafe extern "C" fn rdx_graph_complete_expression(
             return CompletionResult::success(ptr::null_mut());
         };
 
-        run_and_finalize_completion(graph, CompletionReceiver::Expression(name_id), names_to_untrack)
+        let self_decl_id = unsafe { decl_id_from_char_ptr(self_receiver) };
+
+        run_and_finalize_completion(
+            graph,
+            CompletionReceiver::Expression {
+                self_decl_id,
+                nesting_name_id: name_id,
+            },
+            names_to_untrack,
+        )
     })
 }
 
@@ -845,28 +859,34 @@ pub unsafe extern "C" fn rdx_graph_complete_method_call(
 /// - `pointer` must be a valid `GraphPointer` previously returned by this crate.
 /// - `name` must be a valid, null-terminated UTF-8 string (FQN of the method).
 /// - `nesting` must point to `nesting_count` valid, null-terminated UTF-8 strings.
+/// - `self_receiver` must be null or a valid, null-terminated UTF-8 string. See
+///   `rdx_graph_complete_expression` for semantics.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rdx_graph_complete_method_argument(
     pointer: GraphPointer,
     name: *const c_char,
     nesting: *const *const c_char,
     nesting_count: usize,
+    self_receiver: *const c_char,
 ) -> CompletionResult {
     let Ok(name_str) = (unsafe { utils::convert_char_ptr_to_string(name) }) else {
         return CompletionResult::success(ptr::null_mut());
     };
 
     with_mut_graph(pointer, |graph| {
-        let Some((self_name_id, names_to_untrack)) =
+        let Some((nesting_name_id, names_to_untrack)) =
             (unsafe { completion_nesting_name_id(graph, nesting, nesting_count) })
         else {
             return CompletionResult::success(ptr::null_mut());
         };
 
+        let self_decl_id = unsafe { decl_id_from_char_ptr(self_receiver) };
+
         run_and_finalize_completion(
             graph,
             CompletionReceiver::MethodArgument {
-                self_name_id,
+                self_decl_id,
+                nesting_name_id,
                 method_decl_id: DeclarationId::from(name_str.as_str()),
             },
             names_to_untrack,

--- a/rust/rubydex/src/query.rs
+++ b/rust/rubydex/src/query.rs
@@ -6,7 +6,7 @@ use std::thread;
 use url::Url;
 
 use crate::model::built_in::OBJECT_ID;
-use crate::model::declaration::{Ancestor, Declaration};
+use crate::model::declaration::{Ancestor, Declaration, Namespace};
 use crate::model::definitions::{Definition, Parameter};
 use crate::model::graph::Graph;
 use crate::model::identity_maps::IdentityHashSet;
@@ -169,7 +169,17 @@ pub enum CompletionCandidate {
 pub enum CompletionReceiver {
     /// Completion requested for an expression with no previous token (e.g.: at the start of a line with nothing before)
     /// Includes: all keywords, all global variables and reacheable instance variables, class variables, constants and methods
-    Expression(NameId),
+    ///
+    /// `nesting_name_id` represents the lexical scope. It is walked for constants and drives class-variable
+    /// lookup (cvars follow lexical scope in Ruby, not self).
+    /// `self_decl_id` overrides the self-type used for methods and instance variables when the runtime `self`
+    /// diverges from the innermost lexical scope — for example `def Foo.bar` (where self is `Foo` but the
+    /// lexical scope is the outer namespace) or `def self.bar`. Callers may pass a `ConstantAlias` id; it is
+    /// unwrapped to the target namespace. When `None`, self is derived from the innermost lexical scope.
+    Expression {
+        self_decl_id: Option<DeclarationId>,
+        nesting_name_id: NameId,
+    },
     /// Completion requested after a namespace access operator (e.g.: `Foo::`)
     /// Includes: all constants and singleton methods for the namespace and its ancestors
     NamespaceAccess(DeclarationId),
@@ -179,8 +189,11 @@ pub enum CompletionReceiver {
     MethodCall(DeclarationId),
     /// Completion requested inside a method call's argument list (e.g.: `foo.bar(|)`)
     /// Includes: everything expressions do plus keyword parameter names of the method being called
+    ///
+    /// Same `self_decl_id` / `nesting_name_id` split as `Expression`.
     MethodArgument {
-        self_name_id: NameId,
+        self_decl_id: Option<DeclarationId>,
+        nesting_name_id: NameId,
         method_decl_id: DeclarationId,
     },
 }
@@ -245,19 +258,24 @@ macro_rules! collect_candidates {
 ///
 /// # Errors
 ///
-/// Will error if the given `self_name_id` does not point to a namespace declaration
+/// Will error if the given `self_decl_id` does not resolve to a namespace declaration (directly or via
+/// a constant alias).
 pub fn completion_candidates<'a>(
     graph: &'a Graph,
     context: CompletionContext<'a>,
 ) -> Result<Vec<CompletionCandidate>, Box<dyn Error>> {
     match context.completion_receiver {
-        CompletionReceiver::Expression(self_name_id) => expression_completion(graph, self_name_id, context),
+        CompletionReceiver::Expression {
+            self_decl_id,
+            nesting_name_id,
+        } => expression_completion(graph, self_decl_id, nesting_name_id, context),
         CompletionReceiver::NamespaceAccess(decl_id) => namespace_access_completion(graph, decl_id, context),
         CompletionReceiver::MethodCall(decl_id) => method_call_completion(graph, decl_id, context),
         CompletionReceiver::MethodArgument {
-            self_name_id,
+            self_decl_id,
+            nesting_name_id,
             method_decl_id,
-        } => method_argument_completion(graph, self_name_id, method_decl_id, context),
+        } => method_argument_completion(graph, self_decl_id, nesting_name_id, method_decl_id, context),
     }
 }
 
@@ -357,35 +375,169 @@ fn method_call_completion<'a>(
 /// Collect completion for an expression
 fn expression_completion<'a>(
     graph: &'a Graph,
-    self_name_id: NameId,
+    self_decl_id: Option<DeclarationId>,
+    nesting_name_id: NameId,
     mut context: CompletionContext<'a>,
 ) -> Result<Vec<CompletionCandidate>, Box<dyn Error>> {
-    let Some(name_ref) = graph.names().get(&self_name_id) else {
-        return Err(format!("Name {self_name_id} not found in graph").into());
+    let Some(name_ref) = graph.names().get(&nesting_name_id) else {
+        return Err(format!("Name {nesting_name_id} not found in graph").into());
     };
     let NameRef::Resolved(name_ref) = name_ref else {
-        return Err(format!("Expected name {self_name_id} to be resolved").into());
+        return Err(format!("Expected name {nesting_name_id} to be resolved").into());
     };
-    let Some(self_decl) = graph
+    // When no explicit self is given, self is the innermost lexical scope (the nesting's own declaration).
+    // When explicit, follow constant aliases so callers can pass whatever the expression that set self
+    // resolves to without having to unwrap aliases themselves. Missing or non-namespace decls are graph
+    // inconsistencies and surfaced as errors.
+    let resolved_self_decl_id = match self_decl_id {
+        Some(id) => {
+            resolve_to_namespace(graph, id)?.ok_or_else(|| format!("self declaration {id:?} not found in graph"))?
+        }
+        None => *name_ref.declaration_id(),
+    };
+    let self_decl = graph
+        .declarations()
+        .get(&resolved_self_decl_id)
+        .unwrap()
+        .as_namespace()
+        .ok_or("Expected associated declaration to be a namespace")?;
+    let innermost_lexical_decl = graph
         .declarations()
         .get(name_ref.declaration_id())
-        .and_then(|d| d.as_namespace())
-    else {
-        return Err("Expected associated declaration to be a namespace".into());
-    };
+        .unwrap()
+        .as_namespace()
+        .unwrap();
+
     let mut candidates = Vec::new();
 
-    // Walk the name's lexical scopes, collecting all constant completion members
-    let mut current_name_id = Some(self_name_id);
+    // Collect constants. Immediate scope includes inheritance. Outer scopes only include `Object` inheritance when it's a module
+    collect_constants_from_lexical_scope(graph, innermost_lexical_decl, &mut context, &mut candidates);
+    collect_constants_from_outer_nesting(graph, name_ref, &mut context, &mut candidates);
+
+    // Collect class variables, which are based on the inheritance chain of the attached object of the immediate lexical scope
+    collect_class_variables_from_lexical_scope(graph, name_ref, &mut context, &mut candidates);
+
+    // Globals are accessible from anywhere, regardless of lexical scope or `self` type.
+    let object = graph.declarations().get(&OBJECT_ID).unwrap().as_namespace().unwrap();
+    collect_candidates!(graph, &object, context, candidates, Declaration::GlobalVariable(_));
+
+    // Collect methods and instance variables, which are based on the inheritance chain of the `self` type (which may
+    // not match the immediate lexical scope)
+    collect_methods_and_ivars_from_self(graph, self_decl, &mut context, &mut candidates);
+
+    // Keywords are always available in expression contexts
+    candidates.extend(keywords::KEYWORDS.iter().map(CompletionCandidate::Keyword));
+    Ok(candidates)
+}
+
+/// Collects constants reachable from the innermost lexical scope's ancestor chain. Module bodies also fall back to
+/// `Object`'s ancestor chain to mirror Ruby's resolution rules.
+fn collect_constants_from_lexical_scope<'a>(
+    graph: &'a Graph,
+    innermost_lexical_decl: &'a Namespace,
+    context: &mut CompletionContext<'a>,
+    candidates: &mut Vec<CompletionCandidate>,
+) {
+    for ancestor in innermost_lexical_decl.ancestors() {
+        if let Ancestor::Complete(ancestor_id) = ancestor {
+            let ancestor_decl = graph.declarations().get(ancestor_id).unwrap().as_namespace().unwrap();
+
+            collect_candidates!(
+                graph,
+                &ancestor_decl,
+                context,
+                candidates,
+                Declaration::Namespace(_) | Declaration::Constant(_) | Declaration::ConstantAlias(_)
+            );
+        }
+    }
+
+    if matches!(innermost_lexical_decl, Namespace::Module(_)) {
+        let object = graph.declarations().get(&OBJECT_ID).unwrap().as_namespace().unwrap();
+
+        for ancestor in object.ancestors() {
+            if let Ancestor::Complete(ancestor_id) = ancestor {
+                let ancestor_decl = graph.declarations().get(ancestor_id).unwrap().as_namespace().unwrap();
+
+                collect_candidates!(
+                    graph,
+                    &ancestor_decl,
+                    context,
+                    candidates,
+                    Declaration::Namespace(_) | Declaration::Constant(_) | Declaration::ConstantAlias(_)
+                );
+            }
+        }
+    }
+}
+
+/// Collects class variables visible from the current lexical scope. Class variables are resolved
+/// lexically and singleton classes are skipped: inside `class Bar; class << Foo; @@cvar` the
+/// cvar belongs to `Bar`, not `Foo`. We walk the lexical chain (innermost outward) until we find
+/// a non-singleton namespace, then walk that namespace's ancestors.
+fn collect_class_variables_from_lexical_scope<'a>(
+    graph: &'a Graph,
+    name_ref: &crate::model::name::ResolvedName,
+    context: &mut CompletionContext<'a>,
+    candidates: &mut Vec<CompletionCandidate>,
+) {
+    let mut decl = graph
+        .declarations()
+        .get(name_ref.declaration_id())
+        .unwrap()
+        .as_namespace()
+        .unwrap();
+    let mut current_name_id = *name_ref.nesting();
+
+    while matches!(decl, Namespace::SingletonClass(_)) {
+        let Some(parent_name_id) = current_name_id else {
+            // No non-singleton lexical scope (invalid Ruby). Skip cvar collection.
+            return;
+        };
+        let NameRef::Resolved(parent_ref) = graph.names().get(&parent_name_id).unwrap() else {
+            return;
+        };
+        decl = graph
+            .declarations()
+            .get(parent_ref.declaration_id())
+            .unwrap()
+            .as_namespace()
+            .unwrap();
+        current_name_id = *parent_ref.nesting();
+    }
+
+    for ancestor in decl.ancestors() {
+        if let Ancestor::Complete(ancestor_id) = ancestor {
+            let ancestor_decl = graph.declarations().get(ancestor_id).unwrap().as_namespace().unwrap();
+            collect_candidates!(
+                graph,
+                &ancestor_decl,
+                context,
+                candidates,
+                Declaration::ClassVariable(_)
+            );
+        }
+    }
+}
+
+/// Walks the outer lexical nesting chain (excluding the innermost scope) to collect constants reachable through
+/// enclosing classes/modules.
+fn collect_constants_from_outer_nesting<'a>(
+    graph: &'a Graph,
+    name_ref: &crate::model::name::ResolvedName,
+    context: &mut CompletionContext<'a>,
+    candidates: &mut Vec<CompletionCandidate>,
+) {
+    let mut current_name_id = *name_ref.nesting();
 
     while let Some(id) = current_name_id {
-        let NameRef::Resolved(name_ref) = graph.names().get(&id).unwrap() else {
+        let NameRef::Resolved(parent_ref) = graph.names().get(&id).unwrap() else {
             break;
         };
 
         let nesting_decl = graph
             .declarations()
-            .get(name_ref.declaration_id())
+            .get(parent_ref.declaration_id())
             .unwrap()
             .as_namespace()
             .unwrap();
@@ -398,54 +550,42 @@ fn expression_completion<'a>(
             Declaration::Namespace(_) | Declaration::Constant(_) | Declaration::ConstantAlias(_)
         );
 
-        current_name_id = *name_ref.nesting();
+        current_name_id = *parent_ref.nesting();
     }
+}
 
-    // Include all top level constants and globals, which are accessible everywhere
-    let object = graph.declarations().get(&OBJECT_ID).unwrap().as_namespace().unwrap();
-    collect_candidates!(
-        graph,
-        &object,
-        context,
-        candidates,
-        Declaration::Namespace(_)
-            | Declaration::Constant(_)
-            | Declaration::ConstantAlias(_)
-            | Declaration::GlobalVariable(_)
-    );
-
-    // Walk ancestors collecting all applicable completion members
+/// Collects methods and instance variables along `self`'s ancestor chain. The chain may differ
+/// from the lexical chain when `self` was rebound (e.g., `def Foo.baz` written inside `class Bar`).
+fn collect_methods_and_ivars_from_self<'a>(
+    graph: &'a Graph,
+    self_decl: &'a Namespace,
+    context: &mut CompletionContext<'a>,
+    candidates: &mut Vec<CompletionCandidate>,
+) {
     for ancestor in self_decl.ancestors() {
         if let Ancestor::Complete(ancestor_id) = ancestor {
             let ancestor_decl = graph.declarations().get(ancestor_id).unwrap().as_namespace().unwrap();
-            collect_candidates!(&ancestor_decl, context, candidates);
 
-            // Collect class variables from the attached object, which are available at any singleton class level
-            // within self
-            let attached_object = graph.attached_object(ancestor_decl);
             collect_candidates!(
                 graph,
-                &attached_object,
+                &ancestor_decl,
                 context,
                 candidates,
-                Declaration::ClassVariable(_)
+                Declaration::Method(_) | Declaration::InstanceVariable(_)
             );
         }
     }
-
-    // Keywords are always available in expression contexts
-    candidates.extend(keywords::KEYWORDS.iter().map(CompletionCandidate::Keyword));
-    Ok(candidates)
 }
 
 /// Collect completion for a method argument (e.g.: `foo.bar(|)`)
 fn method_argument_completion<'a>(
     graph: &'a Graph,
-    self_name_id: NameId,
+    self_decl_id: Option<DeclarationId>,
+    nesting_name_id: NameId,
     method_decl_id: DeclarationId,
     context: CompletionContext<'a>,
 ) -> Result<Vec<CompletionCandidate>, Box<dyn Error>> {
-    let mut candidates = expression_completion(graph, self_name_id, context)?;
+    let mut candidates = expression_completion(graph, self_decl_id, nesting_name_id, context)?;
     let Some(method_decl) = graph.declarations().get(&method_decl_id) else {
         return Ok(candidates);
     };
@@ -523,30 +663,37 @@ mod tests {
 
     macro_rules! assert_completion_eq {
         ($context:expr, $receiver:expr, $expected:expr) => {
-            assert_eq!(
-                $expected,
-                *completion_candidates($context.graph(), CompletionContext::new($receiver))
-                    .unwrap()
-                    .iter()
-                    .map(|candidate| candidate_label(&$context, candidate))
-                    .collect::<Vec<_>>()
-            );
+            let mut actual: Vec<String> = completion_candidates($context.graph(), CompletionContext::new($receiver))
+                .unwrap()
+                .iter()
+                .map(|candidate| candidate_label(&$context, candidate))
+                .collect();
+            actual.sort();
+
+            let mut expected: Vec<String> = $expected.into_iter().map(String::from).collect();
+            expected.sort();
+
+            assert_eq!(expected, actual);
         };
     }
 
     /// Asserts declaration and keyword argument completion candidates, excluding language keywords.
     /// Language keywords are always present in expression contexts and tested separately.
+    /// Both sides are sorted before comparison so tests are not coupled to candidate emission order.
     macro_rules! assert_declaration_completion_eq {
         ($context:expr, $receiver:expr, $expected:expr) => {
-            assert_eq!(
-                $expected,
-                *completion_candidates($context.graph(), CompletionContext::new($receiver))
-                    .unwrap()
-                    .iter()
-                    .filter(|c| !matches!(c, CompletionCandidate::Keyword(_)))
-                    .map(|candidate| candidate_label(&$context, candidate))
-                    .collect::<Vec<_>>()
-            );
+            let mut actual: Vec<String> = completion_candidates($context.graph(), CompletionContext::new($receiver))
+                .unwrap()
+                .iter()
+                .filter(|c| !matches!(c, CompletionCandidate::Keyword(_)))
+                .map(|candidate| candidate_label(&$context, candidate))
+                .collect();
+            actual.sort();
+
+            let mut expected: Vec<String> = $expected.into_iter().map(String::from).collect();
+            expected.sort();
+
+            assert_eq!(expected, actual);
         };
     }
 
@@ -761,8 +908,12 @@ mod tests {
         let name_id = Name::new(StringId::from("Child"), ParentScope::None, None).id();
         assert_declaration_completion_eq!(
             context,
-            CompletionReceiver::Expression(name_id),
+            CompletionReceiver::Expression {
+                self_decl_id: None,
+                nesting_name_id: name_id,
+            },
             [
+                "Foo::CONST",
                 "Class",
                 "BasicObject",
                 "Child",
@@ -772,7 +923,6 @@ mod tests {
                 "Foo",
                 "Object",
                 "Child#baz()",
-                "Foo::CONST",
                 "Foo#bar()",
                 "Parent#initialize()",
                 "Parent#@var"
@@ -807,7 +957,10 @@ mod tests {
         let name_id = Name::new(StringId::from("Child"), ParentScope::None, None).id();
         assert_declaration_completion_eq!(
             context,
-            CompletionReceiver::Expression(name_id),
+            CompletionReceiver::Expression {
+                self_decl_id: None,
+                nesting_name_id: name_id,
+            },
             [
                 "Class",
                 "BasicObject",
@@ -853,7 +1006,10 @@ mod tests {
         let name_id = Name::new(StringId::from("Foo"), ParentScope::None, None).id();
         assert_declaration_completion_eq!(
             context,
-            CompletionReceiver::Expression(name_id),
+            CompletionReceiver::Expression {
+                self_decl_id: None,
+                nesting_name_id: name_id,
+            },
             [
                 "Foo",
                 "Class",
@@ -900,7 +1056,10 @@ mod tests {
         let name_id = Name::new(StringId::from("<Foo>"), ParentScope::Attached(foo_id), Some(foo_id)).id();
         assert_declaration_completion_eq!(
             context,
-            CompletionReceiver::Expression(name_id),
+            CompletionReceiver::Expression {
+                self_decl_id: None,
+                nesting_name_id: name_id,
+            },
             [
                 "Module",
                 "Class",
@@ -917,7 +1076,10 @@ mod tests {
         let name_id = Name::new(StringId::from("Bar"), ParentScope::None, None).id();
         assert_declaration_completion_eq!(
             context,
-            CompletionReceiver::Expression(name_id),
+            CompletionReceiver::Expression {
+                self_decl_id: None,
+                nesting_name_id: name_id,
+            },
             [
                 "Module",
                 "Class",
@@ -966,9 +1128,11 @@ mod tests {
         .id();
         assert_declaration_completion_eq!(
             context,
-            CompletionReceiver::Expression(name_id),
+            CompletionReceiver::Expression {
+                self_decl_id: None,
+                nesting_name_id: name_id,
+            },
             [
-                "Foo::CONST_A",
                 "Module",
                 "Class",
                 "Object",
@@ -976,6 +1140,7 @@ mod tests {
                 "Kernel",
                 "Foo",
                 "Bar",
+                "Foo::CONST_A",
                 "Bar#bar_m()",
                 "Bar#bar_m2()"
             ]
@@ -984,7 +1149,10 @@ mod tests {
         let name_id = Name::new(StringId::from("Bar"), ParentScope::None, None).id();
         assert_declaration_completion_eq!(
             context,
-            CompletionReceiver::Expression(name_id),
+            CompletionReceiver::Expression {
+                self_decl_id: None,
+                nesting_name_id: name_id,
+            },
             [
                 "Module",
                 "Class",
@@ -1025,16 +1193,19 @@ mod tests {
         // when the user types the unqualified name CONST
         assert_declaration_completion_eq!(
             context,
-            CompletionReceiver::Expression(name_id),
+            CompletionReceiver::Expression {
+                self_decl_id: None,
+                nesting_name_id: name_id,
+            },
             [
-                "Foo::CONST",
-                "Foo::Bar",
                 "Class",
                 "Object",
                 "BasicObject",
                 "Kernel",
                 "Foo",
                 "Module",
+                "Foo::CONST",
+                "Foo::Bar",
                 "Foo::Bar#baz()"
             ]
         );
@@ -1069,19 +1240,11 @@ mod tests {
         .id();
         assert_declaration_completion_eq!(
             context,
-            CompletionReceiver::Expression(name_id),
-            [
-                "Foo::Bar",
-                "$var2",
-                "$var",
-                "BasicObject",
-                "Object",
-                "Kernel",
-                "Module",
-                "Foo",
-                "Class",
-                "Foo::Bar#bar_m()"
-            ]
+            CompletionReceiver::Expression {
+                self_decl_id: None,
+                nesting_name_id: name_id,
+            },
+            ["Foo::Bar", "$var2", "$var", "Foo::Bar#bar_m()"]
         );
     }
 
@@ -1560,7 +1723,8 @@ mod tests {
         assert_declaration_completion_eq!(
             context,
             CompletionReceiver::MethodArgument {
-                self_name_id: name_id,
+                self_decl_id: None,
+                nesting_name_id: name_id,
                 method_decl_id: DeclarationId::from("Foo#greet()"),
             },
             [
@@ -1595,7 +1759,8 @@ mod tests {
         assert_declaration_completion_eq!(
             context,
             CompletionReceiver::MethodArgument {
-                self_name_id: name_id,
+                self_decl_id: None,
+                nesting_name_id: name_id,
                 method_decl_id: DeclarationId::from("Foo#bar()"),
             },
             ["Class", "Object", "BasicObject", "Kernel", "Foo", "Module", "Foo#bar()"]
@@ -1620,7 +1785,8 @@ mod tests {
         assert_declaration_completion_eq!(
             context,
             CompletionReceiver::MethodArgument {
-                self_name_id: name_id,
+                self_decl_id: None,
+                nesting_name_id: name_id,
                 method_decl_id: DeclarationId::from("Foo#search()"),
             },
             // Only RequiredKeyword and OptionalKeyword, not RestKeyword (**opts)
@@ -1663,7 +1829,8 @@ mod tests {
         assert_declaration_completion_eq!(
             context,
             CompletionReceiver::MethodArgument {
-                self_name_id: name_id,
+                self_decl_id: None,
+                nesting_name_id: name_id,
                 method_decl_id: DeclarationId::from("Foo#bar()"),
             },
             [
@@ -1689,7 +1856,10 @@ mod tests {
         let name_id = Name::new(StringId::from("Foo"), ParentScope::None, None).id();
         assert_completion_eq!(
             context,
-            CompletionReceiver::Expression(name_id),
+            CompletionReceiver::Expression {
+                self_decl_id: None,
+                nesting_name_id: name_id,
+            },
             [
                 "Class",
                 "Object",
@@ -1752,7 +1922,8 @@ mod tests {
         assert_completion_eq!(
             context,
             CompletionReceiver::MethodArgument {
-                self_name_id: name_id,
+                self_decl_id: None,
+                nesting_name_id: name_id,
                 method_decl_id: DeclarationId::from("Foo#bar()"),
             },
             [
@@ -1837,5 +2008,582 @@ mod tests {
         .unwrap();
 
         assert!(!candidates.iter().any(|c| matches!(c, CompletionCandidate::Keyword(_))));
+    }
+
+    #[test]
+    fn expression_completion_class_variables_follow_lexical_scope() {
+        // `@@cvar` in Ruby is resolved via the innermost lexical class/module's ancestor chain,
+        // NOT `self`'s ancestor chain. Inside `def Foo.bar` written inside `Outer`, the lexical
+        // scope is `[Outer]`, so `@@outer_cvar` is reachable and `@@foo_cvar` (which lives on
+        // `Foo`, not on any lexical ancestor) must not be offered.
+        let mut context = GraphTest::new();
+
+        context.index_uri(
+            "file:///foo.rb",
+            "
+            module Outer
+              @@outer_cvar = 1
+
+              class Foo
+                @@foo_cvar = 2
+                def self.singleton_m; end
+              end
+            end
+            ",
+        );
+        context.resolve();
+
+        let outer_name_id = Name::new(StringId::from("Outer"), ParentScope::None, None).id();
+        assert_declaration_completion_eq!(
+            context,
+            CompletionReceiver::Expression {
+                self_decl_id: Some(DeclarationId::from("Outer::Foo::<Foo>")),
+                nesting_name_id: outer_name_id,
+            },
+            [
+                "Module",
+                "Class",
+                "Object",
+                "BasicObject",
+                "Kernel",
+                "Outer",
+                "Outer::Foo",
+                "Outer#@@outer_cvar",
+                "Outer::Foo::<Foo>#singleton_m()"
+            ]
+        );
+    }
+
+    #[test]
+    fn expression_completion_follows_self_decl_alias() {
+        let mut context = GraphTest::new();
+
+        context.index_uri(
+            "file:///foo.rb",
+            "
+            module Outer
+              class Original
+                def original_m; end
+              end
+
+              MyAlias = Original
+            end
+            ",
+        );
+        context.resolve();
+
+        let name_id = Name::new(StringId::from("Outer"), ParentScope::None, None).id();
+        // `self_decl_id` points to the alias `Outer::MyAlias`, which is a `ConstantAlias` rather than a `Namespace`.
+        // The completion should still collect members from the aliased namespace (`Outer::Original`) instead of
+        // returning an error, so callers do not have to unwrap aliases themselves.
+        assert_declaration_completion_eq!(
+            context,
+            CompletionReceiver::Expression {
+                self_decl_id: Some(DeclarationId::from("Outer::MyAlias")),
+                nesting_name_id: name_id,
+            },
+            [
+                "Outer::MyAlias",
+                "Outer::Original",
+                "Class",
+                "Object",
+                "BasicObject",
+                "Outer",
+                "Kernel",
+                "Module",
+                "Outer::Original#original_m()"
+            ]
+        );
+    }
+
+    #[test]
+    fn expression_completion_in_method_definition_with_receiver_uses_lexical_scope_for_class_variables() {
+        let mut context = GraphTest::new();
+
+        context.index_uri(
+            "file:///foo.rb",
+            "
+            class Foo
+              @@class_var = 1
+            end
+
+            class Bar
+              @@other_class_var = 2
+
+              def Foo.baz
+                # completion here
+              end
+            end
+            ",
+        );
+        context.resolve();
+
+        let name_id = Name::new(StringId::from("Bar"), ParentScope::None, None).id();
+        assert_declaration_completion_eq!(
+            context,
+            CompletionReceiver::Expression {
+                self_decl_id: Some(DeclarationId::from("Foo::<Foo>")),
+                nesting_name_id: name_id,
+            },
+            [
+                "Module",
+                "Class",
+                "Object",
+                "BasicObject",
+                "Kernel",
+                "Foo",
+                "Bar",
+                "Foo::<Foo>#baz()",
+                "Bar#@@other_class_var"
+            ]
+        );
+    }
+
+    #[test]
+    fn expression_completion_in_method_definition_with_receiver_uses_lexical_scope_for_constants() {
+        let mut context = GraphTest::new();
+
+        context.index_uri(
+            "file:///foo.rb",
+            "
+            class Foo
+              CONST = 1
+            end
+
+            class Bar
+              OTHER_CONST = 2
+
+              def Foo.baz
+                # completion here
+              end
+            end
+            ",
+        );
+        context.resolve();
+
+        let name_id = Name::new(StringId::from("Bar"), ParentScope::None, None).id();
+        assert_declaration_completion_eq!(
+            context,
+            CompletionReceiver::Expression {
+                self_decl_id: Some(DeclarationId::from("Foo::<Foo>")),
+                nesting_name_id: name_id,
+            },
+            [
+                "Bar::OTHER_CONST",
+                "Module",
+                "Class",
+                "Object",
+                "BasicObject",
+                "Kernel",
+                "Foo",
+                "Bar",
+                "Foo::<Foo>#baz()"
+            ]
+        );
+    }
+
+    #[test]
+    fn expression_completion_does_not_leak_constants_reachable_only_through_self_ancestors() {
+        let mut context = GraphTest::new();
+
+        context.index_uri(
+            "file:///foo.rb",
+            "
+            module Mixin
+              MIXIN_CONST = 1
+            end
+
+            class Foo
+              extend Mixin
+            end
+
+            class Bar
+              def Foo.baz
+                # completion here
+              end
+            end
+            ",
+        );
+        context.resolve();
+
+        let name_id = Name::new(StringId::from("Bar"), ParentScope::None, None).id();
+        assert_declaration_completion_eq!(
+            context,
+            CompletionReceiver::Expression {
+                self_decl_id: Some(DeclarationId::from("Foo::<Foo>")),
+                nesting_name_id: name_id,
+            },
+            [
+                "Class",
+                "BasicObject",
+                "Mixin",
+                "Object",
+                "Kernel",
+                "Module",
+                "Foo",
+                "Bar",
+                "Foo::<Foo>#baz()"
+            ]
+        );
+    }
+
+    #[test]
+    fn expression_completion_at_top_level_includes_object_constants() {
+        let mut context = GraphTest::new();
+
+        context.index_uri(
+            "file:///foo.rb",
+            "
+            class Foo
+              CONST = 1
+            end
+
+            TOP_CONST = 2
+            ",
+        );
+        context.resolve();
+
+        let name_id = Name::new(StringId::from("Object"), ParentScope::None, None).id();
+        assert_declaration_completion_eq!(
+            context,
+            CompletionReceiver::Expression {
+                self_decl_id: None,
+                nesting_name_id: name_id,
+            },
+            ["Module", "Class", "Object", "BasicObject", "Kernel", "Foo", "TOP_CONST"]
+        );
+    }
+
+    #[test]
+    fn expression_completion_in_module_body_falls_back_to_object_constants() {
+        let mut context = GraphTest::new();
+
+        context.index_uri(
+            "file:///foo.rb",
+            "
+            TOP_CONST = 1
+
+            module Mod
+              MOD_CONST = 2
+            end
+            ",
+        );
+        context.resolve();
+
+        let name_id = Name::new(StringId::from("Mod"), ParentScope::None, None).id();
+        assert_declaration_completion_eq!(
+            context,
+            CompletionReceiver::Expression {
+                self_decl_id: None,
+                nesting_name_id: name_id,
+            },
+            [
+                "Mod::MOD_CONST",
+                "Module",
+                "Class",
+                "Object",
+                "BasicObject",
+                "Kernel",
+                "TOP_CONST",
+                "Mod"
+            ]
+        );
+    }
+
+    #[test]
+    fn expression_completion_in_module_body_falls_back_to_object_ancestors() {
+        let mut context = GraphTest::new();
+
+        context.index_uri(
+            "file:///foo.rb",
+            "
+            module Kernel
+              CONST = 1
+            end
+
+            module Mod
+              # completion here
+            end
+            ",
+        );
+        context.resolve();
+
+        let name_id = Name::new(StringId::from("Mod"), ParentScope::None, None).id();
+        assert_declaration_completion_eq!(
+            context,
+            CompletionReceiver::Expression {
+                self_decl_id: None,
+                nesting_name_id: name_id,
+            },
+            [
+                "Class",
+                "Object",
+                "Kernel",
+                "BasicObject",
+                "Mod",
+                "Module",
+                "Kernel::CONST",
+            ]
+        );
+    }
+
+    #[test]
+    fn expression_completion_at_top_level_offers_methods_from_object_chain() {
+        let mut context = GraphTest::new();
+
+        context.index_uri(
+            "file:///foo.rb",
+            "
+            def my_top_method; end
+
+            module Kernel
+              def kernel_helper; end
+            end
+            ",
+        );
+        context.resolve();
+
+        let name_id = Name::new(StringId::from("Object"), ParentScope::None, None).id();
+        assert_declaration_completion_eq!(
+            context,
+            CompletionReceiver::Expression {
+                self_decl_id: None,
+                nesting_name_id: name_id,
+            },
+            [
+                "Object",
+                "Kernel",
+                "BasicObject",
+                "Module",
+                "Class",
+                "Object#my_top_method()",
+                "Kernel#kernel_helper()"
+            ]
+        );
+    }
+
+    #[test]
+    fn expression_completion_in_basic_object_subclass_excludes_object_constants() {
+        let mut context = GraphTest::new();
+
+        context.index_uri(
+            "file:///foo.rb",
+            "
+            TOP_CONST = 1
+
+            class Bar < BasicObject
+              BAR_CONST = 2
+            end
+            ",
+        );
+        context.resolve();
+
+        let name_id = Name::new(StringId::from("Bar"), ParentScope::None, None).id();
+        assert_declaration_completion_eq!(
+            context,
+            CompletionReceiver::Expression {
+                self_decl_id: None,
+                nesting_name_id: name_id,
+            },
+            ["Bar::BAR_CONST"]
+        );
+    }
+
+    #[test]
+    fn expression_completion_class_variables_in_singleton_class_block_use_outer_lexical_scope() {
+        let mut context = GraphTest::new();
+
+        context.index_uri(
+            "file:///foo.rb",
+            "
+            class Foo
+              @@foo_cvar = 1
+            end
+
+            class Bar
+              @@bar_cvar = 2
+
+              class << Foo
+                # completion here
+              end
+            end
+            ",
+        );
+        context.resolve();
+
+        let bar_id = Name::new(StringId::from("Bar"), ParentScope::None, None).id();
+        let foo_ref_id = Name::new(StringId::from("Foo"), ParentScope::None, Some(bar_id)).id();
+        let nesting_name_id = Name::new(StringId::from("<Foo>"), ParentScope::Attached(foo_ref_id), Some(bar_id)).id();
+
+        assert_declaration_completion_eq!(
+            context,
+            CompletionReceiver::Expression {
+                self_decl_id: None,
+                nesting_name_id,
+            },
+            ["Bar#@@bar_cvar"]
+        );
+    }
+
+    #[test]
+    fn expression_completion_in_def_self_method_inside_module_body() {
+        let mut context = GraphTest::new();
+
+        context.index_uri(
+            "file:///foo.rb",
+            "
+            module Mod
+              MOD_CONST = 1
+
+              def self.helper
+                # completion here
+              end
+            end
+            ",
+        );
+        context.resolve();
+
+        let name_id = Name::new(StringId::from("Mod"), ParentScope::None, None).id();
+        assert_declaration_completion_eq!(
+            context,
+            CompletionReceiver::Expression {
+                self_decl_id: Some(DeclarationId::from("Mod::<Mod>")),
+                nesting_name_id: name_id,
+            },
+            [
+                "Mod::MOD_CONST",
+                "Module",
+                "Class",
+                "Object",
+                "BasicObject",
+                "Kernel",
+                "Mod",
+                "Mod::<Mod>#helper()"
+            ]
+        );
+    }
+
+    #[test]
+    fn expression_completion_in_singleton_class_block_at_top_level() {
+        let mut context = GraphTest::new();
+
+        context.index_uri(
+            "file:///foo.rb",
+            "
+            class Foo
+              @@foo_cvar = 1
+            end
+
+            class << Foo
+              # completion here
+            end
+            ",
+        );
+        context.resolve();
+
+        let foo_ref_id = Name::new(StringId::from("Foo"), ParentScope::None, None).id();
+        let nesting_name_id = Name::new(StringId::from("<Foo>"), ParentScope::Attached(foo_ref_id), None).id();
+
+        assert_declaration_completion_eq!(
+            context,
+            CompletionReceiver::Expression {
+                self_decl_id: None,
+                nesting_name_id,
+            },
+            ["Module", "Class", "Object", "BasicObject", "Kernel", "Foo"]
+        );
+    }
+
+    #[test]
+    fn expression_completion_errors_when_self_decl_id_does_not_exist() {
+        let mut context = GraphTest::new();
+
+        context.index_uri(
+            "file:///foo.rb",
+            "
+            class Foo
+            end
+            ",
+        );
+        context.resolve();
+
+        let name_id = Name::new(StringId::from("Foo"), ParentScope::None, None).id();
+        let result = completion_candidates(
+            context.graph(),
+            CompletionContext::new(CompletionReceiver::Expression {
+                self_decl_id: Some(DeclarationId::from("Nonexistent")),
+                nesting_name_id: name_id,
+            }),
+        );
+
+        assert!(result.is_err(), "missing self_decl_id should surface as an error");
+    }
+
+    #[test]
+    fn expression_completion_errors_when_self_decl_id_is_not_a_namespace() {
+        let mut context = GraphTest::new();
+
+        context.index_uri(
+            "file:///foo.rb",
+            "
+            class Foo
+              CONST = 1
+            end
+            ",
+        );
+        context.resolve();
+
+        let name_id = Name::new(StringId::from("Foo"), ParentScope::None, None).id();
+        let result = completion_candidates(
+            context.graph(),
+            CompletionContext::new(CompletionReceiver::Expression {
+                // CONST resolves to a `Constant`, not a `Namespace` and not an alias.
+                self_decl_id: Some(DeclarationId::from("Foo::CONST")),
+                nesting_name_id: name_id,
+            }),
+        );
+
+        assert!(result.is_err(), "non-namespace self_decl_id should surface as an error");
+    }
+
+    #[test]
+    fn expression_completion_follows_chained_self_decl_alias() {
+        let mut context = GraphTest::new();
+
+        context.index_uri(
+            "file:///foo.rb",
+            "
+            module Outer
+              class Original
+                def original_m; end
+              end
+
+              FirstAlias = Original
+              SecondAlias = FirstAlias
+            end
+            ",
+        );
+        context.resolve();
+
+        let name_id = Name::new(StringId::from("Outer"), ParentScope::None, None).id();
+        assert_declaration_completion_eq!(
+            context,
+            CompletionReceiver::Expression {
+                self_decl_id: Some(DeclarationId::from("Outer::SecondAlias")),
+                nesting_name_id: name_id,
+            },
+            [
+                "Outer::FirstAlias",
+                "Outer::SecondAlias",
+                "Outer::Original",
+                "Module",
+                "Class",
+                "Object",
+                "BasicObject",
+                "Outer",
+                "Kernel",
+                "Outer::Original#original_m()"
+            ]
+        );
     }
 }

--- a/test/graph_test.rb
+++ b/test/graph_test.rb
@@ -731,6 +731,225 @@ class GraphTest < Minitest::Test
     assert(keywords.any? { |c| c.name == "if" })
   end
 
+  def test_complete_expression_with_singleton_method_receiver
+    graph = Rubydex::Graph.new
+    graph.index_source("file:///foo.rb", <<~RUBY, "ruby")
+      module Outer
+        OUTER_CONST = 1
+        @@outer_cvar = 0
+
+        class Foo
+          FOO_CONST = 2
+          @@foo_cvar = 3
+          @ivar = 4
+
+          def instance_m; end
+          def self.singleton_m; end
+        end
+
+        def Foo.bar
+          # Completion inside here:
+          # - self is Foo (the class), so methods/ivars come from Foo::<Foo>
+          # - class variables follow LEXICAL scope [Outer], NOT self
+          # - constants come from the lexical scope [Outer], NOT from Foo
+        end
+      end
+    RUBY
+    graph.resolve
+
+    # Lexical nesting at `def Foo.bar` is [Outer]; self receiver is Foo::<Foo>
+    candidates = graph.complete_expression(["Outer"], self_receiver: "Outer::Foo::<Foo>")
+
+    # Methods: singleton methods defined on Foo (live on Foo::<Foo>)
+    methods = candidates.select { |c| c.is_a?(Rubydex::Method) }
+    method_names = methods.map(&:name)
+    assert_includes(method_names, "Outer::Foo::<Foo>#singleton_m()")
+    assert_includes(method_names, "Outer::Foo::<Foo>#bar()")
+    # Instance methods of Foo should NOT be callable on the class itself
+    refute_includes(method_names, "Outer::Foo#instance_m()")
+
+    # Instance variables: class instance variables of Foo (stored on Foo::<Foo>)
+    ivars = candidates.select { |c| c.is_a?(Rubydex::InstanceVariable) }
+    assert(ivars.any? { |c| c.name == "Outer::Foo::<Foo>\#@ivar" })
+
+    # Class variables follow lexical scope: Outer's cvars are visible, Foo's must NOT leak
+    cvars = candidates.select { |c| c.is_a?(Rubydex::ClassVariable) }
+    cvar_names = cvars.map(&:name)
+    assert_includes(cvar_names, "Outer\#@@outer_cvar")
+    refute_includes(cvar_names, "Outer::Foo\#@@foo_cvar")
+
+    # Constants: from lexical scope [Outer], plus top-level. Foo::FOO_CONST must NOT leak.
+    declarations = candidates.select { |c| c.is_a?(Rubydex::Declaration) }
+    decl_names = declarations.map(&:name)
+    assert_includes(decl_names, "Outer::OUTER_CONST")
+    assert_includes(decl_names, "Outer::Foo")
+    refute_includes(decl_names, "Outer::Foo::FOO_CONST")
+  end
+
+  def test_complete_expression_with_def_self_method
+    # `def self.bar` inside a class: lexical nesting is [Foo] (NOT [Foo, <Foo>]),
+    # but self is Foo::<Foo>.
+    graph = Rubydex::Graph.new
+    graph.index_source("file:///foo.rb", <<~RUBY, "ruby")
+      class Foo
+        FOO_CONST = 1
+        @@class_var = 2
+        @ivar = 3
+
+        def instance_m; end
+
+        def self.bar
+          # completion point
+        end
+      end
+    RUBY
+    graph.resolve
+
+    candidates = graph.complete_expression(["Foo"], self_receiver: "Foo::<Foo>")
+
+    # Methods: singleton methods only
+    methods = candidates.select { |c| c.is_a?(Rubydex::Method) }
+    method_names = methods.map(&:name)
+    assert_includes(method_names, "Foo::<Foo>#bar()")
+    refute_includes(method_names, "Foo#instance_m()")
+
+    # Instance variables: from Foo::<Foo>
+    ivars = candidates.select { |c| c.is_a?(Rubydex::InstanceVariable) }
+    assert(ivars.any? { |c| c.name == "Foo::<Foo>\#@ivar" })
+
+    # Class variables: from attached object Foo
+    cvars = candidates.select { |c| c.is_a?(Rubydex::ClassVariable) }
+    assert(cvars.any? { |c| c.name == "Foo\#@@class_var" })
+
+    # Constants: FOO_CONST is visible because Foo IS in the lexical nesting
+    declarations = candidates.select { |c| c.is_a?(Rubydex::Declaration) }
+    decl_names = declarations.map(&:name)
+    assert_includes(decl_names, "Foo::FOO_CONST")
+    assert_includes(decl_names, "Foo")
+  end
+
+  def test_complete_method_argument_with_singleton_method_receiver
+    # `def Foo.bar(x:)` — inside the argument list of a call from within this method.
+    # self-type / nesting split must propagate through method_argument_completion too.
+    graph = Rubydex::Graph.new
+    graph.index_source("file:///foo.rb", <<~RUBY, "ruby")
+      module Outer
+        OUTER_CONST = 1
+        @@outer_cvar = 0
+
+        class Foo
+          FOO_CONST = 2
+          @ivar = 3
+          @@foo_cvar = 4
+
+          def self.helper(name:); end
+        end
+
+        def Foo.bar
+          # completion inside `Foo.helper(|)` here
+        end
+      end
+    RUBY
+    graph.resolve
+
+    candidates = graph.complete_method_argument(
+      "Outer::Foo::<Foo>#helper()",
+      ["Outer"],
+      self_receiver: "Outer::Foo::<Foo>",
+    )
+
+    # Keyword argument from the method being called
+    keyword_params = candidates.select { |c| c.is_a?(Rubydex::KeywordParameter) }
+    assert(keyword_params.any? { |c| c.name == "name" })
+
+    # Everything expression_completion provides, with the correct self/nesting split:
+    methods = candidates.select { |c| c.is_a?(Rubydex::Method) }
+    method_names = methods.map(&:name)
+    assert_includes(method_names, "Outer::Foo::<Foo>#helper()")
+    assert_includes(method_names, "Outer::Foo::<Foo>#bar()")
+
+    ivars = candidates.select { |c| c.is_a?(Rubydex::InstanceVariable) }
+    assert(ivars.any? { |c| c.name == "Outer::Foo::<Foo>\#@ivar" })
+
+    # Class variables follow lexical scope [Outer], not self (Foo::<Foo>)
+    cvars = candidates.select { |c| c.is_a?(Rubydex::ClassVariable) }
+    cvar_names = cvars.map(&:name)
+    assert_includes(cvar_names, "Outer\#@@outer_cvar")
+    refute_includes(cvar_names, "Outer::Foo\#@@foo_cvar")
+
+    declarations = candidates.select { |c| c.is_a?(Rubydex::Declaration) }
+    decl_names = declarations.map(&:name)
+    assert_includes(decl_names, "Outer::OUTER_CONST")
+    refute_includes(decl_names, "Outer::Foo::FOO_CONST")
+  end
+
+  def test_complete_expression_raises_on_empty_self_receiver
+    graph = Rubydex::Graph.new
+    assert_raises(ArgumentError) do
+      graph.complete_expression(["Foo"], self_receiver: "")
+    end
+  end
+
+  def test_complete_method_argument_raises_on_empty_self_receiver
+    graph = Rubydex::Graph.new
+    assert_raises(ArgumentError) do
+      graph.complete_method_argument("Foo#bar()", ["Foo"], self_receiver: "")
+    end
+  end
+
+  def test_complete_expression_with_nil_self_receiver_matches_no_kwarg
+    graph = Rubydex::Graph.new
+    graph.index_source("file:///foo.rb", <<~RUBY, "ruby")
+      class Foo
+        def instance_m; end
+      end
+    RUBY
+    graph.resolve
+
+    without_kwarg = graph.complete_expression(["Foo"]).map(&:name)
+    with_nil = graph.complete_expression(["Foo"], self_receiver: nil).map(&:name)
+    assert_equal(without_kwarg.sort, with_nil.sort)
+  end
+
+  def test_complete_expression_raises_on_nonexistent_self_receiver
+    graph = Rubydex::Graph.new
+    graph.index_source("file:///foo.rb", "class Foo; end", "ruby")
+    graph.resolve
+
+    assert_raises(ArgumentError) do
+      graph.complete_expression(["Foo"], self_receiver: "Nonexistent")
+    end
+  end
+
+  def test_complete_expression_raises_on_non_namespace_self_receiver
+    graph = Rubydex::Graph.new
+    graph.index_source("file:///foo.rb", <<~RUBY, "ruby")
+      class Foo
+        def bar; end
+      end
+    RUBY
+    graph.resolve
+
+    # `Foo#bar()` is a Method declaration, not a Namespace and not a ConstantAlias.
+    assert_raises(ArgumentError) do
+      graph.complete_expression(["Foo"], self_receiver: "Foo#bar()")
+    end
+  end
+
+  def test_complete_expression_raises_on_wrong_type_self_receiver
+    graph = Rubydex::Graph.new
+    assert_raises(TypeError) do
+      graph.complete_expression(["Foo"], self_receiver: 42)
+    end
+  end
+
+  def test_complete_method_argument_raises_on_wrong_type_self_receiver
+    graph = Rubydex::Graph.new
+    assert_raises(TypeError) do
+      graph.complete_method_argument("Foo#bar()", ["Foo"], self_receiver: 42)
+    end
+  end
+
   def test_complete_expression_with_empty_nesting
     graph = Rubydex::Graph.new
     graph.index_source("file:///foo.rb", "class Object; end\nclass Foo; end", "ruby")


### PR DESCRIPTION
I noticed that completion for expression-like scenarios was actually wrong under a few scenarios.

The first is that we weren't taking into the correct resolution rules for the top level that we fixed in #729. For completion, we need to match the same idea. For example, a class inheriting from `BasicObject` should not see any top level constants because `Object` is not in its inheritance chain. Also, modules need the `Object` inheritance fallback to show all top level constants and the ones defined in `Kernel`, `BasicObject` and so on.

The second part is that we weren't correctly separating two concepts: the lexical scope from the type of `self`. The lexical scope _might be the type of self_, but that's not always the case. For example:

```ruby
class Foo
end

class Bar
  def Foo.baz
    # Inside this method, the lexical scope is Bar. However, the type of self
    # is Foo::<Foo> (singleton of Foo).
    #
    # Constants and class variables follow the lexical scope
    # Methods and instance variables follow the type of self
    # Globals are accessible anywhere
  end
end
```

This PR fixes expression completion to apply these rules and adds a bunch of new tests to prevent regressions.