### PR TITLE
Add `follow_method_alias` query

### DIFF
--- a/rust/rubydex-sys/src/declaration_api.rs
+++ b/rust/rubydex-sys/src/declaration_api.rs
@@ -197,42 +197,19 @@ pub unsafe extern "C" fn rdx_declaration_find_member(
 
     with_graph(pointer, |graph| {
         let id = DeclarationId::new(declaration_id);
+        let member_id = StringId::from(member_str.as_str());
 
-        let Some(Declaration::Namespace(decl)) = graph.declarations().get(&id) else {
-            return ptr::null();
+        let member_decl_id = match rubydex::query::find_member_in_ancestors(graph, id, member_id, only_inherited) {
+            Ok(decl_id) => decl_id,
+            Err(rubydex::query::FindMemberError::MemberNotFound) => return ptr::null(),
+            Err(err) => unreachable!(
+                "Namespace#find_member is only exposed on namespace declarations, so the declaration must exist and be \
+                 a namespace, got {err:?}"
+            ),
         };
 
-        let member_id = StringId::from(member_str.as_str());
-        let mut found_main_namespace = false;
-
-        decl.ancestors()
-            .iter()
-            .find_map(|ancestor| match ancestor {
-                Ancestor::Complete(ancestor_id) => {
-                    // When only_inherited, skip self and prepended modules
-                    if only_inherited {
-                        let is_self = *ancestor_id == id;
-                        if is_self {
-                            found_main_namespace = true;
-                        }
-                        if is_self || !found_main_namespace {
-                            return None;
-                        }
-                    }
-
-                    let ancestor_decl = graph.declarations().get(ancestor_id).unwrap().as_namespace().unwrap();
-
-                    if let Some(member_decl_id) = ancestor_decl.member(&member_id) {
-                        return Some((member_decl_id, graph.declarations().get(member_decl_id).unwrap()));
-                    }
-
-                    None
-                }
-                Ancestor::Partial(_) => None,
-            })
-            .map_or(ptr::null(), |(member_decl_id, member_decl)| {
-                Box::into_raw(Box::new(CDeclaration::from_declaration(*member_decl_id, member_decl))).cast_const()
-            })
+        let member_decl = graph.declarations().get(&member_decl_id).unwrap();
+        Box::into_raw(Box::new(CDeclaration::from_declaration(member_decl_id, member_decl))).cast_const()
     })
 }
 

--- a/rust/rubydex/src/model/graph.rs
+++ b/rust/rubydex/src/model/graph.rs
@@ -380,13 +380,15 @@ impl Graph {
                 )
             }
             Definition::MethodAlias(it) => {
-                if let Some(Receiver::SelfReceiver(def_id)) = it.receiver() {
-                    return self.find_self_receiver_declaration(*def_id, *it.new_name_str_id());
-                }
-                (
-                    self.find_enclosing_namespace_name_id(it.lexical_nesting_id().as_ref()),
-                    it.new_name_str_id(),
-                )
+                let nesting_name_id = match it.receiver() {
+                    Some(Receiver::SelfReceiver(def_id)) => {
+                        return self.find_self_receiver_declaration(*def_id, *it.new_name_str_id());
+                    }
+                    Some(Receiver::ConstantReceiver(name_id)) => Some(name_id),
+                    None => self.find_enclosing_namespace_name_id(it.lexical_nesting_id().as_ref()),
+                };
+
+                (nesting_name_id, it.new_name_str_id())
             }
         };
 

--- a/rust/rubydex/src/query.rs
+++ b/rust/rubydex/src/query.rs
@@ -10,7 +10,7 @@ use crate::model::declaration::{Ancestor, Declaration, Namespace};
 use crate::model::definitions::{Definition, Parameter};
 use crate::model::graph::Graph;
 use crate::model::identity_maps::IdentityHashSet;
-use crate::model::ids::{DeclarationId, NameId, StringId, UriId};
+use crate::model::ids::{DeclarationId, DefinitionId, NameId, StringId, UriId};
 use crate::model::keywords::{self, Keyword};
 use crate::model::name::NameRef;
 use crate::model::visibility::Visibility;
@@ -672,6 +672,153 @@ fn method_argument_completion<'a>(
     }
 
     Ok(candidates)
+}
+
+/// Reasons [`find_member_in_ancestors`] could not produce a target declaration.
+#[derive(Debug, PartialEq, Eq)]
+pub enum FindMemberError {
+    /// The provided declaration id does not exist in the graph.
+    DeclarationNotFound,
+    /// The declaration exists but is not a namespace, so it has no members or ancestor chain to search.
+    NotNamespace,
+    /// The declaration is a namespace, but no matching member exists on it or any of its ancestors.
+    MemberNotFound,
+}
+
+/// Finds the given member on the ancestor chain of the declaration. Use `only_inherited` to skip all ancestors until
+/// the main namespace and start from its parent.
+///
+/// # Errors
+///
+/// Returns a [`FindMemberError`] describing why no target declaration could be produced (declaration not found, not a
+/// namespace, or member missing on the ancestor chain).
+///
+/// # Panics
+///
+/// Will panic if we incorrectly store ancestors that are not namespaces.
+pub fn find_member_in_ancestors(
+    graph: &Graph,
+    declaration_id: DeclarationId,
+    member_str_id: StringId,
+    only_inherited: bool,
+) -> Result<DeclarationId, FindMemberError> {
+    let declaration = graph
+        .declarations()
+        .get(&declaration_id)
+        .ok_or(FindMemberError::DeclarationNotFound)?;
+    let namespace = declaration.as_namespace().ok_or(FindMemberError::NotNamespace)?;
+    let mut found_main_namespace = false;
+
+    for ancestor in namespace.ancestors() {
+        let Ancestor::Complete(ancestor_id) = ancestor else {
+            continue;
+        };
+
+        if only_inherited && !found_main_namespace {
+            if *ancestor_id == declaration_id {
+                found_main_namespace = true;
+            }
+            continue;
+        }
+
+        if let Some(member_id) = graph
+            .declarations()
+            .get(ancestor_id)
+            .unwrap()
+            .as_namespace()
+            .unwrap()
+            .member(&member_str_id)
+        {
+            return Ok(*member_id);
+        }
+    }
+
+    Err(FindMemberError::MemberNotFound)
+}
+
+/// Reasons [`follow_method_alias`] could not produce a target declaration.
+#[derive(Debug, PartialEq, Eq)]
+pub enum AliasResolutionError {
+    /// The provided definition id is not a `MethodAlias`.
+    NotAnAlias,
+    /// The alias's owner could not be resolved (e.g., a `ConstantReceiver` whose name never resolved to a declaration,
+    /// or a singleton-class chain whose attached object isn't resolvable).
+    UnresolvedOwner,
+    /// The chain of aliases forms a cycle. The chain was abandoned at the first revisit.
+    Cycle,
+    /// The alias's `old_name` does not exist on the owner or any of its ancestors.
+    TargetNotFound,
+    /// The resolved target is not a method declaration. Indicates a graph inconsistency since method-name lookups
+    /// should only land on `Declaration::Method`.
+    TargetNotMethod,
+}
+
+/// Follows `alias_id` through any chain of further `MethodAlias` definitions and returns the `DeclarationId` of the
+/// final method declaration that has at least one non-alias definition (a regular `def`, `attr_*`, etc.).
+///
+/// # Errors
+///
+/// Returns an `AliasResolutionError` describing why the chain could not be resolved (not an alias, unresolved owner,
+/// cyclic chain, target missing, or target not a method).
+///
+/// # Panics
+///
+/// Panics if the graph is internally inconsistent
+pub fn follow_method_alias(graph: &Graph, alias_id: DefinitionId) -> Result<DeclarationId, AliasResolutionError> {
+    let mut seen: IdentityHashSet<DeclarationId> = IdentityHashSet::default();
+    let mut current = alias_id;
+
+    loop {
+        let Some(Definition::MethodAlias(alias)) = graph.definitions().get(&current) else {
+            return Err(AliasResolutionError::NotAnAlias);
+        };
+
+        let owner_id = graph
+            .definition_id_to_declaration_id(current)
+            .and_then(|decl_id| graph.declarations().get(decl_id))
+            .map(|decl| *decl.owner_id())
+            .ok_or(AliasResolutionError::UnresolvedOwner)?;
+
+        let target_id = match find_member_in_ancestors(graph, owner_id, *alias.old_name_str_id(), false) {
+            Ok(id) => id,
+            Err(FindMemberError::MemberNotFound) => return Err(AliasResolutionError::TargetNotFound),
+            Err(err @ (FindMemberError::DeclarationNotFound | FindMemberError::NotNamespace)) => {
+                unreachable!("alias owner must be a valid namespace declaration, got {err:?}")
+            }
+        };
+
+        if !seen.insert(target_id) {
+            return Err(AliasResolutionError::Cycle);
+        }
+
+        let Declaration::Method(target) = graph
+            .declarations()
+            .get(&target_id)
+            .expect("member returned by find_member_in_ancestors must exist")
+        else {
+            return Err(AliasResolutionError::TargetNotMethod);
+        };
+
+        // Stop at the first non-alias definition; otherwise track the smallest alias `DefinitionId` so the trace stays
+        // deterministic across runs. (If two aliases target different methods, we just pick one of them.)
+        let mut maybe_next_alias: Option<DefinitionId> = None;
+
+        for &def_id in target.definitions() {
+            if !matches!(
+                graph
+                    .definitions()
+                    .get(&def_id)
+                    .expect("declaration definition_id must exist in the graph"),
+                Definition::MethodAlias(_),
+            ) {
+                return Ok(target_id);
+            }
+
+            maybe_next_alias = Some(maybe_next_alias.map_or(def_id, |m| m.min(def_id)));
+        }
+
+        current = maybe_next_alias.ok_or(AliasResolutionError::TargetNotFound)?;
+    }
 }
 
 #[cfg(test)]
@@ -3152,6 +3299,456 @@ mod tests {
                 "Foo::SECRET",
                 "Foo#use_it()"
             ]
+        );
+    }
+
+    /// Returns the smallest `MethodAlias` `DefinitionId` for the declaration named `alias_decl_fqn`
+    /// (e.g., `"Foo#aliased()"`). Picking the smallest mirrors `follow_method_alias`'s own
+    /// determinism rule for tests where multiple aliases share a declaration (e.g. cross-file fixtures).
+    fn alias_def_id(context: &GraphTest, alias_decl_fqn: &str) -> DefinitionId {
+        let decl = context
+            .graph()
+            .declarations()
+            .get(&DeclarationId::from(alias_decl_fqn))
+            .unwrap_or_else(|| panic!("expected declaration {alias_decl_fqn}"));
+
+        decl.definitions()
+            .iter()
+            .copied()
+            .filter(|def_id| {
+                matches!(
+                    context.graph().definitions().get(def_id),
+                    Some(Definition::MethodAlias(_)),
+                )
+            })
+            .min()
+            .unwrap_or_else(|| panic!("declaration {alias_decl_fqn} has no MethodAlias definition"))
+    }
+
+    /// Asserts that the alias declared as `$alias_fqn` follows to the declaration `$target_fqn`.
+    macro_rules! assert_alias_target {
+        ($context:expr, $alias_fqn:expr, $target_fqn:expr $(,)?) => {{
+            let context = $context;
+            assert_eq!(
+                follow_method_alias(context.graph(), alias_def_id(context, $alias_fqn)),
+                Ok(DeclarationId::from($target_fqn)),
+            );
+        }};
+    }
+
+    #[test]
+    fn follow_method_alias_to_local_method() {
+        let mut context = GraphTest::new();
+        context.index_uri(
+            "file:///foo.rb",
+            r"
+            class Foo
+              def original; end
+              alias aliased original
+            end
+            ",
+        );
+        context.resolve();
+
+        assert_alias_target!(&context, "Foo#aliased()", "Foo#original()");
+    }
+
+    #[test]
+    fn follow_method_alias_through_chain_of_aliases() {
+        let mut context = GraphTest::new();
+        context.index_uri(
+            "file:///foo.rb",
+            r"
+            class Foo
+              def real; end
+              alias mid real
+              alias outer mid
+            end
+            ",
+        );
+        context.resolve();
+
+        assert_alias_target!(&context, "Foo#outer()", "Foo#real()");
+    }
+
+    #[test]
+    fn follow_method_alias_detects_two_step_cycle() {
+        let mut context = GraphTest::new();
+        context.index_uri(
+            "file:///foo.rb",
+            r"
+            class Foo
+              alias a b
+              alias b a
+            end
+            ",
+        );
+        context.resolve();
+
+        assert_eq!(
+            follow_method_alias(context.graph(), alias_def_id(&context, "Foo#a()")),
+            Err(AliasResolutionError::Cycle),
+        );
+        assert_eq!(
+            follow_method_alias(context.graph(), alias_def_id(&context, "Foo#b()")),
+            Err(AliasResolutionError::Cycle),
+        );
+    }
+
+    #[test]
+    fn follow_method_alias_detects_multi_step_cycle() {
+        let mut context = GraphTest::new();
+        context.index_uri(
+            "file:///foo.rb",
+            r"
+            class Foo
+              alias a b
+              alias b c
+              alias c a
+            end
+            ",
+        );
+        context.resolve();
+
+        for alias_fqn in ["Foo#a()", "Foo#b()", "Foo#c()"] {
+            assert_eq!(
+                follow_method_alias(context.graph(), alias_def_id(&context, alias_fqn)),
+                Err(AliasResolutionError::Cycle),
+                "expected {alias_fqn} to be detected as part of the cycle",
+            );
+        }
+    }
+
+    #[test]
+    fn follow_method_alias_detects_self_cycle() {
+        let mut context = GraphTest::new();
+        context.index_uri(
+            "file:///foo.rb",
+            r"
+            class Foo
+              alias foo foo
+            end
+            ",
+        );
+        context.resolve();
+
+        assert_eq!(
+            follow_method_alias(context.graph(), alias_def_id(&context, "Foo#foo()")),
+            Err(AliasResolutionError::Cycle),
+        );
+    }
+
+    #[test]
+    fn follow_method_alias_to_inherited_method() {
+        let mut context = GraphTest::new();
+        context.index_uri(
+            "file:///foo.rb",
+            r"
+            class Parent
+              def inherited_m; end
+            end
+
+            class Child < Parent
+              alias aliased inherited_m
+            end
+            ",
+        );
+        context.resolve();
+
+        assert_alias_target!(&context, "Child#aliased()", "Parent#inherited_m()");
+    }
+
+    #[test]
+    fn follow_method_alias_with_constant_receiver() {
+        let mut context = GraphTest::new();
+        context.index_uri(
+            "file:///foo.rb",
+            r"
+            class Bar
+              def to_s; end
+            end
+
+            class Foo
+              Bar.alias_method(:new_to_s, :to_s)
+            end
+            ",
+        );
+        context.resolve();
+
+        assert_alias_target!(&context, "Bar#new_to_s()", "Bar#to_s()");
+    }
+
+    #[test]
+    fn follow_method_alias_in_singleton_class_body() {
+        let mut context = GraphTest::new();
+        context.index_uri(
+            "file:///foo.rb",
+            r"
+            class Foo
+              def self.find; end
+
+              class << self
+                alias_method :find_old, :find
+              end
+            end
+            ",
+        );
+        context.resolve();
+
+        assert_alias_target!(&context, "Foo::<Foo>#find_old()", "Foo::<Foo>#find()");
+    }
+
+    #[test]
+    fn follow_method_alias_in_singleton_class_body_misses_instance_method() {
+        let mut context = GraphTest::new();
+        context.index_uri(
+            "file:///foo.rb",
+            r"
+            class Foo
+              def regular; end
+
+              class << self
+                alias_method :other, :regular
+              end
+            end
+            ",
+        );
+        context.resolve();
+
+        assert_eq!(
+            follow_method_alias(context.graph(), alias_def_id(&context, "Foo::<Foo>#other()")),
+            Err(AliasResolutionError::TargetNotFound),
+        );
+    }
+
+    #[test]
+    fn follow_method_alias_to_attr_reader() {
+        let mut context = GraphTest::new();
+        context.index_uri(
+            "file:///foo.rb",
+            r"
+            class Foo
+              attr_reader :name
+              alias display name
+            end
+            ",
+        );
+        context.resolve();
+
+        assert_alias_target!(&context, "Foo#display()", "Foo#name()");
+    }
+
+    #[test]
+    fn follow_method_alias_to_attr_accessor() {
+        let mut context = GraphTest::new();
+        context.index_uri(
+            "file:///foo.rb",
+            r"
+            class Foo
+              attr_accessor :age
+              alias years age
+            end
+            ",
+        );
+        context.resolve();
+
+        assert_alias_target!(&context, "Foo#years()", "Foo#age()");
+    }
+
+    #[test]
+    fn follow_method_alias_to_method_in_prepended_module() {
+        let mut context = GraphTest::new();
+        context.index_uri(
+            "file:///foo.rb",
+            r"
+            module M
+              def original; end
+            end
+
+            class Foo
+              prepend M
+              alias aliased original
+            end
+            ",
+        );
+        context.resolve();
+
+        assert_alias_target!(&context, "Foo#aliased()", "M#original()");
+    }
+
+    #[test]
+    fn follow_method_alias_ignores_visibility_of_target() {
+        let mut context = GraphTest::new();
+        context.index_uri(
+            "file:///foo.rb",
+            r"
+            class Foo
+              private def secret; end
+              alias revealed secret
+            end
+            ",
+        );
+        context.resolve();
+
+        assert_alias_target!(&context, "Foo#revealed()", "Foo#secret()");
+    }
+
+    #[test]
+    fn follow_method_alias_picks_last_when_multiple_targets() {
+        let mut context = GraphTest::new();
+        context.index_uri(
+            "file:///foo.rb",
+            r"
+            class Foo
+              def bar; end
+              def qux; end
+              alias double bar
+              alias double qux
+            end
+            ",
+        );
+        context.resolve();
+
+        assert_alias_target!(&context, "Foo#double()", "Foo#qux()");
+    }
+
+    #[test]
+    fn follow_method_alias_returns_target_not_found_when_target_missing() {
+        let mut context = GraphTest::new();
+        context.index_uri(
+            "file:///foo.rb",
+            r"
+            class Foo
+              alias aliased nonexistent
+            end
+            ",
+        );
+        context.resolve();
+
+        assert_eq!(
+            follow_method_alias(context.graph(), alias_def_id(&context, "Foo#aliased()")),
+            Err(AliasResolutionError::TargetNotFound),
+        );
+    }
+
+    #[test]
+    fn find_member_in_ancestors_returns_member_in_main_namespace() {
+        let mut context = GraphTest::new();
+        context.index_uri(
+            "file:///foo.rb",
+            r"
+            class Foo
+              def bar; end
+            end
+            ",
+        );
+        context.resolve();
+
+        assert_eq!(
+            find_member_in_ancestors(
+                context.graph(),
+                DeclarationId::from("Foo"),
+                StringId::from("bar()"),
+                false,
+            ),
+            Ok(DeclarationId::from("Foo#bar()")),
+        );
+    }
+
+    #[test]
+    fn find_member_in_ancestors_returns_inherited_member() {
+        let mut context = GraphTest::new();
+        context.index_uri(
+            "file:///foo.rb",
+            r"
+            class Parent
+              def inherited_method; end
+            end
+
+            class Child < Parent
+            end
+            ",
+        );
+        context.resolve();
+
+        assert_eq!(
+            find_member_in_ancestors(
+                context.graph(),
+                DeclarationId::from("Child"),
+                StringId::from("inherited_method()"),
+                false,
+            ),
+            Ok(DeclarationId::from("Parent#inherited_method()")),
+        );
+    }
+
+    #[test]
+    fn find_member_in_ancestors_returns_member_not_found_when_member_missing() {
+        let mut context = GraphTest::new();
+        context.index_uri(
+            "file:///foo.rb",
+            r"
+            class Foo
+            end
+            ",
+        );
+        context.resolve();
+
+        assert_eq!(
+            find_member_in_ancestors(
+                context.graph(),
+                DeclarationId::from("Foo"),
+                StringId::from("missing()"),
+                false,
+            ),
+            Err(FindMemberError::MemberNotFound),
+        );
+    }
+
+    #[test]
+    fn find_member_in_ancestors_returns_not_a_namespace_for_method_declaration() {
+        let mut context = GraphTest::new();
+        context.index_uri(
+            "file:///foo.rb",
+            r"
+            class Foo
+              def bar; end
+            end
+            ",
+        );
+        context.resolve();
+
+        assert_eq!(
+            find_member_in_ancestors(
+                context.graph(),
+                DeclarationId::from("Foo#bar()"),
+                StringId::from("anything"),
+                false,
+            ),
+            Err(FindMemberError::NotNamespace),
+        );
+    }
+
+    #[test]
+    fn find_member_in_ancestors_returns_declaration_not_found_for_unknown_id() {
+        let mut context = GraphTest::new();
+        context.index_uri(
+            "file:///foo.rb",
+            r"
+            class Foo
+            end
+            ",
+        );
+        context.resolve();
+
+        assert_eq!(
+            find_member_in_ancestors(
+                context.graph(),
+                DeclarationId::from("DoesNotExist"),
+                StringId::from("anything"),
+                false,
+            ),
+            Err(FindMemberError::DeclarationNotFound),
         );
     }
 }


### PR DESCRIPTION
This PR extracts a portion of #697

The PR implements `follow_method_alias`, which accepts a `definition_id` for an alias and follows the chain until reaching the first concrete method definition. This is required to expose `MethodDefinition#signatures` in the Ruby API (as the definition may be an alias).

This PR also moves the core logic of finding members in the ancestor chain to `query.rs`, so that we can reuse it for this implementation and for the FFI.