### PR TITLE
Indexing `.rake` and `.ru` files

### DIFF
--- a/lib/rubydex/graph.rb
+++ b/lib/rubydex/graph.rb
@@ -17,6 +17,8 @@ module Rubydex
       "tmp",
     ].freeze
 
+    INDEXABLE_EXTENSIONS = [".rb", ".rake", ".rbs", ".ru"].freeze
+
     #: String
     attr_accessor :workspace_path
 
@@ -45,7 +47,7 @@ module Rubydex
 
         if File.directory?(full_path)
           paths << full_path unless IGNORED_DIRECTORIES.include?(entry)
-        elsif File.extname(entry) == ".rb"
+        elsif INDEXABLE_EXTENSIONS.include?(File.extname(entry))
           paths << full_path
         end
       end

--- a/rust/rubydex/src/listing.rs
+++ b/rust/rubydex/src/listing.rs
@@ -38,9 +38,14 @@ impl FileDiscoveryJob {
     }
 }
 
+fn is_indexable_file(path: &Path) -> bool {
+    path.extension()
+        .is_some_and(|ext| ext == "rb" || ext == "rake" || ext == "rbs" || ext == "ru")
+}
+
 impl FileDiscoveryJob {
     fn handle_file(&self, path: &Path) {
-        if path.extension().is_some_and(|ext| ext == "rb" || ext == "rbs") {
+        if is_indexable_file(path) {
             self.paths_tx
                 .send(path.to_path_buf())
                 .expect("file receiver dropped before run completion");
@@ -266,22 +271,28 @@ mod tests {
     }
 
     #[test]
-    fn collect_rbs_files() {
+    fn collect_indexable_files() {
         let context = Context::new();
         let ruby_file = PathBuf::from("lib").join("foo.rb");
+        let rake_file = PathBuf::from("lib").join("task.rake");
         let rbs_file = PathBuf::from("sig").join("foo.rbs");
+        let rack_file = PathBuf::from("config.ru");
         let txt_file = PathBuf::from("lib").join("notes.txt");
         context.touch(&ruby_file);
+        context.touch(&rake_file);
         context.touch(&rbs_file);
+        context.touch(&rack_file);
         context.touch(&txt_file);
 
-        let (files, errors) = collect_document_paths(&context, &["lib", "sig"]);
+        let (files, errors) = collect_document_paths(&context, &["lib", "sig", "config.ru"]);
 
         assert!(errors.is_empty());
 
         assert_eq!(
             [
+                rack_file.to_str().unwrap().to_string(),
                 ruby_file.to_str().unwrap().to_string(),
+                rake_file.to_str().unwrap().to_string(),
                 rbs_file.to_str().unwrap().to_string(),
             ],
             files.as_slice()

--- a/test/graph_test.rb
+++ b/test/graph_test.rb
@@ -23,6 +23,24 @@ class GraphTest < Minitest::Test
     end
   end
 
+  def test_indexing_ruby_file_extensions
+    with_context do |context|
+      context.write!("foo.rb", "class Foo; end")
+      context.write!("task.rake", "class Task; end")
+      context.write!("config.ru", "class Config; end")
+      context.write!("notes.txt", "class Notes; end")
+
+      graph = Rubydex::Graph.new
+      assert_empty(graph.index_all([context.absolute_path]))
+      graph.resolve
+
+      refute_nil(graph["Foo"])
+      refute_nil(graph["Task"])
+      refute_nil(graph["Config"])
+      assert_nil(graph["Notes"])
+    end
+  end
+
   def test_indexing_invalid_file_paths
     graph = Rubydex::Graph.new
 
@@ -601,6 +619,9 @@ class GraphTest < Minitest::Test
       context.write!(".git/config", "")
       context.write!("node_modules/pkg/index.js", "")
       context.write!("top_level.rb", "class TopLevel; end")
+      context.write!("top_level.rake", "class TopLevelRake; end")
+      context.write!("top_level.rbs", "class TopLevelRbs; end")
+      context.write!("config.ru", "class ConfigRu; end")
 
       graph = Rubydex::Graph.new(workspace_path: context.absolute_path)
       paths = graph.workspace_paths
@@ -615,6 +636,9 @@ class GraphTest < Minitest::Test
 
       # Includes the top level files
       assert_includes(paths, context.absolute_path_to("top_level.rb"))
+      assert_includes(paths, context.absolute_path_to("top_level.rake"))
+      assert_includes(paths, context.absolute_path_to("top_level.rbs"))
+      assert_includes(paths, context.absolute_path_to("config.ru"))
 
       # Includes gem dependency paths from Bundler
       gem_require_paths = Bundler.locked_gems.specs.flat_map do |lazy_spec|


### PR DESCRIPTION
So Rubydex is aware of Rake and Rack files.