### PR TITLE
Add attached_class alias for singleton classes

### DIFF
--- a/lib/rubydex/declaration.rb
+++ b/lib/rubydex/declaration.rb
@@ -28,6 +28,11 @@ module Rubydex
     include Visibility
   end
 
+  class SingletonClass < Namespace
+    #: () -> Declaration
+    alias_method :attached_class, :owner
+  end
+
   class Constant < Declaration
     include Visibility
   end

--- a/rbi/rubydex.rbi
+++ b/rbi/rubydex.rbi
@@ -122,7 +122,11 @@ end
 
 class Rubydex::Class < Rubydex::Namespace; end
 class Rubydex::Module < Rubydex::Namespace; end
-class Rubydex::SingletonClass < Rubydex::Namespace; end
+
+class Rubydex::SingletonClass < Rubydex::Namespace
+  sig { returns(Rubydex::Declaration) }
+  def attached_class; end
+end
 
 class Rubydex::Definition
   abstract!

--- a/test/declaration_test.rb
+++ b/test/declaration_test.rb
@@ -154,6 +154,28 @@ class DeclarationTest < Minitest::Test
     end
   end
 
+  def test_singleton_class_attached_class_aliases_owner
+    with_context do |context|
+      context.write!("file1.rb", <<~RUBY)
+        module Foo; end
+
+        class Bar
+          extend Foo
+        end
+      RUBY
+
+      graph = Rubydex::Graph.new
+      graph.index_all(context.glob("**/*.rb"))
+      graph.resolve
+
+      singleton_class = graph["Foo"].descendants.find { |decl| decl.is_a?(Rubydex::SingletonClass) }
+      assert_respond_to(singleton_class, :attached_class)
+      assert_equal("Bar::<Bar>", singleton_class.name)
+      assert_equal("Bar", singleton_class.owner.name)
+      assert_equal(singleton_class.owner.name, singleton_class.attached_class.name)
+    end
+  end
+
   def test_declaration_kinds_return_specialized_classes
     with_context do |context|
       context.write!("file1.rb", <<~RUBY)


### PR DESCRIPTION
## Summary

Adds `Rubydex::SingletonClass#attached_class` as a Ruby-level alias for `#owner`. Closes #815

For singleton class declarations, `owner` represents the class/module the singleton class is attached to. `attached_class` makes that relationship explicit and easier to understand from the Ruby API.

Example:

```ruby
module Foo; end

class Bar
  extend Foo
end
```

`Foo.descendants` includes `Bar`’s singleton class (`Bar::<Bar>`), and:

```ruby
singleton_class.attached_class # => Bar
```

## Changes

* Adds `SingletonClass#attached_class` in `lib/rubydex/declaration.rb`
* Updates the RBI signature
* Adds coverage using an `extend` case where a module descendant is a singleton class
