### PR TITLE
Follow alias target for visibility

### DIFF
--- a/rust/rubydex/src/model/graph.rs
+++ b/rust/rubydex/src/model/graph.rs
@@ -15,7 +15,7 @@ use crate::model::name::{Name, NameRef, ParentScope, ResolvedName};
 use crate::model::references::{ConstantReference, MethodRef};
 use crate::model::string_ref::StringRef;
 use crate::model::visibility::Visibility;
-use crate::stats;
+use crate::{query, stats};
 
 /// An entity whose validity depends on a particular `NameId`.
 /// Used as the value type in the `name_dependents` reverse index.
@@ -650,7 +650,7 @@ impl Graph {
         let definitions = declaration.definitions();
 
         match declaration {
-            Declaration::Namespace(Namespace::Class(_) | Namespace::Module(_))
+            Declaration::Namespace(Namespace::Class(_) | Namespace::Module(_) | Namespace::Todo(_))
             | Declaration::Constant(_)
             | Declaration::ConstantAlias(_) => {
                 for def_id in definitions.iter().rev() {
@@ -661,25 +661,42 @@ impl Graph {
                 Some(Visibility::Public)
             }
             Declaration::Method(_) => {
+                let mut latest_alias: Option<DefinitionId> = None;
+
                 for def_id in definitions.iter().rev() {
                     let Some(definition) = self.definitions.get(def_id) else {
                         continue;
                     };
+
                     let visibility = match definition {
                         Definition::MethodVisibility(vis) => Some(*vis.visibility()),
                         Definition::Method(method) => Some(*method.visibility()),
                         Definition::AttrAccessor(attr) => Some(*attr.visibility()),
                         Definition::AttrReader(attr) => Some(*attr.visibility()),
                         Definition::AttrWriter(attr) => Some(*attr.visibility()),
+                        Definition::MethodAlias(_) => {
+                            if latest_alias.is_none() {
+                                latest_alias = Some(*def_id);
+                            }
+                            None
+                        }
                         _ => None,
                     };
+
                     if visibility.is_some() {
                         return visibility;
                     }
                 }
-                None
+
+                if let Some(alias_def_id) = latest_alias
+                    && let Ok(target_id) = query::follow_method_alias(self, alias_def_id)
+                {
+                    return self.visibility(&target_id);
+                }
+
+                Some(Visibility::Public)
             }
-            Declaration::Namespace(Namespace::SingletonClass(_) | Namespace::Todo(_))
+            Declaration::Namespace(Namespace::SingletonClass(_))
             | Declaration::GlobalVariable(_)
             | Declaration::InstanceVariable(_)
             | Declaration::ClassVariable(_) => None,

--- a/test/declaration_test.rb
+++ b/test/declaration_test.rb
@@ -707,6 +707,58 @@ class DeclarationTest < Minitest::Test
     end
   end
 
+  def test_method_alias_visibility_falls_back_to_public_when_target_unresolvable
+    with_context do |context|
+      context.write!("file1.rb", <<~RUBY)
+        class Foo
+          alias new_to_s to_s
+        end
+      RUBY
+
+      graph = Rubydex::Graph.new
+      graph.index_all(context.glob("**/*.rb"))
+      graph.resolve
+
+      assert_predicate(graph["Foo#new_to_s()"], :public?)
+    end
+  end
+
+  def test_method_alias_visibility_inherits_from_private_target
+    with_context do |context|
+      context.write!("file1.rb", <<~RUBY)
+        class Foo
+          def secret; end
+          private :secret
+          alias revealed secret
+        end
+      RUBY
+
+      graph = Rubydex::Graph.new
+      graph.index_all(context.glob("**/*.rb"))
+      graph.resolve
+
+      assert_predicate(graph["Foo#revealed()"], :private?)
+    end
+  end
+
+  def test_method_alias_visibility_inherits_from_protected_target
+    with_context do |context|
+      context.write!("file1.rb", <<~RUBY)
+        class Foo
+          def guarded; end
+          protected :guarded
+          alias revealed guarded
+        end
+      RUBY
+
+      graph = Rubydex::Graph.new
+      graph.index_all(context.glob("**/*.rb"))
+      graph.resolve
+
+      assert_predicate(graph["Foo#revealed()"], :protected?)
+    end
+  end
+
   def test_method_visibility_via_scope_flag
     with_context do |context|
       context.write!("file1.rb", <<~RUBY)


### PR DESCRIPTION
We were not following alias targets to get the inherited visibility of an alias. Additionally, we were returning `None` as the final fallback, which is reserved for declaration types where visibility simply doesn't apply (like ivars).

This PR makes sure we follow aliases to detect the inherited visibility and I changed the final fallback to `public` in case we fail to determine the visibility of a method. I also moved `Todo` together with `Class` since it's basically the same thing.