### PR TITLE
ci: declare workflow-level `contents: read` on 3 workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@ name: CI
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/indexing_top_gems.yml
+++ b/.github/workflows/indexing_top_gems.yml
@@ -2,6 +2,9 @@ name: Index top 100 gems
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   indexing_top_gems:
     runs-on: ubuntu-latest

--- a/.github/workflows/memleak.yml
+++ b/.github/workflows/memleak.yml
@@ -13,6 +13,9 @@ on:
       - "rust/**"
       - "ext/**"
 
+permissions:
+  contents: read
+
 jobs:
   memleak:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to `contents: read` on 3 workflows in `.github/workflows/` that don't call a GitHub API beyond the initial checkout.

The following files were left implicit because they reference `GITHUB_TOKEN` / use a write-scope action / trigger on `pull_request_target`. Those scopes are best declared by maintainers: `cla.yml`.

## Why

CVE-2025-30066 (March 2025 `tj-actions/changed-files` supply-chain compromise) exfiltrated `GITHUB_TOKEN` from workflow logs. Pinning per workflow caps runtime authority irrespective of the repo or org default, gives drift protection if the default ever widens, and is credited per-file by the OpenSSF Scorecard `Token-Permissions` check.

YAML validated locally with `yaml.safe_load` on each touched file.