### PR TITLE
Accept leading `::` in `Graph#[]` lookups

### DIFF
--- a/rust/rubydex-sys/src/declaration_api.rs
+++ b/rust/rubydex-sys/src/declaration_api.rs
@@ -9,7 +9,7 @@ use crate::definition_api::{DefinitionsIter, rdx_definitions_iter_new_from_ids};
 use crate::graph_api::{GraphPointer, with_graph};
 use crate::reference_api::{CConstantReference, CMethodReference, ConstantReferencesIter, MethodReferencesIter};
 use crate::utils;
-use rubydex::model::ids::{DeclarationId, StringId};
+use rubydex::model::ids::{DeclarationId, StringId, declaration_id_from_lookup_name};
 
 #[repr(C)]
 #[derive(Debug, Clone, Copy)]
@@ -80,7 +80,7 @@ pub(crate) unsafe fn decl_id_from_char_ptr(ptr: *const c_char) -> Option<Declara
     if s.is_empty() {
         return None;
     }
-    Some(DeclarationId::from_lookup_name(&s))
+    Some(declaration_id_from_lookup_name(&s))
 }
 
 /// An iterator over declaration IDs

--- a/rust/rubydex-sys/src/declaration_api.rs
+++ b/rust/rubydex-sys/src/declaration_api.rs
@@ -80,7 +80,7 @@ pub(crate) unsafe fn decl_id_from_char_ptr(ptr: *const c_char) -> Option<Declara
     if s.is_empty() {
         return None;
     }
-    Some(DeclarationId::from(s.as_str()))
+    Some(DeclarationId::from_lookup_name(&s))
 }
 
 /// An iterator over declaration IDs

--- a/rust/rubydex-sys/src/graph_api.rs
+++ b/rust/rubydex-sys/src/graph_api.rs
@@ -458,7 +458,10 @@ pub unsafe extern "C" fn rdx_graph_get_declaration(pointer: GraphPointer, name: 
     };
 
     with_graph(pointer, |graph| {
-        let decl_id = DeclarationId::from(name_str.as_str());
+        // Accept an optional leading `::` root-scope marker so `"::Object"` and `"Object"`
+        // resolve to the same declaration. All stored FQNs are implicitly root-scoped.
+        let lookup_name = name_str.strip_prefix("::").unwrap_or(name_str.as_str());
+        let decl_id = DeclarationId::from(lookup_name);
 
         if let Some(decl) = graph.declarations().get(&decl_id) {
             Box::into_raw(Box::new(CDeclaration::from_declaration(decl_id, decl))).cast_const()

--- a/rust/rubydex-sys/src/graph_api.rs
+++ b/rust/rubydex-sys/src/graph_api.rs
@@ -877,7 +877,7 @@ pub unsafe extern "C" fn rdx_graph_complete_namespace_access(
             graph,
             CompletionReceiver::NamespaceAccess {
                 self_decl_id,
-                namespace_decl_id: DeclarationId::from(name_str.as_str()),
+                namespace_decl_id: DeclarationId::from_lookup_name(&name_str),
             },
             Vec::new(),
         )
@@ -911,7 +911,7 @@ pub unsafe extern "C" fn rdx_graph_complete_method_call(
             graph,
             CompletionReceiver::MethodCall {
                 self_decl_id,
-                receiver_decl_id: DeclarationId::from(name_str.as_str()),
+                receiver_decl_id: DeclarationId::from_lookup_name(&name_str),
             },
             Vec::new(),
         )
@@ -955,7 +955,7 @@ pub unsafe extern "C" fn rdx_graph_complete_method_argument(
             CompletionReceiver::MethodArgument {
                 self_decl_id,
                 nesting_name_id,
-                method_decl_id: DeclarationId::from(name_str.as_str()),
+                method_decl_id: DeclarationId::from_lookup_name(&name_str),
             },
             names_to_untrack,
         )

--- a/rust/rubydex-sys/src/graph_api.rs
+++ b/rust/rubydex-sys/src/graph_api.rs
@@ -10,7 +10,7 @@ use libc::{c_char, c_void};
 use rubydex::indexing::LanguageId;
 use rubydex::model::encoding::Encoding;
 use rubydex::model::graph::Graph;
-use rubydex::model::ids::{DeclarationId, NameId, UriId};
+use rubydex::model::ids::{DeclarationId, NameId, UriId, declaration_id_from_lookup_name};
 use rubydex::model::keywords;
 use rubydex::model::name::NameRef;
 use rubydex::model::visibility::Visibility;
@@ -458,7 +458,7 @@ pub unsafe extern "C" fn rdx_graph_get_declaration(pointer: GraphPointer, name: 
     };
 
     with_graph(pointer, |graph| {
-        let decl_id = DeclarationId::from_lookup_name(&name_str);
+        let decl_id = declaration_id_from_lookup_name(&name_str);
 
         if let Some(decl) = graph.declarations().get(&decl_id) {
             Box::into_raw(Box::new(CDeclaration::from_declaration(decl_id, decl))).cast_const()
@@ -877,7 +877,7 @@ pub unsafe extern "C" fn rdx_graph_complete_namespace_access(
             graph,
             CompletionReceiver::NamespaceAccess {
                 self_decl_id,
-                namespace_decl_id: DeclarationId::from_lookup_name(&name_str),
+                namespace_decl_id: declaration_id_from_lookup_name(&name_str),
             },
             Vec::new(),
         )
@@ -911,7 +911,7 @@ pub unsafe extern "C" fn rdx_graph_complete_method_call(
             graph,
             CompletionReceiver::MethodCall {
                 self_decl_id,
-                receiver_decl_id: DeclarationId::from_lookup_name(&name_str),
+                receiver_decl_id: declaration_id_from_lookup_name(&name_str),
             },
             Vec::new(),
         )
@@ -955,7 +955,7 @@ pub unsafe extern "C" fn rdx_graph_complete_method_argument(
             CompletionReceiver::MethodArgument {
                 self_decl_id,
                 nesting_name_id,
-                method_decl_id: DeclarationId::from_lookup_name(&name_str),
+                method_decl_id: declaration_id_from_lookup_name(&name_str),
             },
             names_to_untrack,
         )

--- a/rust/rubydex-sys/src/graph_api.rs
+++ b/rust/rubydex-sys/src/graph_api.rs
@@ -458,10 +458,7 @@ pub unsafe extern "C" fn rdx_graph_get_declaration(pointer: GraphPointer, name: 
     };
 
     with_graph(pointer, |graph| {
-        // Accept an optional leading `::` root-scope marker so `"::Object"` and `"Object"`
-        // resolve to the same declaration. All stored FQNs are implicitly root-scoped.
-        let lookup_name = name_str.strip_prefix("::").unwrap_or(name_str.as_str());
-        let decl_id = DeclarationId::from(lookup_name);
+        let decl_id = DeclarationId::from_lookup_name(&name_str);
 
         if let Some(decl) = graph.declarations().get(&decl_id) {
             Box::into_raw(Box::new(CDeclaration::from_declaration(decl_id, decl))).cast_const()

--- a/rust/rubydex/src/model/graph.rs
+++ b/rust/rubydex/src/model/graph.rs
@@ -1559,6 +1559,10 @@ mod tests {
         assert_members_eq, assert_no_diagnostics, assert_no_members,
     };
 
+    fn definition_ids(definitions: Vec<&Definition>) -> Vec<DefinitionId> {
+        definitions.into_iter().map(Definition::id).collect()
+    }
+
     #[test]
     fn deleting_a_uri() {
         let mut context = GraphTest::new();
@@ -1991,11 +1995,19 @@ mod tests {
         // Built-in declarations (root-scoped):
         let unqualified = context.graph().get("Object").expect("unqualified `Object` lookup");
         let qualified = context.graph().get("::Object").expect("qualified `::Object` lookup");
-        assert_eq!(unqualified.len(), qualified.len());
+        assert_eq!(definition_ids(unqualified), definition_ids(qualified));
 
         // Indexed declarations, top-level and nested:
-        assert!(context.graph().get("::Foo").is_some());
-        assert!(context.graph().get("::Foo::Bar").is_some());
+        let unqualified = context.graph().get("Foo").expect("unqualified `Foo` lookup");
+        let qualified = context.graph().get("::Foo").expect("qualified `::Foo` lookup");
+        assert_eq!(definition_ids(unqualified), definition_ids(qualified));
+
+        let unqualified = context.graph().get("Foo::Bar").expect("unqualified `Foo::Bar` lookup");
+        let qualified = context
+            .graph()
+            .get("::Foo::Bar")
+            .expect("qualified `::Foo::Bar` lookup");
+        assert_eq!(definition_ids(unqualified), definition_ids(qualified));
 
         // Unknown names still return None when prefixed:
         assert!(context.graph().get("::DoesNotExist").is_none());

--- a/rust/rubydex/src/model/graph.rs
+++ b/rust/rubydex/src/model/graph.rs
@@ -12,7 +12,10 @@ use crate::model::definitions::{Definition, MethodVisibilityDefinition, Receiver
 use crate::model::document::Document;
 use crate::model::encoding::Encoding;
 use crate::model::identity_maps::{IdentityHashMap, IdentityHashSet};
-use crate::model::ids::{ConstantReferenceId, DeclarationId, DefinitionId, MethodReferenceId, NameId, StringId, UriId};
+use crate::model::ids::{
+    ConstantReferenceId, DeclarationId, DefinitionId, MethodReferenceId, NameId, StringId, UriId,
+    declaration_id_from_lookup_name,
+};
 use crate::model::name::{Name, NameRef, ParentScope, ResolvedName};
 use crate::model::references::{ConstantReference, MethodRef};
 use crate::model::string_ref::StringRef;
@@ -564,7 +567,7 @@ impl Graph {
 
     #[must_use]
     pub fn get(&self, name: &str) -> Option<Vec<&Definition>> {
-        let declaration_id = DeclarationId::from_lookup_name(name);
+        let declaration_id = declaration_id_from_lookup_name(name);
         let declaration = self.declarations.get(&declaration_id)?;
 
         Some(

--- a/rust/rubydex/src/model/graph.rs
+++ b/rust/rubydex/src/model/graph.rs
@@ -564,10 +564,7 @@ impl Graph {
 
     #[must_use]
     pub fn get(&self, name: &str) -> Option<Vec<&Definition>> {
-        // Accept an optional leading `::` root-scope marker so `"::Object"` and `"Object"`
-        // resolve to the same declaration. All stored FQNs are implicitly root-scoped.
-        let name = name.strip_prefix("::").unwrap_or(name);
-        let declaration_id = DeclarationId::from(name);
+        let declaration_id = DeclarationId::from_lookup_name(name);
         let declaration = self.declarations.get(&declaration_id)?;
 
         Some(

--- a/rust/rubydex/src/model/graph.rs
+++ b/rust/rubydex/src/model/graph.rs
@@ -564,6 +564,9 @@ impl Graph {
 
     #[must_use]
     pub fn get(&self, name: &str) -> Option<Vec<&Definition>> {
+        // Accept an optional leading `::` root-scope marker so `"::Object"` and `"Object"`
+        // resolve to the same declaration. All stored FQNs are implicitly root-scoped.
+        let name = name.strip_prefix("::").unwrap_or(name);
         let declaration_id = DeclarationId::from(name);
         let declaration = self.declarations.get(&declaration_id)?;
 
@@ -1979,6 +1982,26 @@ mod tests {
         let definitions = context.graph().get("Foo").unwrap();
         assert_eq!(definitions.len(), 1);
         assert_eq!(definitions[0].offset().start(), 6);
+    }
+
+    #[test]
+    fn get_accepts_leading_double_colon() {
+        let mut context = GraphTest::new();
+
+        context.index_uri("file:///foo.rb", "module Foo; module Bar; end; end");
+        context.resolve();
+
+        // Built-in declarations (root-scoped):
+        let unqualified = context.graph().get("Object").expect("unqualified `Object` lookup");
+        let qualified = context.graph().get("::Object").expect("qualified `::Object` lookup");
+        assert_eq!(unqualified.len(), qualified.len());
+
+        // Indexed declarations, top-level and nested:
+        assert!(context.graph().get("::Foo").is_some());
+        assert!(context.graph().get("::Foo::Bar").is_some());
+
+        // Unknown names still return None when prefixed:
+        assert!(context.graph().get("::DoesNotExist").is_none());
     }
 
     #[test]

--- a/rust/rubydex/src/model/ids.rs
+++ b/rust/rubydex/src/model/ids.rs
@@ -9,6 +9,17 @@ pub struct DeclarationMarker;
 /// `DeclarationId` represents the ID of a fully qualified name. For example, `Foo::Bar` or `Foo#my_method`
 pub type DeclarationId = Id<DeclarationMarker>;
 
+impl Id<DeclarationMarker> {
+    /// Creates a `DeclarationId` from a user-facing lookup name.
+    ///
+    /// Declaration names are stored without the root-scope marker, so `"::Object"`
+    /// and `"Object"` must resolve to the same declaration ID.
+    #[must_use]
+    pub fn from_lookup_name(name: &str) -> Self {
+        Self::from(name.strip_prefix("::").unwrap_or(name))
+    }
+}
+
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone, Copy)]
 pub struct DefinitionMarker;
 
@@ -84,3 +95,24 @@ assert_mem_size!(ClassVariableReferenceId, 8);
 pub struct InstanceVariableMarker;
 pub type InstanceVariableReferenceId = Id<InstanceVariableMarker>;
 assert_mem_size!(InstanceVariableReferenceId, 8);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn declaration_id_from_lookup_name_accepts_root_scope_marker() {
+        assert_eq!(
+            DeclarationId::from("Object"),
+            DeclarationId::from_lookup_name("::Object")
+        );
+        assert_eq!(
+            DeclarationId::from("Foo::Bar"),
+            DeclarationId::from_lookup_name("::Foo::Bar")
+        );
+        assert_ne!(
+            DeclarationId::from("Object"),
+            DeclarationId::from_lookup_name("::::Object")
+        );
+    }
+}

--- a/rust/rubydex/src/model/ids.rs
+++ b/rust/rubydex/src/model/ids.rs
@@ -9,15 +9,13 @@ pub struct DeclarationMarker;
 /// `DeclarationId` represents the ID of a fully qualified name. For example, `Foo::Bar` or `Foo#my_method`
 pub type DeclarationId = Id<DeclarationMarker>;
 
-impl Id<DeclarationMarker> {
-    /// Creates a `DeclarationId` from a user-facing lookup name.
-    ///
-    /// Declaration names are stored without the root-scope marker, so `"::Object"`
-    /// and `"Object"` must resolve to the same declaration ID.
-    #[must_use]
-    pub fn from_lookup_name(name: &str) -> Self {
-        Self::from(name.strip_prefix("::").unwrap_or(name))
-    }
+/// Creates a `DeclarationId` from a user-facing lookup name.
+///
+/// Declaration names are stored without the root-scope marker, so `"::Object"`
+/// and `"Object"` must resolve to the same declaration ID.
+#[must_use]
+pub fn declaration_id_from_lookup_name(name: &str) -> DeclarationId {
+    DeclarationId::from(name.strip_prefix("::").unwrap_or(name))
 }
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone, Copy)]
@@ -104,15 +102,15 @@ mod tests {
     fn declaration_id_from_lookup_name_accepts_root_scope_marker() {
         assert_eq!(
             DeclarationId::from("Object"),
-            DeclarationId::from_lookup_name("::Object")
+            declaration_id_from_lookup_name("::Object")
         );
         assert_eq!(
             DeclarationId::from("Foo::Bar"),
-            DeclarationId::from_lookup_name("::Foo::Bar")
+            declaration_id_from_lookup_name("::Foo::Bar")
         );
         assert_ne!(
             DeclarationId::from("Object"),
-            DeclarationId::from_lookup_name("::::Object")
+            declaration_id_from_lookup_name("::::Object")
         );
     }
 }

--- a/test/graph_test.rb
+++ b/test/graph_test.rb
@@ -99,6 +99,28 @@ class GraphTest < Minitest::Test
     end
   end
 
+  def test_graph_get_declaration_accepts_leading_double_colon
+    with_context do |context|
+      context.write!("file.rb", "module Foo; class Bar; end; end")
+
+      graph = Rubydex::Graph.new
+      graph.index_all(context.glob("**/*.rb"))
+      graph.resolve
+
+      # Built-ins are root-scoped, so `Object` and `::Object` must resolve to the same declaration.
+      refute_nil(graph["::Object"])
+      assert_equal(graph["Object"].name, graph["::Object"].name)
+
+      # Same for indexed declarations, top-level and nested.
+      refute_nil(graph["::Foo"])
+      refute_nil(graph["::Foo::Bar"])
+      assert_equal(graph["Foo::Bar"].name, graph["::Foo::Bar"].name)
+
+      # Unknown names still return nil when prefixed.
+      assert_nil(graph["::DoesNotExist"])
+    end
+  end
+
   def test_list_all_declarations_enumerator
     with_context do |context|
       context.write!("file1.rb", "class A; end")

--- a/test/graph_test.rb
+++ b/test/graph_test.rb
@@ -1078,6 +1078,36 @@ class GraphTest < Minitest::Test
     assert(candidates.any? { |c| c.is_a?(Rubydex::Method) && c.name == "Foo::<Foo>#bar()" })
   end
 
+  def test_completion_declaration_lookups_accept_leading_double_colon
+    graph = Rubydex::Graph.new
+    graph.index_source("file:///foo.rb", <<~RUBY, "ruby")
+      class Foo
+        CONST = 1
+
+        def instance_method; end
+        def self.helper(name:); end
+      end
+    RUBY
+    graph.resolve
+
+    namespace_candidates = graph.complete_namespace_access("::Foo", self_receiver: "::Foo")
+    assert(namespace_candidates.any? { |c| c.name == "Foo::CONST" })
+    assert(namespace_candidates.any? { |c| c.name == "Foo::<Foo>#helper()" })
+
+    method_candidates = graph.complete_method_call("::Foo", self_receiver: "::Foo").map(&:name)
+    assert_includes(method_candidates, "Foo#instance_method()")
+
+    expression_candidates = graph.complete_expression(["Foo"], self_receiver: "::Foo").map(&:name)
+    assert_includes(expression_candidates, "Foo#instance_method()")
+
+    argument_candidates = graph.complete_method_argument(
+      "::Foo::<Foo>#helper()",
+      ["Foo"],
+      self_receiver: "::Foo::<Foo>",
+    ).map(&:name)
+    assert_includes(argument_candidates, "name")
+  end
+
   def test_complete_namespace_access_for_non_namespace
     graph = Rubydex::Graph.new
     graph.index_source("file:///foo.rb", <<~RUBY, "ruby")


### PR DESCRIPTION
Closes #813

`Rubydex::Graph.new["::Object"]` returned `nil` because the FFI lookup hashed the input string verbatim, while declarations are keyed on the unqualified name (e.g. `DeclarationId::from("Object")` in `built_in.rs`). The two affected entry points are `Graph::get` and the FFI `rdx_graph_get_declaration` that `Graph#[]` forwards through.

Stripping an optional leading `::` at both lookup sites lets the root-scope marker resolve to the same declaration as the bare name, matching the way nested constants like `Thread::Backtrace` already work. Added a Rust unit test covering built-ins, top-level, nested, and unknown-name cases, plus a Ruby integration test that exercises the full FFI path.

This is the lookup quirk koic hit in the [Rubydex/RuboCop integration](https://github.com/rubocop/rubocop/pull/15173/files#r3270397515).