### PR TITLE
Expose Document#method_references

### DIFF
--- a/ext/rubydex/document.c
+++ b/ext/rubydex/document.c
@@ -3,6 +3,7 @@
 #include "graph.h"
 #include "handle.h"
 #include "rustbindings.h"
+#include "utils.h"
 
 VALUE cDocument;
 
@@ -85,6 +86,40 @@ static VALUE rdxr_document_definitions(VALUE self) {
     return self;
 }
 
+// Size function for the Document#method_references enumerator
+static VALUE document_method_references_size(VALUE self, VALUE _args, VALUE _eobj) {
+    HandleData *data;
+    TypedData_Get_Struct(self, HandleData, &handle_type, data);
+
+    void *graph;
+    TypedData_Get_Struct(data->graph_obj, void *, &graph_type, graph);
+    struct MethodReferencesIter *iter = rdx_document_method_references_iter_new(graph, data->id);
+    size_t len = rdx_method_references_iter_len(iter);
+    rdx_method_references_iter_free(iter);
+
+    return SIZET2NUM(len);
+}
+
+// Document#method_references: () -> Enumerator[MethodReference]
+// Returns an enumerator that yields all method references for this document lazily
+static VALUE rdxr_document_method_references(VALUE self) {
+    if (!rb_block_given_p()) {
+        return rb_enumeratorize_with_size(self, rb_str_new2("method_references"), 0, NULL,
+                                          document_method_references_size);
+    }
+
+    HandleData *data;
+    TypedData_Get_Struct(self, HandleData, &handle_type, data);
+
+    void *graph;
+    TypedData_Get_Struct(data->graph_obj, void *, &graph_type, graph);
+    void *iter = rdx_document_method_references_iter_new(graph, data->id);
+    VALUE args = rb_ary_new_from_args(2, data->graph_obj, ULL2NUM((uintptr_t)iter));
+    rb_ensure(rdxi_method_references_yield, args, rdxi_method_references_ensure, args);
+
+    return self;
+}
+
 void rdxi_initialize_document(VALUE mRubydex) {
     cDocument = rb_define_class_under(mRubydex, "Document", rb_cObject);
 
@@ -92,6 +127,7 @@ void rdxi_initialize_document(VALUE mRubydex) {
     rb_define_method(cDocument, "initialize", rdxr_handle_initialize, 2);
     rb_define_method(cDocument, "uri", rdxr_document_uri, 0);
     rb_define_method(cDocument, "definitions", rdxr_document_definitions, 0);
+    rb_define_method(cDocument, "method_references", rdxr_document_method_references, 0);
 
     rb_funcall(rb_singleton_class(cDocument), rb_intern("private"), 1, ID2SYM(rb_intern("new")));
 }

--- a/rbi/rubydex.rbi
+++ b/rbi/rubydex.rbi
@@ -249,6 +249,9 @@ class Rubydex::Document
   sig { returns(T::Enumerable[Rubydex::Definition]) }
   def definitions; end
 
+  sig { returns(T::Enumerable[Rubydex::MethodReference]) }
+  def method_references; end
+
   sig { returns(String) }
   def uri; end
 

--- a/rust/rubydex-sys/src/document_api.rs
+++ b/rust/rubydex-sys/src/document_api.rs
@@ -6,6 +6,7 @@ use std::ptr;
 
 use crate::definition_api::{DefinitionsIter, rdx_definitions_iter_new_from_ids};
 use crate::graph_api::{GraphPointer, with_graph};
+use crate::reference_api::{CMethodReference, MethodReferencesIter};
 use rubydex::model::ids::UriId;
 
 #[derive(Debug)]
@@ -80,6 +81,33 @@ pub unsafe extern "C" fn rdx_document_definitions_iter_new(pointer: GraphPointer
             rdx_definitions_iter_new_from_ids(graph, doc.definitions())
         } else {
             DefinitionsIter::new(Vec::<_>::new().into_boxed_slice())
+        }
+    })
+}
+
+/// Creates a new iterator over method reference IDs for a given document by snapshotting the current set of IDs.
+///
+/// # Safety
+///
+/// - `pointer` must be a valid `GraphPointer` previously returned by this crate.
+/// - The returned pointer must be freed with `rdx_method_references_iter_free`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rdx_document_method_references_iter_new(
+    pointer: GraphPointer,
+    uri_id: u64,
+) -> *mut MethodReferencesIter {
+    with_graph(pointer, |graph| {
+        let uri_id = UriId::new(uri_id);
+        if let Some(doc) = graph.documents().get(&uri_id) {
+            let entries: Vec<_> = doc
+                .method_references()
+                .iter()
+                .map(|ref_id| CMethodReference { id: **ref_id })
+                .collect();
+
+            MethodReferencesIter::new(entries.into_boxed_slice())
+        } else {
+            MethodReferencesIter::new(Vec::<_>::new().into_boxed_slice())
         }
     })
 }

--- a/test/document_test.rb
+++ b/test/document_test.rb
@@ -68,4 +68,70 @@ class DocumentTest < Minitest::Test
       assert_equal(2, definitions.size)
     end
   end
+
+  def test_method_references_enumerator
+    with_context do |context|
+      context.write!("file1.rb", <<~RUBY)
+        class A
+          def foo
+            bar
+          end
+        end
+      RUBY
+
+      context.write!("file2.rb", <<~RUBY)
+        class B
+          def foo
+            baz
+          end
+        end
+      RUBY
+
+      graph = Rubydex::Graph.new
+      graph.index_all(context.glob("**/*.rb"))
+
+      document = graph.documents.find { |d| d.uri == context.uri_to("file1.rb") }
+      refute_nil(document)
+
+      enumerator = document.method_references
+      assert_equal(1, enumerator.size)
+      assert_equal(1, enumerator.count)
+      assert_equal(1, enumerator.to_a.size)
+      assert_equal(["bar"], enumerator.map(&:name))
+
+      other_document = graph.documents.find { |d| d.uri == context.uri_to("file2.rb") }
+      refute_nil(other_document)
+      assert_equal(["baz"], other_document.method_references.map(&:name))
+    end
+  end
+
+  def test_method_references_with_block
+    with_context do |context|
+      context.write!("file1.rb", <<~RUBY)
+        class A
+          def foo
+            bar
+          end
+        end
+      RUBY
+
+      graph = Rubydex::Graph.new
+      graph.index_all(context.glob("**/*.rb"))
+
+      document = graph.documents.find { |d| d.uri == context.uri_to("file1.rb") }
+      refute_nil(document)
+
+      references = []
+      document.method_references do |reference|
+        references << reference
+      end
+
+      assert_equal(1, references.size)
+
+      reference = references.first
+      assert_kind_of(Rubydex::MethodReference, reference)
+      assert_equal("bar", reference.name)
+      assert_equal("#{context.absolute_path_to("file1.rb")}:3:5-3:8", reference.location.to_display.to_s)
+    end
+  end
 end


### PR DESCRIPTION
## Problems

- The Rust model tracks method references per document, but the Ruby API only exposes method references at the graph level.
- Ruby consumers that need document-scoped method calls currently have to filter graph-level references themselves.

## Solutions

- Add a document-scoped method reference iterator to the Rust FFI.
- Expose `Rubydex::Document#method_references` through the C extension using the existing lazy enumerator pattern.
- Add the RBI signature and focused Ruby coverage for enumerator, block, and document scoping behavior.