### PR TITLE
Store workspace path in config

### DIFF
--- a/ext/rubydex/graph.c
+++ b/ext/rubydex/graph.c
@@ -830,6 +830,42 @@ static VALUE rdxr_graph_excluded_paths(VALUE self) {
 
 /*
  * call-seq:
+ *   workspace_path -> String
+ *
+ * Returns the root directory of the workspace being indexed.
+ */
+static VALUE rdxr_graph_workspace_path(VALUE self) {
+    void *graph;
+    TypedData_Get_Struct(self, void*, &graph_type, graph);
+
+    const char *result = rdx_graph_workspace_path(graph);
+    if (result == NULL) {
+        rb_raise(rb_eRuntimeError, "Converting workspace path to Ruby string failed");
+    }
+
+    VALUE path = rb_utf8_str_new_cstr(result);
+    free_c_string(result);
+    return path;
+}
+
+/*
+ * call-seq:
+ *   workspace_path=(path) -> void
+ *
+ * Sets the root directory of the workspace being indexed.
+ */
+static VALUE rdxr_graph_set_workspace_path(VALUE self, VALUE path) {
+    Check_Type(path, T_STRING);
+
+    void *graph;
+    TypedData_Get_Struct(self, void*, &graph_type, graph);
+
+    rdx_graph_set_workspace_path(graph, StringValueCStr(path));
+    return path;
+}
+
+/*
+ * call-seq:
  *   keyword(name) -> Rubydex::Keyword?
  *
  * Returns the keyword object for the name, or nil if it is not a Ruby keyword.
@@ -884,5 +920,7 @@ void rdxi_initialize_graph(VALUE moduleRubydex) {
     rb_define_method(cGraph, "complete_method_argument", rdxr_graph_complete_method_argument, -1);
     rb_define_method(cGraph, "exclude_paths", rdxr_graph_exclude_paths, 1);
     rb_define_method(cGraph, "excluded_paths", rdxr_graph_excluded_paths, 0);
+    rb_define_method(cGraph, "workspace_path", rdxr_graph_workspace_path, 0);
+    rb_define_method(cGraph, "workspace_path=", rdxr_graph_set_workspace_path, 1);
     rb_define_method(cGraph, "keyword", rdxr_graph_keyword, 1);
 }

--- a/lib/rubydex/graph.rb
+++ b/lib/rubydex/graph.rb
@@ -19,17 +19,14 @@ module Rubydex
 
     INDEXABLE_EXTENSIONS = [".rb", ".rake", ".rbs", ".ru"].freeze
 
-    #: String
-    attr_accessor :workspace_path
+    #: (?workspace_path: String?) -> void
+    def initialize(workspace_path: nil)
+      self.workspace_path = workspace_path if workspace_path
 
-    #: (?workspace_path: String) -> void
-    def initialize(workspace_path: Dir.pwd)
-      @workspace_path = workspace_path
-
-      exclude_paths(IGNORED_DIRECTORIES.map { |dir| File.join(@workspace_path, dir) })
+      exclude_paths(IGNORED_DIRECTORIES.map { |dir| File.join(self.workspace_path, dir) })
     end
 
-    # Index all files and dependencies of the workspace that exists in `@workspace_path`
+    # Index all files and dependencies of the workspace that exists in `workspace_path`
     #: -> Array[String]
     def index_workspace
       index_all(workspace_paths)
@@ -41,9 +38,10 @@ module Rubydex
     #: -> Array[String]
     def workspace_paths
       paths = []
+      root = workspace_path
 
-      Dir.each_child(@workspace_path) do |entry|
-        full_path = File.join(@workspace_path, entry)
+      Dir.each_child(root) do |entry|
+        full_path = File.join(root, entry)
 
         if File.directory?(full_path)
           paths << full_path unless IGNORED_DIRECTORIES.include?(entry)

--- a/rbi/rubydex.rbi
+++ b/rbi/rubydex.rbi
@@ -308,7 +308,7 @@ class Rubydex::Graph
   sig { params(uri: String, source: String, language_id: String).void }
   def index_source(uri, source, language_id); end
 
-  # Index all files and dependencies of the workspace that exists in `@workspace_path`
+  # Index all files and dependencies of the workspace that exists in `workspace_path`
   sig { returns(T::Array[String]) }
   def index_workspace; end
 

--- a/rust/rubydex-sys/src/graph_api.rs
+++ b/rust/rubydex-sys/src/graph_api.rs
@@ -210,6 +210,36 @@ pub unsafe extern "C" fn rdx_graph_excluded_paths(
     })
 }
 
+/// Sets the workspace path used as the root directory for indexing and relative path resolution. Silently ignores the
+/// call if the given path is not valid UTF-8, leaving the existing workspace path untouched (mirrors
+/// `rdx_graph_set_encoding`). This avoids unwinding across the FFI boundary on malformed input.
+///
+/// # Safety
+///
+/// - `pointer` must be a valid `GraphPointer` previously returned by this crate.
+/// - `path` must be a valid, null-terminated string.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rdx_graph_set_workspace_path(pointer: GraphPointer, path: *const c_char) {
+    let Ok(path) = (unsafe { utils::convert_char_ptr_to_string(path) }) else {
+        return;
+    };
+
+    with_mut_graph(pointer, |graph| graph.set_workspace_path(PathBuf::from(path)));
+}
+
+/// Returns the workspace path as a C string. Caller must free with `free_c_string`.
+///
+/// # Safety
+///
+/// - `pointer` must be a valid `GraphPointer` previously returned by this crate.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rdx_graph_workspace_path(pointer: GraphPointer) -> *const c_char {
+    with_graph(pointer, |graph| {
+        CString::new(graph.workspace_path().to_string_lossy().as_ref())
+            .map_or(ptr::null(), |c_string| c_string.into_raw().cast_const())
+    })
+}
+
 /// Indexes all given file paths in parallel using the provided Graph pointer.
 /// Returns an array of error message strings and writes the count to `out_error_count`.
 /// Returns NULL if there are no errors. Caller must free with `free_c_string_array`.

--- a/rust/rubydex/src/config.rs
+++ b/rust/rubydex/src/config.rs
@@ -1,17 +1,44 @@
+use crate::assert_mem_size;
 use std::collections::HashSet;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
-/// Project configuration that controls indexing behavior.
-#[derive(Debug, Default)]
+/// Project configuration
+#[derive(Debug)]
 pub struct Config {
+    /// Path to the workspace being analyzed
+    workspace_path: Box<Path>,
     /// Paths to exclude from file discovery during indexing.
     excluded_paths: HashSet<PathBuf>,
 }
+assert_mem_size!(Config, 64);
+
+impl Default for Config {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 impl Config {
+    /// Creates a configuration whose workspace path defaults to the current working directory.
     #[must_use]
     pub fn new() -> Self {
-        Self::default()
+        Self {
+            workspace_path: std::env::current_dir()
+                .unwrap_or_else(|_| PathBuf::from("."))
+                .into_boxed_path(),
+            excluded_paths: HashSet::new(),
+        }
+    }
+
+    /// Returns the root directory of the workspace being analyzed.
+    #[must_use]
+    pub fn workspace_path(&self) -> &Path {
+        &self.workspace_path
+    }
+
+    /// Sets the root directory of the workspace being analyzed.
+    pub fn set_workspace_path(&mut self, workspace_path: PathBuf) {
+        self.workspace_path = workspace_path.into_boxed_path();
     }
 
     /// Adds paths to exclude from file discovery during indexing. Excluded directories will be skipped entirely during

--- a/rust/rubydex/src/model/graph.rs
+++ b/rust/rubydex/src/model/graph.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 use std::collections::hash_map::Entry;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use crate::assert_mem_size;
 use crate::config::Config;
@@ -89,7 +89,7 @@ pub struct Graph {
     /// Project configuration
     config: Config,
 }
-assert_mem_size!(Graph, 336);
+assert_mem_size!(Graph, 352);
 
 impl Graph {
     #[must_use]
@@ -134,6 +134,17 @@ impl Graph {
     #[must_use]
     pub fn excluded_paths(&self) -> &HashSet<PathBuf> {
         self.config.excluded_paths()
+    }
+
+    /// Returns the root directory of the workspace being indexed.
+    #[must_use]
+    pub fn workspace_path(&self) -> &Path {
+        self.config.workspace_path()
+    }
+
+    /// Sets the root directory of the workspace being indexed.
+    pub fn set_workspace_path(&mut self, workspace_path: PathBuf) {
+        self.config.set_workspace_path(workspace_path);
     }
 
     /// # Panics

--- a/test/graph_test.rb
+++ b/test/graph_test.rb
@@ -203,6 +203,25 @@ class GraphTest < Minitest::Test
     end
   end
 
+  def test_workspace_path_defaults_to_pwd
+    graph = Rubydex::Graph.new
+    assert_equal(Dir.pwd, File.expand_path(graph.workspace_path))
+  end
+
+  def test_workspace_path_can_be_passed_to_initialize
+    with_context do |context|
+      graph = Rubydex::Graph.new(workspace_path: context.absolute_path)
+      assert_equal(context.absolute_path, graph.workspace_path)
+    end
+  end
+
+  def test_workspace_path_setter
+    graph = Rubydex::Graph.new
+    graph.workspace_path = "/some/workspace"
+
+    assert_equal("/some/workspace", graph.workspace_path)
+  end
+
   def test_graph_encoding_setter
     with_context do |context|
       context.write!("foo.rb", <<~RUBY)


### PR DESCRIPTION
Move the storage of the workspace path into the Rust side in `Config`. This is not necessary at the moment, but it will be in the next PR when I introduce a config file. We want people to use relative paths for exclusions, like `vendor/bundle` or `tmp`, but we need to make those absolute in respect to the workspace in order to exclude them correctly during file listing.