### PR TITLE
Allow checking multiple ancestors

### DIFF
--- a/lib/rubydex/declaration.rb
+++ b/lib/rubydex/declaration.rb
@@ -21,9 +21,9 @@ module Rubydex
   end
 
   class Namespace < Declaration
-    #: (String ancestor_name) -> bool
-    def has_ancestor?(ancestor_name)
-      ancestors.any? { |ancestor| ancestor.name == ancestor_name }
+    #: (*String ancestor_names) -> bool
+    def has_ancestor?(*ancestor_names)
+      ancestors.any? { |ancestor| ancestor_names.include?(ancestor.name) }
     end
   end
 

--- a/rbi/rubydex.rbi
+++ b/rbi/rubydex.rbi
@@ -104,8 +104,8 @@ class Rubydex::Namespace < Rubydex::Declaration
   sig { returns(T::Enumerable[Rubydex::Namespace]) }
   def ancestors; end
 
-  sig { params(ancestor_name: String).returns(T::Boolean) }
-  def has_ancestor?(ancestor_name); end
+  sig { params(ancestor_names: String).returns(T::Boolean) }
+  def has_ancestor?(*ancestor_names); end
 
   sig { returns(T::Enumerable[Rubydex::Namespace]) }
   def descendants; end

--- a/test/declaration_test.rb
+++ b/test/declaration_test.rb
@@ -357,15 +357,18 @@ class DeclarationTest < Minitest::Test
       assert(child.has_ancestor?("Namespace::Parent"))
       assert(child.has_ancestor?("Mixins::Foo"))
       assert(child.has_ancestor?("Mixins::Bar"))
+      assert(child.has_ancestor?("Unknown", "Mixins::Foo"))
       refute(child.has_ancestor?("Child"))
       refute(child.has_ancestor?("Foo"))
       refute(child.has_ancestor?("Unknown"))
+      refute(child.has_ancestor?("Unknown", "Other"))
+      refute(child.has_ancestor?)
 
       singleton_class = child.singleton_class
       assert(singleton_class.has_ancestor?("Namespace::Child::<Child>"))
       assert(singleton_class.has_ancestor?("Mixins::Foo"))
       assert(singleton_class.has_ancestor?("Namespace::Parent::<Parent>"))
-      assert(singleton_class.has_ancestor?("Mixins::Bar"))
+      assert(singleton_class.has_ancestor?("Missing", "Mixins::Bar"))
       refute(singleton_class.has_ancestor?("Parent::<Parent>"))
     end
   end


### PR DESCRIPTION
## Summary

Updates `Rubydex::Namespace#has_ancestor?` to accept multiple fully-qualified ancestor names.

This allows callers to replace patterns like:

```ruby
SUPERCLASSES.any? { |superclass| controller.has_ancestor?(superclass) }
```

with:

```ruby
controller.has_ancestor?(*SUPERCLASSES)
```

## Changes

* Changes `Namespace#has_ancestor?` to take splat arguments
* Updates the RBI signature
* Adds coverage for matching any of multiple ancestors and for no-match cases

Closes #828
