### PR TITLE
Re-enqueue work when ivar is inside undefined alias namespace

### DIFF
--- a/rust/rubydex/src/resolution.rs
+++ b/rust/rubydex/src/resolution.rs
@@ -375,10 +375,16 @@ impl<'a> Resolver<'a> {
                         Definition::Method(method) => {
                             if let Some(receiver) = method.receiver() {
                                 let receiver_decl_id = match receiver {
-                                    Receiver::SelfReceiver(def_id) => *self
-                                        .graph
-                                        .definition_id_to_declaration_id(*def_id)
-                                        .expect("SelfReceiver definition should have a declaration"),
+                                    Receiver::SelfReceiver(def_id) => {
+                                        let Some(&receiver_decl_id) =
+                                            self.graph.definition_id_to_declaration_id(*def_id)
+                                        else {
+                                            self.graph.push_work(Unit::Definition(id));
+                                            continue;
+                                        };
+
+                                        receiver_decl_id
+                                    }
                                     Receiver::ConstantReceiver(name_id) => {
                                         let Some(receiver_decl_id) = self.resolve_constant_receiver(*name_id, id)
                                         else {

--- a/rust/rubydex/src/resolution_tests.rs
+++ b/rust/rubydex/src/resolution_tests.rs
@@ -4674,6 +4674,68 @@ mod promotability_tests {
         assert_declaration_does_not_exist!(context, "Foo::<Foo>");
         assert_declaration_does_not_exist!(context, "Foo::<Foo>#bar()");
     }
+
+    #[test]
+    fn ivar_defined_inside_of_undefined_alias_namespace() {
+        let mut context = graph_test();
+        context.index_uri("file:///alias.rb", {
+            r"
+            Aliased = Undefined
+
+            class Aliased::Inner
+              def self.run
+                @ivar = 1
+              end
+            end
+            "
+        });
+
+        context.resolve();
+        assert_no_diagnostics!(&context);
+
+        // Since we have no idea what `Aliased` is, then we cannot create `Inner`, `run()` or `@ivar` declarations
+        assert_declaration_does_not_exist!(context, "Aliased::Inner");
+        assert_declaration_does_not_exist!(context, "Aliased::Inner::<Inner>#run()");
+        assert_declaration_does_not_exist!(context, "Aliased::Inner::<Inner>#@ivar");
+    }
+
+    #[test]
+    fn ivar_inside_undefined_alias_namespace_recovers_when_target_is_defined() {
+        let mut context = graph_test();
+        context.index_uri("file:///alias.rb", {
+            r"
+            Aliased = Undefined
+
+            class Aliased::Inner
+              def self.run
+                @ivar = 1
+              end
+            end
+            "
+        });
+        context.resolve();
+
+        // Nothing can be placed yet: `Aliased` aliases a constant that does not exist.
+        assert_declaration_does_not_exist!(context, "Aliased::Inner");
+
+        // A later edit defines the alias target. The instance variable must not have been
+        // dropped permanently: it should be remembered and placed once its owner exists.
+        context.index_uri("file:///target.rb", {
+            r"
+            module Undefined
+            end
+            "
+        });
+        context.resolve();
+        assert_no_diagnostics!(&context);
+
+        // `Aliased` now resolves to `Undefined`, so the nested declarations materialize under it,
+        // including the previously-deferred instance variable.
+        assert_declaration_kind_eq!(context, "Undefined::Inner", "Class");
+        assert_declaration_kind_eq!(context, "Undefined::Inner::<Inner>", "SingletonClass");
+        assert_declaration_kind_eq!(context, "Undefined::Inner::<Inner>#run()", "Method");
+        assert_declaration_kind_eq!(context, "Undefined::Inner::<Inner>#@ivar", "InstanceVariable");
+    }
 }
 
 mod rbs_tests {


### PR DESCRIPTION
First part of #811

If an alias pointing to an undefined constant is re-opened, we should not crash if we find any members defined inside, but instead enqueue the work to complete in a subsequent resolution run.

This PR starts re-enqueueing the work for instance variables.