### PR TITLE
Resolve module_function visibility

### DIFF
--- a/rust/rubydex/src/indexing/ruby_indexer.rs
+++ b/rust/rubydex/src/indexing/ruby_indexer.rs
@@ -1441,6 +1441,18 @@ impl<'a> RubyIndexer<'a> {
                 ruby_prism::Node::SymbolNode { .. } | ruby_prism::Node::StringNode { .. }
             ) {
                 self.create_method_visibility_definition(&arg, visibility, DefinitionFlags::empty());
+                if visibility == Visibility::ModuleFunction {
+                    // `module_function` also creates a public singleton method, so we emit a
+                    // second def for the singleton side. The two defs stay separate (rather than
+                    // shared) so reverse-lookup invalidation can detach `Foo#bar` and
+                    // `Foo::<Foo>#bar` independently. The `SINGLETON_METHOD_VISIBILITY` flag
+                    // routes this one to the singleton class.
+                    self.create_method_visibility_definition(
+                        &arg,
+                        visibility,
+                        DefinitionFlags::SINGLETON_METHOD_VISIBILITY,
+                    );
+                }
             } else {
                 // Unsupported arg — diagnostic + visit for side effects.
                 let arg_offset = Offset::from_prism_location(&arg.location());

--- a/rust/rubydex/src/indexing/ruby_indexer_tests.rs
+++ b/rust/rubydex/src/indexing/ruby_indexer_tests.rs
@@ -2058,10 +2058,29 @@ mod visibility_tests {
 
         assert_no_local_diagnostics!(&context);
 
-        assert_definition_at!(&context, "4:20-4:23", MethodVisibility, |def| {
-            assert_def_str_eq!(&context, def, "foo()");
-            assert_eq!(def.visibility(), &Visibility::ModuleFunction);
-        });
+        let defs = context.all_definitions_at("4:20-4:23");
+        assert_eq!(defs.len(), 2, "expected two MethodVisibility defs");
+
+        let mut instance_side = None;
+        let mut singleton_side = None;
+        for def in defs {
+            let Definition::MethodVisibility(method_vis) = def else {
+                panic!("expected MethodVisibility, got {:?}", def.kind());
+            };
+            if method_vis.flags().is_singleton_method_visibility() {
+                singleton_side = Some(method_vis.as_ref());
+            } else {
+                instance_side = Some(method_vis.as_ref());
+            }
+        }
+
+        let instance_side = instance_side.expect("missing instance-side def");
+        assert_def_str_eq!(&context, instance_side, "foo()");
+        assert_eq!(instance_side.visibility(), &Visibility::ModuleFunction);
+
+        let singleton_side = singleton_side.expect("missing singleton-side def");
+        assert_def_str_eq!(&context, singleton_side, "foo()");
+        assert_eq!(singleton_side.visibility(), &Visibility::ModuleFunction);
     }
 
     #[test]

--- a/rust/rubydex/src/model/definitions.rs
+++ b/rust/rubydex/src/model/definitions.rs
@@ -837,7 +837,16 @@ impl MethodVisibilityDefinition {
 
     #[must_use]
     pub fn id(&self) -> DefinitionId {
-        DefinitionId::from(&format!("{}{}{}", *self.uri_id, self.offset.start(), *self.str_id))
+        // Flags are part of the hash because `module_function :bar` emits two
+        // `MethodVisibility` defs at the same source location, differing only
+        // in their `SINGLETON_METHOD_VISIBILITY` flag.
+        DefinitionId::from(&format!(
+            "{}{}{}{}",
+            *self.uri_id,
+            self.offset.start(),
+            *self.str_id,
+            self.flags.bits()
+        ))
     }
 
     #[must_use]

--- a/rust/rubydex/src/model/graph.rs
+++ b/rust/rubydex/src/model/graph.rs
@@ -676,6 +676,9 @@ impl Graph {
     ///
     /// For methods, the latest definition wins. For constants, the latest
     /// `private_constant`/`public_constant` wins, otherwise `Public`.
+    ///
+    /// Methods declared via `module_function :bar` return `Private` on the instance
+    /// side (`Foo#bar`) and `Public` on the singleton side (`Foo::<Foo>#bar`).
     #[must_use]
     pub fn visibility(&self, declaration_id: &DeclarationId) -> Option<Visibility> {
         let declaration = self.declarations.get(declaration_id)?;
@@ -701,7 +704,13 @@ impl Graph {
                     };
 
                     let visibility = match definition {
-                        Definition::MethodVisibility(vis) => Some(*vis.visibility()),
+                        Definition::MethodVisibility(vis) => match *vis.visibility() {
+                            Visibility::ModuleFunction if vis.flags().is_singleton_method_visibility() => {
+                                Some(Visibility::Public)
+                            }
+                            Visibility::ModuleFunction => Some(Visibility::Private),
+                            other => Some(other),
+                        },
                         Definition::Method(method) => Some(*method.visibility()),
                         Definition::AttrAccessor(attr) => Some(*attr.visibility()),
                         Definition::AttrReader(attr) => Some(*attr.visibility()),

--- a/rust/rubydex/src/operation/ruby_builder.rs
+++ b/rust/rubydex/src/operation/ruby_builder.rs
@@ -1106,6 +1106,18 @@ impl<'a> RubyOperationBuilder<'a> {
                 ruby_prism::Node::SymbolNode { .. } | ruby_prism::Node::StringNode { .. }
             ) {
                 self.create_method_visibility_operation(&arg, visibility, DefinitionFlags::empty());
+                if visibility == Visibility::ModuleFunction {
+                    // `module_function` also creates a public singleton method, so we emit a
+                    // second def for the singleton side. The two defs stay separate (rather than
+                    // shared) so reverse-lookup invalidation can detach `Foo#bar` and
+                    // `Foo::<Foo>#bar` independently. The `SINGLETON_METHOD_VISIBILITY` flag
+                    // routes this one to the singleton class.
+                    self.create_method_visibility_operation(
+                        &arg,
+                        visibility,
+                        DefinitionFlags::SINGLETON_METHOD_VISIBILITY,
+                    );
+                }
             } else {
                 let arg_offset = Offset::from_prism_location(&arg.location());
                 let message = if Self::is_attr_call(&arg) {

--- a/rust/rubydex/src/resolution.rs
+++ b/rust/rubydex/src/resolution.rs
@@ -16,6 +16,7 @@ use crate::model::{
     identity_maps::{IdentityHashBuilder, IdentityHashMap, IdentityHashSet},
     ids::{ConstantReferenceId, DeclarationId, DefinitionId, NameId, StringId, UriId},
     name::{Name, NameRef, ParentScope},
+    visibility::Visibility,
 };
 
 enum Outcome {
@@ -635,7 +636,7 @@ impl<'a> Resolver<'a> {
     }
 
     /// Resolves retroactive method visibility changes (`private :foo`, `protected :foo`, `public :foo`,
-    /// `private_class_method :foo`, `public_class_method :foo`).
+    /// `private_class_method :foo`, `public_class_method :foo`, `module_function :foo`).
     ///
     /// Runs as a second pass after all methods/attrs are declared, so `private :bar` works
     /// regardless of whether `def bar` appeared before or after it in source.
@@ -652,12 +653,14 @@ impl<'a> Resolver<'a> {
             let offset = method_visibility.offset().clone();
             let lexical_nesting_id = *method_visibility.lexical_nesting_id();
             let is_singleton = method_visibility.flags().is_singleton_method_visibility();
+            let is_module_function = *method_visibility.visibility() == Visibility::ModuleFunction;
+            let is_module_function_singleton = is_singleton && is_module_function;
 
             let Some(lexical_owner_id) = self.resolve_lexical_owner(lexical_nesting_id, id) else {
                 continue;
             };
 
-            let owner_id = if is_singleton {
+            let namespace_id = if is_singleton && !is_module_function {
                 let Some(singleton_id) =
                     self.get_or_create_singleton_class(lexical_owner_id, SingletonAncestors::Eager)
                 else {
@@ -668,12 +671,12 @@ impl<'a> Resolver<'a> {
                 lexical_owner_id
             };
 
-            let Some(Declaration::Namespace(namespace)) = self.graph.declarations().get(&owner_id) else {
+            let Some(Declaration::Namespace(namespace)) = self.graph.declarations().get(&namespace_id) else {
                 continue;
             };
 
-            let mut visibility_applied = false;
-            let mut has_partial = false;
+            let mut visibility_definition_attached = false;
+            let mut ancestor_chain_is_incomplete = false;
 
             for ancestor in namespace.ancestors() {
                 match ancestor {
@@ -687,40 +690,51 @@ impl<'a> Resolver<'a> {
                             .is_some();
 
                         if has_member {
-                            // Direct member: `create_declaration`'s fully qualified name dedup attaches
-                            // this visibility definition to the existing method declaration.
-                            // Inherited: a new child-owned declaration is created.
-                            self.create_declaration(str_id, id, owner_id, |name| {
-                                Declaration::Method(Box::new(MethodDeclaration::new(name, owner_id)))
-                            });
-                            visibility_applied = true;
+                            if is_module_function_singleton {
+                                let Some(singleton_id) =
+                                    self.get_or_create_singleton_class(lexical_owner_id, SingletonAncestors::Eager)
+                                else {
+                                    break;
+                                };
+
+                                self.create_declaration(str_id, id, singleton_id, |name| {
+                                    Declaration::Method(Box::new(MethodDeclaration::new(name, singleton_id)))
+                                });
+                            } else {
+                                self.create_declaration(str_id, id, namespace_id, |name| {
+                                    Declaration::Method(Box::new(MethodDeclaration::new(name, namespace_id)))
+                                });
+                            }
+                            visibility_definition_attached = true;
                             break;
                         }
                     }
-                    Ancestor::Partial(_) => has_partial = true,
+                    Ancestor::Partial(_) => ancestor_chain_is_incomplete = true,
                 }
             }
 
-            if visibility_applied {
+            if visibility_definition_attached {
                 continue;
             }
 
-            if has_partial {
-                // Method might exist on an unresolved ancestor — requeue for retry.
+            if ancestor_chain_is_incomplete {
                 pending_work.push(Unit::Definition(id));
-            } else {
-                // Ancestors are fully resolved — method definitively doesn't exist.
-                let method_name = self.graph.strings().get(&str_id).unwrap().as_str().to_string();
-                let owner_name = self.graph.declarations().get(&owner_id).unwrap().name().to_string();
-                let diagnostic = Diagnostic::new(
-                    Rule::UndefinedMethodVisibilityTarget,
-                    uri_id,
-                    offset,
-                    format!("undefined method `{owner_name}#{method_name}` for visibility change"),
-                );
-
-                self.graph.add_document_diagnostic(uri_id, diagnostic);
+                continue;
             }
+
+            if is_module_function_singleton {
+                continue;
+            }
+
+            let method_name = self.graph.strings().get(&str_id).unwrap().as_str().to_string();
+            let owner_name = self.graph.declarations().get(&namespace_id).unwrap().name().to_string();
+            let diagnostic = Diagnostic::new(
+                Rule::UndefinedMethodVisibilityTarget,
+                uri_id,
+                offset,
+                format!("undefined method `{owner_name}#{method_name}` for visibility change"),
+            );
+            self.graph.add_document_diagnostic(uri_id, diagnostic);
         }
 
         // Must extend work here so incremental resolution can resolve previously unresolved visibility operations

--- a/rust/rubydex/src/resolution_tests.rs
+++ b/rust/rubydex/src/resolution_tests.rs
@@ -5651,4 +5651,164 @@ mod visibility_resolution_tests {
         assert_visibility_eq!(context, "Foo::<Foo>#b()", Visibility::Private);
         assert_visibility_eq!(context, "Foo::<Foo>#c()", Visibility::Public);
     }
+
+    #[test]
+    fn inline_module_function() {
+        let mut context = GraphTest::new();
+        context.index_uri(
+            "file:///foo.rb",
+            r"
+            module Foo
+              module_function def bar; end
+            end
+            ",
+        );
+        context.resolve();
+
+        assert_no_diagnostics!(&context);
+        assert_visibility_eq!(context, "Foo#bar()", Visibility::Private);
+        assert_visibility_eq!(context, "Foo::<Foo>#bar()", Visibility::Public);
+    }
+
+    #[test]
+    fn inline_module_function_singleton_companion_visibility_can_be_changed() {
+        let mut context = graph_test();
+        context.index_uri(
+            "file:///foo.rb",
+            r"
+            module Foo
+              module_function def bar; end
+
+              class << self
+                private :bar
+              end
+            end
+            ",
+        );
+        context.resolve();
+
+        assert_no_diagnostics!(&context);
+        assert_visibility_eq!(context, "Foo#bar()", Visibility::Private);
+        assert_visibility_eq!(context, "Foo::<Foo>#bar()", Visibility::Private);
+    }
+
+    #[test]
+    fn retroactive_module_function() {
+        let mut context = GraphTest::new();
+        context.index_uri(
+            "file:///foo.rb",
+            r"
+            module Foo
+              def bar; end
+              module_function :bar
+            end
+            ",
+        );
+        context.resolve();
+
+        assert_no_diagnostics!(&context);
+        assert_visibility_eq!(context, "Foo#bar()", Visibility::Private);
+        assert_visibility_eq!(context, "Foo::<Foo>#bar()", Visibility::Public);
+
+        // Instance: Method def + MethodVisibility def
+        assert_declaration_definitions_count_eq!(context, "Foo#bar()", 2);
+        // Singleton companion: only the MethodVisibility def is attached
+        assert_declaration_definitions_count_eq!(context, "Foo::<Foo>#bar()", 1);
+    }
+
+    #[test]
+    fn retroactive_module_function_undefined_target_emits_single_diagnostic() {
+        let mut context = GraphTest::new();
+        context.index_uri(
+            "file:///foo.rb",
+            r"
+            module Foo
+              module_function :missing
+            end
+            ",
+        );
+        context.resolve();
+
+        // The singleton-side def stays silent; only the instance-side def emits.
+        assert_diagnostics_eq!(
+            context,
+            &["undefined-method-visibility-target: undefined method `Foo#missing()` for visibility change (2:20-2:27)"]
+        );
+        assert_declaration_does_not_exist!(context, "Foo::<Foo>#missing()");
+        assert_declaration_does_not_exist!(context, "Foo::<Foo>");
+    }
+
+    #[test]
+    fn retroactive_module_function_singleton_companion_cleared_when_removed_multi_file() {
+        let mut context = GraphTest::new();
+        context.index_uri(
+            "file:///a.rb",
+            r"
+            module Foo
+              def bar; end
+              module_function :bar
+            end
+            ",
+        );
+        context.index_uri(
+            "file:///b.rb",
+            r"
+            module Foo
+              def baz; end
+            end
+            ",
+        );
+        context.resolve();
+
+        assert_visibility_eq!(context, "Foo::<Foo>#bar()", Visibility::Public);
+
+        // Re-index a.rb without `module_function :bar`. Foo still has b.rb's Module def, so the
+        // namespace stays alive and no cascade through Foo's singleton class runs. The singleton
+        // companion must still be cleaned up via reverse-lookup invalidation of its own def.
+        context.index_uri(
+            "file:///a.rb",
+            r"
+            module Foo
+              def bar; end
+            end
+            ",
+        );
+        context.resolve();
+
+        assert_no_diagnostics!(&context);
+        assert_visibility_eq!(context, "Foo#bar()", Visibility::Public);
+        assert_declaration_does_not_exist!(context, "Foo::<Foo>#bar()");
+    }
+
+    #[test]
+    fn retroactive_module_function_singleton_companion_cleared_when_removed() {
+        let mut context = GraphTest::new();
+        context.index_uri(
+            "file:///foo.rb",
+            r"
+            module Foo
+              def bar; end
+              module_function :bar
+            end
+            ",
+        );
+        context.resolve();
+
+        assert_visibility_eq!(context, "Foo::<Foo>#bar()", Visibility::Public);
+
+        context.index_uri(
+            "file:///foo.rb",
+            r"
+            module Foo
+              def bar; end
+            end
+            ",
+        );
+        context.resolve();
+
+        assert_no_diagnostics!(&context);
+        assert_visibility_eq!(context, "Foo#bar()", Visibility::Public);
+        assert_declaration_does_not_exist!(context, "Foo::<Foo>#bar()");
+        assert_declaration_does_not_exist!(context, "Foo::<Foo>");
+    }
 }


### PR DESCRIPTION
Closes #89 and finishes the singleton-method visibility resolution work started in #780/#781/#782. This PR resolves retroactive `module_function` visibility:

```ruby
module Foo
  def bar; end
  module_function :bar
end

Foo.bar           # public singleton method
Foo.new.bar       # NoMethodError (private instance method)
```

`Foo#bar` becomes private and `Foo.bar` is added as a public singleton method.

### One definition per side

The indexer emits two `MethodVisibility` definitions at the `module_function :bar` call site: one for `Foo#bar` and one for `Foo::<Foo>#bar`. The singleton-side definition uses the existing `SINGLETON_METHOD_VISIBILITY` flag; both carry `Visibility::ModuleFunction`.

The definitions must remain separate because reverse lookup maps each definition to one declaration. Giving each side its own definition lets invalidation detach the instance and singleton declarations independently when the source method or `module_function` call is removed. The flag bits are included in `MethodVisibilityDefinition::id()` so the two definitions at the same source location have distinct IDs.

### Resolution

The instance-side definition follows the existing method-visibility path. The singleton-side definition looks for the same instance method, then attaches a declaration to the singleton class. `Graph::visibility()` exposes these as `Private` and `Public`, respectively.

The singleton class is created only after the target method is found. For `module_function :missing`, the instance side emits the diagnostic while the singleton side stays silent, leaving no empty `Foo::<Foo>` namespace behind.

The existing inline form (`module_function def bar; end`) is unchanged. Regression coverage verifies that its singleton companion can still be changed by a later singleton visibility call.

### Known difference from Ruby

Rubydex resolves each argument independently. For `module_function :a, :missing`, it makes `Foo#a` private, adds the public `Foo.a`, and reports `:missing`. Ruby makes `Foo#a` private before raising, but creates no singleton copies for the call. Resolving independently preserves useful information while code is incomplete in an editor.
