### PR TITLE
Add memory benchmark through jemalloc allocation trace

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -824,6 +824,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
 name = "pastey"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1066,6 +1072,8 @@ dependencies = [
  "ruby-rbs",
  "rubydex",
  "tempfile",
+ "tikv-jemalloc-ctl",
+ "tikv-jemallocator",
  "url",
  "xxhash-rust",
 ]
@@ -1313,6 +1321,37 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tikv-jemalloc-ctl"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a184c43b8ab2f41df2733b55556e3f5f632f4aeaa205b1bb018f574b7f5f142"
+dependencies = [
+ "libc",
+ "paste",
+ "tikv-jemalloc-sys",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.7.1+5.3.1-0-g81034ce1f1373e37dc865038e1bc8eeecf559ce8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a2825c78386b4ae0314074867860ba9577875de945f05992c38815cbec327f0"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "249f09e49ab1609436f34c776e84231bead18d6a955f119f939bdc1d847561bd"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/rust/rubydex/Cargo.toml
+++ b/rust/rubydex/Cargo.toml
@@ -44,5 +44,13 @@ assert_cmd = "2.0"
 predicates = "3.1"
 regex = "1.10"
 
+[target.'cfg(not(target_os = "windows"))'.dev-dependencies]
+tikv-jemallocator = { version = "0.7.0", features = ["stats"] }
+tikv-jemalloc-ctl = { version = "0.7.0", features = ["stats"] }
+
+[[bench]]
+name = "graph_memory"
+harness = false
+
 [lints]
 workspace = true

--- a/rust/rubydex/benches/graph_memory.rs
+++ b/rust/rubydex/benches/graph_memory.rs
@@ -1,0 +1,52 @@
+//! Jemalloc does not compile on Windows, so this memory benchmark executable is a no-op
+
+#[cfg(not(target_os = "windows"))]
+mod imp {
+    use std::collections::HashSet;
+
+    use rubydex::{
+        indexing::{self, IndexerBackend},
+        listing,
+        model::graph::Graph,
+        resolution::Resolver,
+    };
+    use tikv_jemalloc_ctl::{epoch, stats};
+
+    // Substitute the global allocator by jemalloc, so that we can track all allocations and measure the graph usage
+    #[global_allocator]
+    static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
+    /// Advance the jemalloc epoch (stats are cached between epochs) and read the
+    /// number of bytes currently allocated by the application.
+    fn allocated_bytes() -> usize {
+        epoch::advance().expect("failed to advance jemalloc epoch");
+        stats::allocated::read().expect("failed to read stats.allocated (is the `stats` feature on?)")
+    }
+
+    pub fn run() {
+        let paths: Vec<String> = std::env::args().skip(1).collect();
+        let paths = if paths.is_empty() { vec![".".to_string()] } else { paths };
+        let (file_paths, _) = listing::collect_file_paths(paths, &HashSet::new());
+
+        let mut graph = Graph::new();
+        let _ = indexing::index_files(&mut graph, file_paths, IndexerBackend::RubyIndexer);
+        Resolver::new(&mut graph).resolve();
+
+        // Compare the total memory used in the allocator before and after dropping the graph
+        let before_drop = allocated_bytes();
+        drop(graph);
+        let after_drop = allocated_bytes();
+
+        let total_graph_memory = before_drop.saturating_sub(after_drop);
+
+        #[allow(clippy::cast_precision_loss)]
+        let mega_bytes = total_graph_memory as f64 / 1024.0 / 1024.0;
+
+        println!("Total graph memory: {mega_bytes:.2} MB");
+    }
+}
+
+fn main() {
+    #[cfg(not(target_os = "windows"))]
+    imp::run();
+}

--- a/utils/bench-graph-memory
+++ b/utils/bench-graph-memory
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+# Measure the total memory used by the graph. Allows comparing a branch against main
+#
+# Usage:
+#   utils/bench-graph-memory <path>             # current branch only
+#   utils/bench-graph-memory --compare <path>   # main, then current branch
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+RUST_DIR="$PROJECT_ROOT/rust"
+COMPARE=0
+TARGET=""
+BRANCH="$(git branch --show-current)"
+
+for arg in "$@"; do
+    case "$arg" in
+        --compare) COMPARE=1 ;;
+        *) TARGET="$arg" ;;
+    esac
+done
+
+if [ -z "$TARGET" ]; then
+    echo "Usage: $0 [--compare] <path>" >&2
+    exit 1
+fi
+
+# Expand the target based on Rubydex's root directory
+case "$TARGET" in
+    /*) ;;
+    *) TARGET="$PROJECT_ROOT/$TARGET" ;;
+esac
+
+run_bench() {
+    cd "$RUST_DIR" && cargo bench --bench graph_memory -- "$TARGET"
+}
+
+if [ "$COMPARE" -eq 1 ]; then
+    if ! git merge-base --is-ancestor main HEAD; then
+        echo "Error: $BRANCH is not based on the current local main" >&2
+        echo "Please rebase first and run again." >&2
+        exit 1
+    fi
+
+    STASHED=0
+
+    if [ -n "$(git status --porcelain)" ]; then
+        git stash push --include-untracked --quiet
+        STASHED=1
+    fi
+
+    git checkout --quiet main
+    echo "########### Measuring main ############"
+    run_bench
+
+    git checkout --quiet "$BRANCH"
+
+    if [ "$STASHED" -eq 1 ]; then
+        git stash pop --quiet
+    fi
+fi
+
+echo "########### Measuring $BRANCH ############"
+run_bench


### PR DESCRIPTION
Not exactly #864, but a decent step towards it if we decide to move forward

I've been suspecting that our memory measurements using RSS are not super precise. Based on my understanding, max RSS represents the peak memory used by the process. Since we spawn multiple threads during indexing, I assumed that the peak would probably occur during that phase, but that's not what we're interested in. Instead, we want to know the amount of memory that the final graph consumes.

This PR adds a memory benchmark. The way it works is:

1. Use jemalloc as the global allocator in a benchmark target. Jemalloc allows tracing allocations across epochs, which gives us the opportunity to analyze the diff of bytes between epochs
2. Add the benchmark target. Using `[[bench]]` means that the code is always built in release mode, but can use development-only dependencies. The executable builds the graph and compares the memory being used before and after dropping it

I also added a convenience script that runs the benchmark for a given path and optionally accepts a `--compare` argument. When using `--compare`, it just runs the benchmark against `main` first to allow comparing the results.

In all workspaces I tried, the max RSS approach overestimates the amount of memory being used:

- Core: 46%
- Ruby LSP: 195%
- Rails: 52%