### PR TITLE
Materialize singleton classes for namespace declarations

### DIFF
--- a/docs/ruby-behaviors.md
+++ b/docs/ruby-behaviors.md
@@ -1476,8 +1476,9 @@ Class.instance_method(:new).owner
 # => Class
 ```
 
-When singleton classes for classes are materialized, their ancestor chains mirror normal class inheritance. A subclass's
-singleton class inherits from the superclass's singleton class:
+If singleton classes for classes are materialized, their ancestor chains mirror normal class inheritance. A subclass's
+singleton class inherits from the superclass's singleton class. This describes the semantic relationship that static
+analysis needs to model; it does not mean Ruby eagerly allocates every class object's singleton class:
 
 ```ruby
 class Foo; end

--- a/docs/ruby-behaviors.md
+++ b/docs/ruby-behaviors.md
@@ -1476,6 +1476,32 @@ Class.instance_method(:new).owner
 # => Class
 ```
 
+When singleton classes for classes are materialized, their ancestor chains mirror normal class inheritance. A subclass's
+singleton class inherits from the superclass's singleton class:
+
+```ruby
+class Foo; end
+class Bar < Foo; end
+
+Bar.singleton_class.ancestors
+# => [#<Class:Bar>, #<Class:Foo>, #<Class:Object>, #<Class:BasicObject>, Class, Module, Object, Kernel, BasicObject]
+```
+
+This is why singleton behavior added to a parent class object with `extend` is inherited by child class objects:
+
+```ruby
+module M; end
+
+class Foo
+  extend M
+end
+
+class Bar < Foo; end
+
+Bar.singleton_class.ancestors.include?(M)
+# => true
+```
+
 The singleton class is the receiver for `def self.*`, `class << self`, and it is where modules mixed in via `extend`
 actually insert their methods.
 

--- a/rust/rubydex-mcp/src/server.rs
+++ b/rust/rubydex-mcp/src/server.rs
@@ -1119,7 +1119,7 @@ mod tests {
         let res = parse(&s.codebase_stats());
 
         assert_eq!(res["files"], 3);
-        assert_json_int!(res, "declarations", 7);
+        assert_json_int!(res, "declarations", 14);
         assert_json_int!(res, "definitions", 7);
 
         let breakdown = &res["breakdown_by_kind"];

--- a/rust/rubydex/src/query.rs
+++ b/rust/rubydex/src/query.rs
@@ -3206,6 +3206,38 @@ mod tests {
     }
 
     #[test]
+    fn method_call_completion_includes_protected_singleton_method_inherited_from_extended_parent() {
+        let mut context = GraphTest::new();
+        context.index_uri(
+            "file:///foo.rb",
+            "
+            module Sharable
+              protected
+
+              def shared_secret; end
+            end
+
+            class Parent
+              extend Sharable
+            end
+
+            class Child < Parent
+            end
+            ",
+        );
+        context.resolve();
+
+        assert_completion_eq!(
+            context,
+            CompletionReceiver::MethodCall {
+                self_decl_id: Some(DeclarationId::from("Child::<Child>")),
+                receiver_decl_id: DeclarationId::from("Child::<Child>"),
+            },
+            ["Sharable#shared_secret()"]
+        );
+    }
+
+    #[test]
     fn method_call_completion_excludes_protected_when_caller_class_is_not_descendant_of_defined_class() {
         let mut context = GraphTest::new();
         context.index_uri(
@@ -3760,6 +3792,34 @@ mod tests {
                 false,
             ),
             Ok(DeclarationId::from("Parent#inherited_method()")),
+        );
+    }
+
+    #[test]
+    fn find_member_in_ancestors_returns_inherited_singleton_member() {
+        let mut context = GraphTest::new();
+        context.index_uri(
+            "file:///foo.rb",
+            r"
+            class Parent
+              def self.inherited_class_method
+              end
+            end
+
+            class Child < Parent
+            end
+            ",
+        );
+        context.resolve();
+
+        assert_eq!(
+            find_member_in_ancestors(
+                context.graph(),
+                DeclarationId::from("Child::<Child>"),
+                StringId::from("inherited_class_method()"),
+                false,
+            ),
+            Ok(DeclarationId::from("Parent::<Parent>#inherited_class_method()",)),
         );
     }
 

--- a/rust/rubydex/src/query.rs
+++ b/rust/rubydex/src/query.rs
@@ -49,6 +49,10 @@ pub fn declaration_search(graph: &Graph, query: &str, match_mode: &MatchMode) ->
                         .iter()
                         .filter(|id| {
                             let declaration = declarations.get(id).unwrap();
+                            if !is_searchable_declaration(declaration) {
+                                return false;
+                            }
+
                             let name = declaration.name();
                             match match_mode {
                                 MatchMode::Fuzzy => {
@@ -67,6 +71,10 @@ pub fn declaration_search(graph: &Graph, query: &str, match_mode: &MatchMode) ->
 
         handles.into_iter().flat_map(|h| h.join().unwrap()).collect()
     })
+}
+
+fn is_searchable_declaration(declaration: &Declaration) -> bool {
+    !matches!(declaration, Declaration::Namespace(Namespace::SingletonClass(_)))
 }
 
 #[must_use]
@@ -947,9 +955,15 @@ mod tests {
         context.resolve();
         let exact_results = declaration_search(context.graph(), "", &MatchMode::Exact);
         let fuzzy_results = declaration_search(context.graph(), "", &MatchMode::Fuzzy);
+        let searchable_declarations = context
+            .graph()
+            .declarations()
+            .values()
+            .filter(|declaration| is_searchable_declaration(declaration))
+            .count();
 
         assert_eq!(exact_results.len(), fuzzy_results.len());
-        assert_eq!(context.graph().declarations().len(), exact_results.len());
+        assert_eq!(searchable_declarations, exact_results.len());
     }
 
     #[test]

--- a/rust/rubydex/src/query.rs
+++ b/rust/rubydex/src/query.rs
@@ -2775,14 +2775,25 @@ mod tests {
         let foo_ref_id = Name::new(StringId::from("Foo"), ParentScope::None, Some(bar_id)).id();
         let nesting_name_id = Name::new(StringId::from("<Foo>"), ParentScope::Attached(foo_ref_id), Some(bar_id)).id();
 
-        assert_declaration_completion_eq!(
-            context,
-            CompletionReceiver::Expression {
+        let actual = completion_candidates(
+            context.graph(),
+            CompletionContext::new(CompletionReceiver::Expression {
                 self_decl_id: None,
                 nesting_name_id,
-            },
-            ["Bar#@@bar_cvar"]
-        );
+            }),
+        )
+        .unwrap()
+        .iter()
+        .filter_map(|candidate| {
+            let CompletionCandidate::Declaration(id) = candidate else {
+                return None;
+            };
+            let declaration = context.graph().declarations().get(id).unwrap();
+            declaration.as_class_variable().map(|_| declaration.name().to_string())
+        })
+        .collect::<Vec<_>>();
+
+        assert_eq!(actual, vec!["Bar#@@bar_cvar".to_string()]);
     }
 
     #[test]

--- a/rust/rubydex/src/resolution.rs
+++ b/rust/rubydex/src/resolution.rs
@@ -986,6 +986,8 @@ impl<'a> Resolver<'a> {
         }
 
         let parent_ancestors = self.linearize_parent_ancestors(declaration_id, context);
+        self.materialize_singleton_class_for_namespace(declaration_id);
+
         let declaration = self.graph.declarations().get(&declaration_id).unwrap();
         let mut mixins = Vec::new();
 
@@ -1005,23 +1007,15 @@ impl<'a> Resolver<'a> {
             );
         }
 
-        // Collect prepends and includes for the current declaration, noting if any extends exist
-        let mut has_extends = false;
-
         for definition_id in declaration.definitions() {
             if let Some(def_mixins) = self.mixins_of(*definition_id) {
                 for mixin in def_mixins {
                     match mixin {
                         Mixin::Prepend(_) | Mixin::Include(_) => mixins.push(mixin),
-                        Mixin::Extend(_) => has_extends = true,
+                        Mixin::Extend(_) => {}
                     }
                 }
             }
-        }
-
-        // Ensure that we create the singleton and enqueue it for linearization if we see an extend
-        if has_extends && !is_singleton_class {
-            self.get_or_create_singleton_class(declaration_id, false);
         }
 
         let (linearized_prepends, linearized_includes) =
@@ -1054,6 +1048,15 @@ impl<'a> Resolver<'a> {
 
         context.finalize(declaration_id);
         result
+    }
+
+    fn materialize_singleton_class_for_namespace(&mut self, declaration_id: DeclarationId) {
+        if matches!(
+            self.graph.declarations().get(&declaration_id),
+            Some(Declaration::Namespace(Namespace::Class(_) | Namespace::Module(_)))
+        ) {
+            self.get_or_create_singleton_class(declaration_id, false);
+        }
     }
 
     fn linearize_parent_ancestors(

--- a/rust/rubydex/src/resolution.rs
+++ b/rust/rubydex/src/resolution.rs
@@ -148,15 +148,18 @@ impl<'a> Resolver<'a> {
     /// Handles a unit of work for resolving a constant definition or singleton method
     fn handle_definition_unit(&mut self, unit_id: Unit, id: DefinitionId) {
         let mut needs_linearization = false;
+        let mut needs_singleton_class = false;
 
         let outcome = match self.graph.definitions().get(&id).unwrap() {
             Definition::Class(class) => {
+                needs_singleton_class = true;
                 self.handle_constant_declaration(*class.name_id(), id, false, |name, owner_id| {
                     needs_linearization = true;
                     Declaration::Namespace(Namespace::Class(Box::new(ClassDeclaration::new(name, owner_id))))
                 })
             }
             Definition::Module(module) => {
+                needs_singleton_class = true;
                 self.handle_constant_declaration(*module.name_id(), id, false, |name, owner_id| {
                     needs_linearization = true;
                     Declaration::Namespace(Namespace::Module(Box::new(ModuleDeclaration::new(name, owner_id))))
@@ -219,10 +222,16 @@ impl<'a> Resolver<'a> {
                 if needs_linearization {
                     self.unit_queue.push_back(Unit::Ancestors(id));
                 }
+                if needs_singleton_class {
+                    self.get_or_create_singleton_class(id, false);
+                }
                 self.made_progress = true;
             }
-            Outcome::Resolved(_, Some(id_needing_linearization)) => {
+            Outcome::Resolved(id, Some(id_needing_linearization)) => {
                 self.unit_queue.push_back(Unit::Ancestors(id_needing_linearization));
+                if needs_singleton_class {
+                    self.get_or_create_singleton_class(id, false);
+                }
                 self.made_progress = true;
             }
         }
@@ -986,7 +995,6 @@ impl<'a> Resolver<'a> {
         }
 
         let parent_ancestors = self.linearize_parent_ancestors(declaration_id, context);
-        self.materialize_singleton_class_for_namespace(declaration_id);
 
         let declaration = self.graph.declarations().get(&declaration_id).unwrap();
         let mut mixins = Vec::new();
@@ -1048,15 +1056,6 @@ impl<'a> Resolver<'a> {
 
         context.finalize(declaration_id);
         result
-    }
-
-    fn materialize_singleton_class_for_namespace(&mut self, declaration_id: DeclarationId) {
-        if matches!(
-            self.graph.declarations().get(&declaration_id),
-            Some(Declaration::Namespace(Namespace::Class(_) | Namespace::Module(_)))
-        ) {
-            self.get_or_create_singleton_class(declaration_id, false);
-        }
     }
 
     fn linearize_parent_ancestors(

--- a/rust/rubydex/src/resolution.rs
+++ b/rust/rubydex/src/resolution.rs
@@ -44,15 +44,17 @@ struct LinearizationContext {
     seen_ids: IdentityHashSet<DeclarationId>,
     cyclic: bool,
     partial: bool,
+    eager_singletons: bool,
 }
 
 impl LinearizationContext {
-    fn new() -> Self {
+    fn new(eager_singletons: bool) -> Self {
         Self {
             descendants: IdentityHashSet::default(),
             seen_ids: IdentityHashSet::default(),
             cyclic: false,
             partial: false,
+            eager_singletons,
         }
     }
 
@@ -176,6 +178,7 @@ impl<'a> Resolver<'a> {
                 })
             }
             Definition::SingletonClass(singleton) => {
+                needs_singleton_class = singleton.mixins().iter().any(|mixin| matches!(mixin, Mixin::Extend(_)));
                 self.handle_constant_declaration(*singleton.name_id(), id, true, |name, owner_id| {
                     needs_linearization = true;
                     Declaration::Namespace(Namespace::SingletonClass(Box::new(SingletonClassDeclaration::new(
@@ -888,7 +891,7 @@ impl<'a> Resolver<'a> {
                 });
 
                 if eager_ancestors {
-                    let _ = self.ancestors_of(attached_id);
+                    let _ = self.ancestors_of_with_singletons(attached_id, true);
                 } else {
                     self.unit_queue.push_back(Unit::Ancestors(attached_id));
                 }
@@ -919,13 +922,89 @@ impl<'a> Resolver<'a> {
             )))),
         );
 
+        self.materialize_descendant_singleton_classes(attached_id, decl_id, eager_ancestors);
+
         if eager_ancestors {
-            let _ = self.ancestors_of(decl_id);
+            let _ = self.ancestors_of_with_singletons(decl_id, true);
         } else {
             self.unit_queue.push_back(Unit::Ancestors(decl_id));
         }
 
         Some(decl_id)
+    }
+
+    fn materialize_descendant_singleton_classes(
+        &mut self,
+        attached_id: DeclarationId,
+        singleton_id: DeclarationId,
+        eager_ancestors: bool,
+    ) {
+        let attached_depth = self.singleton_depth(attached_id);
+        let descendants = self
+            .graph
+            .declarations()
+            .get(&attached_id)
+            .and_then(Declaration::as_namespace)
+            .map(|namespace| namespace.descendants().iter().copied().collect::<Vec<_>>())
+            .unwrap_or_default();
+
+        for descendant_id in descendants {
+            if self.singleton_depth(descendant_id) != attached_depth {
+                continue;
+            }
+
+            let Some(descendant_singleton_id) = self.get_or_create_singleton_class(descendant_id, eager_ancestors)
+            else {
+                continue;
+            };
+
+            self.add_descendant(singleton_id, descendant_singleton_id, eager_ancestors);
+        }
+    }
+
+    fn add_descendant(&mut self, ancestor_id: DeclarationId, descendant_id: DeclarationId, eager_ancestors: bool) {
+        let (ancestor_singleton_id, inserted) = {
+            let ancestor = self.graph.declarations_mut().get_mut(&ancestor_id).unwrap();
+            let namespace = ancestor.as_namespace_mut().unwrap();
+            let inserted = !namespace.descendants().contains(&descendant_id);
+            namespace.add_descendant(descendant_id);
+            (namespace.singleton_class().copied(), inserted)
+        };
+
+        if !inserted {
+            return;
+        }
+
+        let Some(ancestor_singleton_id) = ancestor_singleton_id else {
+            return;
+        };
+
+        // Built-in singleton chains can include descendants at different singleton depths
+        // (e.g. `Class::<Class>` and `Object::<Object>::<<Object>>`). Only lift same-depth
+        // descendant edges; deeper singleton classes can still be created by the lazy parent path.
+        if self.singleton_depth(ancestor_id) != self.singleton_depth(descendant_id) {
+            return;
+        }
+
+        let Some(descendant_singleton_id) = self.get_or_create_singleton_class(descendant_id, eager_ancestors) else {
+            return;
+        };
+
+        self.add_descendant(ancestor_singleton_id, descendant_singleton_id, eager_ancestors);
+    }
+
+    fn singleton_depth(&self, declaration_id: DeclarationId) -> usize {
+        let mut depth = 0;
+        let mut current_id = declaration_id;
+
+        while let Some(declaration @ Declaration::Namespace(Namespace::SingletonClass(_))) =
+            self.graph.declarations().get(&current_id)
+        {
+            depth += 1;
+            current_id = *declaration.owner_id();
+        }
+
+        depth
     }
 
     /// Linearizes the ancestors of a declaration, returning the list of ancestor declaration IDs
@@ -935,7 +1014,12 @@ impl<'a> Resolver<'a> {
     /// Can panic if there's inconsistent data in the graph
     #[must_use]
     fn ancestors_of(&mut self, declaration_id: DeclarationId) -> Ancestors {
-        let mut context = LinearizationContext::new();
+        self.ancestors_of_with_singletons(declaration_id, false)
+    }
+
+    #[must_use]
+    fn ancestors_of_with_singletons(&mut self, declaration_id: DeclarationId, eager_singletons: bool) -> Ancestors {
+        let mut context = LinearizationContext::new(eager_singletons);
         self.linearize_ancestors(declaration_id, &mut context)
     }
 
@@ -956,7 +1040,7 @@ impl<'a> Resolver<'a> {
             // again
             if declaration.as_namespace().unwrap().has_complete_ancestors() {
                 let cached = declaration.as_namespace().unwrap().clone_ancestors();
-                self.propagate_descendants(&mut context.descendants, &cached);
+                self.propagate_descendants(&mut context.descendants, &cached, context.eager_singletons);
 
                 context.finalize(declaration_id);
                 return cached;
@@ -983,14 +1067,9 @@ impl<'a> Resolver<'a> {
 
             // Automatically track descendants as we recurse. This has to happen before checking the cache since we may have
             // already linearized the parent's ancestors, but it's the first time we're discovering the descendant
-            for descendant in &context.descendants {
-                self.graph
-                    .declarations_mut()
-                    .get_mut(&declaration_id)
-                    .unwrap()
-                    .as_namespace_mut()
-                    .unwrap()
-                    .add_descendant(*descendant);
+            let descendants = context.descendants.iter().copied().collect::<Vec<_>>();
+            for descendant in descendants {
+                self.add_descendant(declaration_id, descendant, context.eager_singletons);
             }
         }
 
@@ -1221,18 +1300,13 @@ impl<'a> Resolver<'a> {
         &mut self,
         descendants: &mut HashSet<DeclarationId, S>,
         cached: &Ancestors,
+        eager_ancestors: bool,
     ) {
         if !descendants.is_empty() {
             for ancestor in cached {
                 if let Ancestor::Complete(ancestor_id) = ancestor {
                     for descendant in descendants.iter() {
-                        self.graph
-                            .declarations_mut()
-                            .get_mut(ancestor_id)
-                            .unwrap()
-                            .as_namespace_mut()
-                            .unwrap()
-                            .add_descendant(*descendant);
+                        self.add_descendant(*ancestor_id, *descendant, eager_ancestors);
                     }
                 }
             }

--- a/rust/rubydex/src/resolution_tests.rs
+++ b/rust/rubydex/src/resolution_tests.rs
@@ -2487,6 +2487,106 @@ mod singleton_ancestors_tests {
     }
 
     #[test]
+    fn extended_meta_singleton_materializes_descendant_meta_singleton_classes() {
+        use crate::{model::ids::StringId, query::find_member_in_ancestors};
+
+        let mut context = graph_test();
+        context.index_uri(
+            "file:///foo.rb",
+            "
+            module M
+              def m; end
+            end
+
+            class Foo
+              class << self
+                extend M
+              end
+            end
+
+            class Bar < Foo
+            end
+            ",
+        );
+        context.resolve();
+
+        assert_declaration_exists!(context, "Bar::<Bar>::<<Bar>>");
+        assert_ancestors_eq!(
+            context,
+            "Bar::<Bar>::<<Bar>>",
+            [
+                "Bar::<Bar>::<<Bar>>",
+                "Foo::<Foo>::<<Foo>>",
+                "M",
+                "Object::<Object>::<<Object>>",
+                "BasicObject::<BasicObject>::<<BasicObject>>",
+                "Class::<Class>",
+                "Module::<Module>",
+                "Object::<Object>",
+                "BasicObject::<BasicObject>",
+                "Class",
+                "Module",
+                "Object",
+                "Kernel",
+                "BasicObject"
+            ]
+        );
+        assert_descendants!(context, "M", ["Foo::<Foo>::<<Foo>>", "Bar::<Bar>::<<Bar>>"]);
+        assert_eq!(
+            find_member_in_ancestors(
+                context.graph(),
+                DeclarationId::from("Bar::<Bar>::<<Bar>>"),
+                StringId::from("m()"),
+                false,
+            ),
+            Ok(DeclarationId::from("M#m()")),
+        );
+    }
+
+    #[test]
+    fn deeply_nested_meta_singleton_materializes_descendants_at_same_depth() {
+        use crate::{model::ids::StringId, query::find_member_in_ancestors};
+
+        let mut context = graph_test();
+        context.index_uri(
+            "file:///foo.rb",
+            "
+            module M
+              def m; end
+            end
+
+            class Foo
+              class << self
+                class << self
+                  extend M
+                end
+              end
+            end
+
+            class Bar < Foo
+            end
+            ",
+        );
+        context.resolve();
+
+        assert_declaration_exists!(context, "Bar::<Bar>::<<Bar>>::<<<Bar>>>");
+        assert_descendants!(
+            context,
+            "M",
+            ["Foo::<Foo>::<<Foo>>::<<<Foo>>>", "Bar::<Bar>::<<Bar>>::<<<Bar>>>"]
+        );
+        assert_eq!(
+            find_member_in_ancestors(
+                context.graph(),
+                DeclarationId::from("Bar::<Bar>::<<Bar>>::<<<Bar>>>"),
+                StringId::from("m()"),
+                false,
+            ),
+            Ok(DeclarationId::from("M#m()")),
+        );
+    }
+
+    #[test]
     fn extend_creates_singleton_class_with_existing_singleton_method() {
         let mut context = graph_test();
         context.index_uri(

--- a/rust/rubydex/src/resolution_tests.rs
+++ b/rust/rubydex/src/resolution_tests.rs
@@ -2373,6 +2373,39 @@ mod singleton_ancestors_tests {
     }
 
     #[test]
+    fn class_definitions_create_singleton_classes() {
+        let mut context = graph_test();
+        context.index_uri(
+            "file:///foo.rb",
+            "
+            class Foo
+            end
+
+            class Bar < Foo
+            end
+            ",
+        );
+        context.resolve();
+
+        assert_declaration_exists!(context, "Foo::<Foo>");
+        assert_ancestors_eq!(
+            context,
+            "Bar::<Bar>",
+            [
+                "Bar::<Bar>",
+                "Foo::<Foo>",
+                "Object::<Object>",
+                "BasicObject::<BasicObject>",
+                "Class",
+                "Module",
+                "Object",
+                "Kernel",
+                "BasicObject"
+            ]
+        );
+    }
+
+    #[test]
     fn extend_creates_singleton_class() {
         let mut context = graph_test();
         context.index_uri(
@@ -2403,6 +2436,44 @@ mod singleton_ancestors_tests {
                 "BasicObject"
             ]
         );
+    }
+
+    #[test]
+    fn extended_class_materializes_descendant_singleton_classes() {
+        let mut context = graph_test();
+        context.index_uri(
+            "file:///foo.rb",
+            "
+            module M; end
+
+            class Foo
+              extend M
+            end
+
+            class Bar < Foo
+            end
+            ",
+        );
+        context.resolve();
+
+        assert_declaration_exists!(context, "Bar::<Bar>");
+        assert_ancestors_eq!(
+            context,
+            "Bar::<Bar>",
+            [
+                "Bar::<Bar>",
+                "Foo::<Foo>",
+                "M",
+                "Object::<Object>",
+                "BasicObject::<BasicObject>",
+                "Class",
+                "Module",
+                "Object",
+                "Kernel",
+                "BasicObject"
+            ]
+        );
+        assert_descendants!(context, "M", ["Foo::<Foo>", "Bar::<Bar>"]);
     }
 
     #[test]

--- a/rust/rubydex/src/resolution_tests.rs
+++ b/rust/rubydex/src/resolution_tests.rs
@@ -2406,6 +2406,16 @@ mod singleton_ancestors_tests {
     }
 
     #[test]
+    fn class_definitions_keep_meta_singleton_classes_lazy() {
+        let mut context = graph_test();
+        context.index_uri("file:///foo.rb", "class Foo; end");
+        context.resolve();
+
+        assert_declaration_exists!(context, "Foo::<Foo>");
+        assert_declaration_does_not_exist!(context, "Foo::<Foo>::<<Foo>>");
+    }
+
+    #[test]
     fn extend_creates_singleton_class() {
         let mut context = graph_test();
         context.index_uri(

--- a/rust/rubydex/tests/cli.rs
+++ b/rust/rubydex/tests/cli.rs
@@ -62,7 +62,7 @@ fn prints_index_metrics() {
             .success()
             .stderr(predicate::str::is_empty())
             .stdout(predicate::str::contains("Indexed 3 files"))
-            .stdout(predicate::str::contains("Found 7 names"))
+            .stdout(predicate::str::contains("Found 14 names"))
             .stdout(predicate::str::contains("Found 7 definitions"));
     });
 }

--- a/test/declaration_test.rb
+++ b/test/declaration_test.rb
@@ -124,7 +124,7 @@ class DeclarationTest < Minitest::Test
       graph.index_all(context.glob("**/*.rb"))
       graph.resolve
 
-      assert_nil(graph["Foo"].singleton_class)
+      assert_equal("Foo::<Foo>", graph["Foo"].singleton_class.name)
 
       bar = graph["Foo::Bar"]
       assert_equal("Foo::Bar::<Bar>", bar.singleton_class.name)
@@ -581,6 +581,27 @@ class DeclarationTest < Minitest::Test
 
       decl = child.find_member("initialize()", only_inherited: true)
       assert_equal("Parent#initialize()", decl.name)
+    end
+  end
+
+  def test_find_member_returns_inherited_members_on_singleton_class
+    with_context do |context|
+      context.write!("file1.rb", <<~RUBY)
+        class Parent
+          def self.inherited_class_method
+          end
+        end
+
+        class Child < Parent
+        end
+      RUBY
+
+      graph = Rubydex::Graph.new
+      graph.index_all(context.glob("**/*.rb"))
+      graph.resolve
+
+      decl = graph["Child"].singleton_class.find_member("inherited_class_method()")
+      assert_equal("Parent::<Parent>#inherited_class_method()", decl.name)
     end
   end
 

--- a/test/graph_test.rb
+++ b/test/graph_test.rb
@@ -110,10 +110,10 @@ class GraphTest < Minitest::Test
 
       enumerator = graph.declarations
 
-      # Object, Class, Module, BasicObject, Kernel + the indexed files
-      assert_equal(7, enumerator.size)
-      assert_equal(7, enumerator.count)
-      assert_equal(7, enumerator.to_a.size)
+      # Object, Class, Module, BasicObject, Kernel + their singleton classes + the indexed files
+      assert_equal(14, enumerator.size)
+      assert_equal(14, enumerator.count)
+      assert_equal(14, enumerator.to_a.size)
     end
   end
 
@@ -131,7 +131,7 @@ class GraphTest < Minitest::Test
         declarations << declaration
       end
 
-      assert_equal(7, declarations.size)
+      assert_equal(14, declarations.size)
     end
   end
 
@@ -300,6 +300,24 @@ class GraphTest < Minitest::Test
   def test_graph_resolve_non_existing_constant
     graph = Rubydex::Graph.new
     assert_nil(graph.resolve_constant("CONST", ["Foo", "Bar::Baz"]))
+  end
+
+  def test_superclass_extend_module_descendants_include_subclass_singleton_class
+    graph = Rubydex::Graph.new
+    graph.index_source("file:///foo.rb", <<~RUBY, "ruby")
+      module Extension
+      end
+
+      class Parent
+        extend Extension
+      end
+
+      class Child < Parent
+      end
+    RUBY
+    graph.resolve
+
+    assert_includes(graph["Extension"].descendants.map(&:name), "Child::<Child>")
   end
 
   def test_graph_resolve_constant_with_empty_name


### PR DESCRIPTION
This PR materializes all singleton class declarations for class and module namespaces.

This is required for `descendants` enumeration and for `find_member_in_ancestors` correctness. Without these declarations, a subclass singleton class such as `Child::<Child>` may not exist when `Child` is only defined as `class Child < Parent`, so inherited singleton ancestors and members cannot be found.

## Impacted Ruby methods

- `Namespace#descendants` now includes materialized singleton class declarations.
- `Namespace#find_member` now returns members inherited through singleton class ancestors.

## Other user-facing changes

- Declaration search and completion results exclude materialized singleton class declarations, so newly materialized declarations do not appear as extra workspace symbols.

## Performance impact

Because this materializes singleton classes for every namespace declaration, it can add memory use and runtime cost. In practice, the measured impact was small.

- RSS: no measurable increase in synthetic corpus benchmarks or a large internal Ruby codebase
- Runtime: about 1.8% slower on a large internal Ruby codebase; not measurable in synthetic corpus benchmarks

## Validation

- Confirmed the superclass-extend descendants regression fails on `origin/main`: `Extension.descendants` lacks `Child::<Child>`
- Confirmed the singleton `find_member` regression fails on `origin/main`: `Child::<Child>` returns `DeclarationNotFound`
- `shadowenv exec -- cargo test -p rubydex find_member_in_ancestors_returns_inherited_singleton_member`
- `shadowenv exec -- bundle exec ruby -Itest test/declaration_test.rb -n /test_find_member_returns_inherited_members_on_singleton_class/`
- `shadowenv exec -- cargo test -p rubydex exact_match_empty_query_returns_all`
- `shadowenv exec -- cargo test -p rubydex`
- `shadowenv exec -- bundle exec rake ruby_test`
- `git diff --check HEAD~2..HEAD`
