### PR TITLE
Add namespace ancestor predicate

### DIFF
--- a/lib/rubydex/declaration.rb
+++ b/lib/rubydex/declaration.rb
@@ -20,6 +20,13 @@ module Rubydex
     end
   end
 
+  class Namespace < Declaration
+    #: (String ancestor_name) -> bool
+    def has_ancestor?(ancestor_name)
+      ancestors.any? { |ancestor| ancestor.name == ancestor_name }
+    end
+  end
+
   class Class < Namespace
     include Visibility
   end

--- a/rbi/rubydex.rbi
+++ b/rbi/rubydex.rbi
@@ -104,6 +104,9 @@ class Rubydex::Namespace < Rubydex::Declaration
   sig { returns(T::Enumerable[Rubydex::Namespace]) }
   def ancestors; end
 
+  sig { params(ancestor_name: String).returns(T::Boolean) }
+  def has_ancestor?(ancestor_name); end
+
   sig { returns(T::Enumerable[Rubydex::Namespace]) }
   def descendants; end
 

--- a/test/declaration_test.rb
+++ b/test/declaration_test.rb
@@ -305,6 +305,49 @@ class DeclarationTest < Minitest::Test
     end
   end
 
+  def test_has_ancestor
+    with_context do |context|
+      context.write!("file1.rb", <<~RUBY)
+        module Mixins
+          module Foo; end
+          module Bar; end
+        end
+
+        module Namespace
+          class Parent
+            extend Mixins::Bar
+          end
+
+          class Child < Parent
+            include Mixins::Foo
+            prepend Mixins::Bar
+            extend Mixins::Foo
+          end
+        end
+      RUBY
+
+      graph = Rubydex::Graph.new
+      graph.index_all(context.glob("**/*.rb"))
+      graph.resolve
+
+      child = graph["Namespace::Child"]
+      assert(child.has_ancestor?("Namespace::Child"))
+      assert(child.has_ancestor?("Namespace::Parent"))
+      assert(child.has_ancestor?("Mixins::Foo"))
+      assert(child.has_ancestor?("Mixins::Bar"))
+      refute(child.has_ancestor?("Child"))
+      refute(child.has_ancestor?("Foo"))
+      refute(child.has_ancestor?("Unknown"))
+
+      singleton_class = child.singleton_class
+      assert(singleton_class.has_ancestor?("Namespace::Child::<Child>"))
+      assert(singleton_class.has_ancestor?("Mixins::Foo"))
+      assert(singleton_class.has_ancestor?("Namespace::Parent::<Parent>"))
+      assert(singleton_class.has_ancestor?("Mixins::Bar"))
+      refute(singleton_class.has_ancestor?("Parent::<Parent>"))
+    end
+  end
+
   def test_cyclic_ancestors
     with_context do |context|
       context.write!("file1.rb", <<~RUBY)


### PR DESCRIPTION
## Summary

Adds `Rubydex::Namespace#has_ancestor?(ancestor_name)` to the Ruby API.

This provides a small convenience helper for checking whether a namespace’s ancestor chain contains a class or module by fully-qualified name, without requiring callers to manually enumerate and compare `#ancestors`.

Example:

```ruby
child.has_ancestor?("Namespace::Parent")
child.has_ancestor?("Mixins::Foo")
```

Unqualified names are not matched:

```ruby
child.has_ancestor?("Parent") # => false
child.has_ancestor?("Foo")    # => false
```

## Changes

* Adds `Namespace#has_ancestor?(ancestor_name)` in `lib/rubydex/declaration.rb`
* Updates the RBI signature
* Adds coverage showing that ancestor names are matched as fully-qualified names
