### PR TITLE
Return Cypher query results as graph objects

### DIFF
--- a/ext/rubydex/graph.h
+++ b/ext/rubydex/graph.h
@@ -5,6 +5,12 @@
 
 extern const rb_data_type_t graph_type;
 
+static inline void *rdxi_graph_from_object(VALUE graph_obj) {
+    void *graph;
+    TypedData_Get_Struct(graph_obj, void *, &graph_type, graph);
+    return graph;
+}
+
 void rdxi_initialize_graph(VALUE mRubydex);
 
 #endif // RUBYDEX_GRAPH_H

--- a/ext/rubydex/query.c
+++ b/ext/rubydex/query.c
@@ -1,4 +1,7 @@
 #include "query.h"
+#include "declaration.h"
+#include "definition.h"
+#include "document.h"
 #include "graph.h"
 #include "rustbindings.h"
 #include "utils.h"
@@ -77,8 +80,7 @@ static VALUE rdxr_query_render(int argc, VALUE *argv, VALUE self) {
     void *query;
     TypedData_Get_Struct(self, void *, &query_type, query);
 
-    void *graph;
-    TypedData_Get_Struct(graph_obj, void *, &graph_type, graph);
+    void *graph = rdxi_graph_from_object(graph_obj);
 
     struct CQueryResult result = rdx_query_run(query, graph, rdxi_symbol_or_string_cstr(format, "table"));
 
@@ -96,10 +98,119 @@ static VALUE rdxr_query_render(int argc, VALUE *argv, VALUE self) {
     return output;
 }
 
+// Converts a structured result cell into a Ruby value. Node cells become real graph handles
+// (Declaration / Definition / Document) built against `graph_obj`; lists recurse.
+static VALUE cypher_cell_to_value(VALUE graph_obj, const struct CCell *cell) {
+    switch (cell->tag) {
+    case CCellTag_Null:
+        return Qnil;
+    case CCellTag_Bool:
+        return cell->payload.bool_val ? Qtrue : Qfalse;
+    case CCellTag_Int:
+        return LL2NUM(cell->payload.int_val);
+    case CCellTag_Str:
+        return cell->payload.str_val == NULL ? Qnil : rb_utf8_str_new_cstr(cell->payload.str_val);
+    case CCellTag_List: {
+        VALUE array = rb_ary_new_capa((long)cell->payload.list.len);
+        for (size_t i = 0; i < cell->payload.list.len; i++) {
+            rb_ary_push(array, cypher_cell_to_value(graph_obj, &cell->payload.list.items[i]));
+        }
+        return array;
+    }
+    case CCellTag_Map: {
+        VALUE hash = rb_hash_new();
+        for (size_t i = 0; i < cell->payload.map.len; i++) {
+            const char *raw_key = cell->payload.map.keys[i];
+            VALUE key = raw_key == NULL ? Qnil : rb_utf8_str_new_cstr(raw_key);
+            rb_hash_aset(hash, key, cypher_cell_to_value(graph_obj, &cell->payload.map.values[i]));
+        }
+        return hash;
+    }
+    case CCellTag_Node: {
+        VALUE argv[] = {graph_obj, ULL2NUM(cell->payload.node.id)};
+        VALUE klass;
+        switch (cell->payload.node.category) {
+        case CNodeCategory_Declaration:
+            klass = rdxi_declaration_class_for_kind((CDeclarationKind)cell->payload.node.kind);
+            break;
+        case CNodeCategory_Definition:
+            klass = rdxi_definition_class_for_kind((DefinitionKind)cell->payload.node.kind);
+            break;
+        case CNodeCategory_Document:
+        default:
+            klass = cDocument;
+            break;
+        }
+        return rb_class_new_instance(2, argv, klass);
+    }
+    default:
+        return Qnil;
+    }
+}
+
+// Body function for rb_ensure in Query#run — walks the iterator and builds the rows array.
+// May raise if cell conversion (e.g. handle construction) fails; the ensure function frees the
+// iterator regardless.
+static VALUE query_run_yield(VALUE args) {
+    VALUE graph_obj = rb_ary_entry(args, 0);
+    struct CRowsIter *iter = (struct CRowsIter *)(uintptr_t)NUM2ULL(rb_ary_entry(args, 1));
+
+    size_t column_count = rdx_rows_iter_column_count(iter);
+    const char *const *columns = rdx_rows_iter_columns(iter);
+    VALUE rows = rb_ary_new_capa((long)rdx_rows_iter_len(iter));
+
+    struct CResultRow row;
+    while (rdx_rows_iter_next(iter, &row)) {
+        VALUE hash = rb_hash_new();
+        for (size_t c = 0; c < row.len && c < column_count; c++) {
+            VALUE key = rb_utf8_str_new_cstr(columns[c]);
+            rb_hash_aset(hash, key, cypher_cell_to_value(graph_obj, &row.cells[c]));
+        }
+        rb_ary_push(rows, hash);
+    }
+
+    return rows;
+}
+
+// Ensure function for rb_ensure in Query#run to always free the iterator.
+static VALUE query_run_ensure(VALUE args) {
+    struct CRowsIter *iter = (struct CRowsIter *)(uintptr_t)NUM2ULL(rb_ary_entry(args, 1));
+    rdx_rows_iter_free(iter);
+    return Qnil;
+}
+
+/*
+ * call-seq:
+ *   run(graph) -> Array[Hash[String, Object]]
+ *
+ * Runs this parsed query against +graph+ and returns the rows as Ruby objects: each row is a Hash
+ * keyed by RETURN column name. Scalar cells become String/Integer/true/false/nil, lists become
+ * Arrays, and node cells become Declaration / Definition / Document handles. Raises ArgumentError
+ * on an execution error.
+ */
+static VALUE rdxr_query_run(VALUE self, VALUE graph_obj) {
+    void *query;
+    TypedData_Get_Struct(self, void *, &query_type, query);
+
+    void *graph = rdxi_graph_from_object(graph_obj);
+
+    struct CRunRows run = rdx_query_run_rows(query, graph);
+
+    if (run.error != NULL) {
+        VALUE message = rb_utf8_str_new_cstr(run.error);
+        free_c_string(run.error);
+        rb_raise(rb_eArgError, "%s", StringValueCStr(message));
+    }
+
+    VALUE args = rb_ary_new_from_args(2, graph_obj, ULL2NUM((uintptr_t)run.iter));
+    return rb_ensure(query_run_yield, args, query_run_ensure, args);
+}
+
 void rdxi_initialize_query(VALUE mRubydex) {
     VALUE cQuery = rb_define_class_under(mRubydex, "Query", rb_cObject);
     rb_undef_alloc_func(cQuery);
     rb_define_singleton_method(cQuery, "parse", rdxr_query_parse, 1);
     rb_define_singleton_method(cQuery, "schema", rdxr_cypher_schema, -1);
     rb_define_method(cQuery, "render", rdxr_query_render, -1);
+    rb_define_method(cQuery, "run", rdxr_query_run, 1);
 }

--- a/rbi/rubydex.rbi
+++ b/rbi/rubydex.rbi
@@ -287,6 +287,9 @@ class Rubydex::Query
     def schema(format = :table); end
   end
 
+  sig { params(graph: Rubydex::Graph).returns(T::Array[T::Hash[String, T.untyped]]) }
+  def run(graph); end
+
   sig { params(graph: Rubydex::Graph, format: T.any(String, Symbol)).returns(String) }
   def render(graph, format = :table); end
 end

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -262,9 +262,9 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "cypher-parser"
-version = "0.2.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed0d1e561d51e651bdf70f8439da293fd0f1fe34d8431059061eadaefc7abb1"
+checksum = "6ada60f869dbe5818d0ee40b06ad988627cc0d692d1ed42d692353bf0af8ddb6"
 
 [[package]]
 name = "difflib"

--- a/rust/rubydex-sys/src/cypher_api.rs
+++ b/rust/rubydex-sys/src/cypher_api.rs
@@ -1,0 +1,547 @@
+//! This file provides the C API for Cypher query parsing, schema, and structured execution.
+//! It connects to the graph through `graph_api::with_graph`.
+
+use crate::declaration_api::CDeclaration;
+use crate::definition_api::map_definition_to_kind;
+use crate::graph_api::{GraphPointer, with_graph};
+use crate::utils;
+use libc::{c_char, c_void};
+use rubydex::model::graph::Graph;
+use rubydex::query::cypher::schema::NodeRef;
+use rubydex::query::cypher::{self, CypherValue, OutputFormat};
+use std::ffi::CString;
+use std::ptr;
+
+/// The result of running a Cypher query, carrying either the formatted output or an error message.
+#[repr(C)]
+pub struct CQueryResult {
+    /// Non-null on success; null on error. Caller must free with `free_c_string`.
+    pub output: *const c_char,
+    /// Non-null on error; null on success. Caller must free with `free_c_string`.
+    pub error: *const c_char,
+}
+
+impl CQueryResult {
+    #[must_use]
+    pub fn success(output: &str) -> Self {
+        match CString::new(output) {
+            Ok(c_string) => Self {
+                output: c_string.into_raw().cast_const(),
+                error: ptr::null(),
+            },
+            Err(_) => Self::error("query output contained an interior NUL byte"),
+        }
+    }
+
+    #[must_use]
+    pub fn error(message: &str) -> Self {
+        Self {
+            output: ptr::null(),
+            error: utils::cstring_raw(message),
+        }
+    }
+}
+
+/// The result of parsing a Cypher query into an opaque, reusable parsed-query object.
+#[repr(C)]
+pub struct CParseResult {
+    /// Non-null on success: a heap-allocated parsed query. Free with `rdx_cypher_query_free`.
+    pub query: *mut c_void,
+    /// Non-null on error; null on success. Caller must free with `free_c_string`.
+    pub error: *const c_char,
+}
+
+/// Parses a Cypher query string into an opaque parsed-query object, without needing a graph.
+///
+/// On success, `query` is a heap-allocated parsed query that can be executed against a graph with
+/// `rdx_query_run` and must eventually be freed with `rdx_cypher_query_free`. On failure, `error`
+/// holds the message.
+///
+/// # Safety
+///
+/// - `query` must be a valid, null-terminated UTF-8 string.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rdx_cypher_parse(query: *const c_char) -> CParseResult {
+    let Ok(query_str) = (unsafe { utils::convert_char_ptr_to_string(query) }) else {
+        return CParseResult {
+            query: ptr::null_mut(),
+            error: utils::cstring_raw("query is not valid UTF-8"),
+        };
+    };
+
+    match cypher::parse(&query_str) {
+        Ok(parsed) => CParseResult {
+            query: Box::into_raw(Box::new(parsed)).cast::<c_void>(),
+            error: ptr::null(),
+        },
+        Err(error) => CParseResult {
+            query: ptr::null_mut(),
+            error: utils::cstring_raw(&error.to_string()),
+        },
+    }
+}
+
+/// Frees a parsed query previously returned by `rdx_cypher_parse`.
+///
+/// # Safety
+///
+/// - `query` must be a pointer returned by `rdx_cypher_parse`, or null. It must not be used after.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rdx_cypher_query_free(query: *mut c_void) {
+    if query.is_null() {
+        return;
+    }
+    let _ = unsafe { Box::from_raw(query.cast::<cypher::Query>()) };
+}
+
+/// Returns a description of the queryable Cypher schema (node labels, relationship types, and
+/// properties) in the given format (`"table"` or `"json"`). The schema is static and requires no
+/// graph. Caller must free the returned pointer with `free_c_string`.
+///
+/// # Safety
+///
+/// - `format` must be a valid, null-terminated UTF-8 string.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rdx_cypher_schema(format: *const c_char) -> *const c_char {
+    let format_str = unsafe { utils::convert_char_ptr_to_string(format) }.unwrap_or_else(|_| "table".to_string());
+    let output_format = if format_str == "json" {
+        OutputFormat::Json
+    } else {
+        OutputFormat::Table
+    };
+
+    utils::cstring_raw(&cypher::schema(output_format))
+}
+
+// ---------------------------------------------------------------------------
+// Structured result types (object-returning query execution)
+// ---------------------------------------------------------------------------
+
+/// Tag for a structured result cell.
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CCellTag {
+    Null = 0,
+    Bool = 1,
+    Int = 2,
+    Str = 3,
+    Node = 4,
+    List = 5,
+    Map = 6,
+}
+
+/// Which family of graph node a `Node` cell refers to (selects the Ruby handle class family).
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CNodeCategory {
+    Declaration = 0,
+    Definition = 1,
+    Document = 2,
+}
+
+/// `Node` cell payload: which handle family to build, the kind value, and the entity id.
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct CNode {
+    /// Which handle family to build.
+    pub category: CNodeCategory,
+    /// The `CDeclarationKind`/`DefinitionKind` value (ignored for documents).
+    pub kind: u32,
+    /// The entity id to build the handle from.
+    pub id: u64,
+}
+
+/// `List` cell payload: a heap array of nested cells (freed by `rdx_rows_iter_free`).
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct CList {
+    pub items: *mut CCell,
+    pub len: usize,
+}
+
+/// `Map` cell payload: parallel heap arrays of owned key strings and their value cells, in order
+/// (both `len` long, freed by `rdx_rows_iter_free`). Stored as separate arrays rather than an
+/// entry struct so no `CCell` is embedded by value (keeping the generated header well-ordered).
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct CMap {
+    pub keys: *mut *const c_char,
+    pub values: *mut CCell,
+    pub len: usize,
+}
+
+/// Payload of a `CCell`. The active field is selected by the cell's `tag`; reading any other field
+/// is undefined. `Null` carries no payload.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub union CCellPayload {
+    /// `Bool`.
+    pub bool_val: bool,
+    /// `Int`.
+    pub int_val: i64,
+    /// `Str`: owned C string (freed by `rdx_rows_iter_free`).
+    pub str_val: *const c_char,
+    /// `Node`.
+    pub node: CNode,
+    /// `List`.
+    pub list: CList,
+    /// `Map`.
+    pub map: CMap,
+}
+
+/// A single structured result value: a `tag` discriminant plus a `payload` union whose active
+/// field the tag selects.
+#[repr(C)]
+pub struct CCell {
+    pub tag: CCellTag,
+    pub payload: CCellPayload,
+}
+
+impl CCell {
+    fn new(tag: CCellTag, payload: CCellPayload) -> Self {
+        Self { tag, payload }
+    }
+
+    fn null() -> Self {
+        Self {
+            tag: CCellTag::Null,
+            payload: CCellPayload { int_val: 0 },
+        }
+    }
+}
+
+/// One row of structured cells.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct CResultRow {
+    pub cells: *mut CCell,
+    pub len: usize,
+}
+
+/// Iterator over structured query result rows. Opaque from the C side — use
+/// `rdx_rows_iter_column_count`, `rdx_rows_iter_columns`, `rdx_rows_iter_len`, `rdx_rows_iter_next`,
+/// and `rdx_rows_iter_free`.
+pub struct CRowsIter {
+    columns: Box<[*const c_char]>,
+    rows: Box<[CResultRow]>,
+    index: usize,
+}
+
+/// The result of running a query for structured rows: either a row iterator or an error message.
+#[repr(C)]
+pub struct CRunRows {
+    /// Non-null on success; free with `rdx_rows_iter_free`.
+    pub iter: *mut CRowsIter,
+    /// Non-null on error; free with `free_c_string`.
+    pub error: *const c_char,
+}
+
+/// Converts a `CypherValue` into a `CCell`, resolving node identity to a handle-buildable category +
+/// kind + id. A node whose id cannot be decoded or found falls back to its display name as a string.
+fn build_cell(graph: &Graph, value: &CypherValue) -> CCell {
+    match value {
+        CypherValue::Null => CCell::null(),
+        CypherValue::Bool(b) => CCell::new(CCellTag::Bool, CCellPayload { bool_val: *b }),
+        CypherValue::Int(i) => CCell::new(CCellTag::Int, CCellPayload { int_val: *i }),
+        CypherValue::Str(s) => CCell::new(
+            CCellTag::Str,
+            CCellPayload {
+                str_val: utils::cstring_raw(s),
+            },
+        ),
+        CypherValue::List(items) => {
+            let cells: Vec<CCell> = items.iter().map(|item| build_cell(graph, item)).collect();
+            let len = cells.len();
+            let items = if cells.is_empty() {
+                ptr::null_mut()
+            } else {
+                Box::into_raw(cells.into_boxed_slice()).cast::<CCell>()
+            };
+            CCell::new(
+                CCellTag::List,
+                CCellPayload {
+                    list: CList { items, len },
+                },
+            )
+        }
+        CypherValue::Map(pairs) => {
+            let len = pairs.len();
+            let mut keys: Vec<*const c_char> = Vec::with_capacity(len);
+            let mut values: Vec<CCell> = Vec::with_capacity(len);
+            for (key, val) in pairs {
+                keys.push(utils::cstring_raw(key));
+                values.push(build_cell(graph, val));
+            }
+            let (keys, values) = if len == 0 {
+                (ptr::null_mut(), ptr::null_mut())
+            } else {
+                (
+                    Box::into_raw(keys.into_boxed_slice()).cast::<*const c_char>(),
+                    Box::into_raw(values.into_boxed_slice()).cast::<CCell>(),
+                )
+            };
+            CCell::new(
+                CCellTag::Map,
+                CCellPayload {
+                    map: CMap { keys, values, len },
+                },
+            )
+        }
+        CypherValue::Node { id, name, .. } => build_node_cell(graph, id).unwrap_or_else(|| {
+            CCell::new(
+                CCellTag::Str,
+                CCellPayload {
+                    str_val: utils::cstring_raw(name),
+                },
+            )
+        }),
+    }
+}
+
+/// Builds a `Node` cell by decoding the opaque node id and looking up its kind in the graph.
+fn build_node_cell(graph: &Graph, encoded_id: &str) -> Option<CCell> {
+    match NodeRef::decode(encoded_id)? {
+        NodeRef::Declaration(id) => {
+            let kind = CDeclaration::kind_from_declaration(graph.declarations().get(&id)?);
+            Some(CCell::new(
+                CCellTag::Node,
+                CCellPayload {
+                    node: CNode {
+                        category: CNodeCategory::Declaration,
+                        kind: kind as u32,
+                        id: *id,
+                    },
+                },
+            ))
+        }
+        NodeRef::Definition(id) => {
+            let kind = map_definition_to_kind(graph.definitions().get(&id)?);
+            Some(CCell::new(
+                CCellTag::Node,
+                CCellPayload {
+                    node: CNode {
+                        category: CNodeCategory::Definition,
+                        kind: kind as u32,
+                        id: *id,
+                    },
+                },
+            ))
+        }
+        NodeRef::Document(id) => graph.documents().contains_key(&id).then(|| {
+            CCell::new(
+                CCellTag::Node,
+                CCellPayload {
+                    node: CNode {
+                        category: CNodeCategory::Document,
+                        kind: 0,
+                        id: *id,
+                    },
+                },
+            )
+        }),
+    }
+}
+
+/// Runs a previously parsed query and returns a row iterator (column names + typed rows),
+/// so callers can build their own value/handle objects instead of a formatted string.
+///
+/// # Safety
+///
+/// - `query` must be a valid pointer returned by `rdx_cypher_parse`.
+/// - `pointer` must be a valid `GraphPointer` previously returned by this crate.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rdx_query_run_rows(query: *const c_void, pointer: GraphPointer) -> CRunRows {
+    if query.is_null() {
+        return CRunRows {
+            iter: ptr::null_mut(),
+            error: utils::cstring_raw("query is null"),
+        };
+    }
+
+    let parsed = unsafe { &*query.cast::<cypher::Query>() };
+
+    with_graph(pointer, |graph| {
+        let result_set = match cypher::execute(graph, parsed) {
+            Ok(result_set) => result_set,
+            Err(error) => {
+                return CRunRows {
+                    iter: ptr::null_mut(),
+                    error: utils::cstring_raw(&error.to_string()),
+                };
+            }
+        };
+
+        let columns: Box<[*const c_char]> = result_set.columns.iter().map(|name| utils::cstring_raw(name)).collect();
+
+        let rows: Box<[CResultRow]> = result_set
+            .rows
+            .iter()
+            .map(|row| {
+                let cells: Vec<CCell> = row.iter().map(|cell| build_cell(graph, cell)).collect();
+                let len = cells.len();
+                let cells_ptr = if cells.is_empty() {
+                    ptr::null_mut()
+                } else {
+                    Box::into_raw(cells.into_boxed_slice()).cast::<CCell>()
+                };
+                CResultRow { cells: cells_ptr, len }
+            })
+            .collect();
+
+        CRunRows {
+            iter: Box::into_raw(Box::new(CRowsIter {
+                columns,
+                rows,
+                index: 0,
+            })),
+            error: ptr::null(),
+        }
+    })
+}
+
+/// Returns the number of columns in the result set.
+///
+/// # Safety
+///
+/// - `iter` must be a valid pointer returned by `rdx_query_run_rows`, or null.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rdx_rows_iter_column_count(iter: *const CRowsIter) -> usize {
+    if iter.is_null() {
+        return 0;
+    }
+    let iter = unsafe { &*iter };
+    iter.columns.len()
+}
+
+/// Returns a pointer to the array of column name C strings. The array has
+/// `rdx_rows_iter_column_count(iter)` entries and is valid for the lifetime of the iterator.
+///
+/// # Safety
+///
+/// - `iter` must be a valid pointer returned by `rdx_query_run_rows`, or null.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rdx_rows_iter_columns(iter: *const CRowsIter) -> *const *const c_char {
+    if iter.is_null() {
+        return ptr::null();
+    }
+    let iter = unsafe { &*iter };
+    iter.columns.as_ptr()
+}
+
+/// Returns the number of rows in the result set.
+///
+/// # Safety
+///
+/// - `iter` must be a valid pointer returned by `rdx_query_run_rows`, or null.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rdx_rows_iter_len(iter: *const CRowsIter) -> usize {
+    if iter.is_null() {
+        return 0;
+    }
+    let iter = unsafe { &*iter };
+    iter.rows.len()
+}
+
+/// Advances the iterator and copies the next row into `out`. Returns `true` if a row was read,
+/// `false` if the iterator is exhausted. The copied `CResultRow` is a view into the iterator's
+/// owned cells — it remains valid until `rdx_rows_iter_free` is called.
+///
+/// # Safety
+///
+/// - `iter` must be a valid pointer returned by `rdx_query_run_rows`, or null.
+/// - `out` must be a valid, writable pointer, or null.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rdx_rows_iter_next(iter: *mut CRowsIter, out: *mut CResultRow) -> bool {
+    if iter.is_null() || out.is_null() {
+        return false;
+    }
+
+    let it = unsafe { &mut *iter };
+    if it.index >= it.rows.len() {
+        return false;
+    }
+
+    let row = it.rows[it.index];
+    it.index += 1;
+    unsafe {
+        *out = row;
+    }
+
+    true
+}
+
+/// Recursively frees a `CCell`'s owned allocations (its string, or its nested list cells).
+unsafe fn free_cell(cell: &CCell) {
+    match cell.tag {
+        // SAFETY: the tag selects the active union field.
+        CCellTag::Str => {
+            let str_val = unsafe { cell.payload.str_val };
+            if !str_val.is_null() {
+                let _ = unsafe { CString::from_raw(str_val.cast_mut()) };
+            }
+        }
+        // SAFETY: the tag selects the active union field.
+        CCellTag::List => {
+            let list = unsafe { cell.payload.list };
+            if !list.items.is_null() && list.len > 0 {
+                let slice = unsafe { Box::from_raw(ptr::slice_from_raw_parts_mut(list.items, list.len)) };
+                for nested in &slice {
+                    unsafe { free_cell(nested) };
+                }
+            }
+        }
+        // SAFETY: the tag selects the active union field.
+        CCellTag::Map => {
+            let map = unsafe { cell.payload.map };
+            if map.len > 0 {
+                if !map.keys.is_null() {
+                    let keys = unsafe { Box::from_raw(ptr::slice_from_raw_parts_mut(map.keys, map.len)) };
+                    for key in &keys {
+                        if !key.is_null() {
+                            let _ = unsafe { CString::from_raw(key.cast_mut()) };
+                        }
+                    }
+                }
+                if !map.values.is_null() {
+                    let values = unsafe { Box::from_raw(ptr::slice_from_raw_parts_mut(map.values, map.len)) };
+                    for nested in &values {
+                        unsafe { free_cell(nested) };
+                    }
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Frees a `CRowsIter` previously returned by `rdx_query_run_rows`, including all column strings,
+/// row cells, and nested allocations.
+///
+/// # Safety
+///
+/// - `iter` must be a pointer returned by `rdx_query_run_rows`, or null. It must not be used after.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rdx_rows_iter_free(iter: *mut CRowsIter) {
+    if iter.is_null() {
+        return;
+    }
+
+    let it = unsafe { Box::from_raw(iter) };
+
+    // Free column C strings (the boxed slice itself is freed when `it` drops).
+    for &col in &it.columns {
+        if !col.is_null() {
+            let _ = unsafe { CString::from_raw(col.cast_mut()) };
+        }
+    }
+
+    // Free cells in each row (the boxed slice of CResultRow is freed when `it` drops).
+    for row in &it.rows {
+        if !row.cells.is_null() && row.len > 0 {
+            let cells = unsafe { Box::from_raw(ptr::slice_from_raw_parts_mut(row.cells, row.len)) };
+            for cell in &cells {
+                unsafe { free_cell(cell) };
+            }
+        }
+    }
+}

--- a/rust/rubydex-sys/src/graph_api.rs
+++ b/rust/rubydex-sys/src/graph_api.rs
@@ -1,5 +1,6 @@
 //! This file provides the C API for the Graph object
 
+use crate::cypher_api::CQueryResult;
 use crate::declaration_api::CDeclaration;
 use crate::declaration_api::DeclarationsIter;
 use crate::declaration_api::decl_id_from_char_ptr;
@@ -1063,86 +1064,6 @@ pub unsafe extern "C" fn rdx_keyword_get(name: *const c_char) -> *const CKeyword
     }
 }
 
-/// The result of running a Cypher query, carrying either the formatted output or an error message.
-#[repr(C)]
-pub struct CQueryResult {
-    /// Non-null on success; null on error. Caller must free with `free_c_string`.
-    pub output: *const c_char,
-    /// Non-null on error; null on success. Caller must free with `free_c_string`.
-    pub error: *const c_char,
-}
-
-impl CQueryResult {
-    fn success(output: &str) -> Self {
-        match CString::new(output) {
-            Ok(c_string) => Self {
-                output: c_string.into_raw().cast_const(),
-                error: ptr::null(),
-            },
-            Err(_) => Self::error("query output contained an interior NUL byte"),
-        }
-    }
-
-    fn error(message: &str) -> Self {
-        Self {
-            output: ptr::null(),
-            error: CString::new(message).map_or(ptr::null(), |s| s.into_raw().cast_const()),
-        }
-    }
-}
-
-/// The result of parsing a Cypher query into an opaque, reusable parsed-query object.
-#[repr(C)]
-pub struct CParseResult {
-    /// Non-null on success: a heap-allocated parsed query. Free with `rdx_cypher_query_free`.
-    pub query: *mut c_void,
-    /// Non-null on error; null on success. Caller must free with `free_c_string`.
-    pub error: *const c_char,
-}
-
-/// Parses a Cypher query string into an opaque parsed-query object, without needing a graph.
-///
-/// On success, `query` is a heap-allocated parsed query that can be executed against a graph with
-/// `rdx_query_run` and must eventually be freed with `rdx_cypher_query_free`. On failure, `error`
-/// holds the message.
-///
-/// # Safety
-///
-/// - `query` must be a valid, null-terminated UTF-8 string.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn rdx_cypher_parse(query: *const c_char) -> CParseResult {
-    let Ok(query_str) = (unsafe { utils::convert_char_ptr_to_string(query) }) else {
-        return CParseResult {
-            query: ptr::null_mut(),
-            error: CString::new("query is not valid UTF-8").map_or(ptr::null(), |s| s.into_raw().cast_const()),
-        };
-    };
-
-    match cypher::parse(&query_str) {
-        Ok(parsed) => CParseResult {
-            query: Box::into_raw(Box::new(parsed)).cast::<c_void>(),
-            error: ptr::null(),
-        },
-        Err(error) => CParseResult {
-            query: ptr::null_mut(),
-            error: CString::new(error.to_string()).map_or(ptr::null(), |s| s.into_raw().cast_const()),
-        },
-    }
-}
-
-/// Frees a parsed query previously returned by `rdx_cypher_parse`.
-///
-/// # Safety
-///
-/// - `query` must be a pointer returned by `rdx_cypher_parse`, or null. It must not be used after.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn rdx_cypher_query_free(query: *mut c_void) {
-    if query.is_null() {
-        return;
-    }
-    let _ = unsafe { Box::from_raw(query.cast::<cypher::Query>()) };
-}
-
 /// Executes a previously parsed query (from `rdx_cypher_parse`) against the graph and returns the
 /// formatted output or an error message. `format` must be `"table"` or `"json"`.
 ///
@@ -1181,25 +1102,6 @@ pub unsafe extern "C" fn rdx_query_run(
             Err(error) => CQueryResult::error(&error.to_string()),
         }
     })
-}
-
-/// Returns a description of the queryable Cypher schema (node labels, relationship types, and
-/// properties) in the given format (`"table"` or `"json"`). The schema is static and requires no
-/// graph. Caller must free the returned pointer with `free_c_string`.
-///
-/// # Safety
-///
-/// - `format` must be a valid, null-terminated UTF-8 string.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn rdx_cypher_schema(format: *const c_char) -> *const c_char {
-    let format_str = unsafe { utils::convert_char_ptr_to_string(format) }.unwrap_or_else(|_| "table".to_string());
-    let output_format = if format_str == "json" {
-        OutputFormat::Json
-    } else {
-        OutputFormat::Table
-    };
-
-    CString::new(cypher::schema(output_format)).map_or(ptr::null(), |s| s.into_raw().cast_const())
 }
 
 #[repr(u8)]

--- a/rust/rubydex-sys/src/lib.rs
+++ b/rust/rubydex-sys/src/lib.rs
@@ -68,6 +68,7 @@ macro_rules! iterator {
     };
 }
 
+pub mod cypher_api;
 pub mod declaration_api;
 pub mod definition_api;
 pub mod diagnostic_api;

--- a/rust/rubydex-sys/src/utils.rs
+++ b/rust/rubydex-sys/src/utils.rs
@@ -68,3 +68,14 @@ pub unsafe extern "C" fn free_c_string_array(ptr: *const *const c_char, count: u
         .map(|arg| unsafe { CString::from_raw((*arg).cast_mut()) })
         .collect();
 }
+
+/// Converts a Rust `&str` to an owned C string (`*const c_char`), suitable for returning across the
+/// FFI boundary. The caller is responsible for freeing it with `free_c_string`.
+///
+/// # Panics
+///
+/// Panics if `value` contains an interior null byte, which should never occur in rubydex data.
+#[must_use]
+pub fn cstring_raw(value: &str) -> *const c_char {
+    CString::new(value).unwrap().into_raw().cast_const()
+}

--- a/rust/rubydex/Cargo.toml
+++ b/rust/rubydex/Cargo.toml
@@ -27,7 +27,7 @@ jemalloc_dylib = ["jemalloc", "tikv-jemallocator/disable_initial_exec_tls"]
 test_utils = ["dep:tempfile"]
 
 [dependencies]
-cypher-parser = "0.2"
+cypher-parser = "0.8.1"
 ruby-prism = "1.9.0"
 ruby-rbs = "0.3"
 url = "2.5.4"

--- a/rust/rubydex/src/query/cypher.rs
+++ b/rust/rubydex/src/query/cypher.rs
@@ -19,7 +19,7 @@
 //
 // `Query` is the opaque parsed-query object: callers can `parse` a query string once (failing fast
 // on syntax errors), then `run_parsed` it against a graph that was built afterwards.
-pub use cypher_parser::{CypherError, OutputFormat, Query, parse};
+pub use cypher_parser::{CypherError, CypherValue, OutputFormat, Query, ResultSet, execute, parse};
 
 pub mod schema;
 pub mod schema_info;

--- a/rust/rubydex/src/query/cypher/schema.rs
+++ b/rust/rubydex/src/query/cypher/schema.rs
@@ -39,6 +39,22 @@ pub enum NodeRef {
     Document(UriId),
 }
 
+impl NodeRef {
+    /// Decodes the opaque id produced by [`GraphProvider::node_id`] back into a `NodeRef`. Returns
+    /// `None` if the string is not a recognized `tag:id` form.
+    #[must_use]
+    pub fn decode(encoded: &str) -> Option<NodeRef> {
+        let (tag, rest) = encoded.split_once(':')?;
+        let value: u64 = rest.parse().ok()?;
+        match tag {
+            "decl" => Some(NodeRef::Declaration(DeclarationId::new(value))),
+            "def" => Some(NodeRef::Definition(DefinitionId::new(value))),
+            "doc" => Some(NodeRef::Document(UriId::new(value))),
+            _ => None,
+        }
+    }
+}
+
 /// A relationship type.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum RelType {
@@ -377,6 +393,10 @@ impl GraphProvider for Graph {
         RelType::parse(rel_type).map_or_else(Vec::new, |rel| rel_source_nodes(self, rel))
     }
 
+    fn expand_in(&self, node: NodeRef, rel_type: &str) -> Option<Vec<NodeRef>> {
+        RelType::parse(rel_type).and_then(|rel| expand_in(self, node, rel))
+    }
+
     fn property(&self, node: NodeRef, prop: &str) -> CypherValue {
         property(self, node, prop)
     }
@@ -387,6 +407,17 @@ impl GraphProvider for Graph {
 
     fn name(&self, node: NodeRef) -> String {
         node_name(self, node)
+    }
+
+    fn node_id(&self, node: NodeRef) -> String {
+        // Encode the node category plus the underlying hashed id so a consumer can decode it back to
+        // the right handle. The category tag is required because labels alone are ambiguous
+        // (a class declaration and a class definition both have the label "Class").
+        match node {
+            NodeRef::Declaration(id) => format!("decl:{}", *id),
+            NodeRef::Definition(id) => format!("def:{}", *id),
+            NodeRef::Document(id) => format!("doc:{}", *id),
+        }
     }
 }
 
@@ -579,6 +610,38 @@ pub fn rel_source_nodes(graph: &Graph, rel: RelType) -> Vec<NodeRef> {
             .keys()
             .map(|id| NodeRef::Declaration(*id))
             .collect(),
+    }
+}
+
+/// Expands the *incoming* edges of `node` for the given relationship type — the targeted reverse of
+/// [`expand_out`], returning `Some` only when the graph stores the reverse cheaply and exactly.
+/// Returning `None` lets the executor fall back to `rel_sources` + `expand` (always correct, but an
+/// O(all sources) whole-graph build).
+///
+/// Only the Document → Definition → Declaration spine is answered directly:
+/// - reverse `DEFINES`: a definition's document (each definition belongs to exactly one).
+/// - reverse `DECLARES`: the per-file definitions composing a declaration.
+///
+/// The remaining edges either have no stored reverse (e.g. direct subclasses of `HAS_PARENT`) or a
+/// reverse that isn't an exact set match (the `HAS_DESCENDANT` set is self-inclusive, unlike the
+/// `HAS_ANCESTOR` walk), so they fall through to the default.
+#[must_use]
+pub fn expand_in(graph: &Graph, node: NodeRef, rel: RelType) -> Option<Vec<NodeRef>> {
+    match (node, rel) {
+        (NodeRef::Definition(def_id), RelType::Defines) => {
+            let uri_id = *graph.definitions().get(&def_id)?.uri_id();
+            Some(vec![NodeRef::Document(uri_id)])
+        }
+        (NodeRef::Declaration(decl_id), RelType::Declares) => Some(
+            graph
+                .declarations()
+                .get(&decl_id)?
+                .definitions()
+                .iter()
+                .map(|id| NodeRef::Definition(*id))
+                .collect(),
+        ),
+        _ => None,
     }
 }
 

--- a/rust/rubydex/src/query/cypher/tests.rs
+++ b/rust/rubydex/src/query/cypher/tests.rs
@@ -198,6 +198,17 @@ fn run_query_json_output() {
 }
 
 #[test]
+fn incoming_declares_and_defines_reach_the_document() {
+    // Exercises `expand_in`: walk the Document -> Definition -> Declaration spine backwards.
+    let graph = fixture_graph();
+    let result = run(
+        &graph,
+        "MATCH (decl:Class {name: 'Dog'})<-[:DECLARES]-(def:Definition)<-[:DEFINES]-(d:Document) RETURN DISTINCT d.name",
+    );
+    assert_eq!(column_strings(&result, 0), vec!["zoo.rb".to_string()]);
+}
+
+#[test]
 fn unknown_relationship_type_errors() {
     let graph = fixture_graph();
     let parsed = parse("MATCH (a)-[:BOGUS]->(b) RETURN a").unwrap();

--- a/test/graph_test.rb
+++ b/test/graph_test.rb
@@ -1604,7 +1604,7 @@ class GraphTest < Minitest::Test
     assert(parsed["relationships"].any? { |r| r["type"] == "DEFINES" })
   end
 
-  def test_parsed_query_runs_against_graph
+  def test_run_returns_rows_of_hashes
     with_context do |context|
       context.write!("zoo.rb", "class Animal; end\nclass Dog < Animal; end\n")
 
@@ -1615,7 +1615,81 @@ class GraphTest < Minitest::Test
       graph.index_all(context.glob("**/*.rb"))
       graph.resolve
 
-      assert_equal("[{\"p.name\":\"Animal\"}]", query.render(graph, :json))
+      rows = query.run(graph)
+      assert_equal([{ "p.name" => "Animal" }], rows)
+    end
+  end
+
+  def test_run_returns_declaration_handles_for_node_cells
+    with_context do |context|
+      context.write!("zoo.rb", "class Animal; end\nclass Dog < Animal; end\n")
+
+      query = Rubydex::Query.parse("MATCH (c:Class {name: 'Dog'}) RETURN c")
+
+      graph = Rubydex::Graph.new
+      graph.index_all(context.glob("**/*.rb"))
+      graph.resolve
+
+      rows = query.run(graph)
+      assert_equal(1, rows.length)
+      node = rows.first["c"]
+      assert_kind_of(Rubydex::Declaration, node)
+      assert_equal("Dog", node.name)
+    end
+  end
+
+  def test_run_maps_scalars_and_aggregates
+    with_context do |context|
+      context.write!("zoo.rb", "class Animal; end\nclass Dog < Animal; end\nclass Cat < Animal; end\n")
+
+      query = Rubydex::Query.parse(
+        "MATCH (c:Class)-[:HAS_PARENT]->(p:Class) WHERE p.name = 'Animal' RETURN p.name, count(c) AS subclasses",
+      )
+
+      graph = Rubydex::Graph.new
+      graph.index_all(context.glob("**/*.rb"))
+      graph.resolve
+
+      assert_equal([{ "p.name" => "Animal", "subclasses" => 2 }], query.run(graph))
+    end
+  end
+
+  def test_run_returns_hashes_for_map_projections
+    with_context do |context|
+      context.write!("zoo.rb", "class Dog; end\n")
+
+      query = Rubydex::Query.parse("MATCH (c:Class {name: 'Dog'}) RETURN c { .name, .kind }")
+
+      graph = Rubydex::Graph.new
+      graph.index_all(context.glob("**/*.rb"))
+      graph.resolve
+
+      rows = query.run(graph)
+      assert_equal(1, rows.length)
+      projection = rows.first.values.first
+      assert_kind_of(Hash, projection)
+      assert_equal("Dog", projection["name"])
+      assert_equal("Class", projection["kind"])
+    end
+  end
+
+  def test_run_matches_label_disjunction
+    with_context do |context|
+      context.write!("zoo.rb", <<~RUBY)
+        class Animal; end
+        module Walkable; end
+        class Dog < Animal; end
+      RUBY
+
+      query = Rubydex::Query.parse(
+        "MATCH (n:Class|Module) WHERE n.name = 'Animal' OR n.name = 'Walkable' RETURN n.name ORDER BY n.name",
+      )
+
+      graph = Rubydex::Graph.new
+      graph.index_all(context.glob("**/*.rb"))
+      graph.resolve
+
+      assert_equal([{ "n.name" => "Animal" }, { "n.name" => "Walkable" }], query.run(graph))
     end
   end
 
@@ -1633,11 +1707,11 @@ class GraphTest < Minitest::Test
       graph.index_all(context.glob("**/*.rb"))
       graph.resolve
 
-      assert_equal("[{\"c.name\":\"Dog\"}]", query.render(graph, :json))
+      assert_equal([{ "c.name" => "Dog" }], query.run(graph))
     end
   end
 
-  def test_query_returns_table_output
+  def test_render_returns_table_output
     with_context do |context|
       context.write!("zoo.rb", <<~RUBY)
         class Animal; end
@@ -1659,27 +1733,7 @@ class GraphTest < Minitest::Test
     end
   end
 
-  def test_query_label_disjunction
-    with_context do |context|
-      context.write!("zoo.rb", <<~RUBY)
-        class Animal; end
-        module Walkable; end
-        class Dog < Animal; end
-      RUBY
-
-      graph = Rubydex::Graph.new
-      graph.index_all(context.glob("**/*.rb"))
-      graph.resolve
-
-      query = Rubydex::Query.parse(
-        "MATCH (n:Class|Module) WHERE n.name = 'Animal' OR n.name = 'Walkable' RETURN n.name ORDER BY n.name",
-      )
-
-      assert_equal("[{\"n.name\":\"Animal\"},{\"n.name\":\"Walkable\"}]", query.render(graph, :json))
-    end
-  end
-
-  def test_query_accepts_string_format
+  def test_render_json_and_string_format
     with_context do |context|
       context.write!("zoo.rb", "class Dog; end\n")
 
@@ -1688,6 +1742,7 @@ class GraphTest < Minitest::Test
       graph.resolve
 
       query = Rubydex::Query.parse("MATCH (c:Class {name: 'Dog'}) RETURN c.name")
+      assert_equal("[{\"c.name\":\"Dog\"}]", query.render(graph, :json))
       assert_equal("[{\"c.name\":\"Dog\"}]", query.render(graph, "json"))
     end
   end


### PR DESCRIPTION
## Goal

Build on the Cypher query engine from #868 so callers get **matched graph nodes back as first-class objects**, not as formatted text they have to re-parse or iterate over.

#868 added `Rubydex::Query#render(graph, format)`, which runs a query and returns a `table`/`json` **string** — great for the CLI and humans, but a dead end for programmatic callers: to actually *use* a matched class or method you'd have to parse the formatted output, then look the node back up in the graph by name. This PR adds an object-returning sibling, `Query#run(graph)`, that hands you the matched nodes directly.

## What changes

- **`Rubydex::Query#render(graph, format = :table)`** — unchanged: rows → formatted `String`.
- **`Rubydex::Query#run(graph)`** — new: rows → `Array<Hash>` (`T::Array[T::Hash[String, T::untyped]]`), where the values are real Ruby objects:
  - a column that binds a node (e.g. `RETURN c`) comes back as a live `Rubydex::Declaration` / `Definition` / `Document` handle;
  - scalar columns (`RETURN c.name`, `count(c)`) come back as plain Ruby values (`String`, `Integer`, `true`/`false`, `nil`);
  - a map projection (`RETURN c { .name, .kind }`) comes back as a Ruby `Hash`, and a list comes back as a Ruby `Array` (elements decoded recursively).

So instead of:

```ruby
# Before: query returns a string; you re-parse it, then re-find the node.
text = query.render(graph, :json)
JSON.parse(text).each do |row|
  decl = graph.find_declaration(row["c.name"])  # extra lookup just to get an object
  decl.definitions.each { ... }
end
```

you write:

```ruby
# After: the matched node IS the object. No iteration to re-resolve it.
query = Rubydex::Query.parse("MATCH (c:Class)-[:HAS_PARENT]->(:Class {name: 'Animal'}) RETURN c")
query.run(graph).each do |row|
  decl = row["c"]            # => Rubydex::Declaration, already resolved
  decl.definitions           # navigate the graph directly
end
```

The query language does the matching and filtering; you get the resulting nodes back ready to use, without writing your own traversal/iteration to turn names back into graph objects.

## How it works

- **`cypher-parser` 0.8.1**: the generic executor carries node identity and structured values. `CypherValue` covers `Null`/`Bool`/`Int`/`Str` scalars, `Node { id, name, .. }` for a bound graph node, and `List` / `Map` containers (so map projections like `c { .name, .kind }` survive execution). `GraphProvider` gains:
  - `node_id(node)` — encodes a node to an opaque id, so a bound node survives execution as an id rather than being flattened to text;
  - `expand_in(node, rel_type)` — walks a relationship **backwards** (incoming edges), enabling queries like `(:Definition)<-[:DEFINES]-(:Document)`.

  The crate stays dependency-free and rubydex-agnostic.
- **rubydex schema** (`query::cypher::schema`): implements `node_id` and `NodeRef::decode` over the existing `decl:/def:/doc:<u64>` id scheme, and implements `expand_in` for the reversible relationships (`DEFINES`, `DECLARES`) so incoming traversals resolve to the right nodes.
- **FFI** (`rubydex-sys`): all Cypher-related code lives in a new `cypher_api.rs` module — `CQueryResult`, `CParseResult`, `rdx_cypher_parse`, `rdx_cypher_query_free`, `rdx_cypher_schema`, and the structured-result types. Only `rdx_query_run` (the formatted-string runner) remains in `graph_api.rs`. `rdx_query_run_rows` returns a `CRunRows` wrapping a `CRowsIter` opaque iterator (following the existing `DeclarationsIter` / `DocumentsIter` pattern), walked via `rdx_rows_iter_{column_count,columns,len,next,free}`. `CCell` is a tagged union (`CCellTag`: `Null`/`Bool`/`Int`/`Str`/`Node`/`List`/`Map`); `Node` cells carry a category (declaration/definition/document) plus the entity id, and `Map` stores parallel key/value arrays. A `cstring_raw` helper was added to `utils.rs` for allocating owned C strings across the FFI boundary.
- **Gem** (`ext/rubydex/query.c`, extending the file added in #868): `Query#run` walks the `CRowsIter` iterator into an `Array<Hash>`, decoding each cell — node cells into the appropriate `Declaration` / `Definition` / `Document` handle, lists into `Array`, maps into `Hash`, scalars into plain values. The iterator walk is wrapped in `rb_ensure` so `rdx_rows_iter_free` runs even if Ruby raises during cell conversion. Both `render` and `run` use a new `rdxi_graph_from_object` helper in `graph.h` to extract the graph pointer from the Graph VALUE.

## Why this matters for both APIs

- **Ruby API**: queries become a graph-navigation tool, not just a reporting tool. Match with Cypher, then call methods on the returned handles — no manual name-based re-lookup, no iterating the whole graph to find what the query already found.
- **Rust API**: the executor now preserves node identity end-to-end (`CypherValue::Node`) and supports incoming-edge traversal (`expand_in`), so any `GraphProvider`-backed consumer — Rust callers, the FFI layer, future language servers/tools — can get matched nodes back by id and resolve them to their own representation, rather than being limited to formatted strings.

In short: **the query does the matching; callers get the nodes, not a transcript of them.**

## Verification

- `cargo build` / `cargo test` green; clippy clean (`-D warnings`); `cargo fmt --check` clean.
- `rake compile` green; `bundle exec ruby -Itest test/graph_test.rb` → 110 runs, 0 failures (includes new object-result, map-projection, aggregation, reverse-traversal, and label-disjunction tests).

