### PR TITLE
Index private_class_method / public_class_method calls

### DIFF
--- a/rust/rubydex/src/indexing/ruby_indexer.rs
+++ b/rust/rubydex/src/indexing/ruby_indexer.rs
@@ -1200,9 +1200,7 @@ impl<'a> RubyIndexer<'a> {
             }
             Some(ruby_prism::Node::SelfNode { .. }) | None => match self.nesting_stack.last() {
                 Some(Nesting::Method(_)) => {
-                    // Dynamic private constant (called from a method), we ignore it but don't report an error since it's valid Ruby
-                    // if being called from a singleton method.
-
+                    self.visit_call_node_parts(node);
                     return;
                 }
                 None => {
@@ -1211,7 +1209,7 @@ impl<'a> RubyIndexer<'a> {
                         Offset::from_prism_location(&node.location()),
                         "Private constant called at top level".to_string(),
                     );
-
+                    self.visit_call_node_parts(node);
                     return;
                 }
                 _ => None,
@@ -1222,7 +1220,7 @@ impl<'a> RubyIndexer<'a> {
                     Offset::from_prism_location(&node.location()),
                     "Dynamic receiver for private constant".to_string(),
                 );
-
+                self.visit_call_node_parts(node);
                 return;
             }
         };
@@ -1252,8 +1250,8 @@ impl<'a> RubyIndexer<'a> {
                         Offset::from_prism_location(&argument.location()),
                         "Private constant called with non-symbol argument".to_string(),
                     );
-
-                    return;
+                    self.visit(&argument);
+                    continue;
                 }
             };
 
@@ -1273,6 +1271,60 @@ impl<'a> RubyIndexer<'a> {
             let definition_id = self.local_graph.add_definition(definition);
 
             self.add_member_to_current_owner(definition_id);
+        }
+    }
+
+    fn handle_singleton_method_visibility(
+        &mut self,
+        node: &ruby_prism::CallNode,
+        visibility: Visibility,
+        call_name: &str,
+    ) {
+        match node.receiver() {
+            Some(ruby_prism::Node::SelfNode { .. }) | None => match self.nesting_stack.last() {
+                Some(Nesting::Method(_)) => {
+                    self.visit_call_node_parts(node);
+                    return;
+                }
+                None => {
+                    self.local_graph.add_diagnostic(
+                        Rule::InvalidMethodVisibility,
+                        Offset::from_prism_location(&node.location()),
+                        format!("`{call_name}` called at top level"),
+                    );
+                    self.visit_call_node_parts(node);
+                    return;
+                }
+                _ => {}
+            },
+            _ => {
+                self.visit_call_node_parts(node);
+                return;
+            }
+        }
+
+        let Some(arguments) = node.arguments() else {
+            return;
+        };
+
+        for argument in &arguments.arguments() {
+            match argument {
+                ruby_prism::Node::SymbolNode { .. } | ruby_prism::Node::StringNode { .. } => {
+                    self.create_method_visibility_definition(
+                        &argument,
+                        visibility,
+                        DefinitionFlags::SINGLETON_METHOD_VISIBILITY,
+                    );
+                }
+                _ => {
+                    self.local_graph.add_diagnostic(
+                        Rule::InvalidMethodVisibility,
+                        Offset::from_prism_location(&argument.location()),
+                        format!("`{call_name}` called with a non-literal argument"),
+                    );
+                    self.visit(&argument);
+                }
+            }
         }
     }
 
@@ -1313,7 +1365,7 @@ impl<'a> RubyIndexer<'a> {
                 arg,
                 ruby_prism::Node::SymbolNode { .. } | ruby_prism::Node::StringNode { .. }
             ) {
-                self.create_method_visibility_definition(&arg, visibility);
+                self.create_method_visibility_definition(&arg, visibility, DefinitionFlags::empty());
             } else {
                 // Unsupported arg — diagnostic + visit for side effects.
                 let arg_offset = Offset::from_prism_location(&arg.location());
@@ -1329,7 +1381,12 @@ impl<'a> RubyIndexer<'a> {
         }
     }
 
-    fn create_method_visibility_definition(&mut self, arg: &ruby_prism::Node, visibility: Visibility) {
+    fn create_method_visibility_definition(
+        &mut self,
+        arg: &ruby_prism::Node,
+        visibility: Visibility,
+        flags: DefinitionFlags,
+    ) {
         let (name, location) = match arg {
             ruby_prism::Node::SymbolNode { .. } => {
                 let symbol = arg.as_symbol_node().unwrap();
@@ -1355,7 +1412,7 @@ impl<'a> RubyIndexer<'a> {
             self.uri_id,
             arg_offset,
             Box::default(),
-            DefinitionFlags::empty(),
+            flags,
             self.current_nesting_definition_id(),
         )));
 
@@ -2048,6 +2105,12 @@ impl Visit<'_> for RubyIndexer<'_> {
             }
             "public_constant" => {
                 self.handle_constant_visibility(node, Visibility::Public);
+            }
+            "private_class_method" => {
+                self.handle_singleton_method_visibility(node, Visibility::Private, "private_class_method");
+            }
+            "public_class_method" => {
+                self.handle_singleton_method_visibility(node, Visibility::Public, "public_class_method");
             }
             _ => {
                 // For method calls that we don't explicitly handle each part, we continue visiting their parts as we

--- a/rust/rubydex/src/indexing/ruby_indexer_tests.rs
+++ b/rust/rubydex/src/indexing/ruby_indexer_tests.rs
@@ -3337,6 +3337,7 @@ mod visibility_tests {
                 "invalid-private-constant: Private constant called at top level (2:1-2:35)",
                 "invalid-private-constant: Dynamic receiver for private constant (3:1-3:34)",
                 "invalid-private-constant: Private constant called with non-symbol argument (6:20-6:31)",
+                "invalid-private-constant: Private constant called with non-symbol argument (6:33-6:44)",
             ]
         );
 
@@ -3734,6 +3735,141 @@ mod visibility_tests {
                 "should not create MethodVisibility for module_function in class"
             );
         }
+    }
+
+    #[test]
+    fn index_private_class_method_calls() {
+        let context = index_source(
+            r#"
+            class Foo
+              def self.bar; end
+              def self.baz; end
+              def self.qux; end
+
+              private_class_method :bar, :baz
+              public_class_method "qux"
+            end
+            "#,
+        );
+
+        assert_no_local_diagnostics!(&context);
+
+        assert_definition_at!(&context, "6:25-6:28", MethodVisibility, |def| {
+            assert!(def.flags().is_singleton_method_visibility());
+            assert_string_eq!(&context, def.str_id(), "bar()");
+            assert_eq!(def.visibility(), &Visibility::Private);
+        });
+        assert_definition_at!(&context, "6:31-6:34", MethodVisibility, |def| {
+            assert!(def.flags().is_singleton_method_visibility());
+            assert_string_eq!(&context, def.str_id(), "baz()");
+            assert_eq!(def.visibility(), &Visibility::Private);
+        });
+        assert_definition_at!(&context, "7:23-7:28", MethodVisibility, |def| {
+            assert!(def.flags().is_singleton_method_visibility());
+            assert_string_eq!(&context, def.str_id(), "qux()");
+            assert_eq!(def.visibility(), &Visibility::Public);
+        });
+    }
+
+    #[test]
+    fn index_public_class_method_calls() {
+        let context = index_source(
+            r"
+            class Foo
+              def self.bar; end
+
+              public_class_method :bar
+            end
+            ",
+        );
+
+        assert_no_local_diagnostics!(&context);
+
+        assert_definition_at!(&context, "4:24-4:27", MethodVisibility, |def| {
+            assert!(def.flags().is_singleton_method_visibility());
+            assert_string_eq!(&context, def.str_id(), "bar()");
+            assert_eq!(def.visibility(), &Visibility::Public);
+        });
+    }
+
+    #[test]
+    fn index_private_class_method_calls_diagnostics() {
+        let context = index_source(
+            r"
+            private_class_method :NOT_INDEXED
+            self.private_class_method :NOT_INDEXED
+            foo.private_class_method :NOT_INDEXED
+
+            module Foo
+              private_class_method NOT_INDEXED
+            end
+            ",
+        );
+
+        assert_local_diagnostics_eq!(
+            &context,
+            vec![
+                "invalid-method-visibility: `private_class_method` called at top level (1:1-1:34)",
+                "invalid-method-visibility: `private_class_method` called at top level (2:1-2:39)",
+                "invalid-method-visibility: `private_class_method` called with a non-literal argument (6:24-6:35)",
+            ]
+        );
+    }
+
+    #[test]
+    fn index_private_class_method_inside_method_body_emits_no_diagnostic() {
+        let context = index_source(
+            r"
+            class Foo
+              def self.qux
+                private_class_method :bar
+              end
+            end
+            ",
+        );
+
+        assert_no_local_diagnostics!(&context);
+    }
+
+    #[test]
+    fn index_private_class_method_continues_past_invalid_arg() {
+        let context = index_source(
+            r"
+            class Foo
+              def self.a; end
+              def self.c; end
+
+              private_class_method :a, dynamic_name, :c
+            end
+            ",
+        );
+
+        assert_local_diagnostics_eq!(
+            &context,
+            vec!["invalid-method-visibility: `private_class_method` called with a non-literal argument (5:28-5:40)"]
+        );
+
+        assert_definition_at!(&context, "5:25-5:26", MethodVisibility, |def| {
+            assert!(def.flags().is_singleton_method_visibility());
+            assert_string_eq!(&context, def.str_id(), "a()");
+            assert_eq!(def.visibility(), &Visibility::Private);
+        });
+        assert_definition_at!(&context, "5:43-5:44", MethodVisibility, |def| {
+            assert!(def.flags().is_singleton_method_visibility());
+            assert_string_eq!(&context, def.str_id(), "c()");
+            assert_eq!(def.visibility(), &Visibility::Private);
+        });
+    }
+
+    #[test]
+    fn index_private_class_method_at_top_level_visits_args() {
+        let context = index_source("private_class_method NESTED_REF");
+
+        assert_local_diagnostics_eq!(
+            &context,
+            vec!["invalid-method-visibility: `private_class_method` called at top level (1:1-1:32)"]
+        );
+        assert_constant_references_eq!(&context, ["NESTED_REF"]);
     }
 }
 

--- a/rust/rubydex/src/model/definitions.rs
+++ b/rust/rubydex/src/model/definitions.rs
@@ -40,6 +40,7 @@ bitflags! {
     pub struct DefinitionFlags: u8 {
         const DEPRECATED = 0b0001;
         const PROMOTABLE = 0b0010;
+        const SINGLETON_METHOD_VISIBILITY = 0b0100;
     }
 }
 
@@ -52,6 +53,11 @@ impl DefinitionFlags {
     #[must_use]
     pub fn is_promotable(&self) -> bool {
         self.contains(Self::PROMOTABLE)
+    }
+
+    #[must_use]
+    pub fn is_singleton_method_visibility(&self) -> bool {
+        self.contains(Self::SINGLETON_METHOD_VISIBILITY)
     }
 }
 

--- a/rust/rubydex/src/resolution.rs
+++ b/rust/rubydex/src/resolution.rs
@@ -604,8 +604,10 @@ impl<'a> Resolver<'a> {
                         self.graph.add_document_diagnostic(uri_id, diagnostic);
                     }
                 }
-                Definition::MethodVisibility(_) => {
-                    method_visibility_ids.push(id);
+                Definition::MethodVisibility(visibility_def) => {
+                    if !visibility_def.flags().is_singleton_method_visibility() {
+                        method_visibility_ids.push(id);
+                    }
                 }
                 Definition::Class(_)
                 | Definition::SingletonClass(_)


### PR DESCRIPTION
Part of #89 

This PR adds indexer support for `private_class_method` and `public_class_method` calls. Each call becomes a `MethodVisibilityDefinition` with the `SINGLETON_METHOD_VISIBILITY` flag set, which the resolver applies to the singleton method declaration in a follow-up PR. This is the base of a Graphite stack.

We need a definition because the indexer can't yet attach the visibility change to the singleton method:

```ruby
class Foo
  def self.bar; end
  private_class_method :bar
end
```

The method declaration for `Foo::<Foo>#bar()` only exists after resolution.

### Why a bit flag

I added a `DefinitionFlags::SINGLETON_METHOD_VISIBILITY` bit on the existing `MethodVisibilityDefinition` rather than introducing a parallel `SingletonMethodVisibilityDefinition` type. The two would have carried the same fields and the indexer treats instance and singleton visibility calls almost identically. A bit flag captures the singleton-vs-instance distinction without doubling the definition variants and the FFI plumbing that comes with them.

### Why no explicit receiver support

`Foo.private_class_method :bar` is legal Ruby but rare in practice. Supporting it would require a new definition type to carry the receiver. Ignoring it lets us fold the singleton case into the existing `MethodVisibilityDefinition` and get resolution-time differentiation from a single bit flag, which keeps the blast radius of the change small. Calls with an explicit receiver bypass the visibility logic, though the call is still visited so nested references stay indexed.

### In this PR

- add `DefinitionFlags::SINGLETON_METHOD_VISIBILITY`
- index `private_class_method` / `public_class_method` calls with literal symbol or string targets, with an implicit receiver only
- skip singleton-flagged definitions from `resolve_method_visibilities` so the new flag stays inert until the follow-up PR wires up resolution
- diagnose top-level calls and non-literal arguments

### Not in this PR

A few things are intentionally deferred to follow-up PRs in the stack:

- applying the visibility to the singleton method declaration
- extracting the literal-extraction helper we duplicate from `handle_constant_visibility`
- supporting array arguments (`private_class_method [:a, :b]`)
- supporting inline-def arguments (`private_class_method def self.foo; end`)
