### PR TITLE
Expose `Definition#declaration` in the Ruby API

### DIFF
--- a/ext/rubydex/definition.c
+++ b/ext/rubydex/definition.c
@@ -1,4 +1,5 @@
 #include "definition.h"
+#include "declaration.h"
 #include "graph.h"
 #include "handle.h"
 #include "location.h"
@@ -172,6 +173,28 @@ static VALUE rdxr_definition_name_location(VALUE self) {
     return location;
 }
 
+// Definition#declaration -> Rubydex::Declaration?
+// Returns the declaration this definition belongs to or nil when it cannot be located (for example, before
+// `Graph#resolve` has run).
+static VALUE rdxr_definition_declaration(VALUE self) {
+    HandleData *data;
+    TypedData_Get_Struct(self, HandleData, &handle_type, data);
+
+    void *graph;
+    TypedData_Get_Struct(data->graph_obj, void *, &graph_type, graph);
+
+    const struct CDeclaration *decl = rdx_definition_declaration(graph, data->id);
+    if (decl == NULL) {
+        return Qnil;
+    }
+
+    VALUE decl_class = rdxi_declaration_class_for_kind(decl->kind);
+    VALUE argv[] = {data->graph_obj, ULL2NUM(decl->id)};
+    free_c_declaration(decl);
+
+    return rb_class_new_instance(2, argv, decl_class);
+}
+
 static VALUE rdxi_build_constant_reference(VALUE graph_obj, const CConstantReference *cref) {
     VALUE ref_class = (cref->declaration_id == 0)
         ? cUnresolvedConstantReference
@@ -282,6 +305,7 @@ void rdxi_initialize_definition(VALUE mod) {
     rb_define_method(cDefinition, "name", rdxr_definition_name, 0);
     rb_define_method(cDefinition, "deprecated?", rdxr_definition_deprecated, 0);
     rb_define_method(cDefinition, "name_location", rdxr_definition_name_location, 0);
+    rb_define_method(cDefinition, "declaration", rdxr_definition_declaration, 0);
 
     cClassDefinition = rb_define_class_under(mRubydex, "ClassDefinition", cDefinition);
     rb_define_method(cClassDefinition, "superclass", rdxr_class_definition_superclass, 0);

--- a/rbi/rubydex.rbi
+++ b/rbi/rubydex.rbi
@@ -142,6 +142,9 @@ class Rubydex::Definition
   sig { returns(T.nilable(Rubydex::Location)) }
   def name_location; end
 
+  sig { returns(T.nilable(Rubydex::Declaration)) }
+  def declaration; end
+
   class << self
     private
 

--- a/rust/rubydex-sys/src/definition_api.rs
+++ b/rust/rubydex-sys/src/definition_api.rs
@@ -1,5 +1,6 @@
 //! This file provides the C API for Definition accessors
 
+use crate::declaration_api::CDeclaration;
 use crate::graph_api::{GraphPointer, with_graph};
 use crate::location_api::{Location, create_location_for_uri_and_offset};
 use crate::reference_api::CConstantReference;
@@ -247,6 +248,31 @@ pub unsafe extern "C" fn rdx_definition_location(pointer: GraphPointer, definiti
 
         let document = graph.documents().get(defn.uri_id()).expect("document should exist");
         create_location_for_uri_and_offset(graph, document, defn.offset())
+    })
+}
+
+/// Returns the declaration that the given definition belongs to. Returns NULL when the definition has no associated
+/// declaration (for example, before resolution has run or when the declaration cannot be located). Caller must free
+/// with `free_c_declaration`.
+///
+/// # Safety
+/// - `pointer` must be a valid pointer previously returned by `rdx_graph_new`.
+/// - `definition_id` must be a valid definition id.
+///
+/// # Panics
+/// This function will panic if the definition cannot be found.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rdx_definition_declaration(pointer: GraphPointer, definition_id: u64) -> *const CDeclaration {
+    with_graph(pointer, |graph| {
+        let def_id = DefinitionId::new(definition_id);
+        let Some(decl_id) = graph.definition_id_to_declaration_id(def_id) else {
+            return ptr::null();
+        };
+        let Some(decl) = graph.declarations().get(decl_id) else {
+            return ptr::null();
+        };
+
+        Box::into_raw(Box::new(CDeclaration::from_declaration(*decl_id, decl))).cast_const()
     })
 }
 

--- a/test/definition_test.rb
+++ b/test/definition_test.rb
@@ -668,6 +668,53 @@ class DefinitionTest < Minitest::Test
     end
   end
 
+  def test_definition_declaration
+    with_context do |context|
+      context.write!("file1.rb", <<~RUBY)
+        class Foo
+          def bar; end
+        end
+
+        module M; end
+        FOO = 1
+      RUBY
+
+      graph = Rubydex::Graph.new
+      graph.index_all(context.glob("**/*.rb"))
+
+      defs = graph.documents.find { |d| d.uri == context.uri_to("file1.rb") }.definitions
+
+      class_def = defs.find { |d| d.name == "Foo" }
+      method_def = defs.find { |d| d.name == "bar()" }
+      module_def = defs.find { |d| d.name == "M" }
+      const_def = defs.find { |d| d.name == "FOO" }
+
+      # Before resolution, declarations do not exist yet
+      assert_nil(class_def.declaration)
+      assert_nil(method_def.declaration)
+      assert_nil(module_def.declaration)
+      assert_nil(const_def.declaration)
+
+      graph.resolve
+
+      class_decl = class_def.declaration
+      assert_instance_of(Rubydex::Class, class_decl)
+      assert_equal("Foo", class_decl.name)
+
+      method_decl = method_def.declaration
+      assert_instance_of(Rubydex::Method, method_decl)
+      assert_equal("Foo#bar()", method_decl.name)
+
+      module_decl = module_def.declaration
+      assert_instance_of(Rubydex::Module, module_decl)
+      assert_equal("M", module_decl.name)
+
+      const_decl = const_def.declaration
+      assert_instance_of(Rubydex::Constant, const_decl)
+      assert_equal("FOO", const_decl.name)
+    end
+  end
+
   private
 
   # Comment locations on Windows include the carriage return. This means that the end column is off by one when compared


### PR DESCRIPTION
I forgot we didn't already expose a way to go from `definition` -> `declaration` in the Ruby API. The Tapioca add-on needs to go from a `uri` to `document` -> `definitions` -> `declarations` -> `names`.

This PR exposes `Definition#declaration` in the Ruby API, which is basically the `definition_id_to_declaration_id` method that we always had.