### PR TITLE
Index constant references in parameter default values

### DIFF
--- a/rust/rubydex/src/indexing/ruby_indexer.rs
+++ b/rust/rubydex/src/indexing/ruby_indexer.rs
@@ -234,6 +234,7 @@ impl<'a> RubyIndexer<'a> {
                     Offset::from_prism_location(&name_loc),
                     str_id,
                 )));
+                self.visit(&opt_param.value());
             }
 
             if let Some(rest) = parameters_list.rest() {
@@ -276,6 +277,7 @@ impl<'a> RubyIndexer<'a> {
                         let str_id = self.local_graph.intern_string(self.offset_to_string(&offset));
 
                         parameters.push(Parameter::OptionalKeyword(ParameterStruct::new(offset, str_id)));
+                        self.visit(&optional.value());
                     }
                     _ => {}
                 }

--- a/rust/rubydex/src/indexing/ruby_indexer_tests.rs
+++ b/rust/rubydex/src/indexing/ruby_indexer_tests.rs
@@ -4061,6 +4061,19 @@ mod constant_reference_tests {
     }
 
     #[test]
+    fn index_unresolved_constant_references_in_default_values() {
+        let context = index_source({
+            "
+            def foo(a = C1, b = C2::C3); end
+            def bar(a: C4, b: C5::C6); end
+            "
+        });
+
+        assert_no_local_diagnostics!(&context);
+        assert_constant_references_eq!(&context, ["C1", "C2", "C3", "C4", "C5", "C6"]);
+    }
+
+    #[test]
     fn index_constant_path_and_write_visits_value() {
         let context = index_source({
             "


### PR DESCRIPTION
### Related

- [PR #764](https://github.com/Shopify/rubydex/pull/764) — sibling fix for constant resolution inside `class << self`; same shape: data-layer fix in the indexer, not the resolver.
- Checkout Classic cleanup graph — downstream tool that surfaced the bug by mistakenly flagging `MoneyBagContainer` as unused.

### Context

Constants referenced only in a method-parameter default value are silently dropped from `graph.constant_references`. Any tool relying on `constant_references` for reachability or rename analysis treats those constants as unused.

```ruby
class Foo
  def for(price, container: MoneyBagContainer.new)
    container.presentment_money(price)
  end
end
```

Today: `PresentmentMoneyResponseFormat` and friends from the body are indexed; `MoneyBagContainer` is missing entirely.

### Solution

`visit_def_node` overrides the default ruby-prism visitor and only descends into `node.body()`. Parameter sub-nodes go to `collect_parameters`, which extracts names but never walks default-value expressions. Visiting those sub-trees in `visit_def_node` — before pushing `Nesting::Method` — feeds the missing references to the existing resolution algorithm. Visiting *outside* `Nesting::Method` matches Ruby semantics: defaults resolve against the method's enclosing lexical scope, not its local scope.