### PR TITLE
Create Config object and move excluded paths inside

### DIFF
--- a/rust/rubydex/src/config.rs
+++ b/rust/rubydex/src/config.rs
@@ -1,0 +1,28 @@
+use std::collections::HashSet;
+use std::path::PathBuf;
+
+/// Project configuration that controls indexing behavior.
+#[derive(Debug, Default)]
+pub struct Config {
+    /// Paths to exclude from file discovery during indexing.
+    excluded_paths: HashSet<PathBuf>,
+}
+
+impl Config {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Adds paths to exclude from file discovery during indexing. Excluded directories will be skipped entirely during
+    /// directory traversal.
+    pub fn exclude_paths(&mut self, paths: Vec<PathBuf>) {
+        self.excluded_paths.extend(paths);
+    }
+
+    /// Returns the set of paths excluded from file discovery.
+    #[must_use]
+    pub fn excluded_paths(&self) -> &HashSet<PathBuf> {
+        &self.excluded_paths
+    }
+}

--- a/rust/rubydex/src/lib.rs
+++ b/rust/rubydex/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod compile_assertions;
+pub mod config;
 pub mod diagnostic;
 pub mod dot;
 pub mod errors;

--- a/rust/rubydex/src/model/graph.rs
+++ b/rust/rubydex/src/model/graph.rs
@@ -3,6 +3,7 @@ use std::collections::hash_map::Entry;
 use std::path::PathBuf;
 
 use crate::assert_mem_size;
+use crate::config::Config;
 use crate::diagnostic::Diagnostic;
 use crate::indexing::local_graph::LocalGraph;
 use crate::model::built_in::{OBJECT_ID, add_built_in_data};
@@ -85,8 +86,8 @@ pub struct Graph {
     /// Drained by `take_pending_work()` before resolution.
     pending_work: Vec<Unit>,
 
-    /// Paths to exclude from file discovery during indexing.
-    excluded_paths: HashSet<PathBuf>,
+    /// Project configuration
+    config: Config,
 }
 assert_mem_size!(Graph, 336);
 
@@ -104,7 +105,7 @@ impl Graph {
             position_encoding: Encoding::default(),
             name_dependents: IdentityHashMap::default(),
             pending_work: Vec::default(),
-            excluded_paths: HashSet::new(),
+            config: Config::new(),
         };
 
         add_built_in_data(&mut graph);
@@ -126,13 +127,13 @@ impl Graph {
     /// Adds paths to exclude from file discovery during indexing. Excluded directories will be skipped entirely during
     /// directory traversal.
     pub fn exclude_paths(&mut self, paths: Vec<PathBuf>) {
-        self.excluded_paths.extend(paths);
+        self.config.exclude_paths(paths);
     }
 
     /// Returns the set of paths excluded from file discovery.
     #[must_use]
     pub fn excluded_paths(&self) -> &HashSet<PathBuf> {
-        &self.excluded_paths
+        self.config.excluded_paths()
     }
 
     /// # Panics


### PR DESCRIPTION
First step in supporting a workspace configuration file. This PR only creates the `Config` object and moves excluded paths inside.