### PR TITLE
Package rubydex MCP executable in gem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ THIRD_PARTY_LICENSES.html
 rust/THIRD_PARTY_LICENSES.html
 lib/rubydex/*.dylib
 lib/rubydex/*.so
+lib/rubydex/bin/

--- a/exe/rubydex_mcp
+++ b/exe/rubydex_mcp
@@ -1,0 +1,17 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "rbconfig"
+
+host_os = RbConfig::CONFIG.fetch("host_os")
+executable = host_os.match?(/mswin|mingw|cygwin/) ? "rubydex_mcp.exe" : "rubydex_mcp"
+binary = File.expand_path("../lib/rubydex/bin/#{executable}", __dir__)
+
+unless File.executable?(binary)
+  abort(<<~MESSAGE.chomp)
+    rubydex_mcp is not available at #{binary}.
+    Install a precompiled rubydex gem, or reinstall rubydex with Cargo available so the MCP executable can be built locally.
+  MESSAGE
+end
+
+exec(binary, *ARGV)

--- a/ext/rubydex/extconf.rb
+++ b/ext/rubydex/extconf.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "mkmf"
+require "fileutils"
 require "pathname"
 
 unless system("cargo", "--version", out: File::NULL, err: File::NULL)
@@ -81,6 +82,12 @@ else
 end
 
 lib_dir = gem_dir.join("lib").join("rubydex")
+mcp_bin_dir = lib_dir.join("bin")
+FileUtils.mkdir_p(mcp_bin_dir)
+
+mcp_executable = Gem.win_platform? ? "rubydex_mcp.exe" : "rubydex_mcp"
+mcp_src = target_dir.join(mcp_executable)
+mcp_dst = mcp_bin_dir.join(mcp_executable)
 
 copy_dylib_commands = if Gem.win_platform?
   ""
@@ -107,6 +114,7 @@ new_makefile = makefile.gsub("$(OBJS): $(HDRS) $(ruby_headers)", <<~MAKEFILE.cho
   .rust_built: $(RUST_SRCS)
   \t#{cargo_command} || (echo "Compiling Rust failed" && exit 1)
   \t$(COPY) #{bindings_path} #{__dir__}
+  \t$(COPY) #{mcp_src} #{mcp_dst}
   \ttouch $@
 
   compile_rust: .rust_built

--- a/rubydex.gemspec
+++ b/rubydex.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
 
   if ENV["RELEASE"]
     spec.files << "THIRD_PARTY_LICENSES.html"
+    spec.files << "lib/rubydex/bin/#{Gem.win_platform? ? "rubydex_mcp.exe" : "rubydex_mcp"}"
     if RUBY_PLATFORM.include?("darwin")
       spec.files << "lib/rubydex/librubydex_sys.dylib"
     elsif RUBY_PLATFORM.include?("linux")


### PR DESCRIPTION
## Summary

Package `rubydex_mcp` with release gems so users can run the MCP server without installing the Rust crate or building it manually.

## Changes

- Add `exe/rubydex_mcp` as the RubyGems executable wrapper.
- Copy the Cargo-built MCP binary into `lib/rubydex/bin/` during extension compilation.
- Include the platform MCP binary in release gem files.

## Verification

- `bundle exec rake compile_release`
- Built and installed `tmp/rubydex-local.gem` into an isolated `GEM_HOME`.
- Verified installed `rubydex_mcp --version`.
- Verified MCP `initialize` and `tools/list` through the installed executable.
