### PR TITLE
Add `MethodAliasDefinition#signatures`

### DIFF
--- a/ext/rubydex/definition.c
+++ b/ext/rubydex/definition.c
@@ -252,6 +252,18 @@ static VALUE rdxr_method_definition_signatures(VALUE self) {
     return rdxi_signatures_to_ruby(arr);
 }
 
+// MethodAliasDefinition#signatures -> [Rubydex::Signature]
+static VALUE rdxr_method_alias_definition_signatures(VALUE self) {
+    HandleData *data;
+    TypedData_Get_Struct(self, HandleData, &handle_type, data);
+
+    void *graph;
+    TypedData_Get_Struct(data->graph_obj, void *, &graph_type, graph);
+
+    SignatureArray *arr = rdx_method_alias_definition_signatures(graph, data->id);
+    return rdxi_signatures_to_ruby(arr);
+}
+
 void rdxi_initialize_definition(VALUE mod) {
     mRubydex = mod;
 
@@ -294,5 +306,6 @@ void rdxi_initialize_definition(VALUE mod) {
     cInstanceVariableDefinition = rb_define_class_under(mRubydex, "InstanceVariableDefinition", cDefinition);
     cClassVariableDefinition = rb_define_class_under(mRubydex, "ClassVariableDefinition", cDefinition);
     cMethodAliasDefinition = rb_define_class_under(mRubydex, "MethodAliasDefinition", cDefinition);
+    rb_define_method(cMethodAliasDefinition, "signatures", rdxr_method_alias_definition_signatures, 0);
     cGlobalVariableAliasDefinition = rb_define_class_under(mRubydex, "GlobalVariableAliasDefinition", cDefinition);
 }

--- a/rust/rubydex-sys/src/signature_api.rs
+++ b/rust/rubydex-sys/src/signature_api.rs
@@ -3,6 +3,7 @@
 use crate::graph_api::{GraphPointer, with_graph};
 use crate::location_api::{Location, create_location_for_uri_and_offset};
 use libc::c_char;
+use rubydex::model::declaration::Declaration;
 use rubydex::model::definitions::{Definition, MethodDefinition, Parameter};
 use rubydex::model::graph::Graph;
 use rubydex::model::ids::DefinitionId;
@@ -123,6 +124,49 @@ fn collect_method_signatures(graph: &Graph, method_def: &MethodDefinition) -> Ve
             }
         })
         .collect()
+}
+
+/// Returns signatures for a `MethodAliasDefinition` by following the alias chain.
+/// Always returns a valid `SignatureArray` pointer (possibly with `len == 0`).
+/// Errors during alias resolution (unresolved receivers, circular chains, etc.)
+/// are silently ignored.
+///
+/// # Safety
+/// - `pointer` must be a valid pointer previously returned by `rdx_graph_new`.
+/// - `definition_id` must be a valid definition id.
+///
+/// # Panics
+/// Panics if `definition_id` does not exist or is not a `MethodAliasDefinition`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rdx_method_alias_definition_signatures(
+    pointer: GraphPointer,
+    definition_id: u64,
+) -> *mut SignatureArray {
+    with_graph(pointer, |graph| {
+        let def_id = DefinitionId::new(definition_id);
+        let resolved = rubydex::query::follow_method_alias(graph, def_id);
+
+        let mut sig_entries: Vec<SignatureEntry> = Vec::new();
+
+        if let Ok(declaration_id) = resolved {
+            if let Some(Declaration::Method(method_def)) = graph.declarations().get(&declaration_id) {
+                for definition_id in method_def.definitions() {
+                    if let Some(Definition::Method(method_definition)) = graph.definitions().get(definition_id) {
+                        sig_entries.extend(collect_method_signatures(graph, method_definition));
+                    }
+                }
+            } else {
+                panic!("expected a method declaration");
+            }
+        }
+
+        let mut boxed = sig_entries.into_boxed_slice();
+        let len = boxed.len();
+        let items_ptr = boxed.as_mut_ptr();
+        std::mem::forget(boxed);
+
+        Box::into_raw(Box::new(SignatureArray { items: items_ptr, len }))
+    })
 }
 
 /// Frees a `SignatureArray` previously returned by `rdx_definition_signatures`.

--- a/test/definition_test.rb
+++ b/test/definition_test.rb
@@ -622,6 +622,52 @@ class DefinitionTest < Minitest::Test
     end
   end
 
+  def test_method_alias_definition_signatures
+    with_context do |context|
+      context.write!("file1.rb", <<~RUBY)
+        class Foo
+          def foo(a, b); end
+          alias bar foo
+        end
+      RUBY
+
+      graph = Rubydex::Graph.new
+      graph.index_all(context.glob("**/*.rb"))
+      graph.resolve
+
+      alias_def = graph["Foo#bar()"].definitions.first
+      assert_instance_of(Rubydex::MethodAliasDefinition, alias_def)
+
+      signatures = alias_def.signatures
+      assert_equal(1, signatures.length)
+
+      params = signatures.first.parameters
+      assert_equal(2, params.length)
+      assert_equal(:a, params[0].name)
+      assert_equal(:b, params[1].name)
+    end
+  end
+
+  def test_method_alias_definition_signatures_unresolved
+    with_context do |context|
+      context.write!("file1.rb", <<~RUBY)
+        class Foo
+          alias bar nonexistent
+        end
+      RUBY
+
+      graph = Rubydex::Graph.new
+      graph.index_all(context.glob("**/*.rb"))
+      graph.resolve
+
+      alias_def = graph["Foo#bar()"].definitions.first
+      assert_instance_of(Rubydex::MethodAliasDefinition, alias_def)
+
+      signatures = alias_def.signatures
+      assert_empty(signatures)
+    end
+  end
+
   private
 
   # Comment locations on Windows include the carriage return. This means that the end column is off by one when compared


### PR DESCRIPTION
This PR adds `MethodAliasDefinition#signatures` Ruby API on top of the https://github.com/Shopify/rubydex/pull/779.

Towards #668