### PR TITLE
Extract shared helpers for visibility-call processing

### DIFF
--- a/rust/rubydex/src/indexing/ruby_indexer.rs
+++ b/rust/rubydex/src/indexing/ruby_indexer.rs
@@ -386,21 +386,8 @@ impl<'a> RubyIndexer<'a> {
     {
         if let Some(arguments) = node.arguments() {
             for argument in &arguments.arguments() {
-                match argument {
-                    ruby_prism::Node::SymbolNode { .. } => {
-                        let symbol = argument.as_symbol_node().unwrap();
-
-                        if let Some(value_loc) = symbol.value_loc() {
-                            let name = Self::location_to_string(&value_loc);
-                            f(name, value_loc);
-                        }
-                    }
-                    ruby_prism::Node::StringNode { .. } => {
-                        let string = argument.as_string_node().unwrap();
-                        let name = String::from_utf8_lossy(string.unescaped()).to_string();
-                        f(name, argument.location());
-                    }
-                    _ => {}
+                if let Some((name, location)) = Self::extract_literal_name(&argument) {
+                    f(name, location);
                 }
             }
         }
@@ -1230,29 +1217,14 @@ impl<'a> RubyIndexer<'a> {
         };
 
         for argument in &arguments.arguments() {
-            let (name, location) = match argument {
-                ruby_prism::Node::SymbolNode { .. } => {
-                    let symbol = argument.as_symbol_node().unwrap();
-                    if let Some(value_loc) = symbol.value_loc() {
-                        (Self::location_to_string(&value_loc), value_loc)
-                    } else {
-                        continue;
-                    }
-                }
-                ruby_prism::Node::StringNode { .. } => {
-                    let string = argument.as_string_node().unwrap();
-                    let name = String::from_utf8_lossy(string.unescaped()).to_string();
-                    (name, argument.location())
-                }
-                _ => {
-                    self.local_graph.add_diagnostic(
-                        Rule::InvalidPrivateConstant,
-                        Offset::from_prism_location(&argument.location()),
-                        "Private constant called with non-symbol argument".to_string(),
-                    );
-                    self.visit(&argument);
-                    continue;
-                }
+            let Some((name, location)) = Self::extract_literal_name(&argument) else {
+                self.local_graph.add_diagnostic(
+                    Rule::InvalidPrivateConstant,
+                    Offset::from_prism_location(&argument.location()),
+                    "Private constant called with non-symbol argument".to_string(),
+                );
+                self.visit(&argument);
+                continue;
             };
 
             let str_id = self.local_graph.intern_string(name);
@@ -1414,6 +1386,22 @@ impl<'a> RubyIndexer<'a> {
         }
     }
 
+    fn extract_literal_name<'b>(arg: &ruby_prism::Node<'b>) -> Option<(String, ruby_prism::Location<'b>)> {
+        match arg {
+            ruby_prism::Node::SymbolNode { .. } => {
+                let symbol = arg.as_symbol_node().unwrap();
+                let value_loc = symbol.value_loc()?;
+                Some((Self::location_to_string(&value_loc), value_loc))
+            }
+            ruby_prism::Node::StringNode { .. } => {
+                let string = arg.as_string_node().unwrap();
+                let name = String::from_utf8_lossy(string.unescaped()).to_string();
+                Some((name, arg.location()))
+            }
+            _ => None,
+        }
+    }
+
     fn is_attr_call(arg: &ruby_prism::Node) -> bool {
         arg.as_call_node().is_some_and(|call| {
             let receiver = call.receiver();
@@ -1473,18 +1461,8 @@ impl<'a> RubyIndexer<'a> {
         visibility: Visibility,
         flags: DefinitionFlags,
     ) {
-        let (name, location) = match arg {
-            ruby_prism::Node::SymbolNode { .. } => {
-                let symbol = arg.as_symbol_node().unwrap();
-                let Some(value_loc) = symbol.value_loc() else { return };
-                (Self::location_to_string(&value_loc), value_loc)
-            }
-            ruby_prism::Node::StringNode { .. } => {
-                let string = arg.as_string_node().unwrap();
-                let name = String::from_utf8_lossy(string.unescaped()).to_string();
-                (name, arg.location())
-            }
-            _ => return,
+        let Some((name, location)) = Self::extract_literal_name(arg) else {
+            return;
         };
 
         self.create_method_visibility_definition_from_name(&name, &location, visibility, flags);

--- a/rust/rubydex/src/operation/ruby_builder.rs
+++ b/rust/rubydex/src/operation/ruby_builder.rs
@@ -611,20 +611,8 @@ impl<'a> RubyOperationBuilder<'a> {
     {
         if let Some(arguments) = node.arguments() {
             for argument in &arguments.arguments() {
-                match argument {
-                    ruby_prism::Node::SymbolNode { .. } => {
-                        let symbol = argument.as_symbol_node().unwrap();
-                        if let Some(value_loc) = symbol.value_loc() {
-                            let name = Self::location_to_string(&value_loc);
-                            f(name, value_loc);
-                        }
-                    }
-                    ruby_prism::Node::StringNode { .. } => {
-                        let string = argument.as_string_node().unwrap();
-                        let name = String::from_utf8_lossy(string.unescaped()).to_string();
-                        f(name, argument.location());
-                    }
-                    _ => {}
+                if let Some((name, location)) = Self::extract_literal_name(&argument) {
+                    f(name, location);
                 }
             }
         }
@@ -931,28 +919,13 @@ impl<'a> RubyOperationBuilder<'a> {
         };
 
         for argument in &arguments.arguments() {
-            let (name, location) = match argument {
-                ruby_prism::Node::SymbolNode { .. } => {
-                    let symbol = argument.as_symbol_node().unwrap();
-                    if let Some(value_loc) = symbol.value_loc() {
-                        (Self::location_to_string(&value_loc), value_loc)
-                    } else {
-                        continue;
-                    }
-                }
-                ruby_prism::Node::StringNode { .. } => {
-                    let string = argument.as_string_node().unwrap();
-                    let name = String::from_utf8_lossy(string.unescaped()).to_string();
-                    (name, argument.location())
-                }
-                _ => {
-                    self.add_diagnostic(
-                        Rule::InvalidPrivateConstant,
-                        Offset::from_prism_location(&argument.location()),
-                        "Private constant called with non-symbol argument".to_string(),
-                    );
-                    continue;
-                }
+            let Some((name, location)) = Self::extract_literal_name(&argument) else {
+                self.add_diagnostic(
+                    Rule::InvalidPrivateConstant,
+                    Offset::from_prism_location(&argument.location()),
+                    "Private constant called with non-symbol argument".to_string(),
+                );
+                continue;
             };
 
             let str_id = self.intern_string(name);
@@ -1067,6 +1040,22 @@ impl<'a> RubyOperationBuilder<'a> {
         Some(())
     }
 
+    fn extract_literal_name<'b>(arg: &ruby_prism::Node<'b>) -> Option<(String, ruby_prism::Location<'b>)> {
+        match arg {
+            ruby_prism::Node::SymbolNode { .. } => {
+                let symbol = arg.as_symbol_node().unwrap();
+                let value_loc = symbol.value_loc()?;
+                Some((Self::location_to_string(&value_loc), value_loc))
+            }
+            ruby_prism::Node::StringNode { .. } => {
+                let string = arg.as_string_node().unwrap();
+                let name = String::from_utf8_lossy(string.unescaped()).to_string();
+                Some((name, arg.location()))
+            }
+            _ => None,
+        }
+    }
+
     fn is_attr_call(arg: &ruby_prism::Node) -> bool {
         arg.as_call_node().is_some_and(|call| {
             let receiver = call.receiver();
@@ -1135,21 +1124,8 @@ impl<'a> RubyOperationBuilder<'a> {
         visibility: Visibility,
         flags: DefinitionFlags,
     ) {
-        let (name, location) = match arg {
-            ruby_prism::Node::SymbolNode { .. } => {
-                let symbol = arg.as_symbol_node().unwrap();
-                if let Some(value_loc) = symbol.value_loc() {
-                    (Self::location_to_string(&value_loc), value_loc)
-                } else {
-                    return;
-                }
-            }
-            ruby_prism::Node::StringNode { .. } => {
-                let string = arg.as_string_node().unwrap();
-                let name = String::from_utf8_lossy(string.unescaped()).to_string();
-                (name, arg.location())
-            }
-            _ => return,
+        let Some((name, location)) = Self::extract_literal_name(arg) else {
+            return;
         };
 
         let str_id = self.intern_string(format!("{name}()"));


### PR DESCRIPTION
The preceding stack (#780, #781, #782) built up the visibility-call repeated the same symbol and string argument parsing across the visibility-call handlers and `each_string_or_symbol_arg`. This PR extracts that parsing into `extract_literal_name`. The visibility handlers call it directly when they need custom handling for non-literal arguments, while `each_string_or_symbol_arg` now builds on it. No behaviour change.

Both indexer backends (`RubyIndexer` and `RubyOperationBuilder`) carry the duplication and get their own copy of the helper.