### PR TITLE
MCP: Fix `get_declaration` leaking internal `Debug` representation for `Unresolved` ancestors

### DIFF
--- a/rust/rubydex-mcp/src/server.rs
+++ b/rust/rubydex-mcp/src/server.rs
@@ -196,13 +196,10 @@ fn format_ancestors(graph: &Graph, ancestors: &Ancestors) -> Vec<serde_json::Val
                     "kind": ancestor_decl.kind(),
                 }))
             }
-            Ancestor::Partial(name_id) => {
-                let name_ref = graph.names().get(name_id)?;
-                Some(serde_json::json!({
-                    "name": format!("{name_ref:?}"),
-                    "kind": "Unresolved",
-                }))
-            }
+            Ancestor::Partial(name_id) => Some(serde_json::json!({
+                "name": graph.build_concatenated_name_from_name(*name_id),
+                "kind": "Unresolved",
+            })),
         })
         .collect()
 }
@@ -847,6 +844,22 @@ mod tests {
             ",
         );
         assert_includes!(get_declaration(&s, "Person"), "ancestors", "Greetable");
+    }
+
+    #[test]
+    fn get_declaration_unresolved_ancestor_renders_qualified_name() {
+        // A superclass defined outside the indexed workspace (e.g. a gem) stays an
+        // unresolved ancestor. Its name must still serialize as a readable constant
+        // path, not the internal `Name` debug representation.
+        let s = server_with_source("class Dog < ActiveRecord::Base; end");
+        let res = get_declaration(&s, "Dog");
+
+        let unresolved = array!(res, "ancestors")
+            .iter()
+            .find(|a| a["kind"].as_str() == Some("Unresolved"))
+            .expect("expected an Unresolved ancestor");
+        let name = unresolved["name"].as_str().expect("expected 'name' to be a string");
+        assert_eq!(name, "ActiveRecord::Base");
     }
 
     #[test]

--- a/rust/rubydex/src/stats/orphan_report.rs
+++ b/rust/rubydex/src/stats/orphan_report.rs
@@ -56,8 +56,10 @@ impl Graph {
     /// Falls back to `nesting` for enclosing scope context when there is no explicit parent scope.
     ///
     /// Note: this produces a concatenated name by piecing together name parts, not a properly
-    /// resolved qualified name.
-    pub(crate) fn build_concatenated_name_from_name(&self, name_id: NameId) -> String {
+    /// resolved qualified name. This is the best available rendering for names that never
+    /// resolve to a declaration -- e.g. an ancestor defined outside the indexed workspace.
+    #[must_use]
+    pub fn build_concatenated_name_from_name(&self, name_id: NameId) -> String {
         let Some(name_ref) = self.names().get(&name_id) else {
             return "<unknown>".to_string();
         };


### PR DESCRIPTION
## Background

While working with the MCP Claude was complaining about debug output in `get_declaration`, digging into it it seems that when you have a ancestor that is unindexed (for instance, something defined in a gem), rather than say what the ancestor is rubydex prints the debug info. For instance for a class like `class Dog < ActiveRecord::Base; end`

you get:

```
      "ancestors": [{
        "name": "Unresolved(Name { str: Id { value: 13424087348773472403, _marker: PhantomData<...> }, parent_scope: Some(Id { value: 13486303262390686460,
  _marker: PhantomData<...> }), nesting: None, ref_count: 1 })",
        "kind": "Unresolved"
      }]
```

instead of: 

```
      "ancestors": [{
        "name": "ActiveRecord::Base",
        "kind": "Unresolved"
      }]
```

The latter seems to make a bit more sense to me but I don't know if perhaps there's reasoning I'm missing for the former. So feel free to close this (obvs) if this is way off base and not in fact a bug or a fix that makes total sense. 

## Approach


Went with a very simple/minimal fix by reusing `Graph::build_concatenated_name_from_name`, which already existed in `stats/orphan_report.rs` for the orphan report. It walks the `parent_scope` chain off the `Name` and concatenates each segment into a qualified constant path.

Buuuut to call it from the MCP crate, its visibility moves from `pub(crate)` to `pub`. 

The architecture docs note that `model/graph.rs` is where all the `Graph`-y public bits are so it seems like this my make sense to be moved over there. But in the interest of keeping this PR for a bug that may not even be a bug I kept the fix narrow. Happy to move things around. 

There's a slight behavior change with this approach too. Previously, if `graph.names().get(name_id)` returned `None`, the `?` would short-circuit `filter_map` and the ancestor would silently vanish from the response. After this change, that case renders as `"<unknown>"` (the existing fallback inside `build_concatenated_name_from_name`) and the ancestor stays in the array. TLDR; a missing name is now visible rather than swallowed. That seems preferable to me at first glance but may not be desired. 

I do believe old swallowing behavior could be maintained pretty easily. 

## Testing

Added a regression test: 

`cargo test -p rubydex-mcp get_declaration_unresolved_ancestor_renders_qualified_name`

Also if you want to test manually, index a workspace whose classes inherit from gem-provided base classes (any `ActiveRecord` model should do), and call `get_declaration`. You should no longer see the debug output but instead see `ActiveRecord::Base`

## Notes
(For the cross linking context sickos out there [that's me])

- Distinct from #707 (resolver creating `TODODeclaration`s for unresolved references), that's about why something is unresolved; this is about how the `Unresolved` variant is serialized to the MCP client.
- Distinct from #708 (singleton class ancestor chain correctness), different failure mode.
- Not currently tracked in #608 (MCP server follow-up improvements).
- Related: #803 (`index_workspace` doesn't index gems) explains why these ancestors are unresolved