### PR TITLE
Expose getter for documents in the graph

### DIFF
--- a/ext/rubydex/graph.c
+++ b/ext/rubydex/graph.c
@@ -303,6 +303,24 @@ static VALUE rdxr_graph_method_references(VALUE self) {
     return self;
 }
 
+// Graph#document: (String uri) -> Document?
+// Returns the Document for the given URI, or nil if it doesn't exist.
+static VALUE rdxr_graph_document(VALUE self, VALUE uri) {
+    Check_Type(uri, T_STRING);
+
+    void *graph;
+    TypedData_Get_Struct(self, void *, &graph_type, graph);
+    const uint64_t *uri_id = rdx_graph_get_document(graph, StringValueCStr(uri));
+
+    if (uri_id == NULL) {
+        return Qnil;
+    }
+
+    VALUE argv[] = {self, ULL2NUM(*uri_id)};
+    free_u64(uri_id);
+    return rb_class_new_instance(2, argv, cDocument);
+}
+
 // Graph#delete_document: (String uri) -> Document?
 // Deletes a document and all of its definitions from the graph.
 // Returns the removed Document or nil if it doesn't exist.
@@ -676,6 +694,7 @@ void rdxi_initialize_graph(VALUE moduleRubydex) {
     rb_define_alloc_func(cGraph, rdxr_graph_alloc);
     rb_define_method(cGraph, "index_all", rdxr_graph_index_all, 1);
     rb_define_method(cGraph, "index_source", rdxr_graph_index_source, 3);
+    rb_define_method(cGraph, "document", rdxr_graph_document, 1);
     rb_define_method(cGraph, "delete_document", rdxr_graph_delete_document, 1);
     rb_define_method(cGraph, "resolve", rdxr_graph_resolve, 0);
     rb_define_method(cGraph, "resolve_constant", rdxr_graph_resolve_constant, 2);

--- a/rbi/rubydex.rbi
+++ b/rbi/rubydex.rbi
@@ -259,6 +259,9 @@ class Rubydex::Graph
   sig { params(uri: String).returns(T.nilable(Rubydex::Document)) }
   def delete_document(uri); end
 
+  sig { params(uri: String).returns(T.nilable(Rubydex::Document)) }
+  def document(uri); end
+
   sig { returns(T::Array[Rubydex::Diagnostic]) }
   def diagnostics; end
 

--- a/rust/rubydex-sys/src/graph_api.rs
+++ b/rust/rubydex-sys/src/graph_api.rs
@@ -9,7 +9,7 @@ use libc::{c_char, c_void};
 use rubydex::indexing::LanguageId;
 use rubydex::model::encoding::Encoding;
 use rubydex::model::graph::Graph;
-use rubydex::model::ids::{DeclarationId, NameId};
+use rubydex::model::ids::{DeclarationId, NameId, UriId};
 use rubydex::model::keywords;
 use rubydex::model::name::NameRef;
 use rubydex::query::{CompletionCandidate, CompletionContext, CompletionReceiver};
@@ -257,6 +257,29 @@ pub unsafe extern "C" fn rdx_index_all(
 
         let boxed = c_strings.into_boxed_slice();
         Box::into_raw(boxed).cast::<*const c_char>()
+    })
+}
+
+/// Returns a pointer to the URI ID of the document identified by `uri`, or NULL if it doesn't exist.
+/// Caller must free the returned pointer with `free_u64`.
+///
+/// # Safety
+///
+/// Expects both the graph pointer and uri string pointer to be valid
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rdx_graph_get_document(pointer: GraphPointer, uri: *const c_char) -> *const u64 {
+    let Ok(uri_str) = (unsafe { utils::convert_char_ptr_to_string(uri) }) else {
+        return ptr::null();
+    };
+
+    with_graph(pointer, |graph| {
+        let uri_id = UriId::from(uri_str.as_str());
+
+        if graph.documents().contains_key(&uri_id) {
+            Box::into_raw(Box::new(*uri_id)).cast_const()
+        } else {
+            ptr::null()
+        }
     })
 }
 

--- a/test/graph_test.rb
+++ b/test/graph_test.rb
@@ -987,6 +987,49 @@ class GraphTest < Minitest::Test
     assert_raises(TypeError) { graph.keyword(nil) }
   end
 
+  def test_document_returns_specific_document
+    graph = Rubydex::Graph.new
+    graph.index_source("file:///foo.rb", <<~RUBY, "ruby")
+      class Foo
+      end
+    RUBY
+
+    document = graph.document("file:///foo.rb")
+    assert_instance_of(Rubydex::Document, document)
+    assert_equal(1, document.definitions.count)
+  end
+
+  def test_document_returns_nil_for_non_existing_uri
+    graph = Rubydex::Graph.new
+    assert_nil(graph.document("file:///non_existing.rb"))
+  end
+
+  def test_document_with_invalid_argument
+    graph = Rubydex::Graph.new
+    assert_raises(TypeError) { graph.document(123) }
+  end
+
+  def test_document_returns_nil_after_delete_document
+    graph = Rubydex::Graph.new
+    graph.index_source("file:///foo.rb", "class Foo; end", "ruby")
+
+    refute_nil(graph.document("file:///foo.rb"))
+
+    graph.delete_document("file:///foo.rb")
+    assert_nil(graph.document("file:///foo.rb"))
+  end
+
+  def test_document_returns_correct_document_with_multiple_documents
+    graph = Rubydex::Graph.new
+    graph.index_source("file:///foo.rb", "class Foo; end", "ruby")
+    graph.index_source("file:///bar.rb", "class Bar; end", "ruby")
+    graph.index_source("file:///baz.rb", "class Baz; end", "ruby")
+
+    document = graph.document("file:///bar.rb")
+    assert_instance_of(Rubydex::Document, document)
+    assert_equal("file:///bar.rb", document.uri)
+  end
+
   private
 
   def assert_diagnostics(expected, actual)


### PR DESCRIPTION
Expose `Graph#document(uri)` to allow consumers to get a specific document from the graph.

The Tapioca add-on needs this to inspect which definitions were modified for a given URI.