### PR TITLE
Expose method definition name locations

### DIFF
--- a/ext/rubydex/definition.c
+++ b/ext/rubydex/definition.c
@@ -154,8 +154,8 @@ static VALUE rdxr_definition_deprecated(VALUE self) {
 }
 
 // Definition#name_location -> Rubydex::Location or nil
-// For class, module, and singleton class definitions, returns the location of just the name
-// (e.g., "Bar" in "class Foo::Bar"). For other definition types, returns nil.
+// For class, module, singleton class, and method definitions, returns the location of just the name
+// (e.g., "Bar" in "class Foo::Bar", or "foo" in "def foo"). For other definition types, returns nil.
 static VALUE rdxr_definition_name_location(VALUE self) {
     HandleData *data;
     TypedData_Get_Struct(self, HandleData, &handle_type, data);

--- a/rust/rubydex-sys/src/definition_api.rs
+++ b/rust/rubydex-sys/src/definition_api.rs
@@ -346,8 +346,8 @@ pub unsafe extern "C" fn rdx_definition_is_deprecated(pointer: GraphPointer, def
 }
 
 /// Returns a newly allocated `Location` for the name portion of a definition id.
-/// For class, module, and singleton class definitions, this returns the location of just
-/// the name (e.g., "Bar" in `class Foo::Bar`).
+/// For class, module, singleton class, and method definitions, this returns the location of just
+/// the name (e.g., "Bar" in `class Foo::Bar`, or "foo" in `def foo`).
 /// For other definition types, returns NULL.
 /// Caller must free the returned pointer with `rdx_location_free`.
 ///

--- a/rust/rubydex/src/indexing/rbs_indexer.rs
+++ b/rust/rubydex/src/indexing/rbs_indexer.rs
@@ -565,7 +565,7 @@ impl Visit for RBSIndexer<'_> {
     fn visit_method_definition_node(&mut self, def_node: &node::MethodDefinitionNode) {
         let str_id = self.local_graph.intern_string(format!("{}()", def_node.name()));
         let offset = Offset::from_rbs_location(&def_node.location());
-        let name_offset = offset.clone();
+        let name_offset = Offset::from_rbs_location(&def_node.name_location());
         let comments = self.collect_comments(def_node.comment());
         let flags = Self::flags(&def_node.annotations());
         let lexical_nesting_id = self.parent_lexical_scope_id();
@@ -1210,6 +1210,7 @@ mod tests {
 
             assert_definition_at!(&context, "2:3-2:22", Method, |def| {
                 assert_def_str_eq!(&context, def, "foo()");
+                assert_def_name_offset_eq!(&context, def, "2:7-2:10");
                 assert!(def.receiver().is_none());
                 assert_eq!(def.visibility(), &Visibility::Public);
                 assert_eq!(class_def.id(), def.lexical_nesting_id().unwrap());
@@ -1218,6 +1219,7 @@ mod tests {
 
             assert_definition_at!(&context, "4:3-4:23", Method, |def| {
                 assert_def_str_eq!(&context, def, "bar()");
+                assert_def_name_offset_eq!(&context, def, "4:7-4:10");
                 assert!(def.receiver().is_none());
                 assert_eq!(def.visibility(), &Visibility::Public);
                 assert_eq!(class_def.id(), def.lexical_nesting_id().unwrap());
@@ -1411,6 +1413,7 @@ mod tests {
             panic!()
         };
         assert_def_str_eq!(&context, instance_method, "foo()");
+        assert_def_name_offset_eq!(&context, instance_method, "2:13-2:16");
         assert_eq!(instance_method.visibility(), &Visibility::Private);
 
         let singleton_method = definitions
@@ -1421,6 +1424,7 @@ mod tests {
             panic!()
         };
         assert_def_str_eq!(&context, singleton_method, "foo()");
+        assert_def_name_offset_eq!(&context, singleton_method, "2:13-2:16");
         assert_eq!(singleton_method.visibility(), &Visibility::Public);
     }
 
@@ -1438,6 +1442,7 @@ mod tests {
 
         assert_definition_at!(&context, "2:3-2:27", Method, |def| {
             assert_def_str_eq!(&context, def, "foo()");
+            assert_def_name_offset_eq!(&context, def, "2:12-2:15");
             let sigs = def.signatures().as_slice();
             assert_eq!(sigs.len(), 1);
             assert_eq!(sigs[0].len(), 0);

--- a/rust/rubydex/src/indexing/rbs_indexer.rs
+++ b/rust/rubydex/src/indexing/rbs_indexer.rs
@@ -338,6 +338,7 @@ impl<'a> RBSIndexer<'a> {
         &mut self,
         str_id: StringId,
         offset: Offset,
+        name_offset: Offset,
         comments: Box<[Comment]>,
         flags: DefinitionFlags,
         lexical_nesting_id: Option<DefinitionId>,
@@ -347,6 +348,7 @@ impl<'a> RBSIndexer<'a> {
             str_id,
             self.uri_id,
             offset.clone(),
+            name_offset.clone(),
             comments.clone(),
             flags.clone(),
             lexical_nesting_id,
@@ -360,6 +362,7 @@ impl<'a> RBSIndexer<'a> {
             str_id,
             self.uri_id,
             offset,
+            name_offset,
             comments,
             flags,
             lexical_nesting_id,
@@ -562,13 +565,22 @@ impl Visit for RBSIndexer<'_> {
     fn visit_method_definition_node(&mut self, def_node: &node::MethodDefinitionNode) {
         let str_id = self.local_graph.intern_string(format!("{}()", def_node.name()));
         let offset = Offset::from_rbs_location(&def_node.location());
+        let name_offset = offset.clone();
         let comments = self.collect_comments(def_node.comment());
         let flags = Self::flags(&def_node.annotations());
         let lexical_nesting_id = self.parent_lexical_scope_id();
         let signatures = self.collect_overload_signatures(def_node);
 
         if def_node.kind() == node::MethodDefinitionKind::SingletonInstance {
-            self.register_singleton_instance_method(str_id, offset, comments, flags, lexical_nesting_id, signatures);
+            self.register_singleton_instance_method(
+                str_id,
+                offset,
+                name_offset,
+                comments,
+                flags,
+                lexical_nesting_id,
+                signatures,
+            );
             return;
         }
 
@@ -602,6 +614,7 @@ impl Visit for RBSIndexer<'_> {
             str_id,
             self.uri_id,
             offset,
+            name_offset,
             comments,
             flags,
             lexical_nesting_id,

--- a/rust/rubydex/src/indexing/ruby_indexer.rs
+++ b/rust/rubydex/src/indexing/ruby_indexer.rs
@@ -1811,6 +1811,7 @@ impl Visit<'_> for RubyIndexer<'_> {
         let name = Self::location_to_string(&node.name_loc());
         let str_id = self.local_graph.intern_string(format!("{name}()"));
         let offset = Offset::from_prism_location(&node.location());
+        let name_offset = Offset::from_prism_location(&node.name_loc());
         let parent_nesting_id = self.current_nesting_definition_id();
         let parameters = self.collect_parameters(node);
         let is_singleton = node.receiver().is_some();
@@ -1862,6 +1863,7 @@ impl Visit<'_> for RubyIndexer<'_> {
                 str_id,
                 self.uri_id,
                 offset.clone(),
+                name_offset.clone(),
                 comments.clone(),
                 flags.clone(),
                 parent_nesting_id,
@@ -1878,6 +1880,7 @@ impl Visit<'_> for RubyIndexer<'_> {
                 str_id,
                 self.uri_id,
                 offset,
+                name_offset,
                 comments,
                 flags,
                 parent_nesting_id,
@@ -1895,6 +1898,7 @@ impl Visit<'_> for RubyIndexer<'_> {
                 str_id,
                 self.uri_id,
                 offset,
+                name_offset,
                 comments,
                 flags,
                 parent_nesting_id,

--- a/rust/rubydex/src/model/definitions.rs
+++ b/rust/rubydex/src/model/definitions.rs
@@ -181,6 +181,7 @@ impl Definition {
             Definition::Class(d) => Some(d.name_offset()),
             Definition::Module(d) => Some(d.name_offset()),
             Definition::SingletonClass(d) => Some(d.name_offset()),
+            Definition::Method(d) => Some(d.name_offset()),
             _ => None,
         }
     }
@@ -915,6 +916,7 @@ pub struct MethodDefinition {
     str_id: StringId,
     uri_id: UriId,
     offset: Offset,
+    name_offset: Offset,
     flags: DefinitionFlags,
     comments: Box<[Comment]>,
     lexical_nesting_id: Option<DefinitionId>,
@@ -923,7 +925,7 @@ pub struct MethodDefinition {
     receiver: Option<Receiver>,
 }
 
-assert_mem_size!(MethodDefinition, 96);
+assert_mem_size!(MethodDefinition, 104);
 
 /// The receiver of a singleton method definition.
 #[derive(Debug, Clone)]
@@ -943,6 +945,7 @@ impl MethodDefinition {
         str_id: StringId,
         uri_id: UriId,
         offset: Offset,
+        name_offset: Offset,
         comments: Box<[Comment]>,
         flags: DefinitionFlags,
         lexical_nesting_id: Option<DefinitionId>,
@@ -954,6 +957,7 @@ impl MethodDefinition {
             str_id,
             uri_id,
             offset,
+            name_offset,
             flags,
             comments,
             lexical_nesting_id,
@@ -981,6 +985,11 @@ impl MethodDefinition {
     #[must_use]
     pub fn offset(&self) -> &Offset {
         &self.offset
+    }
+
+    #[must_use]
+    pub fn name_offset(&self) -> &Offset {
+        &self.name_offset
     }
 
     #[must_use]

--- a/rust/rubydex/src/operation/applier.rs
+++ b/rust/rubydex/src/operation/applier.rs
@@ -219,6 +219,7 @@ impl OperationApplier {
             op.str_id,
             op.uri_id,
             op.offset,
+            op.name_offset,
             op.comments,
             op.flags,
             lexical_nesting_id,

--- a/rust/rubydex/src/operation/mod.rs
+++ b/rust/rubydex/src/operation/mod.rs
@@ -152,6 +152,7 @@ pub struct EnterMethod {
     pub str_id: StringId,
     pub uri_id: UriId,
     pub offset: Offset,
+    pub name_offset: Offset,
     pub comments: Box<[Comment]>,
     pub flags: DefinitionFlags,
     pub signatures: Signatures,

--- a/rust/rubydex/src/operation/ruby_builder.rs
+++ b/rust/rubydex/src/operation/ruby_builder.rs
@@ -1524,6 +1524,7 @@ impl Visit<'_> for RubyOperationBuilder<'_> {
         let name = Self::location_to_string(&node.name_loc());
         let str_id = self.intern_string(format!("{name}()"));
         let offset = Offset::from_prism_location(&node.location());
+        let name_offset = Offset::from_prism_location(&node.name_loc());
         let parameters = self.collect_parameters(node);
         let is_singleton = node.receiver().is_some();
 
@@ -1586,6 +1587,7 @@ impl Visit<'_> for RubyOperationBuilder<'_> {
                 str_id,
                 uri_id: self.uri_id,
                 offset: offset.clone(),
+                name_offset: name_offset.clone(),
                 comments: comments.clone(),
                 flags: flags.clone(),
                 signatures: Signatures::Simple(parameters.clone().into_boxed_slice()),
@@ -1604,6 +1606,7 @@ impl Visit<'_> for RubyOperationBuilder<'_> {
                 str_id,
                 uri_id: self.uri_id,
                 offset: offset.clone(),
+                name_offset: name_offset.clone(),
                 comments,
                 flags,
                 signatures: Signatures::Simple(parameters.into_boxed_slice()),
@@ -1638,6 +1641,7 @@ impl Visit<'_> for RubyOperationBuilder<'_> {
                 str_id,
                 uri_id: self.uri_id,
                 offset: offset.clone(),
+                name_offset,
                 comments,
                 flags,
                 signatures: Signatures::Simple(parameters.into_boxed_slice()),

--- a/test/definition_test.rb
+++ b/test/definition_test.rb
@@ -103,6 +103,14 @@ class DefinitionTest < Minitest::Test
       assert_equal(3, location.start_column)
       assert_equal(2, location.end_line)
       assert_equal(15, location.end_column)
+
+      name_location = def_foo.name_location.to_display
+      refute_nil(name_location)
+      assert_equal(context.uri_to("file1.rb"), name_location.uri)
+      assert_equal(2, name_location.start_line)
+      assert_equal(7, name_location.start_column)
+      assert_equal(2, name_location.end_line)
+      assert_equal(10, name_location.end_column)
     end
   end
 

--- a/test/definition_test.rb
+++ b/test/definition_test.rb
@@ -490,6 +490,7 @@ class DefinitionTest < Minitest::Test
 
       method_def = graph["Foo#baz()"].definitions.first
 
+      assert_equal("#{path}:2:7-2:10", method_def.name_location.to_display.to_s)
       assert_equal(1, method_def.signatures.length)
 
       sig = method_def.signatures[0]


### PR DESCRIPTION
## Summary

* Store a `name_offset` on `MethodDefinition`.
* Populate method name offsets from Ruby method definitions.
* Carry method name offsets through the operation builder/applier path.
* Add coverage for `MethodDefinition#name_location` returning the method name span.
