### PR TITLE
Fix panic resolving singleton methods on non-namespace owners

### DIFF
--- a/rust/rubydex/src/model/graph.rs
+++ b/rust/rubydex/src/model/graph.rs
@@ -447,20 +447,21 @@ impl Graph {
     }
 
     /// Looks up the declaration for a `SelfReceiver` method/alias through the singleton class.
+    ///
+    /// Returns `None` when the owner cannot be resolved to a namespace with a singleton class. This
+    /// can happen when the enclosing construct resolved to a non-namespace declaration (e.g. a
+    /// constant or constant alias that a same-named `class`/`module` reopened without promotion), in
+    /// which case the method has no owning declaration.
     fn find_self_receiver_declaration(&self, def_id: DefinitionId, member_str_id: StringId) -> Option<&DeclarationId> {
         let owner_decl_id = self.definition_id_to_declaration_id(def_id)?;
         let singleton_id = self
             .declarations
-            .get(owner_decl_id)
-            .unwrap()
-            .as_namespace()
-            .unwrap()
+            .get(owner_decl_id)?
+            .as_namespace()?
             .singleton_class()?;
         self.declarations
-            .get(singleton_id)
-            .unwrap()
-            .as_namespace()
-            .unwrap()
+            .get(singleton_id)?
+            .as_namespace()?
             .member(&member_str_id)
     }
 
@@ -1545,8 +1546,8 @@ mod tests {
     use crate::model::declaration::Ancestors;
     use crate::test_utils::GraphTest;
     use crate::{
-        assert_declaration_does_not_exist, assert_dependents, assert_descendants, assert_members_eq,
-        assert_no_diagnostics, assert_no_members,
+        assert_declaration_does_not_exist, assert_declaration_kind_eq, assert_dependents, assert_descendants,
+        assert_members_eq, assert_no_diagnostics, assert_no_members,
     };
 
     #[test]
@@ -1566,6 +1567,41 @@ mod tests {
                 .get(&DeclarationId::from("Foo"))
                 .is_none()
         );
+    }
+
+    #[test]
+    fn singleton_method_in_non_namespace_owner_does_not_panic() {
+        // `Aliased = Bar` assigns a constant to another constant, producing a (non-promotable)
+        // `ConstantAlias` declaration. Reopening it with `class Aliased` is valid Ruby (it reopens
+        // `Bar`), but the class definition is attached to the existing `ConstantAlias` declaration
+        // without promoting it to a namespace. A `def self.foo` inside then has a `SelfReceiver`
+        // owner whose declaration is not a namespace. Resolving that definition to its declaration
+        // must return `None` rather than panicking.
+        let mut context = GraphTest::new();
+
+        context.index_uri(
+            "file:///foo.rb",
+            "
+            class Bar
+            end
+
+            Aliased = Bar
+
+            class Aliased
+              def self.foo; end
+            end
+            ",
+        );
+        context.resolve();
+
+        // The declaration stays a non-namespace constant alias.
+        assert_declaration_kind_eq!(context, "Aliased", "ConstantAlias");
+
+        // Mirrors what consumers like the DOT exporter do: resolve every definition to its
+        // declaration. This previously panicked on the singleton method's non-namespace owner.
+        for definition in context.graph().definitions().values() {
+            let _ = context.graph().definition_to_declaration_id(definition);
+        }
     }
 
     #[test]

--- a/rust/rubydex/src/model/graph.rs
+++ b/rust/rubydex/src/model/graph.rs
@@ -311,9 +311,6 @@ impl Graph {
         self.definition_to_declaration_id(self.definitions.get(&definition_id).unwrap())
     }
 
-    /// # Panics
-    ///
-    /// Panics if the definition is not found
     #[must_use]
     pub fn definition_to_declaration_id(&self, definition: &Definition) -> Option<&DeclarationId> {
         let (nesting_name_id, member_str_id) = match definition {


### PR DESCRIPTION
## Summary

`Graph::find_self_receiver_declaration` resolves the owner of a `def self.foo`-style singleton method and then `unwrap()`ed both the declaration lookup and `as_namespace()`. That hard-codes the assumption that the owner always exists and is always a namespace.

That assumption breaks for valid Ruby where a `class`/`module` reopens a same-named **constant** or **constant alias** that was not promoted to a namespace. In that case the owning declaration stays a non-namespace (`Constant`/`ConstantAlias`), `as_namespace()` returns `None`, and the `unwrap()` panics:

```
thread 'main' panicked at rubydex/src/model/graph.rs:457:14:
called `Option::unwrap()` on a `None` value
```

The fix resolves the owner and singleton class with `?` so the lookup returns `None` instead of panicking — consistent with the sibling `find_singleton_method_visibility_declaration`, which already handles the same situation gracefully. A method whose owner can't be resolved to a namespace simply has no owning declaration (an orphan), which is an already-expected outcome elsewhere in resolution.

## How to reproduce (without any new tooling)

This is a latent bug in core graph code, reachable through any consumer that resolves definitions to declarations via the public `Graph::definition_to_declaration_id` — for example the built-in DOT exporter (`--dot`), which calls it for every definition.

Minimal valid Ruby that triggers it:

```ruby
class Bar
end

Aliased = Bar      # non-promotable: produces a ConstantAlias declaration

class Aliased      # valid Ruby: reopens Bar
  def self.foo; end
end
```

`Aliased = Bar` assigns a constant to another constant, producing a `ConstantAlias` declaration (a constant read value is not promotable). `class Aliased` reopens `Bar` at runtime, but rubydex attaches the class definition to the existing `ConstantAlias` declaration without promoting it to a namespace. The `def self.foo` then has a `SelfReceiver` owner whose declaration is not a namespace.

To observe the crash on `main`, run any path that resolves definitions over that file, e.g.:

```
rubydex_cli /path/to/dir --dot
```

or iterate definitions in a test:

```rust
for definition in graph.definitions().values() {
    let _ = graph.definition_to_declaration_id(definition);
}
```

Before this change that panics; after it, it returns `None` for the singleton method and completes normally.

## Test

Adds `singleton_method_in_non_namespace_owner_does_not_panic`, which indexes the snippet above, asserts the declaration stays a `ConstantAlias`, and resolves every definition to its declaration (mirroring the DOT exporter). The test panics on the unpatched code and passes with the fix.
