### PR TITLE
Add `Location.from_prism` helper

### DIFF
--- a/lib/rubydex/location.rb
+++ b/lib/rubydex/location.rb
@@ -14,6 +14,19 @@ module Rubydex
     #: Integer
     attr_reader :start_line, :end_line, :start_column, :end_column
 
+    class << self
+      #: (Prism::Location prism_location, uri: String) -> Location
+      def from_prism(prism_location, uri:)
+        Location.new(
+          uri: uri,
+          start_line: prism_location.start_line - 1,
+          start_column: prism_location.start_column,
+          end_line: prism_location.end_line - 1,
+          end_column: prism_location.end_column,
+        )
+      end
+    end
+
     #: (?uri: String, ?start_line: Integer, ?end_line: Integer, ?start_column: Integer, ?end_column: Integer) -> void
     def initialize(uri:, start_line:, end_line:, start_column:, end_column:)
       @uri = uri
@@ -68,6 +81,17 @@ module Rubydex
   # A one based location intended for display purposes. This is what should be used when displaying a location to users,
   # like in CLIs
   class DisplayLocation < Location
+    class << self
+      #: (Prism::Location prism_location, uri: String) -> Location
+      def from_prism(prism_location, uri:)
+        raise NotImplementedError, <<~MESSAGE
+          Cannot convert Prism::Location directly to a Rubydex::DisplayLocation.
+          Start with `Rubydex::Location.from_prism(...)` and then convert the resulting
+          location with `to_display`
+        MESSAGE
+      end
+    end
+
     # Returns itself
     #
     #: () -> DisplayLocation

--- a/rbi/rubydex.rbi
+++ b/rbi/rubydex.rbi
@@ -415,6 +415,11 @@ class Rubydex::Graph
 end
 
 class Rubydex::DisplayLocation < Rubydex::Location
+  class << self
+    sig { params(prism_location: Prism::Location, uri: String).returns(T.noreturn) }
+    def from_prism(prism_location, uri:); end
+  end
+
   sig { returns([String, Integer, Integer, Integer, Integer]) }
   def comparable_values; end
 
@@ -427,6 +432,11 @@ end
 
 class Rubydex::Location
   include ::Comparable
+
+  class << self
+    sig { params(prism_location: Prism::Location, uri: String).returns(Rubydex::Location) }
+    def from_prism(prism_location, uri:); end
+  end
 
   sig do
     params(

--- a/test/location_test.rb
+++ b/test/location_test.rb
@@ -3,6 +3,33 @@
 require "test_helper"
 
 class LocationTest < Minitest::Test
+  PrismLocation = Struct.new(:start_line, :start_column, :end_line, :end_column, keyword_init: true)
+
+  def test_location_from_prism
+    prism_location = PrismLocation.new(start_line: 2, start_column: 12, end_line: 3, end_column: 19)
+
+    location = Rubydex::Location.from_prism(prism_location, uri: "file:///foo.rb")
+
+    assert_equal(
+      Rubydex::Location.new(uri: "file:///foo.rb", start_line: 1, end_line: 2, start_column: 12, end_column: 19),
+      location,
+    )
+  end
+
+  def test_display_location_from_prism_raises_with_conversion_path
+    prism_location = PrismLocation.new(start_line: 2, start_column: 12, end_line: 3, end_column: 19)
+
+    error = assert_raises(NotImplementedError) do
+      Rubydex::DisplayLocation.from_prism(prism_location, uri: "file:///foo.rb")
+    end
+
+    assert_equal(<<~MESSAGE, error.message)
+      Cannot convert Prism::Location directly to a Rubydex::DisplayLocation.
+      Start with `Rubydex::Location.from_prism(...)` and then convert the resulting
+      location with `to_display`
+    MESSAGE
+  end
+
   def test_location_equality
     a = Rubydex::Location.new(uri: "file:///foo.rb", start_line: 0, end_line: 0, start_column: 0, end_column: 5)
     b = Rubydex::Location.new(uri: "file:///foo.rb", start_line: 0, end_line: 0, start_column: 0, end_column: 5)


### PR DESCRIPTION
Closes #849

`Prism::Location` and `Rubydex::Location` use different line conventions: Prism lines are 1-based, while Rubydex internal locations are 0-based. Callers that need to compare Prism-derived locations with Rubydex locations currently have to repeat the same conversion by hand.

This PR adds `Rubydex::Location.from_prism(prism_location, uri:)` so the conversion lives behind the `Location` API:

```ruby
Rubydex::Location.from_prism(prism_location, uri:)
```

The helper subtracts 1 from Prism's line values and keeps Prism's default column values as-is. `DisplayLocation.from_prism` is intentionally unavailable; callers that need a display location can convert explicitly with `Rubydex::Location.from_prism(...).to_display`.