### PR TITLE
Store the constant visibility target as a StringId

### DIFF
--- a/rust/rubydex/src/indexing/ruby_indexer.rs
+++ b/rust/rubydex/src/indexing/ruby_indexer.rs
@@ -1258,11 +1258,8 @@ impl<'a> RubyIndexer<'a> {
             let str_id = self.local_graph.intern_string(name);
             let offset = Offset::from_prism_location(&location);
             let definition = Definition::ConstantVisibility(Box::new(ConstantVisibilityDefinition::new(
-                self.local_graph.add_name(Name::new(
-                    str_id,
-                    receiver_name_id.map_or(ParentScope::None, ParentScope::Some),
-                    self.current_lexical_scope_name_id(),
-                )),
+                receiver_name_id,
+                str_id,
                 visibility,
                 self.uri_id,
                 offset,

--- a/rust/rubydex/src/indexing/ruby_indexer_tests.rs
+++ b/rust/rubydex/src/indexing/ruby_indexer_tests.rs
@@ -3271,31 +3271,38 @@ mod visibility_tests {
         assert_no_local_diagnostics!(&context);
 
         assert_definition_at!(&context, "6:21-6:24", ConstantVisibility, |def| {
-            assert_def_name_eq!(&context, def, "BAR");
+            assert_string_eq!(&context, def.target(), "BAR");
+            assert!(def.receiver().is_none());
             assert_eq!(def.visibility(), &Visibility::Private);
         });
         assert_definition_at!(&context, "6:27-6:30", ConstantVisibility, |def| {
-            assert_def_name_eq!(&context, def, "BAZ");
+            assert_string_eq!(&context, def.target(), "BAZ");
+            assert!(def.receiver().is_none());
             assert_eq!(def.visibility(), &Visibility::Private);
         });
         assert_definition_at!(&context, "7:20-7:25", ConstantVisibility, |def| {
-            assert_def_name_eq!(&context, def, "FOO");
+            assert_string_eq!(&context, def.target(), "FOO");
+            assert!(def.receiver().is_none());
             assert_eq!(def.visibility(), &Visibility::Private);
         });
         assert_definition_at!(&context, "13:26-13:29", ConstantVisibility, |def| {
-            assert_def_name_eq!(&context, def, "Foo::BAR");
+            assert_string_eq!(&context, def.target(), "BAR");
+            assert_name_path_eq!(&context, "Foo", def.receiver().unwrap());
             assert_eq!(def.visibility(), &Visibility::Public);
         });
         assert_definition_at!(&context, "14:25-14:30", ConstantVisibility, |def| {
-            assert_def_name_eq!(&context, def, "Foo::BAZ");
+            assert_string_eq!(&context, def.target(), "BAZ");
+            assert_name_path_eq!(&context, "Foo", def.receiver().unwrap());
             assert_eq!(def.visibility(), &Visibility::Public);
         });
         assert_definition_at!(&context, "17:26-17:29", ConstantVisibility, |def| {
-            assert_def_name_eq!(&context, def, "Qux");
+            assert_string_eq!(&context, def.target(), "Qux");
+            assert!(def.receiver().is_none());
             assert_eq!(def.visibility(), &Visibility::Private);
         });
         assert_definition_at!(&context, "20:22-20:25", ConstantVisibility, |def| {
-            assert_def_name_eq!(&context, def, "Foo::BAR");
+            assert_string_eq!(&context, def.target(), "BAR");
+            assert_name_path_eq!(&context, "Foo", def.receiver().unwrap());
             assert_eq!(def.visibility(), &Visibility::Public);
         });
     }

--- a/rust/rubydex/src/model/definitions.rs
+++ b/rust/rubydex/src/model/definitions.rs
@@ -155,8 +155,8 @@ impl Definition {
             Definition::Module(d) => Some(d.name_id()),
             Definition::Constant(d) => Some(d.name_id()),
             Definition::ConstantAlias(d) => Some(d.name_id()),
-            Definition::ConstantVisibility(d) => Some(d.name_id()),
-            Definition::MethodVisibility(_)
+            Definition::ConstantVisibility(_)
+            | Definition::MethodVisibility(_)
             | Definition::GlobalVariable(_)
             | Definition::InstanceVariable(_)
             | Definition::ClassVariable(_)
@@ -711,7 +711,8 @@ impl ConstantAliasDefinition {
 
 #[derive(Debug)]
 pub struct ConstantVisibilityDefinition {
-    name_id: NameId,
+    receiver: Option<NameId>,
+    target: StringId,
     visibility: Visibility,
     uri_id: UriId,
     offset: Offset,
@@ -722,8 +723,10 @@ pub struct ConstantVisibilityDefinition {
 
 impl ConstantVisibilityDefinition {
     #[must_use]
+    #[allow(clippy::too_many_arguments)]
     pub const fn new(
-        name_id: NameId,
+        receiver: Option<NameId>,
+        target: StringId,
         visibility: Visibility,
         uri_id: UriId,
         offset: Offset,
@@ -732,7 +735,8 @@ impl ConstantVisibilityDefinition {
         lexical_nesting_id: Option<DefinitionId>,
     ) -> Self {
         Self {
-            name_id,
+            receiver,
+            target,
             visibility,
             uri_id,
             offset,
@@ -744,12 +748,17 @@ impl ConstantVisibilityDefinition {
 
     #[must_use]
     pub fn id(&self) -> DefinitionId {
-        DefinitionId::from(&format!("{}{}{}", *self.uri_id, self.offset.start(), *self.name_id))
+        DefinitionId::from(&format!("{}{}{}", *self.uri_id, self.offset.start(), *self.target))
     }
 
     #[must_use]
-    pub fn name_id(&self) -> &NameId {
-        &self.name_id
+    pub fn receiver(&self) -> &Option<NameId> {
+        &self.receiver
+    }
+
+    #[must_use]
+    pub fn target(&self) -> &StringId {
+        &self.target
     }
 
     #[must_use]
@@ -782,7 +791,7 @@ impl ConstantVisibilityDefinition {
         &self.flags
     }
 }
-assert_mem_size!(ConstantVisibilityDefinition, 56);
+assert_mem_size!(ConstantVisibilityDefinition, 64);
 
 #[derive(Debug)]
 pub struct MethodVisibilityDefinition {

--- a/rust/rubydex/src/model/graph.rs
+++ b/rust/rubydex/src/model/graph.rs
@@ -260,10 +260,7 @@ impl Graph {
                 let name = self.names.get(it.name_id()).unwrap();
                 name.str()
             }
-            Definition::ConstantVisibility(it) => {
-                let name = self.names.get(it.name_id()).unwrap();
-                name.str()
-            }
+            Definition::ConstantVisibility(it) => it.target(),
             Definition::MethodVisibility(it) => it.str_id(),
             Definition::GlobalVariable(it) => it.str_id(),
             Definition::InstanceVariable(it) => it.str_id(),
@@ -320,9 +317,12 @@ impl Graph {
             Definition::ConstantAlias(it) => {
                 return self.name_id_to_declaration_id(*it.name_id());
             }
-            Definition::ConstantVisibility(it) => {
-                return self.name_id_to_declaration_id(*it.name_id());
-            }
+            Definition::ConstantVisibility(it) => (
+                it.receiver()
+                    .as_ref()
+                    .or_else(|| self.find_enclosing_namespace_name_id(it.lexical_nesting_id().as_ref())),
+                it.target(),
+            ),
             Definition::MethodVisibility(it) => (
                 self.find_enclosing_namespace_name_id(it.lexical_nesting_id().as_ref()),
                 it.str_id(),


### PR DESCRIPTION
Constant visibility resolution (in #766) needs the target constant's name to look up the member on the resolved owner. Currently, the only way to get that name from a `ConstantVisibilityDefinition` is to walk the `name_id` through the graph (`graph.names().get(*def.name_id()).str()`), even though the indexer already had the `StringId` in hand when it built the definition.

By storing the target as a `StringId` on the definition, the resolver gets a direct handle (`owner.member(*def.target())`), and consumers that still want the full name (receiver and lexical scope) are unaffected.