### PR TITLE
Query the in-memory graph with Cypher

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,41 @@ diagnostic.message
 diagnostic.location
 ```
 
+## Querying with Cypher
+
+Rubydex exposes the indexed graph through a read-only subset of the
+[Cypher](https://opencypher.org/) query language. Only read clauses (`MATCH`,
+`WHERE`, `RETURN`, ...) are supported; there is no way to mutate the graph.
+
+From the command line:
+
+```bash
+# Run a query against the current workspace
+bundle exec rdx query "MATCH (c:Class)-[:DEFINES]->(m:Method) RETURN c.name, m.name"
+
+# Render results as JSON instead of a table
+bundle exec rdx query "MATCH (c:Class) RETURN c.name" --format json
+
+# Describe the queryable schema (node labels and relationship types) without indexing
+bundle exec rdx query --schema
+```
+
+From Ruby:
+
+```ruby
+graph = Rubydex::Graph.new
+graph.index_workspace
+graph.resolve
+
+# Parse once, render against a graph as a table or JSON string
+query = Rubydex::Query.parse("MATCH (c:Class) RETURN c.name")
+puts query.render(graph, "table")
+puts query.render(graph, "json")
+
+# Describe the schema
+puts Rubydex::Query.schema("table")
+```
+
 ## MCP Server (Experimental)
 
 Rubydex can run as an MCP (Model Context Protocol) server, enabling AI assistants
@@ -94,16 +129,16 @@ like Claude to semantically query your Ruby codebase.
    bundle install
    ```
 
-3. Configure your MCP client to run `bundle exec rdx --mcp`.
+3. Configure your MCP client to run `bundle exec rdx mcp`.
 
    Using Claude Code as an example:
    ```bash
-   claude mcp add --scope project rubydex -- bundle exec rdx --mcp
+   claude mcp add --scope project rubydex -- bundle exec rdx mcp
    ```
 
    Using Codex as an example:
    ```bash
-   codex mcp add rubydex -- bundle exec rdx --mcp
+   codex mcp add rubydex -- bundle exec rdx mcp
    ```
 
    Start your MCP client from that project directory. The MCP server indexes

--- a/exe/rdx
+++ b/exe/rdx
@@ -5,75 +5,151 @@ $LOAD_PATH.unshift(File.expand_path("../lib", __dir__))
 
 require "optparse"
 
-options = {}
+USAGE = <<~TEXT
+  Usage: rdx <command> [options]
 
-option_parser = OptionParser.new do |parser|
-  parser.on("--version", "Print the gem's version") do
-    require "rubydex/version"
-    puts "v#{Rubydex::VERSION}"
-    exit
-  end
+  Commands:
+    query <CYPHER>   Run a Cypher query against the workspace graph and print the result.
+                     Use `query --schema` to describe the queryable schema (labels,
+                     relationships, properties) without indexing the workspace.
+    console          Open an interactive session with a populated graph for the current workspace
+    mcp [PATH]       Run the MCP server for AI assistants (workspace defaults to the current dir)
+    help             Show this help message
 
-  parser.on("-h", "--help", "Prints this help") do
-    puts parser
-    exit
-  end
+  Run `rdx <command> --help` for command-specific options.
+TEXT
 
-  parser.on("-i", "--interactive", "Open an interactive session with a populated graph for the current workspace") do
-    options[:interactive] = true
-  end
-
-  parser.on("--mcp", "Run the MCP server for AI assistants") do
-    options[:mcp] = true
-  end
+def abort_with_usage(message)
+  warn(message)
+  warn("")
+  warn(USAGE)
+  exit(1)
 end
 
-begin
-  arguments = option_parser.parse(ARGV)
-rescue OptionParser::ParseError => e
-  warn("error: #{e.message}")
-  warn
-  warn(option_parser)
-  exit(2)
+# Top-level --version / --help / bare invocation, handled before command dispatch. Each branch
+# performs its action and reports whether it handled the invocation, so we exit exactly once here
+# rather than from inside every branch.
+handled =
+  case ARGV.first
+  when "--version", "version"
+    require "rubydex/version"
+    puts "v#{Rubydex::VERSION}"
+    true
+  when nil, "-h", "--help", "help"
+    puts USAGE
+    true
+  else
+    false
+  end
+
+exit if handled
+
+command = ARGV.shift
+
+def with_timer(io, message)
+  io.print(message)
+  start = Process.clock_gettime(Process::CLOCK_MONOTONIC, :float_millisecond)
+  yield
+  duration = Process.clock_gettime(Process::CLOCK_MONOTONIC, :float_millisecond) - start
+  io.puts(" finished in #{duration.round(2)}ms")
+end
+
+# Builds the workspace graph, sending progress messages to `progress_io`.
+def build_graph(progress_io)
+  graph = Rubydex::Graph.new
+  graph.load_config
+  with_timer(progress_io, "Indexing workspace...") { graph.index_workspace }
+  with_timer(progress_io, "Resolving graph...") { graph.resolve }
+  graph
 end
 
 require "rubydex"
 
-if options[:mcp]
-  if arguments.length > 1
-    warn("error: unexpected argument '#{arguments[1]}' found")
-    warn
-    warn(option_parser)
-    exit(2)
+# Resolve the command into an operation on a populated graph. Each command parses its own options
+# and does any graph-independent work here; a command that needs no graph (like `query --schema`)
+# handles itself and exits. Whatever falls through returns a lambda that runs against the graph.
+operation =
+  case command
+  when "query"
+    schema = false
+    format = "table"
+    OptionParser.new do |parser|
+      parser.banner = "Usage: rdx query <CYPHER> [options]"
+      parser.on("--schema", "Describe the queryable schema instead of running a query") { schema = true }
+      parser.on("--format FORMAT", ["table", "json"], "Output format (table or json)") { |value| format = value }
+      parser.on("-h", "--help", "Show this help") do
+        puts parser
+        exit
+      end
+    end.parse!
+
+    query = ARGV.shift
+
+    if schema
+      warn("warning: ignoring query argument because `--schema` was given") if query
+      # The schema is static, so describe it without building a graph, then exit.
+      print(Rubydex::Query.schema(format))
+      exit
+    end
+
+    abort_with_usage("`query` requires a Cypher query argument (or pass `--schema`)") if query.nil? || query.empty?
+
+    # Parse the query up front so a malformed query fails fast, before the expensive indexing below.
+    parsed = begin
+      Rubydex::Query.parse(query)
+    rescue ArgumentError => e
+      abort(e.message)
+    end
+
+    lambda do |graph|
+      print(parsed.render(graph, format))
+    rescue ArgumentError => e
+      abort(e.message)
+    end
+  when "console"
+    OptionParser.new do |parser|
+      parser.banner = "Usage: rdx console"
+      parser.on("-h", "--help", "Show this help") do
+        puts parser
+        exit
+      end
+    end.parse!
+
+    lambda do |graph|
+      require "irb"
+      IRB.setup(nil)
+      IRB.conf[:IRB_NAME] = "rubydex"
+      IRB::Irb.new(IRB::WorkSpace.new(binding)).run(IRB.conf)
+    rescue LoadError
+      abort("Interactive mode requires `irb` to be in the bundle")
+    end
+  when "mcp"
+    parser = OptionParser.new do |p|
+      p.banner = "Usage: rdx mcp [PATH]"
+      p.on("-h", "--help", "Show this help") do
+        puts p
+        exit
+      end
+    end
+    begin
+      parser.parse!
+    rescue OptionParser::ParseError => e
+      abort_with_usage(e.message)
+    end
+
+    path = ARGV.shift || Dir.pwd
+    abort_with_usage("unexpected argument: #{ARGV.first}") unless ARGV.empty?
+
+    # The MCP server manages its own graph lifecycle for the given workspace, so it runs here
+    # instead of falling through to the shared graph build below.
+    require "rubydex/mcp_server"
+    Rubydex::MCPServer.run(path)
+    exit
+  else
+    abort_with_usage("unknown command: #{command}")
   end
 
-  require "rubydex/mcp_server"
-  Rubydex::MCPServer.run(arguments.fetch(0, Dir.pwd))
-  exit
-end
-
-def __with_timer(message, &block)
-  print(message)
-  start = Process.clock_gettime(Process::CLOCK_MONOTONIC, :float_millisecond)
-  block.call
-  duration = Process.clock_gettime(Process::CLOCK_MONOTONIC, :float_millisecond) - start
-  puts " finished in #{duration.round(2)}ms"
-end
-
-graph = Rubydex::Graph.new
-graph.load_config
-
-__with_timer("Indexing workspace...") { graph.index_workspace }
-__with_timer("Resolving graph...") { graph.resolve }
-
-if options[:interactive]
-  begin
-    require "irb"
-    IRB.setup(nil)
-    IRB.conf[:IRB_NAME] = "rubydex"
-    workspace = IRB::WorkSpace.new(binding)
-    IRB::Irb.new(workspace).run(IRB.conf)
-  rescue LoadError
-    abort("Interactive mode requires `irb` to be in the bundle")
-  end
-end
+# Everything that reaches here operates on a populated graph. Progress goes to stderr so stdout
+# carries only the command's output (e.g. for piping a query's JSON).
+graph = build_graph($stderr)
+operation.call(graph)

--- a/ext/rubydex/query.c
+++ b/ext/rubydex/query.c
@@ -1,0 +1,105 @@
+#include "query.h"
+#include "graph.h"
+#include "rustbindings.h"
+#include "utils.h"
+
+/*
+ * call-seq:
+ *   Rubydex::Query.schema(format = :table) -> String
+ *
+ * Returns a description of the queryable Cypher schema. +format+ may be +:table+ (default) or
+ * +:json+. The schema is static, so it does not require a graph.
+ */
+static VALUE rdxr_cypher_schema(int argc, VALUE *argv, VALUE self) {
+    VALUE format;
+    rb_scan_args(argc, argv, "01", &format);
+
+    const char *output = rdx_cypher_schema(rdxi_symbol_or_string_cstr(format, "table"));
+    VALUE result = output == NULL ? rb_utf8_str_new_cstr("") : rb_utf8_str_new_cstr(output);
+    if (output != NULL) {
+        free_c_string(output);
+    }
+
+    return result;
+}
+
+// Free function for Rubydex::Query: releases the parsed query allocated by Rust.
+static void query_free(void *ptr) {
+    if (ptr) {
+        rdx_cypher_query_free(ptr);
+    }
+}
+
+static const rb_data_type_t query_type = {
+    .wrap_struct_name = "Rubydex::Query",
+    .function = {
+        .dmark = NULL,
+        .dfree = query_free,
+        .dsize = NULL,
+        .dcompact = NULL,
+    },
+    .parent = NULL,
+    .data = NULL,
+    .flags = RUBY_TYPED_FREE_IMMEDIATELY,
+};
+
+/*
+ * call-seq:
+ *   Rubydex::Query.parse(query) -> Rubydex::Query
+ *
+ * Parses a Cypher query into an opaque, reusable object without needing a graph. Raises
+ * ArgumentError on a syntax error, so a query can be validated before building a graph.
+ */
+static VALUE rdxr_query_parse(VALUE klass, VALUE query) {
+    Check_Type(query, T_STRING);
+
+    struct CParseResult result = rdx_cypher_parse(StringValueCStr(query));
+    if (result.error != NULL) {
+        VALUE message = rb_utf8_str_new_cstr(result.error);
+        free_c_string(result.error);
+        rb_raise(rb_eArgError, "%s", StringValueCStr(message));
+    }
+
+    return TypedData_Wrap_Struct(klass, &query_type, result.query);
+}
+
+/*
+ * call-seq:
+ *   render(graph, format = :table) -> String
+ *
+ * Runs this parsed query against +graph+ and returns the formatted output. +format+ may be
+ * +:table+ (default) or +:json+. Raises ArgumentError on an execution or format error.
+ */
+static VALUE rdxr_query_render(int argc, VALUE *argv, VALUE self) {
+    VALUE graph_obj, format;
+    rb_scan_args(argc, argv, "11", &graph_obj, &format);
+
+    void *query;
+    TypedData_Get_Struct(self, void *, &query_type, query);
+
+    void *graph;
+    TypedData_Get_Struct(graph_obj, void *, &graph_type, graph);
+
+    struct CQueryResult result = rdx_query_run(query, graph, rdxi_symbol_or_string_cstr(format, "table"));
+
+    if (result.error != NULL) {
+        VALUE message = rb_utf8_str_new_cstr(result.error);
+        free_c_string(result.error);
+        rb_raise(rb_eArgError, "%s", StringValueCStr(message));
+    }
+
+    VALUE output = result.output == NULL ? rb_utf8_str_new_cstr("") : rb_utf8_str_new_cstr(result.output);
+    if (result.output != NULL) {
+        free_c_string(result.output);
+    }
+
+    return output;
+}
+
+void rdxi_initialize_query(VALUE mRubydex) {
+    VALUE cQuery = rb_define_class_under(mRubydex, "Query", rb_cObject);
+    rb_undef_alloc_func(cQuery);
+    rb_define_singleton_method(cQuery, "parse", rdxr_query_parse, 1);
+    rb_define_singleton_method(cQuery, "schema", rdxr_cypher_schema, -1);
+    rb_define_method(cQuery, "render", rdxr_query_render, -1);
+}

--- a/ext/rubydex/query.h
+++ b/ext/rubydex/query.h
@@ -1,0 +1,8 @@
+#ifndef RUBYDEX_QUERY_H
+#define RUBYDEX_QUERY_H
+
+#include "ruby.h"
+
+void rdxi_initialize_query(VALUE mRubydex);
+
+#endif // RUBYDEX_QUERY_H

--- a/ext/rubydex/rubydex.c
+++ b/ext/rubydex/rubydex.c
@@ -4,6 +4,7 @@
 #include "document.h"
 #include "graph.h"
 #include "location.h"
+#include "query.h"
 #include "reference.h"
 #include "signature.h"
 
@@ -19,6 +20,7 @@ void Init_rubydex(void) {
      */
     mRubydex = rb_define_module("Rubydex");
     rdxi_initialize_graph(mRubydex);
+    rdxi_initialize_query(mRubydex);
     rdxi_initialize_declaration(mRubydex);
     rdxi_initialize_document(mRubydex);
     rdxi_initialize_definition(mRubydex);

--- a/ext/rubydex/utils.c
+++ b/ext/rubydex/utils.c
@@ -52,6 +52,18 @@ VALUE rdxi_owned_c_string_to_ruby(const char *string) {
     return value;
 }
 
+// Coerce an optional String, Symbol, or nil to a C string, defaulting to `default_value` for nil.
+const char *rdxi_symbol_or_string_cstr(VALUE value, const char *default_value) {
+    if (NIL_P(value)) {
+        return default_value;
+    }
+    if (RB_TYPE_P(value, T_SYMBOL)) {
+        value = rb_sym2str(value);
+    }
+    Check_Type(value, T_STRING);
+    return StringValueCStr(value);
+}
+
 // Yield body for iterating over declarations
 VALUE rdxi_declarations_yield(VALUE args) {
     VALUE self = rb_ary_entry(args, 0);

--- a/ext/rubydex/utils.h
+++ b/ext/rubydex/utils.h
@@ -17,6 +17,11 @@ void rdxi_check_array_of_strings(VALUE array);
 // Returns nil when the Rust side returned NULL.
 VALUE rdxi_owned_c_string_to_ruby(const char *string);
 
+// Coerce an optional String, Symbol, or nil to a C string, returning `default_value` when the value
+// is nil. A non-nil value must be a String or Symbol, otherwise a `TypeError` is raised. The
+// returned pointer is owned by the Ruby VALUE and is only valid while it stays live.
+const char *rdxi_symbol_or_string_cstr(VALUE value, const char *default_value);
+
 // Yield body for iterating over declarations
 VALUE rdxi_declarations_yield(VALUE args);
 

--- a/rbi/rubydex.rbi
+++ b/rbi/rubydex.rbi
@@ -278,6 +278,19 @@ end
 
 class Rubydex::IntegrityFailure < Rubydex::Failure; end
 
+class Rubydex::Query
+  class << self
+    sig { params(query: String).returns(Rubydex::Query) }
+    def parse(query); end
+
+    sig { params(format: T.any(String, Symbol)).returns(String) }
+    def schema(format = :table); end
+  end
+
+  sig { params(graph: Rubydex::Graph, format: T.any(String, Symbol)).returns(String) }
+  def render(graph, format = :table); end
+end
+
 class Rubydex::Graph
   sig { params(workspace_path: T.nilable(String)).void }
   def initialize(workspace_path: nil); end

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -261,6 +261,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "cypher-parser"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed0d1e561d51e651bdf70f8439da293fd0f1fe34d8431059061eadaefc7abb1"
+
+[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -763,6 +769,7 @@ dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
  "crossbeam-utils",
+ "cypher-parser",
  "glob",
  "libc",
  "line-index",

--- a/rust/rubydex-sys/src/graph_api.rs
+++ b/rust/rubydex-sys/src/graph_api.rs
@@ -15,6 +15,7 @@ use rubydex::model::ids::{DeclarationId, NameId, UriId, declaration_id_from_look
 use rubydex::model::keywords;
 use rubydex::model::name::NameRef;
 use rubydex::model::visibility::Visibility;
+use rubydex::query::cypher::{self, OutputFormat};
 use rubydex::query::{CompletionCandidate, CompletionContext, CompletionReceiver};
 use rubydex::resolution::Resolver;
 use rubydex::{indexing, integrity, listing, query};
@@ -1060,6 +1061,145 @@ pub unsafe extern "C" fn rdx_keyword_get(name: *const c_char) -> *const CKeyword
         }
         None => ptr::null(),
     }
+}
+
+/// The result of running a Cypher query, carrying either the formatted output or an error message.
+#[repr(C)]
+pub struct CQueryResult {
+    /// Non-null on success; null on error. Caller must free with `free_c_string`.
+    pub output: *const c_char,
+    /// Non-null on error; null on success. Caller must free with `free_c_string`.
+    pub error: *const c_char,
+}
+
+impl CQueryResult {
+    fn success(output: &str) -> Self {
+        match CString::new(output) {
+            Ok(c_string) => Self {
+                output: c_string.into_raw().cast_const(),
+                error: ptr::null(),
+            },
+            Err(_) => Self::error("query output contained an interior NUL byte"),
+        }
+    }
+
+    fn error(message: &str) -> Self {
+        Self {
+            output: ptr::null(),
+            error: CString::new(message).map_or(ptr::null(), |s| s.into_raw().cast_const()),
+        }
+    }
+}
+
+/// The result of parsing a Cypher query into an opaque, reusable parsed-query object.
+#[repr(C)]
+pub struct CParseResult {
+    /// Non-null on success: a heap-allocated parsed query. Free with `rdx_cypher_query_free`.
+    pub query: *mut c_void,
+    /// Non-null on error; null on success. Caller must free with `free_c_string`.
+    pub error: *const c_char,
+}
+
+/// Parses a Cypher query string into an opaque parsed-query object, without needing a graph.
+///
+/// On success, `query` is a heap-allocated parsed query that can be executed against a graph with
+/// `rdx_query_run` and must eventually be freed with `rdx_cypher_query_free`. On failure, `error`
+/// holds the message.
+///
+/// # Safety
+///
+/// - `query` must be a valid, null-terminated UTF-8 string.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rdx_cypher_parse(query: *const c_char) -> CParseResult {
+    let Ok(query_str) = (unsafe { utils::convert_char_ptr_to_string(query) }) else {
+        return CParseResult {
+            query: ptr::null_mut(),
+            error: CString::new("query is not valid UTF-8").map_or(ptr::null(), |s| s.into_raw().cast_const()),
+        };
+    };
+
+    match cypher::parse(&query_str) {
+        Ok(parsed) => CParseResult {
+            query: Box::into_raw(Box::new(parsed)).cast::<c_void>(),
+            error: ptr::null(),
+        },
+        Err(error) => CParseResult {
+            query: ptr::null_mut(),
+            error: CString::new(error.to_string()).map_or(ptr::null(), |s| s.into_raw().cast_const()),
+        },
+    }
+}
+
+/// Frees a parsed query previously returned by `rdx_cypher_parse`.
+///
+/// # Safety
+///
+/// - `query` must be a pointer returned by `rdx_cypher_parse`, or null. It must not be used after.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rdx_cypher_query_free(query: *mut c_void) {
+    if query.is_null() {
+        return;
+    }
+    let _ = unsafe { Box::from_raw(query.cast::<cypher::Query>()) };
+}
+
+/// Executes a previously parsed query (from `rdx_cypher_parse`) against the graph and returns the
+/// formatted output or an error message. `format` must be `"table"` or `"json"`.
+///
+/// # Safety
+///
+/// - `query` must be a valid pointer returned by `rdx_cypher_parse`.
+/// - `pointer` must be a valid `GraphPointer` previously returned by this crate.
+/// - `format` must be a valid, null-terminated UTF-8 string.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rdx_query_run(
+    query: *const c_void,
+    pointer: GraphPointer,
+    format: *const c_char,
+) -> CQueryResult {
+    if query.is_null() {
+        return CQueryResult::error("query is null");
+    }
+
+    let Ok(format_str) = (unsafe { utils::convert_char_ptr_to_string(format) }) else {
+        return CQueryResult::error("format is not valid UTF-8");
+    };
+
+    let output_format = match format_str.as_str() {
+        "table" => OutputFormat::Table,
+        "json" => OutputFormat::Json,
+        other => {
+            return CQueryResult::error(&format!("unknown query format `{other}` (expected `table` or `json`)"));
+        }
+    };
+
+    let parsed = unsafe { &*query.cast::<cypher::Query>() };
+
+    with_graph(pointer, |graph| {
+        match cypher::run_parsed(graph, parsed, output_format) {
+            Ok(output) => CQueryResult::success(&output),
+            Err(error) => CQueryResult::error(&error.to_string()),
+        }
+    })
+}
+
+/// Returns a description of the queryable Cypher schema (node labels, relationship types, and
+/// properties) in the given format (`"table"` or `"json"`). The schema is static and requires no
+/// graph. Caller must free the returned pointer with `free_c_string`.
+///
+/// # Safety
+///
+/// - `format` must be a valid, null-terminated UTF-8 string.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rdx_cypher_schema(format: *const c_char) -> *const c_char {
+    let format_str = unsafe { utils::convert_char_ptr_to_string(format) }.unwrap_or_else(|_| "table".to_string());
+    let output_format = if format_str == "json" {
+        OutputFormat::Json
+    } else {
+        OutputFormat::Table
+    };
+
+    CString::new(cypher::schema(output_format)).map_or(ptr::null(), |s| s.into_raw().cast_const())
 }
 
 #[repr(u8)]

--- a/rust/rubydex/Cargo.toml
+++ b/rust/rubydex/Cargo.toml
@@ -27,6 +27,7 @@ jemalloc_dylib = ["jemalloc", "tikv-jemallocator/disable_initial_exec_tls"]
 test_utils = ["dep:tempfile"]
 
 [dependencies]
+cypher-parser = "0.2"
 ruby-prism = "1.9.0"
 ruby-rbs = "0.3"
 url = "2.5.4"

--- a/rust/rubydex/src/model/document.rs
+++ b/rust/rubydex/src/model/document.rs
@@ -84,6 +84,39 @@ impl Document {
         self.diagnostics.push(diagnostic);
     }
 
+    /// The file-system path of this document, decoded from its URI.
+    ///
+    /// Returns `None` when the URI is not a `file://` URL (e.g. the synthetic built-in document) or
+    /// cannot be converted to a path. Uses `Url` so percent-encoding and platform-specific paths
+    /// (including Windows drive paths) are handled correctly.
+    #[must_use]
+    pub fn file_path(&self) -> Option<PathBuf> {
+        let url = Url::parse(&self.uri).ok()?;
+        if url.scheme() != "file" {
+            return None;
+        }
+        url.to_file_path().ok()
+    }
+
+    /// The base file name of this document (the last path segment), decoded from its URI.
+    ///
+    /// Prefers the platform file path, but falls back to the last URL path segment so it still works
+    /// for `file://` URIs that don't convert to a local path on the current platform (e.g. a
+    /// drive-less path like `file:///foo.rb` on Windows). Returns `None` only when the URI has no
+    /// usable path segment (e.g. the synthetic built-in document).
+    #[must_use]
+    pub fn file_name(&self) -> Option<String> {
+        if let Some(path) = self.file_path()
+            && let Some(name) = path.file_name()
+        {
+            return Some(name.to_string_lossy().into_owned());
+        }
+
+        let url = Url::parse(&self.uri).ok()?;
+        let segment = url.path_segments()?.rfind(|segment| !segment.is_empty())?;
+        Some(segment.to_string())
+    }
+
     /// Computes the require path for this document given load paths.
     ///
     /// Returns `None` if:
@@ -97,12 +130,7 @@ impl Document {
     /// Panics if load path entries exceed u16.
     #[must_use]
     pub fn require_path(&self, load_paths: &[PathBuf]) -> Option<(String, u16)> {
-        let url = Url::parse(&self.uri).ok()?;
-        if url.scheme() != "file" {
-            return None;
-        }
-
-        let file_path = url.to_file_path().ok()?;
+        let file_path = self.file_path()?;
         if file_path.extension().is_none_or(|ext| ext != "rb") {
             return None;
         }

--- a/rust/rubydex/src/query.rs
+++ b/rust/rubydex/src/query.rs
@@ -15,6 +15,8 @@ use crate::model::keywords::{self, Keyword};
 use crate::model::name::NameRef;
 use crate::model::visibility::Visibility;
 
+pub mod cypher;
+
 /// Controls how declaration names are matched against the search query.
 #[derive(Default)]
 pub enum MatchMode {

--- a/rust/rubydex/src/query/cypher.rs
+++ b/rust/rubydex/src/query/cypher.rs
@@ -1,0 +1,57 @@
+//! A small Cypher query engine that runs read-only queries directly against the in-memory
+//! [`Graph`](crate::model::graph::Graph).
+//!
+//! Supported subset:
+//! - `MATCH` with node patterns `(v:Label {prop: value})` — labels may be a disjunction
+//!   (`(v:Class|Module)` matches a node with **any** of the listed labels) — and relationship
+//!   patterns `-[:TYPE]->`, `<-[:TYPE]-`, `-[:TYPE]-`, including variable-length `-[:TYPE*min..max]->`.
+//! - `WHERE` with `=`, `<>`, `<`, `<=`, `>`, `>=`, `CONTAINS`, `STARTS WITH`, `ENDS WITH`,
+//!   combined with `AND`, `OR`, `NOT`.
+//! - `RETURN` with `DISTINCT`, `AS` aliases, and the aggregates `count`, `collect`, `min`, `max`,
+//!   `sum`, `avg`.
+//! - `ORDER BY`, `SKIP`, `LIMIT`.
+//!
+//! See [`schema`] for the node labels and relationship types exposed to queries.
+
+// The whole Cypher engine — lexer, parser, AST, executor, values, and formatting — lives in the
+// graph-independent `cypher-parser` crate. rubydex only provides the `GraphProvider` mapping for its
+// `Graph` (in `schema`) and the static schema description (in `schema_info`).
+//
+// `Query` is the opaque parsed-query object: callers can `parse` a query string once (failing fast
+// on syntax errors), then `run_parsed` it against a graph that was built afterwards.
+pub use cypher_parser::{CypherError, OutputFormat, Query, parse};
+
+pub mod schema;
+pub mod schema_info;
+
+use crate::model::graph::Graph;
+
+/// Parses and executes a Cypher query against the graph, returning the formatted output.
+///
+/// # Errors
+///
+/// Returns a [`CypherError`] if the query cannot be parsed or executed.
+pub fn run_query(graph: &Graph, query: &str, output_format: OutputFormat) -> Result<String, CypherError> {
+    cypher_parser::run_query(graph, query, output_format)
+}
+
+/// Executes an already-parsed [`Query`] against the graph and formats the result. Pair with
+/// [`parse`] to validate a query before building the graph.
+///
+/// # Errors
+///
+/// Returns a [`CypherError`] if the query cannot be executed.
+pub fn run_parsed(graph: &Graph, query: &Query, output_format: OutputFormat) -> Result<String, CypherError> {
+    let result = cypher_parser::execute(graph, query)?;
+    Ok(cypher_parser::format::format(&result, output_format))
+}
+
+/// Returns a description of the queryable schema (node labels, relationship types, and properties)
+/// in the requested format. The schema is static and does not require a graph.
+#[must_use]
+pub fn schema(output_format: OutputFormat) -> String {
+    schema_info::describe(output_format)
+}
+
+#[cfg(test)]
+mod tests;

--- a/rust/rubydex/src/query/cypher/schema.rs
+++ b/rust/rubydex/src/query/cypher/schema.rs
@@ -1,0 +1,790 @@
+//! Maps the rubydex [`Graph`] onto a property-graph schema for Cypher execution.
+//!
+//! Node labels:
+//! - `Document` — a source file.
+//! - `Definition` — a per-file occurrence of a Ruby construct.
+//! - `Declaration` — the global, merged concept of a named entity. Declarations also carry
+//!   kind sub-labels (`Class`, `Module`, `SingletonClass`, `Method`, `Constant`, `ConstantAlias`,
+//!   `GlobalVariable`, `InstanceVariable`, `ClassVariable`) plus the grouping label `Namespace`
+//!   (any of `Class`/`Module`/`SingletonClass`).
+//!
+//! Relationship types mirror `dot.rs`:
+//! - `DEFINES`: `Document` → `Definition`
+//! - `DECLARES`: `Definition` → `Declaration`
+//! - `CONTAINS`: `Definition` → `Definition` (lexical nesting in one file, e.g. a class written
+//!   inside a module; the source-level counterpart of declaration-level `OWNS`)
+//! - `HAS_PARENT`: `Declaration` → `Declaration` (direct superclass; reverse-traverse for direct
+//!   subclasses, `*` for the full chain)
+//! - `INCLUDES` / `PREPENDS` / `EXTENDS`: `Declaration` → `Declaration` (mixins)
+//! - `OWNS`: `Declaration` → `Declaration` (declaration-level membership, e.g. a namespace's methods
+//!   and nested constants, merged across all files)
+//! - `HAS_ANCESTOR`: `Declaration` → `Declaration` (linearized ancestor chain, incl. modules)
+//! - `HAS_DESCENDANT`: `Declaration` → `Declaration` (reverse of `HAS_ANCESTOR`)
+//! - `REFERENCES`: `Document` → `Declaration` (constant references)
+
+use std::collections::{HashSet, VecDeque};
+
+use crate::model::declaration::Declaration;
+use crate::model::definitions::{Definition, Mixin};
+use crate::model::graph::Graph;
+use crate::model::ids::{ConstantReferenceId, DeclarationId, DefinitionId, UriId};
+
+use cypher_parser::{CypherValue, GraphProvider};
+
+/// A handle to a node in the graph.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum NodeRef {
+    Declaration(DeclarationId),
+    Definition(DefinitionId),
+    Document(UriId),
+}
+
+/// A relationship type.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum RelType {
+    /// `Document` → `Definition`: a file defines a construct occurrence.
+    Defines,
+    /// `Definition` → `Declaration`: a per-file occurrence declares the global merged entity.
+    Declares,
+    /// `Definition` → `Definition`: lexical nesting within a single file, e.g. a class written
+    /// inside a module. This is the source-level structure; the declaration-level (merged across
+    /// files) counterpart is [`RelType::Owns`].
+    Contains,
+    /// `Declaration` → `Declaration`: the direct superclass (a single hop). Reverse-traverse for
+    /// direct subclasses, or use `*` for the full class chain. For the transitive relation
+    /// (including modules) see [`RelType::HasAncestor`].
+    HasParent,
+    /// `Declaration` → `Declaration`: an included module mixin.
+    Includes,
+    /// `Declaration` → `Declaration`: a prepended module mixin.
+    Prepends,
+    /// `Declaration` → `Declaration`: an extended module mixin.
+    Extends,
+    /// `Declaration` → `Declaration`: declaration-level membership (a namespace's methods and
+    /// nested constants), merged across all files. The per-file source counterpart is
+    /// [`RelType::Contains`].
+    Owns,
+    /// `Declaration` → `Declaration`: an entry in the linearized ancestor chain (transitive
+    /// superclasses plus included/prepended modules).
+    HasAncestor,
+    /// `Declaration` → `Declaration`: the reverse of [`RelType::HasAncestor`].
+    HasDescendant,
+    /// `Document` → `Declaration`: a constant reference in the file resolves to a declaration.
+    References,
+}
+
+/// Catalog metadata for a relationship type: the type itself, its canonical name, endpoint labels,
+/// and a short description. Entries live in [`REL_SCHEMAS`], the single source of truth that
+/// `RelType`'s accessors and the `--schema` catalog both derive from.
+pub struct RelSchema {
+    pub rel: RelType,
+    pub name: &'static str,
+    pub from: &'static str,
+    pub to: &'static str,
+    pub description: &'static str,
+}
+
+/// The single source of truth for every relationship type: its name, endpoints, and description.
+/// `RelType::all`/`name`/`parse`/`schema` and the `--schema` catalog all derive from this table.
+const REL_SCHEMAS: &[RelSchema] = &[
+    RelSchema {
+        rel: RelType::Defines,
+        name: "DEFINES",
+        from: "Document",
+        to: "Definition",
+        description: "A file defines a construct occurrence",
+    },
+    RelSchema {
+        rel: RelType::Declares,
+        name: "DECLARES",
+        from: "Definition",
+        to: "Declaration",
+        description: "An occurrence contributes to a declaration",
+    },
+    RelSchema {
+        rel: RelType::Contains,
+        name: "CONTAINS",
+        from: "Definition",
+        to: "Definition",
+        description: "Lexical nesting of definitions",
+    },
+    RelSchema {
+        rel: RelType::HasParent,
+        name: "HAS_PARENT",
+        from: "Class",
+        to: "Class",
+        description: "Direct superclass (use `*` for the full chain)",
+    },
+    RelSchema {
+        rel: RelType::Includes,
+        name: "INCLUDES",
+        from: "Declaration",
+        to: "Declaration",
+        description: "`include` mixin",
+    },
+    RelSchema {
+        rel: RelType::Prepends,
+        name: "PREPENDS",
+        from: "Declaration",
+        to: "Declaration",
+        description: "`prepend` mixin",
+    },
+    RelSchema {
+        rel: RelType::Extends,
+        name: "EXTENDS",
+        from: "Declaration",
+        to: "Declaration",
+        description: "`extend` mixin",
+    },
+    RelSchema {
+        rel: RelType::Owns,
+        name: "OWNS",
+        from: "Declaration",
+        to: "Declaration",
+        description: "A namespace owns a member declaration",
+    },
+    RelSchema {
+        rel: RelType::HasAncestor,
+        name: "HAS_ANCESTOR",
+        from: "Declaration",
+        to: "Declaration",
+        description: "An entry in the linearized ancestor chain (incl. modules)",
+    },
+    RelSchema {
+        rel: RelType::HasDescendant,
+        name: "HAS_DESCENDANT",
+        from: "Declaration",
+        to: "Declaration",
+        description: "A declaration that descends from this one",
+    },
+    RelSchema {
+        rel: RelType::References,
+        name: "REFERENCES",
+        from: "Document",
+        to: "Declaration",
+        description: "A file references a constant declaration",
+    },
+];
+
+impl RelType {
+    /// All relationship types, in catalog order. Used when a pattern leaves the type unspecified.
+    pub fn all() -> impl Iterator<Item = RelType> {
+        REL_SCHEMAS.iter().map(|schema| schema.rel)
+    }
+
+    /// The catalog metadata for this relationship type, looked up in the [`REL_SCHEMAS`] table.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a `RelType` variant has no `REL_SCHEMAS` entry. The table is exhaustive by
+    /// construction (guarded by a test), so this cannot happen in practice.
+    #[must_use]
+    pub fn schema(self) -> &'static RelSchema {
+        REL_SCHEMAS
+            .iter()
+            .find(|schema| schema.rel == self)
+            .expect("every RelType has a REL_SCHEMAS entry")
+    }
+
+    /// The canonical uppercase name of this relationship type.
+    #[must_use]
+    pub fn name(self) -> &'static str {
+        self.schema().name
+    }
+
+    /// Parses a relationship type name (case-insensitive). Returns `None` if unknown.
+    #[must_use]
+    pub fn parse(name: &str) -> Option<Self> {
+        let upper = name.to_ascii_uppercase();
+        REL_SCHEMAS
+            .iter()
+            .find(|schema| schema.name == upper)
+            .map(|schema| schema.rel)
+    }
+}
+
+/// A node label and what it matches, for the `--schema` catalog.
+pub struct LabelSchema {
+    pub label: &'static str,
+    pub matches: &'static str,
+    pub description: &'static str,
+}
+
+/// A property exposed on a node type, for the `--schema` catalog.
+pub struct PropertySchema {
+    pub node_type: &'static str,
+    pub property: &'static str,
+    pub description: &'static str,
+}
+
+/// The node labels queries can match against. Single source of truth for the `--schema` catalog;
+/// the matching behavior lives in [`scan_label`] and [`declaration_matches_label`].
+pub const NODE_LABELS: &[LabelSchema] = &[
+    LabelSchema {
+        label: "Document",
+        matches: "source files",
+        description: "A source file in the workspace",
+    },
+    LabelSchema {
+        label: "Definition",
+        matches: "per-file occurrences",
+        description: "A single occurrence of a Ruby construct in one file",
+    },
+    LabelSchema {
+        label: "Declaration",
+        matches: "merged entities",
+        description: "The global, merged concept of a named entity",
+    },
+    LabelSchema {
+        label: "Namespace",
+        matches: "Class | Module | SingletonClass declarations",
+        description: "Grouping label for namespace-like declarations",
+    },
+    LabelSchema {
+        label: "Class",
+        matches: "declarations of kind Class",
+        description: "A class declaration",
+    },
+    LabelSchema {
+        label: "Module",
+        matches: "declarations of kind Module",
+        description: "A module declaration",
+    },
+    LabelSchema {
+        label: "SingletonClass",
+        matches: "declarations of kind SingletonClass",
+        description: "A singleton class declaration",
+    },
+    LabelSchema {
+        label: "Method",
+        matches: "declarations of kind Method",
+        description: "A method declaration",
+    },
+    LabelSchema {
+        label: "Constant",
+        matches: "declarations of kind Constant",
+        description: "A constant declaration",
+    },
+    LabelSchema {
+        label: "ConstantAlias",
+        matches: "declarations of kind ConstantAlias",
+        description: "A constant alias declaration",
+    },
+    LabelSchema {
+        label: "GlobalVariable",
+        matches: "declarations of kind GlobalVariable",
+        description: "A global variable declaration",
+    },
+    LabelSchema {
+        label: "InstanceVariable",
+        matches: "declarations of kind InstanceVariable",
+        description: "An instance variable declaration",
+    },
+    LabelSchema {
+        label: "ClassVariable",
+        matches: "declarations of kind ClassVariable",
+        description: "A class variable declaration",
+    },
+];
+
+/// The node properties queries can read. Single source of truth for the `--schema` catalog; the
+/// value resolution lives in [`property`] and its per-node-type helpers.
+pub const NODE_PROPERTIES: &[PropertySchema] = &[
+    PropertySchema {
+        node_type: "(any)",
+        property: "label",
+        description: "The node's top-level label / kind",
+    },
+    PropertySchema {
+        node_type: "(any)",
+        property: "kind",
+        description: "Alias of `label`",
+    },
+    PropertySchema {
+        node_type: "Declaration",
+        property: "name",
+        description: "Fully qualified name",
+    },
+    PropertySchema {
+        node_type: "Declaration",
+        property: "unqualified_name",
+        description: "Name without its namespace prefix",
+    },
+    PropertySchema {
+        node_type: "Declaration",
+        property: "visibility",
+        description: "public / protected / private (when applicable)",
+    },
+    PropertySchema {
+        node_type: "Declaration",
+        property: "definition_count",
+        description: "Number of definitions that compose the declaration",
+    },
+    PropertySchema {
+        node_type: "Definition",
+        property: "name",
+        description: "Name of the declaration this definition contributes to",
+    },
+    PropertySchema {
+        node_type: "Definition",
+        property: "file",
+        description: "URI of the file containing the definition",
+    },
+    PropertySchema {
+        node_type: "Definition",
+        property: "line",
+        description: "1-indexed start line of the definition",
+    },
+    PropertySchema {
+        node_type: "Document",
+        property: "uri",
+        description: "Full document URI",
+    },
+    PropertySchema {
+        node_type: "Document",
+        property: "path",
+        description: "File system path of the document",
+    },
+    PropertySchema {
+        node_type: "Document",
+        property: "name",
+        description: "Base file name of the document",
+    },
+];
+
+/// Exposes the rubydex [`Graph`] to the `cypher-parser` executor as a property graph. This is the
+/// rubydex-specific mapping; the executor itself is generic over this trait.
+impl GraphProvider for Graph {
+    type NodeId = NodeRef;
+
+    fn scan(&self, labels: &[String]) -> Vec<NodeRef> {
+        scan(self, labels)
+    }
+
+    fn matches_label(&self, node: NodeRef, label: &str) -> bool {
+        matches_label(self, node, label)
+    }
+
+    fn relationship_types(&self) -> Vec<String> {
+        RelType::all().map(|rel| rel.name().to_string()).collect()
+    }
+
+    fn expand(&self, node: NodeRef, rel_type: &str) -> Vec<NodeRef> {
+        RelType::parse(rel_type).map_or_else(Vec::new, |rel| expand_out(self, node, rel))
+    }
+
+    fn rel_sources(&self, rel_type: &str) -> Vec<NodeRef> {
+        RelType::parse(rel_type).map_or_else(Vec::new, |rel| rel_source_nodes(self, rel))
+    }
+
+    fn property(&self, node: NodeRef, prop: &str) -> CypherValue {
+        property(self, node, prop)
+    }
+
+    fn label(&self, node: NodeRef) -> String {
+        node_label(self, node)
+    }
+
+    fn name(&self, node: NodeRef) -> String {
+        node_name(self, node)
+    }
+}
+
+/// Returns all nodes matching the given labels. An empty slice matches every node; otherwise a node
+/// is returned if it matches **any** of the labels (label disjunction, e.g. `(:Class|Module)`).
+#[must_use]
+pub fn scan(graph: &Graph, labels: &[String]) -> Vec<NodeRef> {
+    if labels.is_empty() {
+        let mut nodes = Vec::new();
+        nodes.extend(graph.documents().keys().map(|id| NodeRef::Document(*id)));
+        nodes.extend(graph.definitions().keys().map(|id| NodeRef::Definition(*id)));
+        nodes.extend(graph.declarations().keys().map(|id| NodeRef::Declaration(*id)));
+        return nodes;
+    }
+
+    let mut seen = HashSet::new();
+    let mut nodes = Vec::new();
+    for label in labels {
+        for node in scan_label(graph, label) {
+            if seen.insert(node) {
+                nodes.push(node);
+            }
+        }
+    }
+    nodes
+}
+
+/// Returns all nodes matching a single label.
+fn scan_label(graph: &Graph, label: &str) -> Vec<NodeRef> {
+    match label {
+        "Document" => graph.documents().keys().map(|id| NodeRef::Document(*id)).collect(),
+        "Definition" => graph.definitions().keys().map(|id| NodeRef::Definition(*id)).collect(),
+        other => graph
+            .declarations()
+            .iter()
+            .filter(|(_, declaration)| declaration_matches_label(declaration, other))
+            .map(|(id, _)| NodeRef::Declaration(*id))
+            .collect(),
+    }
+}
+
+/// Returns whether a node matches a single label.
+#[must_use]
+pub fn matches_label(graph: &Graph, node: NodeRef, label: &str) -> bool {
+    match node {
+        NodeRef::Document(_) => label == "Document",
+        NodeRef::Definition(_) => label == "Definition",
+        NodeRef::Declaration(id) => graph
+            .declarations()
+            .get(&id)
+            .is_some_and(|declaration| declaration_matches_label(declaration, label)),
+    }
+}
+
+fn declaration_matches_label(declaration: &Declaration, label: &str) -> bool {
+    match label {
+        "Declaration" => true,
+        "Namespace" => declaration.as_namespace().is_some(),
+        other => declaration.kind() == other,
+    }
+}
+
+/// Returns the top-level label name of a node, used for display and JSON output.
+#[must_use]
+pub fn node_label(graph: &Graph, node: NodeRef) -> String {
+    match node {
+        NodeRef::Document(_) => "Document".to_string(),
+        NodeRef::Definition(id) => graph
+            .definitions()
+            .get(&id)
+            .map_or_else(|| "Definition".to_string(), |definition| definition.kind().to_string()),
+        NodeRef::Declaration(id) => graph.declarations().get(&id).map_or_else(
+            || "Declaration".to_string(),
+            |declaration| declaration.kind().to_string(),
+        ),
+    }
+}
+
+/// The primary display name of a node (FQN for declarations, URI basename for documents).
+#[must_use]
+pub fn node_name(graph: &Graph, node: NodeRef) -> String {
+    match node {
+        NodeRef::Declaration(id) => graph
+            .declarations()
+            .get(&id)
+            .map_or_else(String::new, |declaration| declaration.name().to_string()),
+        NodeRef::Definition(id) => graph
+            .definitions()
+            .get(&id)
+            .and_then(|definition| graph.definition_to_declaration_id(definition))
+            .and_then(|decl_id| graph.declarations().get(decl_id))
+            .map_or_else(String::new, |declaration| declaration.name().to_string()),
+        NodeRef::Document(id) => graph.documents().get(&id).map_or_else(String::new, |document| {
+            document.file_name().unwrap_or_else(|| document.uri().to_string())
+        }),
+    }
+}
+
+/// Resolves a node property to a value, where `prop` is the property name read off the node (the
+/// `x` in `RETURN n.x` / `WHERE n.x = ...`). Unknown properties yield `NULL`.
+#[must_use]
+pub fn property(graph: &Graph, node: NodeRef, prop: &str) -> CypherValue {
+    match prop {
+        "label" | "kind" => CypherValue::Str(node_label(graph, node)),
+        _ => match node {
+            NodeRef::Declaration(id) => declaration_property(graph, id, prop),
+            NodeRef::Definition(id) => definition_property(graph, id, prop),
+            NodeRef::Document(id) => document_property(graph, id, prop),
+        },
+    }
+}
+
+fn declaration_property(graph: &Graph, id: DeclarationId, prop: &str) -> CypherValue {
+    let Some(declaration) = graph.declarations().get(&id) else {
+        return CypherValue::Null;
+    };
+
+    match prop {
+        "name" => CypherValue::Str(declaration.name().to_string()),
+        "unqualified_name" => CypherValue::Str(declaration.unqualified_name()),
+        "visibility" => graph
+            .visibility(&id)
+            .map_or(CypherValue::Null, |visibility| CypherValue::Str(visibility.to_string())),
+        "definition_count" => CypherValue::Int(i64::try_from(declaration.definitions().len()).unwrap_or(i64::MAX)),
+        _ => CypherValue::Null,
+    }
+}
+
+fn definition_property(graph: &Graph, id: DefinitionId, prop: &str) -> CypherValue {
+    let Some(definition) = graph.definitions().get(&id) else {
+        return CypherValue::Null;
+    };
+
+    match prop {
+        "name" => CypherValue::Str(node_name(graph, NodeRef::Definition(id))),
+        "file" => graph
+            .documents()
+            .get(definition.uri_id())
+            .map_or(CypherValue::Null, |document| {
+                CypherValue::Str(document.uri().to_string())
+            }),
+        "line" => graph
+            .documents()
+            .get(definition.uri_id())
+            .map_or(CypherValue::Null, |document| {
+                let location = definition.offset().to_location(document).to_presentation();
+                CypherValue::Int(i64::from(location.start_line()))
+            }),
+        _ => CypherValue::Null,
+    }
+}
+
+fn document_property(graph: &Graph, id: UriId, prop: &str) -> CypherValue {
+    let Some(document) = graph.documents().get(&id) else {
+        return CypherValue::Null;
+    };
+
+    // Non-`file://` URIs (the synthetic built-in document) have no file path, so `path`/`name` fall
+    // back to the raw URI.
+    match prop {
+        // Full document URI, e.g. `file:///app/models/user.rb`.
+        "uri" => CypherValue::Str(document.uri().to_string()),
+        // File-system path, e.g. `/app/models/user.rb`.
+        "path" => CypherValue::Str(document.file_path().map_or_else(
+            || document.uri().to_string(),
+            |path| path.to_string_lossy().into_owned(),
+        )),
+        // Base file name, e.g. `user.rb`.
+        "name" => CypherValue::Str(document.file_name().unwrap_or_else(|| document.uri().to_string())),
+        _ => CypherValue::Null,
+    }
+}
+
+/// Returns the candidate source nodes for a relationship type, used to build reverse adjacency.
+#[must_use]
+pub fn rel_source_nodes(graph: &Graph, rel: RelType) -> Vec<NodeRef> {
+    match rel {
+        RelType::Defines | RelType::References => graph.documents().keys().map(|id| NodeRef::Document(*id)).collect(),
+        RelType::Declares | RelType::Contains => {
+            graph.definitions().keys().map(|id| NodeRef::Definition(*id)).collect()
+        }
+        RelType::HasParent
+        | RelType::Includes
+        | RelType::Prepends
+        | RelType::Extends
+        | RelType::Owns
+        | RelType::HasAncestor
+        | RelType::HasDescendant => graph
+            .declarations()
+            .keys()
+            .map(|id| NodeRef::Declaration(*id))
+            .collect(),
+    }
+}
+
+/// Expands the outgoing edges of `node` for the given relationship type.
+#[must_use]
+pub fn expand_out(graph: &Graph, node: NodeRef, rel: RelType) -> Vec<NodeRef> {
+    match (node, rel) {
+        (NodeRef::Document(uri_id), RelType::Defines) => graph
+            .documents()
+            .get(&uri_id)
+            .map(|document| {
+                document
+                    .definitions()
+                    .iter()
+                    .map(|id| NodeRef::Definition(*id))
+                    .collect()
+            })
+            .unwrap_or_default(),
+        (NodeRef::Document(uri_id), RelType::References) => document_references(graph, uri_id),
+        (NodeRef::Definition(def_id), RelType::Declares) => graph
+            .definitions()
+            .get(&def_id)
+            .and_then(|definition| graph.definition_to_declaration_id(definition))
+            .map(|decl_id| vec![NodeRef::Declaration(*decl_id)])
+            .unwrap_or_default(),
+        (NodeRef::Definition(def_id), RelType::Contains) => definition_children(graph, def_id),
+        (NodeRef::Declaration(decl_id), RelType::HasParent) => superclasses(graph, decl_id),
+        (NodeRef::Declaration(decl_id), RelType::Includes) => mixin_targets(graph, decl_id, MixinKind::Include),
+        (NodeRef::Declaration(decl_id), RelType::Prepends) => mixin_targets(graph, decl_id, MixinKind::Prepend),
+        (NodeRef::Declaration(decl_id), RelType::Extends) => mixin_targets(graph, decl_id, MixinKind::Extend),
+        (NodeRef::Declaration(decl_id), RelType::Owns) => members(graph, decl_id),
+        (NodeRef::Declaration(decl_id), RelType::HasAncestor) => ancestors(graph, decl_id),
+        (NodeRef::Declaration(decl_id), RelType::HasDescendant) => descendants(graph, decl_id),
+        _ => Vec::new(),
+    }
+}
+
+fn document_references(graph: &Graph, uri_id: UriId) -> Vec<NodeRef> {
+    let Some(document) = graph.documents().get(&uri_id) else {
+        return Vec::new();
+    };
+
+    let mut seen = HashSet::new();
+    let mut targets = Vec::new();
+    for ref_id in document.constant_references() {
+        if let Some(decl_id) = resolve_ref(graph, *ref_id)
+            && seen.insert(decl_id)
+        {
+            targets.push(NodeRef::Declaration(decl_id));
+        }
+    }
+    targets
+}
+
+fn definition_children(graph: &Graph, def_id: DefinitionId) -> Vec<NodeRef> {
+    let Some(definition) = graph.definitions().get(&def_id) else {
+        return Vec::new();
+    };
+
+    let children: &[DefinitionId] = match definition {
+        Definition::Class(d) => d.members(),
+        Definition::Module(d) => d.members(),
+        Definition::SingletonClass(d) => d.members(),
+        _ => &[],
+    };
+    children.iter().map(|id| NodeRef::Definition(*id)).collect()
+}
+
+fn superclasses(graph: &Graph, decl_id: DeclarationId) -> Vec<NodeRef> {
+    let Some(declaration) = graph.declarations().get(&decl_id) else {
+        return Vec::new();
+    };
+
+    let mut seen = HashSet::new();
+    let mut targets = Vec::new();
+    for definition_id in declaration.definitions() {
+        if let Some(Definition::Class(class_def)) = graph.definitions().get(definition_id)
+            && let Some(superclass_ref) = class_def.superclass_ref()
+            && let Some(target) = resolve_ref_to_namespace(graph, *superclass_ref)
+            && seen.insert(target)
+        {
+            targets.push(NodeRef::Declaration(target));
+        }
+    }
+    targets
+}
+
+#[derive(Clone, Copy)]
+enum MixinKind {
+    Include,
+    Prepend,
+    Extend,
+}
+
+fn mixin_targets(graph: &Graph, decl_id: DeclarationId, kind: MixinKind) -> Vec<NodeRef> {
+    let Some(declaration) = graph.declarations().get(&decl_id) else {
+        return Vec::new();
+    };
+
+    let mut seen = HashSet::new();
+    let mut targets = Vec::new();
+    for definition_id in declaration.definitions() {
+        let mixins: &[Mixin] = match graph.definitions().get(definition_id) {
+            Some(Definition::Class(d)) => d.mixins(),
+            Some(Definition::Module(d)) => d.mixins(),
+            Some(Definition::SingletonClass(d)) => d.mixins(),
+            _ => &[],
+        };
+
+        for mixin in mixins {
+            let matches = matches!(
+                (kind, mixin),
+                (MixinKind::Include, Mixin::Include(_))
+                    | (MixinKind::Prepend, Mixin::Prepend(_))
+                    | (MixinKind::Extend, Mixin::Extend(_))
+            );
+            if matches
+                && let Some(target) = resolve_ref_to_namespace(graph, *mixin.constant_reference_id())
+                && seen.insert(target)
+            {
+                targets.push(NodeRef::Declaration(target));
+            }
+        }
+    }
+    targets
+}
+
+fn members(graph: &Graph, decl_id: DeclarationId) -> Vec<NodeRef> {
+    graph
+        .declarations()
+        .get(&decl_id)
+        .and_then(Declaration::as_namespace)
+        .map(|namespace| {
+            namespace
+                .members()
+                .values()
+                .map(|id| NodeRef::Declaration(*id))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn ancestors(graph: &Graph, decl_id: DeclarationId) -> Vec<NodeRef> {
+    use crate::model::declaration::Ancestor;
+
+    graph
+        .declarations()
+        .get(&decl_id)
+        .and_then(Declaration::as_namespace)
+        .map(|namespace| {
+            namespace
+                .ancestors()
+                .iter()
+                .filter_map(|ancestor| match ancestor {
+                    Ancestor::Complete(id) if *id != decl_id => Some(NodeRef::Declaration(*id)),
+                    _ => None,
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn descendants(graph: &Graph, decl_id: DeclarationId) -> Vec<NodeRef> {
+    graph
+        .declarations()
+        .get(&decl_id)
+        .and_then(Declaration::as_namespace)
+        .map(|namespace| {
+            namespace
+                .descendants()
+                .iter()
+                .map(|id| NodeRef::Declaration(*id))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Resolves a constant reference to the declaration of the name it points to.
+fn resolve_ref(graph: &Graph, ref_id: ConstantReferenceId) -> Option<DeclarationId> {
+    let constant_ref = graph.constant_references().get(&ref_id)?;
+    graph.name_id_to_declaration_id(*constant_ref.name_id()).copied()
+}
+
+/// Resolves a constant reference to a namespace declaration, following constant aliases.
+fn resolve_ref_to_namespace(graph: &Graph, ref_id: ConstantReferenceId) -> Option<DeclarationId> {
+    resolve_to_namespace(graph, resolve_ref(graph, ref_id)?)
+}
+
+/// Walks constant-alias chains until reaching a namespace declaration.
+fn resolve_to_namespace(graph: &Graph, declaration_id: DeclarationId) -> Option<DeclarationId> {
+    let mut queue = VecDeque::from([declaration_id]);
+    let mut seen = HashSet::new();
+
+    while let Some(current_id) = queue.pop_front() {
+        if !seen.insert(current_id) {
+            continue;
+        }
+
+        match graph.declarations().get(&current_id)? {
+            Declaration::Namespace(_) => return Some(current_id),
+            Declaration::ConstantAlias(_) => {
+                queue.extend(graph.alias_targets(&current_id)?);
+            }
+            _ => {}
+        }
+    }
+
+    None
+}

--- a/rust/rubydex/src/query/cypher/schema_info.rs
+++ b/rust/rubydex/src/query/cypher/schema_info.rs
@@ -1,0 +1,161 @@
+//! Renders the Cypher property-graph model — node labels, relationship types, and node properties —
+//! for the `--schema` output. The model itself is defined once in [`super::schema`] (labels and
+//! properties as `NODE_LABELS`/`NODE_PROPERTIES`, relationships as [`RelType`]); this module only
+//! formats it, so there is a single source of truth.
+
+use cypher_parser::OutputFormat;
+use cypher_parser::value::write_json_string;
+
+use super::schema::{NODE_LABELS, NODE_PROPERTIES, RelType};
+
+/// Renders the schema catalog in the requested format.
+#[must_use]
+pub fn describe(format: OutputFormat) -> String {
+    match format {
+        OutputFormat::Table => render_table(),
+        OutputFormat::Json => render_json(),
+    }
+}
+
+fn render_table() -> String {
+    let mut out = String::new();
+
+    out.push_str("Node labels\n");
+    let label_rows: Vec<[&str; 3]> = NODE_LABELS
+        .iter()
+        .map(|l| [l.label, l.matches, l.description])
+        .collect();
+    push_table(&mut out, &["Label", "Matches", "Description"], &label_rows);
+
+    out.push_str("\nRelationship types\n");
+    let rel_rows: Vec<[&str; 4]> = RelType::all()
+        .map(|rel| {
+            let schema = rel.schema();
+            [schema.name, schema.from, schema.to, schema.description]
+        })
+        .collect();
+    push_table(&mut out, &["Type", "From", "To", "Description"], &rel_rows);
+
+    out.push_str("\nProperties\n");
+    let prop_rows: Vec<[&str; 3]> = NODE_PROPERTIES
+        .iter()
+        .map(|p| [p.node_type, p.property, p.description])
+        .collect();
+    push_table(&mut out, &["Node type", "Property", "Description"], &prop_rows);
+
+    out
+}
+
+/// Renders a single aligned table section. `N` is the column count.
+fn push_table<const N: usize>(out: &mut String, headers: &[&str; N], rows: &[[&str; N]]) {
+    let mut widths: [usize; N] = std::array::from_fn(|i| headers[i].chars().count());
+    for row in rows {
+        for (index, cell) in row.iter().enumerate() {
+            widths[index] = widths[index].max(cell.chars().count());
+        }
+    }
+
+    push_table_row(out, headers, &widths);
+    for (index, width) in widths.iter().enumerate() {
+        if index > 0 {
+            out.push_str("-+-");
+        }
+        for _ in 0..*width {
+            out.push('-');
+        }
+    }
+    out.push('\n');
+    for row in rows {
+        push_table_row(out, row, &widths);
+    }
+}
+
+fn push_table_row<const N: usize>(out: &mut String, cells: &[&str; N], widths: &[usize; N]) {
+    for (index, width) in widths.iter().enumerate() {
+        if index > 0 {
+            out.push_str(" | ");
+        }
+        let cell = cells[index];
+        out.push_str(cell);
+        for _ in 0..width.saturating_sub(cell.chars().count()) {
+            out.push(' ');
+        }
+    }
+    out.push('\n');
+}
+
+fn render_json() -> String {
+    let mut out = String::from("{\"node_labels\":[");
+    for (index, label) in NODE_LABELS.iter().enumerate() {
+        if index > 0 {
+            out.push(',');
+        }
+        out.push_str("{\"label\":");
+        write_json_string(&mut out, label.label);
+        out.push_str(",\"matches\":");
+        write_json_string(&mut out, label.matches);
+        out.push_str(",\"description\":");
+        write_json_string(&mut out, label.description);
+        out.push('}');
+    }
+
+    out.push_str("],\"relationships\":[");
+    for (index, rel) in RelType::all().enumerate() {
+        if index > 0 {
+            out.push(',');
+        }
+        let schema = rel.schema();
+        out.push_str("{\"type\":");
+        write_json_string(&mut out, schema.name);
+        out.push_str(",\"from\":");
+        write_json_string(&mut out, schema.from);
+        out.push_str(",\"to\":");
+        write_json_string(&mut out, schema.to);
+        out.push_str(",\"description\":");
+        write_json_string(&mut out, schema.description);
+        out.push('}');
+    }
+
+    out.push_str("],\"properties\":[");
+    for (index, prop) in NODE_PROPERTIES.iter().enumerate() {
+        if index > 0 {
+            out.push(',');
+        }
+        out.push_str("{\"node_type\":");
+        write_json_string(&mut out, prop.node_type);
+        out.push_str(",\"property\":");
+        write_json_string(&mut out, prop.property);
+        out.push_str(",\"description\":");
+        write_json_string(&mut out, prop.description);
+        out.push('}');
+    }
+
+    out.push_str("]}");
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn table_lists_labels_relationships_and_properties() {
+        let output = describe(OutputFormat::Table);
+        assert!(output.contains("Node labels"));
+        assert!(output.contains("Relationship types"));
+        assert!(output.contains("Properties"));
+        assert!(output.contains("Namespace"));
+        assert!(output.contains("HAS_PARENT"));
+        assert!(output.contains("unqualified_name"));
+    }
+
+    #[test]
+    fn json_is_well_formed_object() {
+        let output = describe(OutputFormat::Json);
+        assert!(output.starts_with("{\"node_labels\":["));
+        assert!(output.contains("\"relationships\":["));
+        assert!(output.contains("\"properties\":["));
+        assert!(output.contains("\"type\":\"DEFINES\""));
+        assert!(output.ends_with("]}"));
+    }
+}

--- a/rust/rubydex/src/query/cypher/tests.rs
+++ b/rust/rubydex/src/query/cypher/tests.rs
@@ -1,0 +1,228 @@
+use super::run_query;
+use super::schema::RelType;
+use crate::model::graph::Graph;
+use crate::test_utils::GraphTest;
+use cypher_parser::{CypherValue, OutputFormat, ResultSet, execute, parse};
+
+#[test]
+fn relationship_metadata_is_self_consistent() {
+    // Guards the single source of truth: every relationship's catalog name must round-trip through
+    // `parse`, and every field must be populated.
+    for rel in RelType::all() {
+        let schema = rel.schema();
+        assert_eq!(RelType::parse(schema.name), Some(rel));
+        assert_eq!(RelType::parse(&schema.name.to_ascii_lowercase()), Some(rel));
+        assert!(!schema.from.is_empty(), "{} missing `from`", schema.name);
+        assert!(!schema.to.is_empty(), "{} missing `to`", schema.name);
+        assert!(!schema.description.is_empty(), "{} missing description", schema.name);
+    }
+}
+
+// Parser-only tests live in the `cypher-parser` crate. These exercise the executor and the
+// end-to-end query/format path against a real graph.
+
+fn fixture_graph() -> Graph {
+    let mut context = GraphTest::new();
+    context.index_uri(
+        "file:///zoo.rb",
+        "
+            module Walkable
+            end
+
+            class Animal
+              def speak; end
+            end
+
+            class Dog < Animal
+              include Walkable
+            end
+
+            class Cat < Animal
+            end
+        ",
+    );
+    context.resolve();
+    context.into_graph()
+}
+
+fn run(graph: &Graph, query: &str) -> ResultSet {
+    let parsed = parse(query).unwrap();
+    execute(graph, &parsed).unwrap()
+}
+
+fn column_strings(result: &ResultSet, column: usize) -> Vec<String> {
+    let mut values: Vec<String> = result.rows.iter().map(|row| row[column].to_display_string()).collect();
+    values.sort();
+    values
+}
+
+#[test]
+fn scans_declarations_by_label_and_property() {
+    let graph = fixture_graph();
+    let result = run(&graph, "MATCH (c:Class {name: 'Dog'}) RETURN c.name");
+    assert_eq!(result.columns, vec!["c.name".to_string()]);
+    assert_eq!(column_strings(&result, 0), vec!["Dog".to_string()]);
+}
+
+#[test]
+fn scans_label_disjunction() {
+    let graph = fixture_graph();
+    let result = run(
+        &graph,
+        "MATCH (n:Class|Module) WHERE n.name = 'Animal' OR n.name = 'Walkable' RETURN n.name, n.kind",
+    );
+    let names = column_strings(&result, 0);
+    assert_eq!(names, vec!["Animal".to_string(), "Walkable".to_string()]);
+}
+
+#[test]
+fn follows_inherits_relationship() {
+    let graph = fixture_graph();
+    let result = run(
+        &graph,
+        "MATCH (c:Class)-[:HAS_PARENT]->(p:Class) WHERE c.name = 'Dog' RETURN p.name",
+    );
+    assert_eq!(column_strings(&result, 0), vec!["Animal".to_string()]);
+}
+
+#[test]
+fn follows_incoming_relationship() {
+    let graph = fixture_graph();
+    let result = run(
+        &graph,
+        "MATCH (p:Class)<-[:HAS_PARENT]-(c:Class) WHERE p.name = 'Animal' RETURN c.name",
+    );
+    assert_eq!(column_strings(&result, 0), vec!["Cat".to_string(), "Dog".to_string()]);
+}
+
+#[test]
+fn follows_includes_relationship() {
+    let graph = fixture_graph();
+    let result = run(
+        &graph,
+        "MATCH (c:Class)-[:INCLUDES]->(m) WHERE c.name = 'Dog' RETURN m.name",
+    );
+    assert_eq!(column_strings(&result, 0), vec!["Walkable".to_string()]);
+}
+
+#[test]
+fn follows_owns_to_method() {
+    let graph = fixture_graph();
+    let result = run(
+        &graph,
+        "MATCH (c:Class)-[:OWNS]->(m:Method) WHERE c.name = 'Animal' RETURN m.unqualified_name",
+    );
+    assert!(column_strings(&result, 0).iter().any(|name| name.contains("speak")));
+}
+
+#[test]
+fn variable_length_ancestor_chain() {
+    let graph = fixture_graph();
+    let result = run(
+        &graph,
+        "MATCH (c:Class)-[:HAS_ANCESTOR]->(a) WHERE c.name = 'Dog' RETURN a.name",
+    );
+    let ancestors = column_strings(&result, 0);
+    assert!(ancestors.contains(&"Animal".to_string()));
+    assert!(ancestors.contains(&"Walkable".to_string()));
+    assert!(ancestors.contains(&"Object".to_string()));
+}
+
+#[test]
+fn traverses_document_to_declaration() {
+    let graph = fixture_graph();
+    let result = run(
+        &graph,
+        "MATCH (d:Document)-[:DEFINES]->(def:Definition)-[:DECLARES]->(decl) WHERE decl.name = 'Dog' RETURN decl.name",
+    );
+    assert_eq!(column_strings(&result, 0), vec!["Dog".to_string()]);
+}
+
+#[test]
+fn aggregation_counts_subclasses() {
+    let graph = fixture_graph();
+    let result = run(
+        &graph,
+        "MATCH (c:Class)-[:HAS_PARENT]->(p:Class) WHERE p.name = 'Animal' RETURN p.name, count(c) AS subclasses",
+    );
+    assert_eq!(result.rows.len(), 1);
+    assert_eq!(result.rows[0][0], CypherValue::Str("Animal".into()));
+    assert_eq!(result.rows[0][1], CypherValue::Int(2));
+}
+
+#[test]
+fn distinct_and_order_and_limit() {
+    let graph = fixture_graph();
+    let result = run(
+        &graph,
+        "MATCH (c:Class)-[:HAS_PARENT]->(p:Class) RETURN DISTINCT p.name ORDER BY p.name LIMIT 1",
+    );
+    assert_eq!(result.rows.len(), 1);
+    assert_eq!(result.rows[0][0], CypherValue::Str("Animal".into()));
+}
+
+#[test]
+fn where_with_boolean_operators() {
+    let graph = fixture_graph();
+    let result = run(
+        &graph,
+        "MATCH (c:Class) WHERE c.name = 'Dog' OR c.name = 'Cat' RETURN c.name",
+    );
+    assert_eq!(column_strings(&result, 0), vec!["Cat".to_string(), "Dog".to_string()]);
+}
+
+#[test]
+fn run_query_table_output() {
+    let graph = fixture_graph();
+    let output = run_query(
+        &graph,
+        "MATCH (c:Class {name: 'Dog'}) RETURN c.name",
+        OutputFormat::Table,
+    )
+    .unwrap();
+    assert!(output.contains("c.name"));
+    assert!(output.contains("Dog"));
+    assert!(output.contains("1 row"));
+}
+
+#[test]
+fn run_query_json_output() {
+    let graph = fixture_graph();
+    let output = run_query(
+        &graph,
+        "MATCH (c:Class {name: 'Dog'}) RETURN c.name",
+        OutputFormat::Json,
+    )
+    .unwrap();
+    assert_eq!(output, "[{\"c.name\":\"Dog\"}]");
+}
+
+#[test]
+fn unknown_relationship_type_errors() {
+    let graph = fixture_graph();
+    let parsed = parse("MATCH (a)-[:BOGUS]->(b) RETURN a").unwrap();
+    assert!(execute(&graph, &parsed).is_err());
+}
+
+#[test]
+fn document_uri_path_and_name_are_distinct() {
+    let graph = fixture_graph();
+    let result = run(
+        &graph,
+        "MATCH (d:Document) WHERE d.uri = 'file:///zoo.rb' RETURN d.uri, d.path, d.name",
+    );
+    assert_eq!(
+        result.columns,
+        vec!["d.uri".to_string(), "d.path".to_string(), "d.name".to_string()]
+    );
+    // `uri` is the full URI and `name` is the basename on every platform.
+    assert_eq!(column_strings(&result, 0), vec!["file:///zoo.rb".to_string()]);
+    assert_eq!(column_strings(&result, 2), vec!["zoo.rb".to_string()]);
+
+    // `path` is the decoded file-system path. A drive-less `file://` URI has no valid Windows path,
+    // so there it falls back to the raw URI; on Unix it decodes to `/zoo.rb`.
+    #[cfg(not(windows))]
+    assert_eq!(column_strings(&result, 1), vec!["/zoo.rb".to_string()]);
+    #[cfg(windows)]
+    assert_eq!(column_strings(&result, 1), vec!["file:///zoo.rb".to_string()]);
+}

--- a/test/graph_test.rb
+++ b/test/graph_test.rb
@@ -2,6 +2,7 @@
 
 require "test_helper"
 require "helpers/context"
+require "json"
 
 class GraphTest < Minitest::Test
   include Test::Helpers::WithContext
@@ -1583,6 +1584,126 @@ class GraphTest < Minitest::Test
     document = graph.document("file:///bar.rb")
     assert_instance_of(Rubydex::Document, document)
     assert_equal("file:///bar.rb", document.uri)
+  end
+
+  def test_cypher_schema_table
+    output = Rubydex::Query.schema
+
+    assert_match(/Node labels/, output)
+    assert_match(/Relationship types/, output)
+    assert_match(/Properties/, output)
+    assert_match(/HAS_PARENT/, output)
+    assert_match(/unqualified_name/, output)
+  end
+
+  def test_cypher_schema_json
+    output = Rubydex::Query.schema(:json)
+
+    parsed = JSON.parse(output)
+    assert_equal(["node_labels", "relationships", "properties"], parsed.keys)
+    assert(parsed["relationships"].any? { |r| r["type"] == "DEFINES" })
+  end
+
+  def test_parsed_query_runs_against_graph
+    with_context do |context|
+      context.write!("zoo.rb", "class Animal; end\nclass Dog < Animal; end\n")
+
+      query = Rubydex::Query.parse("MATCH (c:Class)-[:HAS_PARENT]->(p:Class) WHERE c.name = 'Dog' RETURN p.name")
+      assert_instance_of(Rubydex::Query, query)
+
+      graph = Rubydex::Graph.new
+      graph.index_all(context.glob("**/*.rb"))
+      graph.resolve
+
+      assert_equal("[{\"p.name\":\"Animal\"}]", query.render(graph, :json))
+    end
+  end
+
+  def test_parse_raises_on_syntax_error
+    error = assert_raises(ArgumentError) { Rubydex::Query.parse("MATCH (c RETURN c") }
+    assert_match(/Cypher syntax error/, error.message)
+  end
+
+  def test_parsed_query_reusable_across_graphs
+    query = Rubydex::Query.parse("MATCH (c:Class {name: 'Dog'}) RETURN c.name")
+
+    with_context do |context|
+      context.write!("zoo.rb", "class Dog; end\n")
+      graph = Rubydex::Graph.new
+      graph.index_all(context.glob("**/*.rb"))
+      graph.resolve
+
+      assert_equal("[{\"c.name\":\"Dog\"}]", query.render(graph, :json))
+    end
+  end
+
+  def test_query_returns_table_output
+    with_context do |context|
+      context.write!("zoo.rb", <<~RUBY)
+        class Animal; end
+        class Dog < Animal; end
+        class Cat < Animal; end
+      RUBY
+
+      graph = Rubydex::Graph.new
+      graph.index_all(context.glob("**/*.rb"))
+      graph.resolve
+
+      query = Rubydex::Query.parse("MATCH (c:Class)-[:HAS_PARENT]->(p:Class) WHERE p.name = 'Animal' RETURN c.name ORDER BY c.name")
+      output = query.render(graph)
+
+      assert_match(/c\.name/, output)
+      assert_match(/Cat/, output)
+      assert_match(/Dog/, output)
+      assert_match(/2 rows/, output)
+    end
+  end
+
+  def test_query_label_disjunction
+    with_context do |context|
+      context.write!("zoo.rb", <<~RUBY)
+        class Animal; end
+        module Walkable; end
+        class Dog < Animal; end
+      RUBY
+
+      graph = Rubydex::Graph.new
+      graph.index_all(context.glob("**/*.rb"))
+      graph.resolve
+
+      query = Rubydex::Query.parse(
+        "MATCH (n:Class|Module) WHERE n.name = 'Animal' OR n.name = 'Walkable' RETURN n.name ORDER BY n.name",
+      )
+
+      assert_equal("[{\"n.name\":\"Animal\"},{\"n.name\":\"Walkable\"}]", query.render(graph, :json))
+    end
+  end
+
+  def test_query_accepts_string_format
+    with_context do |context|
+      context.write!("zoo.rb", "class Dog; end\n")
+
+      graph = Rubydex::Graph.new
+      graph.index_all(context.glob("**/*.rb"))
+      graph.resolve
+
+      query = Rubydex::Query.parse("MATCH (c:Class {name: 'Dog'}) RETURN c.name")
+      assert_equal("[{\"c.name\":\"Dog\"}]", query.render(graph, "json"))
+    end
+  end
+
+  def test_render_raises_on_invalid_format
+    with_context do |context|
+      context.write!("zoo.rb", "class Dog; end\n")
+
+      graph = Rubydex::Graph.new
+      graph.index_all(context.glob("**/*.rb"))
+      graph.resolve
+
+      query = Rubydex::Query.parse("MATCH (c:Class) RETURN c.name")
+      error = assert_raises(ArgumentError) { query.render(graph, :yaml) }
+      assert_match(/unknown query format/, error.message)
+    end
   end
 
   private

--- a/test/mcp_server_test.rb
+++ b/test/mcp_server_test.rb
@@ -313,7 +313,7 @@ class MCPServerIntegrationTest < Minitest::Test
     stdout, _stderr, status = run_executable("--help")
 
     assert_predicate(status, :success?)
-    assert_includes(stdout, "--mcp")
+    assert_includes(stdout, "mcp [PATH]")
     assert_includes(stdout, "Run the MCP server for AI assistants")
   end
 
@@ -325,21 +325,21 @@ class MCPServerIntegrationTest < Minitest::Test
   end
 
   def test_executable_rejects_extra_arguments
-    stdout, stderr, status = run_executable("--mcp", "foo", "bar")
+    stdout, stderr, status = run_executable("mcp", "foo", "bar")
 
-    assert_equal(2, status.exitstatus)
+    assert_equal(1, status.exitstatus)
     assert_empty(stdout)
-    assert_includes(stderr, "error: unexpected argument 'bar' found")
-    assert_includes(stderr, "--mcp")
+    assert_includes(stderr, "unexpected argument: bar")
+    assert_includes(stderr, "mcp [PATH]")
   end
 
   def test_executable_rejects_unknown_options
-    stdout, stderr, status = run_executable("--mcp", "--unknown")
+    stdout, stderr, status = run_executable("mcp", "--unknown")
 
-    assert_equal(2, status.exitstatus)
+    assert_equal(1, status.exitstatus)
     assert_empty(stdout)
-    assert_includes(stderr, "error: invalid option: --unknown")
-    assert_includes(stderr, "--mcp")
+    assert_includes(stderr, "invalid option: --unknown")
+    assert_includes(stderr, "mcp [PATH]")
   end
 
   def test_mcp_server_can_be_required_directly
@@ -402,7 +402,7 @@ class MCPServerIntegrationTest < Minitest::Test
       RUBY
 
       stderr_output = +""
-      Open3.popen3(RbConfig.ruby, "-rbundler/setup", executable_path, "--mcp", context.absolute_path) do |stdin, stdout, stderr, wait_thr|
+      Open3.popen3(RbConfig.ruby, "-rbundler/setup", executable_path, "mcp", context.absolute_path) do |stdin, stdout, stderr, wait_thr|
         stderr_reader = Thread.new { stderr_output << stderr.read }
 
         initialize_session(stdin, stdout)
@@ -459,7 +459,7 @@ class MCPServerIntegrationTest < Minitest::Test
         stderr_reader.join
       rescue Timeout::Error
         Process.kill("TERM", wait_thr.pid)
-        flunk("rdx --mcp did not exit after stdin closed. stderr:\n#{stderr_output}")
+        flunk("rdx mcp did not exit after stdin closed. stderr:\n#{stderr_output}")
       end
     end
   end


### PR DESCRIPTION
## Goal

Give clients a flexible, future-proof way to query the in-memory graph using **Cypher** — the de facto standard graph query language. Instead of adding a bespoke method for every traversal, this exposes the graph through a query language clients already know, so new introspection needs become queries rather than new APIs. Queries are **read-only**, run directly against the existing in-memory `Graph` (no duplication, no embedded database).

### References
- openCypher specification: https://opencypher.org/resources/
- Cypher query language (Neo4j docs): https://neo4j.com/docs/cypher-manual/current/

## Architecture

The Cypher engine itself — lexer, recursive-descent parser, AST, the tree-walking executor, values, and result formatting — lives in a separate, published crate, [`cypher-parser`](https://crates.io/crates/cypher-parser). The executor is generic over a `GraphProvider` trait, so it has no dependency on rubydex.

`rubydex` depends on `cypher-parser` and provides only the rubydex-specific pieces:
- `query::cypher::schema` — `impl GraphProvider for Graph`, the property-graph mapping.
- `query::cypher::schema_info` — the static schema description.

## How it's exposed

- **`rubydex_cli`**: `--query "<CYPHER>"`, `--schema`, `--format table|json`.
- **Ruby API** — the whole query API lives on `Rubydex::Query`:
  - `Rubydex::Query.parse(str)` → an opaque, reusable parsed query (raises `ArgumentError` on syntax errors, needs no graph).
  - `Rubydex::Query#render(graph, format = :table)` → runs a parsed query against a graph and returns the formatted output (table or JSON).
  - `Rubydex::Query.schema(format = :table)` → describes the queryable schema.
- **`rdx` command CLI**:
  ```
  rdx query <CYPHER>  [--format table|json]
  rdx query --schema  [--format table|json]
  rdx console
  ```

### Parse first, then build the graph

Both CLIs parse the query into the opaque parsed object **before** indexing/resolution, so a malformed query fails fast (~0.1s) instead of after a full workspace index:

```
parse query  ->  build graph (index + resolve)  ->  run parsed query
```

A parsed `Rubydex::Query` is reusable: parse once, run against many graphs.

## Graph schema exposed to queries

`rdx query --schema` / `rubydex_cli --schema` / `Rubydex::Query.schema` print this model:

**Node labels:** `Document`, `Definition`, `Declaration`, the grouping label `Namespace`, and declaration kind sub-labels (`Class`, `Module`, `SingletonClass`, `Method`, `Constant`, `ConstantAlias`, `GlobalVariable`, `InstanceVariable`, `ClassVariable`).

**Relationship types:** `DEFINES` (Document→Definition), `DECLARES` (Definition→Declaration), `CONTAINS` (lexical nesting), `HAS_PARENT` (direct superclass; reverse-traverse for direct subclasses, `*` for the chain), `INCLUDES`/`PREPENDS`/`EXTENDS` (mixins), `OWNS` (members), `HAS_ANCESTOR` (linearized ancestor chain, incl. modules), `HAS_DESCENDANT` (reverse of `HAS_ANCESTOR`), `REFERENCES` (Document→Declaration).

**Properties:** Declaration: `name`, `unqualified_name`, `kind`, `visibility`, `definition_count`; Definition: `kind`, `name`, `file`, `line`; Document: `uri`, `path` (file-system path), `name` (base file name).

**Supported syntax:** `MATCH` (node patterns with label disjunction `:A|B` and inline properties; relationship patterns with direction, type lists, and variable length `*min..max`), `WHERE` (`=, <>, <, <=, >, >=, CONTAINS, STARTS WITH, ENDS WITH`, `AND/OR/NOT`), `RETURN` (`DISTINCT`, `AS`, aggregates `count/collect/min/max/sum/avg`), `ORDER BY`, `SKIP`, `LIMIT`. Read-only; write clauses are intentionally unsupported.

## Try it

```bash
# Discover the model
rdx query --schema

# All classes or modules
rdx query "MATCH (n:Class|Module) RETURN n.name ORDER BY n.name"

# All (transitive) subclasses of a base class, as JSON
rdx query "MATCH (c:Class)-[:HAS_PARENT*1..]->(p {name: 'ApplicationRecord'}) RETURN DISTINCT c.name" --format json

# Count definitions per file
rdx query "MATCH (d:Document)-[:DEFINES]->(def:Definition) RETURN d.path, count(def) AS defs ORDER BY defs DESC"
```

From Ruby:
```ruby
query = Rubydex::Query.parse("MATCH (n:Class|Module) RETURN n.name")  # fails fast on bad syntax
graph = Rubydex::Graph.new
graph.index_workspace
graph.resolve
puts query.render(graph, :json)
```

## What's here

Core work:
1. A read-only Cypher engine over the in-memory graph, extracted into the standalone [`cypher-parser`](https://crates.io/crates/cypher-parser) crate (generic over `GraphProvider`).
2. rubydex's `GraphProvider` mapping plus a single-source schema catalog (`RelType` + `NODE_LABELS`/`NODE_PROPERTIES`), rendered by `schema_info`.
3. `--query`/`--schema` on `rubydex_cli` and a `rdx query` / `console` command CLI, parsing the query up front so a syntax error fails fast before indexing.

Review refinements folded in: direction-correct `HAS_PARENT`/`HAS_ANCESTOR`/`HAS_DESCENDANT` edge naming, `rdx query --schema` as a flag, a single "build graph once, then dispatch" CLI structure, extraction of `Rubydex::Query` into `query.c` and a shared `utils` helper, robust `file://` path handling, and clap validation that rejects nonsensical flag combinations.


