### PR TITLE
Expose definition lexical owner and nesting

### DIFF
--- a/ext/rubydex/definition.c
+++ b/ext/rubydex/definition.c
@@ -195,6 +195,60 @@ static VALUE rdxr_definition_declaration(VALUE self) {
     return rb_class_new_instance(2, argv, decl_class);
 }
 
+static VALUE rdxi_build_definition(VALUE graph_obj, void *graph, uint64_t definition_id) {
+    DefinitionKind kind = rdx_definition_kind(graph, definition_id);
+    VALUE defn_class = rdxi_definition_class_for_kind(kind);
+    VALUE argv[] = {graph_obj, ULL2NUM(definition_id)};
+
+    return rb_class_new_instance(2, argv, defn_class);
+}
+
+// Definition#lexical_owner -> Rubydex::Definition?
+// Returns the lexically enclosing definition, if any.
+static VALUE rdxr_definition_lexical_owner(VALUE self) {
+    HandleData *data;
+    TypedData_Get_Struct(self, HandleData, &handle_type, data);
+
+    void *graph;
+    TypedData_Get_Struct(data->graph_obj, void *, &graph_type, graph);
+
+    const uint64_t *owner_id = rdx_definition_lexical_nesting_id(graph, data->id);
+    if (owner_id == NULL) {
+        return Qnil;
+    }
+
+    VALUE owner = rdxi_build_definition(data->graph_obj, graph, *owner_id);
+    free_u64(owner_id);
+
+    return owner;
+}
+
+// Definition#lexical_nesting -> Array<Rubydex::Definition>
+// Returns the lexical nesting from the direct owner up to the root.
+static VALUE rdxr_definition_lexical_nesting(VALUE self) {
+    HandleData *data;
+    TypedData_Get_Struct(self, HandleData, &handle_type, data);
+
+    void *graph;
+    TypedData_Get_Struct(data->graph_obj, void *, &graph_type, graph);
+
+    VALUE nesting = rb_ary_new();
+    uint64_t definition_id = data->id;
+
+    while (true) {
+        const uint64_t *owner_id = rdx_definition_lexical_nesting_id(graph, definition_id);
+        if (owner_id == NULL) {
+            break;
+        }
+
+        rb_ary_push(nesting, rdxi_build_definition(data->graph_obj, graph, *owner_id));
+        definition_id = *owner_id;
+        free_u64(owner_id);
+    }
+
+    return nesting;
+}
+
 static VALUE rdxi_build_constant_reference(VALUE graph_obj, const CConstantReference *cref) {
     VALUE ref_class = (cref->declaration_id == 0)
         ? cUnresolvedConstantReference
@@ -306,6 +360,8 @@ void rdxi_initialize_definition(VALUE mod) {
     rb_define_method(cDefinition, "deprecated?", rdxr_definition_deprecated, 0);
     rb_define_method(cDefinition, "name_location", rdxr_definition_name_location, 0);
     rb_define_method(cDefinition, "declaration", rdxr_definition_declaration, 0);
+    rb_define_method(cDefinition, "lexical_owner", rdxr_definition_lexical_owner, 0);
+    rb_define_method(cDefinition, "lexical_nesting", rdxr_definition_lexical_nesting, 0);
 
     cClassDefinition = rb_define_class_under(mRubydex, "ClassDefinition", cDefinition);
     rb_define_method(cClassDefinition, "superclass", rdxr_class_definition_superclass, 0);

--- a/rbi/rubydex.rbi
+++ b/rbi/rubydex.rbi
@@ -152,6 +152,12 @@ class Rubydex::Definition
   sig { returns(T.nilable(Rubydex::Declaration)) }
   def declaration; end
 
+  sig { returns(T.nilable(Rubydex::Definition)) }
+  def lexical_owner; end
+
+  sig { returns(T::Array[Rubydex::Definition]) }
+  def lexical_nesting; end
+
   class << self
     private
 

--- a/rust/rubydex-sys/src/definition_api.rs
+++ b/rust/rubydex-sys/src/definition_api.rs
@@ -276,6 +276,30 @@ pub unsafe extern "C" fn rdx_definition_declaration(pointer: GraphPointer, defin
     })
 }
 
+/// Returns the lexical nesting definition id for the given definition, or NULL if there is no lexical nesting.
+/// Caller must free the returned pointer with `free_u64`.
+///
+/// # Safety
+/// - `pointer` must be a valid pointer previously returned by `rdx_graph_new`.
+/// - `definition_id` must be a valid definition id.
+///
+/// # Panics
+/// This function will panic if the definition cannot be found.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rdx_definition_lexical_nesting_id(pointer: GraphPointer, definition_id: u64) -> *const u64 {
+    with_graph(pointer, |graph| {
+        let def_id = DefinitionId::new(definition_id);
+        let Some(defn) = graph.definitions().get(&def_id) else {
+            panic!("Definition not found: {definition_id:?}");
+        };
+
+        match defn.lexical_nesting_id() {
+            Some(lexical_nesting_id) => Box::into_raw(Box::new(**lexical_nesting_id)).cast_const(),
+            None => ptr::null(),
+        }
+    })
+}
+
 /// Creates a new iterator over definition IDs for a given declaration by snapshotting the current set of IDs.
 ///
 /// # Panics

--- a/test/definition_test.rb
+++ b/test/definition_test.rb
@@ -668,6 +668,78 @@ class DefinitionTest < Minitest::Test
     end
   end
 
+  def test_definition_lexical_owner_and_lexical_nesting
+    with_context do |context|
+      context.write!("file1.rb", <<~RUBY)
+        class Foo
+          class Bar
+            class Baz; end
+          end
+        end
+
+        class Foo::Qux
+          module Quux
+            def hello; end
+          end
+        end
+
+        class Foo
+          Class.new do
+            def world; end
+          end
+        end
+      RUBY
+
+      graph = Rubydex::Graph.new
+      graph.index_all(context.glob("**/*.rb"))
+      graph.resolve
+
+      definitions = graph.documents.find { |d| d.uri == context.uri_to("file1.rb") }.definitions
+
+      foo_def = definitions.find { |d| d.name == "Foo" }
+      assert_nil(foo_def.lexical_owner)
+      assert_lexical_nesting_equal([], foo_def)
+
+      bar_def = definitions.find { |d| d.name == "Bar" }
+      assert_same_definition(foo_def, bar_def.lexical_owner)
+      assert_lexical_nesting_equal(["Foo"], bar_def)
+
+      baz_def = definitions.find { |d| d.name == "Baz" }
+      assert_same_definition(bar_def, baz_def.lexical_owner)
+      assert_lexical_nesting_equal(["Foo::Bar", "Foo"], baz_def)
+
+      hello_def = definitions.find { |d| d.name == "hello()" }
+      assert_lexical_nesting_equal(["Foo::Qux::Quux", "Foo::Qux"], hello_def)
+      assert_instance_of(Rubydex::ModuleDefinition, hello_def.lexical_owner)
+
+      world_def = definitions.find { |d| d.name == "world()" }
+      assert_lexical_nesting_equal([/<anonymous>\z/, "Foo"], world_def)
+    end
+  end
+
+  def test_definition_lexical_owner_for_absolute_constant_path
+    with_context do |context|
+      context.write!("file1.rb", <<~RUBY)
+        class Foo
+          class ::Bar; end
+        end
+      RUBY
+
+      graph = Rubydex::Graph.new
+      graph.index_all(context.glob("**/*.rb"))
+      graph.resolve
+
+      definitions = graph.documents.find { |d| d.uri == context.uri_to("file1.rb") }.definitions
+
+      foo_def = definitions.find { |d| d.name == "Foo" }
+      bar_def = definitions.find { |d| d.name == "Bar" }
+
+      assert_equal("Bar", bar_def.declaration.name)
+      assert_same_definition(foo_def, bar_def.lexical_owner)
+      assert_lexical_nesting_equal(["Foo"], bar_def)
+    end
+  end
+
   def test_definition_declaration
     with_context do |context|
       context.write!("file1.rb", <<~RUBY)
@@ -716,6 +788,24 @@ class DefinitionTest < Minitest::Test
   end
 
   private
+
+  def assert_same_definition(expected, actual)
+    assert_equal(expected.name, actual.name)
+    assert_equal(expected.location.to_display, actual.location.to_display)
+  end
+
+  def assert_lexical_nesting_equal(expected, definition)
+    actual = definition.lexical_nesting.map { |nesting| nesting.declaration.name }
+
+    assert_equal(expected.size, actual.size)
+    expected.zip(actual).each do |expected_name, actual_name|
+      if expected_name.is_a?(Regexp)
+        assert_match(expected_name, actual_name)
+      else
+        assert_equal(expected_name, actual_name)
+      end
+    end
+  end
 
   # Comment locations on Windows include the carriage return. This means that the end column is off by one when compared
   # to Unix locations. This method creates a fake adjusted location for Windows so that we can assert locations once


### PR DESCRIPTION
## Summary

* Add `Definition#lexical_owner` to return the direct lexical owner definition.
* Add `Definition#lexical_nesting` to return lexical owners from nearest to root.
* Add Ruby API signatures and coverage for nested classes, namespaced classes, methods, anonymous class nesting, and absolute constant paths opened inside another lexical scope.

Closes #831
