### PR TITLE
Add interactive CLI mode

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem "rubocop"
 gem "rubocop-shopify"
 gem "extconf_compile_commands_json"
 gem "rbs"
+gem "irb"
 
 # Gems that aren't supported on Windows
 platforms :ruby do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,15 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.3)
+    date (3.5.1)
+    erb (6.0.2)
     extconf_compile_commands_json (0.0.7)
+    io-console (0.8.2)
+    irb (1.17.0)
+      pp (>= 0.6.0)
+      prism (>= 1.3.0)
+      rdoc (>= 4.0.0)
+      reline (>= 0.4.2)
     json (2.19.4)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
@@ -24,7 +32,13 @@ GEM
     parser (3.3.11.1)
       ast (~> 2.4.1)
       racc
+    pp (0.6.3)
+      prettyprint
+    prettyprint (0.2.0)
     prism (1.9.0)
+    psych (5.3.1)
+      date
+      stringio
     racc (1.8.1)
     rainbow (3.1.1)
     rake (13.3.1)
@@ -33,7 +47,13 @@ GEM
     rbs (3.10.3)
       logger
       tsort
+    rdoc (7.2.0)
+      erb
+      psych (>= 4.0.0)
+      tsort
     regexp_parser (2.12.0)
+    reline (0.6.3)
+      io-console (~> 0.5)
     rubocop (1.84.0)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
@@ -53,6 +73,7 @@ GEM
     ruby-progressbar (1.13.0)
     ruby_memcheck (3.0.1)
       nokogiri
+    stringio (3.2.0)
     tsort (0.2.0)
     unicode-display_width (3.2.0)
       unicode-emoji (~> 4.1)
@@ -64,6 +85,7 @@ PLATFORMS
 
 DEPENDENCIES
   extconf_compile_commands_json
+  irb
   minitest
   rake (~> 13.3)
   rake-compiler

--- a/dev.yml
+++ b/dev.yml
@@ -4,6 +4,8 @@ up:
   - ruby
   - bundler
   - rust
+  - packages:
+    - libyaml
   # met? checks: 1) binary exists, 2) no file under rust/ (excluding rust/target/) is newer than the binary
   - custom:
       name: Install rubydex MCP server

--- a/exe/rdx
+++ b/exe/rdx
@@ -2,11 +2,12 @@
 # frozen_string_literal: true
 
 $LOAD_PATH.unshift(File.expand_path("../lib", __dir__))
+
 require "optparse"
 
-OptionParser.new do |parser|
-  parser.banner = "Usage: [path1, path2]"
+options = {}
 
+OptionParser.new do |parser|
   parser.on("--version", "Print the gem's version") do
     require "rubydex/version"
     puts "v#{Rubydex::VERSION}"
@@ -17,31 +18,34 @@ OptionParser.new do |parser|
     puts parser
     exit
   end
+
+  parser.on("-i", "--interactive", "Open an interactive session with a populated graph for the current workspace") do
+    options[:interactive] = true
+  end
 end.parse!
 
 require "rubydex"
 
-workspace_path = ARGV.first
-
-# If a workspace path is passed, we need to ensure that Bundler is setup in that context so that we find the
-# dependencies for that project
-if workspace_path
-  gemfile_path = File.join(workspace_path, "Gemfile")
-
-  if File.exist?(gemfile_path)
-    ENV["BUNDLE_GEMFILE"] = gemfile_path
-
-    begin
-      Bundler.setup
-    rescue Bundler::BundlerError => e
-      $stderr.puts(<<~MESSAGE)
-        Bundle setup failed for #{gemfile_path}. Indexing of dependencies may be partial
-        Error:
-          #{e.message}
-      MESSAGE
-    end
-  end
+def __with_timer(message, &block)
+  print(message)
+  start = Process.clock_gettime(Process::CLOCK_MONOTONIC, :float_millisecond)
+  block.call
+  duration = Process.clock_gettime(Process::CLOCK_MONOTONIC, :float_millisecond) - start
+  puts " finished in #{duration.round(2)}ms"
 end
 
-graph = Rubydex::Graph.new(workspace_path: workspace_path)
-graph.index_workspace
+graph = Rubydex::Graph.new
+__with_timer("Indexing workspace...") { graph.index_workspace }
+__with_timer("Resolving graph...") { graph.resolve }
+
+if options[:interactive]
+  begin
+    require "irb"
+    IRB.setup(nil)
+    IRB.conf[:IRB_NAME] = "rubydex"
+    workspace = IRB::WorkSpace.new(binding)
+    IRB::Irb.new(workspace).run(IRB.conf)
+  rescue LoadError
+    abort("Interactive mode requires `irb` to be in the bundle")
+  end
+end


### PR DESCRIPTION
Closes #6

We weren't really doing much with our Ruby executable. I propose that we add an interactive CLI mode through IRB.

The idea is that we always index and resolve the current workspace. By default, we just print the time it takes to index and resolve. If you pass the interactive flag, then we start a custom IRB session where you can query the populated graph. It's quite useful for a quick exploration.

Usage:

```sh
bundle exec rdx -i

# Indexing workspace... finished in xxms
# Resolving graph... finished in xxms
# rubydex> graph
```