### PR TITLE
Prepare Rust crates for publication

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1048,7 +1048,7 @@ dependencies = [
 
 [[package]]
 name = "rubydex"
-version = "0.1.0"
+version = "0.2.5"
 dependencies = [
  "assert_cmd",
  "bitflags",
@@ -1072,7 +1072,7 @@ dependencies = [
 
 [[package]]
 name = "rubydex-mcp"
-version = "0.1.0"
+version = "0.2.5"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -1087,7 +1087,7 @@ dependencies = [
 
 [[package]]
 name = "rubydex-sys"
-version = "0.1.0"
+version = "0.2.5"
 dependencies = [
  "cbindgen",
  "libc",

--- a/rust/rubydex-mcp/Cargo.toml
+++ b/rust/rubydex-mcp/Cargo.toml
@@ -1,16 +1,22 @@
 [package]
 name = "rubydex-mcp"
-version = "0.1.0"
+version = "0.2.5"
 edition = "2024"
 rust-version = "1.89.0"
 license = "MIT"
+description = "MCP server exposing Rubydex semantic Ruby code intelligence tools."
+homepage = "https://github.com/Shopify/rubydex"
+repository = "https://github.com/Shopify/rubydex"
+readme = "README.md"
+keywords = ["ruby", "mcp", "static-analysis"]
+categories = ["development-tools"]
 
 [[bin]]
 name = "rubydex_mcp"
 path = "src/main.rs"
 
 [dependencies]
-rubydex = { path = "../rubydex" }
+rubydex = { version = "0.2.5", path = "../rubydex" }
 clap = { version = "4.5.16", features = ["derive"] }
 rmcp = { version = "1.4", features = ["server", "macros", "transport-io", "schemars"] }
 tokio = { version = "1", features = ["macros", "rt", "io-std"] }
@@ -20,7 +26,7 @@ schemars = "1"
 url = "2"
 
 [dev-dependencies]
-rubydex = { path = "../rubydex", features = ["test_utils"] }
+rubydex = { version = "0.2.5", path = "../rubydex", features = ["test_utils"] }
 assert_cmd = "2.0"
 serde_json = "1"
 

--- a/rust/rubydex-mcp/README.md
+++ b/rust/rubydex-mcp/README.md
@@ -1,0 +1,10 @@
+# rubydex-mcp
+
+`rubydex-mcp` provides an MCP server backed by Rubydex.
+
+The server indexes a Ruby workspace and exposes semantic code intelligence
+tools for AI assistants, including declaration search, declaration details,
+descendant lookup, constant reference search, file declarations, and codebase
+statistics.
+
+For Ruby-project setup, see the MCP section in the repository README.

--- a/rust/rubydex-sys/Cargo.toml
+++ b/rust/rubydex-sys/Cargo.toml
@@ -1,14 +1,21 @@
 [package]
 name = "rubydex-sys"
-version = "0.1.0"
+version = "0.2.5"
 edition = "2024"
+rust-version = "1.89.0"
 license = "MIT"
+description = "C FFI bindings for the Rubydex Ruby code indexing engine."
+homepage = "https://github.com/Shopify/rubydex"
+repository = "https://github.com/Shopify/rubydex"
+readme = "README.md"
+keywords = ["ruby", "ffi", "static-analysis"]
+categories = ["development-tools", "external-ffi-bindings"]
 
 [lib]
 crate-type = ["cdylib", "staticlib"]
 
 [dependencies]
-rubydex = { path = "../rubydex" }
+rubydex = { version = "0.2.5", path = "../rubydex" }
 libc = "0.2.174"
 url = "2.5.4"
 line-index = "0.1.2"

--- a/rust/rubydex-sys/README.md
+++ b/rust/rubydex-sys/README.md
@@ -1,0 +1,10 @@
+# rubydex-sys
+
+`rubydex-sys` exposes the Rubydex Rust library through a C FFI boundary.
+
+This crate is primarily consumed by the Rubydex Ruby native extension. It
+builds static and dynamic libraries plus generated C bindings for integrating
+the Rust indexer with the Ruby VM.
+
+Most users should depend on the `rubydex` Ruby gem or the `rubydex` Rust crate
+instead of using this crate directly.

--- a/rust/rubydex/Cargo.toml
+++ b/rust/rubydex/Cargo.toml
@@ -1,9 +1,15 @@
 [package]
 name = "rubydex"
-version = "0.1.0"
+version = "0.2.5"
 edition = "2024"
 rust-version = "1.89.0"
 license = "MIT"
+description = "High-performance Ruby code indexing and static analysis library."
+homepage = "https://github.com/Shopify/rubydex"
+repository = "https://github.com/Shopify/rubydex"
+readme = "README.md"
+keywords = ["ruby", "indexing", "static-analysis"]
+categories = ["development-tools"]
 
 [[bin]]
 name = "rubydex_cli"

--- a/rust/rubydex/README.md
+++ b/rust/rubydex/README.md
@@ -1,0 +1,11 @@
+# rubydex
+
+`rubydex` is the Rust library that powers Rubydex's Ruby code indexing and
+static analysis.
+
+The crate is part of the Rubydex project. It provides the graph, indexing,
+resolution, query, and diagnostic logic used by the Ruby gem, the native FFI
+crate, and the MCP server.
+
+See the repository README for Ruby-level usage examples and project
+documentation.


### PR DESCRIPTION
## Summary

- Add crates.io metadata and crate-local READMEs for the `rubydex`, `rubydex-sys`, and `rubydex-mcp` crates.
- Add `rust-version` to `rubydex-sys` for consistency with the rest of the workspace.
- Make internal `rubydex` dependencies publishable by pairing local `path` dependencies with `version = "0.2.5"`, matching the Ruby gem version.

## Notes

This keeps local workspace and Ruby gem builds using path dependencies, while making the manifests valid for crates.io publication. For the first publish, `rubydex` must be published first. After the crates.io index sees `rubydex 0.2.5`, `rubydex-sys` and `rubydex-mcp` can be published.

## Test plan

- `PATH="/Users/hung-wulo/.cargo/bin:$PATH" cargo check --workspace --locked`
- `PATH="/Users/hung-wulo/.cargo/bin:$PATH" cargo test --workspace --locked`
- `PATH="/Users/hung-wulo/.cargo/bin:$PATH" cargo publish --dry-run -p rubydex --locked --allow-dirty`
