### PR TITLE
Introduce configuration file support

### DIFF
--- a/exe/rdx
+++ b/exe/rdx
@@ -35,6 +35,8 @@ def __with_timer(message, &block)
 end
 
 graph = Rubydex::Graph.new
+graph.load_config
+
 __with_timer("Indexing workspace...") { graph.index_workspace }
 __with_timer("Resolving graph...") { graph.resolve }
 

--- a/ext/rubydex/graph.c
+++ b/ext/rubydex/graph.c
@@ -865,6 +865,40 @@ static VALUE rdxr_graph_set_workspace_path(VALUE self, VALUE path) {
 
 /*
  * call-seq:
+ *   load_config(config_path = nil) -> void
+ *
+ * Loads a configuration file for the graph. If `config_path` is nil, loads the default configuration file at
+ * `workspace_path/rubydex.toml` if it exists. Will raise on malformed files or if an explicit path is given but the
+ * file does not exist.
+ */
+static VALUE rdxr_graph_load_config(int argc, VALUE *argv, VALUE self) {
+    VALUE config_path;
+    rb_scan_args(argc, argv, "01", &config_path);
+
+    void *graph;
+    TypedData_Get_Struct(self, void *, &graph_type, graph);
+
+    const char *config_path_cstr = NULL;
+
+    if (!NIL_P(config_path)) {
+        Check_Type(config_path, T_STRING);
+        config_path_cstr = StringValueCStr(config_path);
+    }
+
+    const char *error = rdx_graph_load_config(graph, config_path_cstr);
+    if (error == NULL) {
+        return Qnil;
+    }
+
+    VALUE message = rb_utf8_str_new_cstr(error);
+    free_c_string(error);
+
+    VALUE config_error = rb_const_get(mRubydex, rb_intern("ConfigError"));
+    rb_exc_raise(rb_exc_new_str(config_error, message));
+}
+
+/*
+ * call-seq:
  *   keyword(name) -> Rubydex::Keyword?
  *
  * Returns the keyword object for the name, or nil if it is not a Ruby keyword.
@@ -921,5 +955,6 @@ void rdxi_initialize_graph(VALUE moduleRubydex) {
     rb_define_method(cGraph, "excluded_paths", rdxr_graph_excluded_paths, 0);
     rb_define_method(cGraph, "workspace_path", rdxr_graph_workspace_path, 0);
     rb_define_method(cGraph, "workspace_path=", rdxr_graph_set_workspace_path, 1);
+    rb_define_method(cGraph, "load_config", rdxr_graph_load_config, -1);
     rb_define_method(cGraph, "keyword", rdxr_graph_keyword, 1);
 }

--- a/lib/rubydex/errors.rb
+++ b/lib/rubydex/errors.rb
@@ -5,4 +5,7 @@ module Rubydex
 
   # Raised when `MethodAliasDefinition#target` walks an alias chain that loops back on itself.
   class AliasCycleError < Error; end
+
+  # Raised by `Graph#load_config` when the requested config file does not exist, cannot be read, or is malformed
+  class ConfigError < Error; end
 end

--- a/lib/rubydex/graph.rb
+++ b/lib/rubydex/graph.rb
@@ -5,25 +5,11 @@ module Rubydex
   #
   # Note: this class is partially defined in C to integrate with the Rust backend
   class Graph
-    IGNORED_DIRECTORIES = [
-      ".bundle",
-      ".claude",
-      ".git",
-      ".github",
-      ".ruby-lsp",
-      ".vscode",
-      "log",
-      "node_modules",
-      "tmp",
-    ].freeze
-
     INDEXABLE_EXTENSIONS = [".rb", ".rake", ".rbs", ".ru"].freeze
 
     #: (?workspace_path: String?) -> void
     def initialize(workspace_path: nil)
       self.workspace_path = workspace_path if workspace_path
-
-      exclude_paths(IGNORED_DIRECTORIES.map { |dir| File.join(self.workspace_path, dir) })
     end
 
     # Index all files and dependencies of the workspace that exists in `workspace_path`
@@ -32,8 +18,7 @@ module Rubydex
       index_all(workspace_paths)
     end
 
-    # Returns all workspace paths that should be indexed, excluding directories that we don't need to descend into such
-    # as `.git`, `node_modules`. Also includes any top level Ruby files
+    # Returns all workspace paths that should be indexed
     #
     #: -> Array[String]
     def workspace_paths
@@ -43,9 +28,7 @@ module Rubydex
       Dir.each_child(root) do |entry|
         full_path = File.join(root, entry)
 
-        if File.directory?(full_path)
-          paths << full_path unless IGNORED_DIRECTORIES.include?(entry)
-        elsif INDEXABLE_EXTENSIONS.include?(File.extname(entry))
+        if File.directory?(full_path) || INDEXABLE_EXTENSIONS.include?(File.extname(entry))
           paths << full_path
         end
       end

--- a/rbi/rubydex.rbi
+++ b/rbi/rubydex.rbi
@@ -174,10 +174,12 @@ class Rubydex::ConstantDefinition < Rubydex::Definition; end
 class Rubydex::GlobalVariableAliasDefinition < Rubydex::Definition; end
 class Rubydex::GlobalVariableDefinition < Rubydex::Definition; end
 class Rubydex::InstanceVariableDefinition < Rubydex::Definition; end
+
 class Rubydex::MethodAliasDefinition < Rubydex::Definition
   sig { returns(T.nilable(Rubydex::Method)) }
   def target; end
 end
+
 class Rubydex::MethodDefinition < Rubydex::Definition; end
 
 class Rubydex::ModuleDefinition < Rubydex::Definition
@@ -264,6 +266,7 @@ end
 
 class Rubydex::Error < StandardError; end
 class Rubydex::AliasCycleError < Rubydex::Error; end
+class Rubydex::ConfigError < Rubydex::Error; end
 
 class Rubydex::Failure
   sig { params(message: String).void }
@@ -276,8 +279,6 @@ end
 class Rubydex::IntegrityFailure < Rubydex::Failure; end
 
 class Rubydex::Graph
-  IGNORED_DIRECTORIES = T.let(T.unsafe(nil), T::Array[String])
-
   sig { params(workspace_path: T.nilable(String)).void }
   def initialize(workspace_path: nil); end
 
@@ -311,6 +312,13 @@ class Rubydex::Graph
   # Index all files and dependencies of the workspace that exists in `workspace_path`
   sig { returns(T::Array[String]) }
   def index_workspace; end
+
+  # Loads configuration, merging its excluded paths into the graph's configuration (the workspace path is never
+  # overridden). With `config_path` (resolved relative to the workspace path), an explicitly named file that does not
+  # exist raises `Rubydex::ConfigError`. With no argument, the default `.rubydex` is loaded if present and ignored if
+  # missing. Raises `Rubydex::ConfigError` if a file cannot be read or is malformed.
+  sig { params(config_path: T.nilable(String)).void }
+  def load_config(config_path = nil); end
 
   sig { returns(T::Enumerable[Rubydex::MethodReference]) }
   def method_references; end

--- a/rubydex.toml
+++ b/rubydex.toml
@@ -1,0 +1,1 @@
+exclude = ["docs", "ext", "rust", "target"]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -180,7 +180,7 @@ dependencies = [
  "serde_json",
  "syn",
  "tempfile",
- "toml",
+ "toml 0.8.23",
 ]
 
 [[package]]
@@ -536,9 +536,9 @@ checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.4"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -685,9 +685,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.10.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -1071,9 +1071,11 @@ dependencies = [
  "ruby-prism",
  "ruby-rbs",
  "rubydex",
+ "serde",
  "tempfile",
  "tikv-jemalloc-ctl",
  "tikv-jemallocator",
+ "toml 1.1.2+spec-1.1.0",
  "url",
  "xxhash-rust",
 ]
@@ -1163,18 +1165,28 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1211,6 +1223,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
 ]
 
 [[package]]
@@ -1406,9 +1427,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
  "toml_edit",
+]
+
+[[package]]
+name = "toml"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned 1.1.1",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -1421,6 +1457,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1428,10 +1473,19 @@ checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap",
  "serde",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
  "toml_write",
- "winnow",
+ "winnow 0.7.12",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -1439,6 +1493,12 @@ name = "toml_write"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tracing"
@@ -1789,6 +1849,12 @@ checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "winnow"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 
 [[package]]
 name = "wit-bindgen-rt"

--- a/rust/rubydex-sys/src/graph_api.rs
+++ b/rust/rubydex-sys/src/graph_api.rs
@@ -7,6 +7,7 @@ use crate::document_api::DocumentsIter;
 use crate::reference_api::{CConstantReference, CMethodReference, ConstantReferencesIter, MethodReferencesIter};
 use crate::{name_api, utils};
 use libc::{c_char, c_void};
+use rubydex::errors::Errors;
 use rubydex::indexing::LanguageId;
 use rubydex::model::encoding::Encoding;
 use rubydex::model::graph::Graph;
@@ -18,7 +19,7 @@ use rubydex::query::{CompletionCandidate, CompletionContext, CompletionReceiver}
 use rubydex::resolution::Resolver;
 use rubydex::{indexing, integrity, listing, query};
 use std::ffi::CString;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::{mem, ptr};
 
 pub type GraphPointer = *mut c_void;
@@ -197,7 +198,13 @@ pub unsafe extern "C" fn rdx_graph_excluded_paths(
         let c_strings: Vec<*const c_char> = excluded
             .iter()
             .filter_map(|path| {
-                CString::new(path.to_string_lossy().as_ref())
+                // Normalize all paths to use forward slashes. Otherwise, you get mixed backslashes and forward slashes
+                // on Windows if a configuration file is using forward slashes. For example:
+                //
+                // C:\project/vendor/bundle
+                let normalized = path.to_string_lossy().replace(std::path::MAIN_SEPARATOR, "/");
+
+                CString::new(normalized)
                     .ok()
                     .map(|c_string| c_string.into_raw().cast_const())
             })
@@ -240,6 +247,39 @@ pub unsafe extern "C" fn rdx_graph_workspace_path(pointer: GraphPointer) -> *con
     })
 }
 
+/// Loads configuration into the graph. A null `config_path` attempts to load the default configuration file.
+///
+/// Returns NULL on success. On failure returns an owned, null-terminated error message that the caller must free with
+/// `free_c_string`.
+///
+/// A `config_path` that is not valid UTF-8 is reported as an error message.
+///
+/// # Safety
+///
+/// - `pointer` must be a valid `GraphPointer` previously returned by this crate.
+/// - `config_path` must either be NULL or a valid, null-terminated string.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rdx_graph_load_config(pointer: GraphPointer, config_path: *const c_char) -> *const c_char {
+    let result = with_mut_graph(pointer, |graph| {
+        if config_path.is_null() {
+            graph.load_config(None)
+        } else {
+            match unsafe { utils::convert_char_ptr_to_string(config_path) } {
+                Ok(config_path) => graph.load_config(Some(Path::new(&config_path))),
+                Err(_) => Err(Errors::ConfigError("config file path is not valid UTF-8".to_string())),
+            }
+        }
+    });
+
+    match result {
+        Ok(()) => ptr::null(),
+        Err(error) => CString::new(error.to_string())
+            .unwrap_or_default()
+            .into_raw()
+            .cast_const(),
+    }
+}
+
 /// Indexes all given file paths in parallel using the provided Graph pointer.
 /// Returns an array of error message strings and writes the count to `out_error_count`.
 /// Returns NULL if there are no errors. Caller must free with `free_c_string_array`.
@@ -262,7 +302,7 @@ pub unsafe extern "C" fn rdx_index_all(
     let file_paths: Vec<String> = unsafe { utils::convert_double_pointer_to_vec(file_paths, count).unwrap() };
 
     with_mut_graph(pointer, |graph| {
-        let (file_paths, listing_errors) = listing::collect_file_paths(file_paths, graph.excluded_paths());
+        let (file_paths, listing_errors) = listing::collect_file_paths(file_paths, &graph.excluded_paths());
         let indexing_errors = indexing::index_files(graph, file_paths, indexing::IndexerBackend::RubyIndexer);
 
         let all_errors: Vec<String> = listing_errors

--- a/rust/rubydex/Cargo.toml
+++ b/rust/rubydex/Cargo.toml
@@ -37,10 +37,12 @@ bitflags = "2.9"
 bytecount = "0.6.9"
 libc = "0.2"
 line-index = "0.1.2"
+serde = { version = "1.0", features = ["derive"] }
 tempfile = { version = "3.0", optional = true }
 crossbeam-deque = "0.8"
 crossbeam-utils = "0.8"
 crossbeam-channel = "0.5"
+toml = "1.1.2"
 
 [target.'cfg(not(target_os = "windows"))'.dependencies]
 tikv-jemallocator = { version = "0.7.0", optional = true }

--- a/rust/rubydex/src/config.rs
+++ b/rust/rubydex/src/config.rs
@@ -1,6 +1,30 @@
 use crate::assert_mem_size;
+use crate::errors::Errors;
+use serde::Deserialize;
 use std::collections::HashSet;
+use std::fs;
+use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
+
+pub const DEFAULT_EXCLUDED_DIRECTORIES: &[&str] = &[
+    ".bundle",
+    ".claude",
+    ".git",
+    ".github",
+    ".ruby-lsp",
+    ".vscode",
+    "log",
+    "node_modules",
+    "tmp",
+];
+
+/// Configuration coming from a config file
+#[derive(Debug, Default, Deserialize)]
+struct ConfigFile {
+    /// Paths to exclude from file discovery during indexing.
+    #[serde(default)]
+    exclude: Vec<PathBuf>,
+}
 
 /// Project configuration
 #[derive(Debug)]
@@ -26,7 +50,7 @@ impl Config {
             workspace_path: std::env::current_dir()
                 .unwrap_or_else(|_| PathBuf::from("."))
                 .into_boxed_path(),
-            excluded_paths: HashSet::new(),
+            excluded_paths: DEFAULT_EXCLUDED_DIRECTORIES.iter().map(PathBuf::from).collect(),
         }
     }
 
@@ -43,13 +67,209 @@ impl Config {
 
     /// Adds paths to exclude from file discovery during indexing. Excluded directories will be skipped entirely during
     /// directory traversal.
-    pub fn exclude_paths(&mut self, paths: Vec<PathBuf>) {
+    pub fn exclude_paths(&mut self, paths: impl IntoIterator<Item = PathBuf>) {
         self.excluded_paths.extend(paths);
     }
 
-    /// Returns the set of paths excluded from file discovery.
+    /// Returns the set of paths excluded from file discovery
     #[must_use]
-    pub fn excluded_paths(&self) -> &HashSet<PathBuf> {
-        &self.excluded_paths
+    pub fn excluded_paths(&self) -> HashSet<PathBuf> {
+        self.excluded_paths
+            .iter()
+            .map(|path| self.workspace_path.join(path))
+            .collect()
+    }
+
+    /// Merges the default `rubydex.toml` configuration file from the workspace root into this config, if present.
+    ///
+    /// The default config file is optional, so a missing `rubydex.toml` is silently ignored. Any other failure (an
+    /// unreadable or malformed file) is still reported.
+    ///
+    /// # Errors
+    ///
+    /// Will error if the config file exists but cannot be read or has invalid syntax.
+    pub fn load_default(&mut self) -> Result<(), Errors> {
+        let config_path = self.workspace_path.join("rubydex.toml");
+
+        match self.load_file(&config_path) {
+            Err(Errors::ConfigNotFound(_)) => Ok(()),
+            other => other,
+        }
+    }
+
+    /// Merges the configuration at `config_path` into this config
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Errors::ConfigNotFound`] if the file does not exist or [`Errors::ConfigError`] if it cannot otherwise
+    /// be read or has invalid syntax.
+    pub fn load_file(&mut self, config_path: &Path) -> Result<(), Errors> {
+        let content = match fs::read_to_string(config_path) {
+            Ok(content) => content,
+            Err(error) if error.kind() == ErrorKind::NotFound => {
+                return Err(Errors::ConfigNotFound(format!(
+                    "Config file `{}` does not exist",
+                    config_path.display()
+                )));
+            }
+            Err(error) => {
+                return Err(Errors::ConfigError(format!(
+                    "Failed to read config file `{}`: {error}",
+                    config_path.display()
+                )));
+            }
+        };
+
+        let parsed = Self::parse(&content).map_err(|error| {
+            Errors::ConfigError(format!("Invalid config file `{}`: {error}", config_path.display()))
+        })?;
+
+        self.excluded_paths.extend(parsed.exclude);
+        Ok(())
+    }
+
+    /// Parses the content into a [`ConfigFile`]
+    fn parse(content: &str) -> Result<ConfigFile, toml::de::Error> {
+        toml::from_str(content)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    #[test]
+    fn excluded_paths_are_resolved_against_the_workspace_path() {
+        let mut config = Config::new();
+        config.set_workspace_path(PathBuf::from("/workspace"));
+        config.exclude_paths([PathBuf::from("vendor"), PathBuf::from("/absolute/path")]);
+
+        let excluded = config.excluded_paths();
+
+        // Relative entries (including the defaults) are joined with the workspace path.
+        assert!(excluded.contains(Path::new("/workspace/vendor")));
+        assert!(excluded.contains(Path::new("/workspace/.git")));
+        // Absolute entries pass through unchanged.
+        assert!(excluded.contains(Path::new("/absolute/path")));
+    }
+
+    #[test]
+    fn new_seeds_the_default_excluded_directories() {
+        let config = Config::new();
+
+        for default in DEFAULT_EXCLUDED_DIRECTORIES {
+            assert!(
+                config.excluded_paths.contains(Path::new(default)),
+                "expected `{default}` to be excluded by default"
+            );
+        }
+    }
+
+    #[test]
+    fn load_file_merges_excluded_paths_and_leaves_the_workspace_path_untouched() {
+        let dir = tempfile::tempdir().expect("failed to create temp dir");
+        let config_path = dir.path().join("rubydex.toml");
+        fs::write(&config_path, "exclude = [\"vendor\", \"generated\"]\n").unwrap();
+
+        let mut config = Config::new();
+        config.set_workspace_path(PathBuf::from("/workspace"));
+
+        config
+            .load_file(&config_path)
+            .expect("expected the config file to load");
+
+        let excluded = config.excluded_paths();
+        // Entries from the file are merged in and resolved against the workspace path.
+        assert!(excluded.contains(Path::new("/workspace/vendor")));
+        assert!(excluded.contains(Path::new("/workspace/generated")));
+        // Defaults seeded at construction survive the merge.
+        assert!(excluded.contains(Path::new("/workspace/node_modules")));
+        // A config file cannot override the programmatically-set workspace path.
+        assert_eq!(config.workspace_path(), Path::new("/workspace"));
+    }
+
+    #[test]
+    fn load_file_accumulates_exclusions_across_multiple_loads() {
+        let dir = tempfile::tempdir().expect("failed to create temp dir");
+        fs::write(dir.path().join("a.toml"), "exclude = [\"vendor\"]\n").unwrap();
+        fs::write(dir.path().join("b.toml"), "exclude = [\"generated\"]\n").unwrap();
+
+        let mut config = Config::new();
+        config.set_workspace_path(PathBuf::from("/workspace"));
+        config
+            .load_file(&dir.path().join("a.toml"))
+            .expect("expected the first file to load");
+        config
+            .load_file(&dir.path().join("b.toml"))
+            .expect("expected the second file to load");
+
+        let excluded = config.excluded_paths();
+        assert!(excluded.contains(Path::new("/workspace/vendor")));
+        assert!(excluded.contains(Path::new("/workspace/generated")));
+    }
+
+    #[test]
+    fn load_file_errors_when_the_file_is_missing() {
+        let dir = tempfile::tempdir().expect("failed to create temp dir");
+        let mut config = Config::new();
+
+        let error = config
+            .load_file(&dir.path().join("does_not_exist.toml"))
+            .expect_err("an explicitly requested missing file must be an error");
+
+        assert!(
+            matches!(error, Errors::ConfigNotFound(_)),
+            "unexpected error: {error:?}"
+        );
+    }
+
+    #[test]
+    fn load_default_ignores_a_missing_config_file() {
+        let dir = tempfile::tempdir().expect("failed to create temp dir");
+        let mut config = Config::new();
+        config.set_workspace_path(dir.path().to_path_buf());
+
+        config
+            .load_default()
+            .expect("a missing rubydex.toml must not be an error");
+    }
+
+    #[test]
+    fn load_default_loads_an_existing_config_file() {
+        let dir = tempfile::tempdir().expect("failed to create temp dir");
+        fs::write(dir.path().join("rubydex.toml"), "exclude = [\"vendor\"]\n").unwrap();
+
+        let mut config = Config::new();
+        config.set_workspace_path(dir.path().to_path_buf());
+        config.load_default().expect("expected rubydex.toml to load");
+
+        assert!(config.excluded_paths().contains(&dir.path().join("vendor")));
+    }
+
+    #[test]
+    fn load_default_propagates_malformed_config_errors() {
+        let dir = tempfile::tempdir().expect("failed to create temp dir");
+        fs::write(dir.path().join("rubydex.toml"), "exclude = [\n").unwrap();
+
+        let mut config = Config::new();
+        config.set_workspace_path(dir.path().to_path_buf());
+
+        let error = config
+            .load_default()
+            .expect_err("a malformed default config must still be an error");
+
+        assert!(matches!(error, Errors::ConfigError(_)), "unexpected error: {error:?}");
+    }
+
+    #[test]
+    fn parse_defaults_the_excluded_paths_to_empty_when_the_key_is_absent() {
+        let file = Config::parse("").expect("an empty config is valid");
+        assert!(file.exclude.is_empty());
+    }
+
+    #[test]
+    fn parse_rejects_an_exclude_value_of_the_wrong_type() {
+        Config::parse("exclude = \"vendor\"").expect_err("exclude must be an array of strings, not a string");
     }
 }

--- a/rust/rubydex/src/errors.rs
+++ b/rust/rubydex/src/errors.rs
@@ -25,4 +25,6 @@ macro_rules! errors {
 
 errors!(
     FileError;
+    ConfigError;
+    ConfigNotFound;
 );

--- a/rust/rubydex/src/model/graph.rs
+++ b/rust/rubydex/src/model/graph.rs
@@ -5,6 +5,7 @@ use std::path::{Path, PathBuf};
 use crate::assert_mem_size;
 use crate::config::Config;
 use crate::diagnostic::Diagnostic;
+use crate::errors::Errors;
 use crate::indexing::local_graph::LocalGraph;
 use crate::model::built_in::{OBJECT_ID, add_built_in_data};
 use crate::model::declaration::{Ancestor, Declaration, Namespace};
@@ -132,7 +133,7 @@ impl Graph {
 
     /// Returns the set of paths excluded from file discovery.
     #[must_use]
-    pub fn excluded_paths(&self) -> &HashSet<PathBuf> {
+    pub fn excluded_paths(&self) -> HashSet<PathBuf> {
         self.config.excluded_paths()
     }
 
@@ -145,6 +146,22 @@ impl Graph {
     /// Sets the root directory of the workspace being indexed.
     pub fn set_workspace_path(&mut self, workspace_path: PathBuf) {
         self.config.set_workspace_path(workspace_path);
+    }
+
+    /// Loads a configuration file. Pass `None` to load the default `rubydex.toml` configuration file if it exists
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`Errors::ConfigNotFound`] if an explicitly requested file does not exist or an
+    /// [`Errors::ConfigError`] if a file cannot otherwise be read or its contents are malformed.
+    pub fn load_config(&mut self, config_path: Option<&Path>) -> Result<(), Errors> {
+        match config_path {
+            Some(path) => {
+                let path = self.config.workspace_path().join(path);
+                self.config.load_file(&path)
+            }
+            None => self.config.load_default(),
+        }
     }
 
     /// # Panics

--- a/test/graph_test.rb
+++ b/test/graph_test.rb
@@ -50,6 +50,53 @@ class GraphTest < Minitest::Test
     assert_match(/FileError: Path `.*not_found.rb` does not exist/, errors.first)
   end
 
+  def test_load_config_from_explicit_path_adds_exclusions
+    with_context do |context|
+      context.write!(".rubydex_custom", "exclude = vendor, generated\n")
+
+      graph = Rubydex::Graph.new(workspace_path: context.absolute_path)
+      graph.load_config(".rubydex_custom")
+
+      # Excluded paths are resolved against the workspace path.
+      assert_includes(graph.excluded_paths, context.absolute_path_to("vendor"))
+      assert_includes(graph.excluded_paths, context.absolute_path_to("generated"))
+      assert_includes(graph.excluded_paths, context.absolute_path_to("node_modules"))
+    end
+  end
+
+  def test_load_config_without_argument_loads_the_default_rubydex
+    with_context do |context|
+      context.write!(".rubydex", "exclude = vendor, generated\n")
+
+      graph = Rubydex::Graph.new(workspace_path: context.absolute_path)
+      graph.load_config
+
+      assert_includes(graph.excluded_paths, context.absolute_path_to("vendor"))
+      assert_includes(graph.excluded_paths, context.absolute_path_to("generated"))
+      assert_includes(graph.excluded_paths, context.absolute_path_to("node_modules"))
+    end
+  end
+
+  def test_load_config_without_argument_ignores_a_missing_default_rubydex
+    with_context do |context|
+      graph = Rubydex::Graph.new(workspace_path: context.absolute_path)
+
+      # A missing default `.rubydex` is not an error; defaults remain in place.
+      graph.load_config
+      assert_includes(graph.excluded_paths, context.absolute_path_to("node_modules"))
+    end
+  end
+
+  def test_load_config_raises_when_file_is_missing
+    graph = Rubydex::Graph.new
+    assert_raises(Rubydex::ConfigError) { graph.load_config(".rubydex_missing") }
+  end
+
+  def test_load_config_fails_if_argument_is_not_string
+    graph = Rubydex::Graph.new
+    assert_raises(TypeError) { graph.load_config(123) }
+  end
+
   def test_indexing_with_parse_errors
     with_context do |context|
       context.write!("file.rb", "class Foo")
@@ -635,8 +682,6 @@ class GraphTest < Minitest::Test
     with_context do |context|
       context.write!("lib/foo.rb", "class Foo; end")
       context.write!("app/bar.rb", "class Bar; end")
-      context.write!(".git/config", "")
-      context.write!("node_modules/pkg/index.js", "")
       context.write!("top_level.rb", "class TopLevel; end")
       context.write!("top_level.rake", "class TopLevelRake; end")
       context.write!("top_level.rbs", "class TopLevelRbs; end")
@@ -648,10 +693,6 @@ class GraphTest < Minitest::Test
       # Includes workspace directories
       assert_includes(paths, context.absolute_path_to("lib"))
       assert_includes(paths, context.absolute_path_to("app"))
-
-      # Excludes ignored directories
-      refute_includes(paths, context.absolute_path_to(".git"))
-      refute_includes(paths, context.absolute_path_to("node_modules"))
 
       # Includes the top level files
       assert_includes(paths, context.absolute_path_to("top_level.rb"))
@@ -1349,7 +1390,7 @@ class GraphTest < Minitest::Test
       context.write!("vendor/bundle/bar.rb", "class Bar; end")
 
       graph = Rubydex::Graph.new(workspace_path: context.absolute_path)
-      graph.exclude_paths([context.absolute_path_to("vendor/bundle")])
+      graph.exclude_paths(["vendor/bundle"])
 
       assert_includes(graph.excluded_paths, context.absolute_path_to("vendor/bundle"))
 
@@ -1380,15 +1421,17 @@ class GraphTest < Minitest::Test
 
   def test_default_ignored_directories_are_excluded
     with_context do |context|
-      context.write!(".git/config", "")
-      context.write!("node_modules/pkg/index.js", "")
+      context.write!("node_modules/pkg/in_node_modules.rb", "class InNodeModules; end")
+      context.write!("tmp/in_tmp.rb", "class InTmp; end")
       context.write!("lib/foo.rb", "class Foo; end")
 
       graph = Rubydex::Graph.new(workspace_path: context.absolute_path)
+      graph.index_all(graph.workspace_paths)
+      graph.resolve
 
-      Rubydex::Graph::IGNORED_DIRECTORIES.each do |dir|
-        assert_includes(graph.excluded_paths, context.absolute_path_to(dir))
-      end
+      refute_nil(graph["Foo"])
+      assert_nil(graph["InNodeModules"])
+      assert_nil(graph["InTmp"])
     end
   end
 

--- a/test/graph_test.rb
+++ b/test/graph_test.rb
@@ -52,7 +52,7 @@ class GraphTest < Minitest::Test
 
   def test_load_config_from_explicit_path_adds_exclusions
     with_context do |context|
-      context.write!(".rubydex_custom", "exclude = vendor, generated\n")
+      context.write!(".rubydex_custom", "exclude = [\"vendor\", \"generated\"]\n")
 
       graph = Rubydex::Graph.new(workspace_path: context.absolute_path)
       graph.load_config(".rubydex_custom")
@@ -66,7 +66,7 @@ class GraphTest < Minitest::Test
 
   def test_load_config_without_argument_loads_the_default_rubydex
     with_context do |context|
-      context.write!(".rubydex", "exclude = vendor, generated\n")
+      context.write!("rubydex.toml", "exclude = [\"vendor\", \"generated\"]\n")
 
       graph = Rubydex::Graph.new(workspace_path: context.absolute_path)
       graph.load_config
@@ -81,7 +81,7 @@ class GraphTest < Minitest::Test
     with_context do |context|
       graph = Rubydex::Graph.new(workspace_path: context.absolute_path)
 
-      # A missing default `.rubydex` is not an error; defaults remain in place.
+      # A missing default `rubydex.toml` is not an error; defaults remain in place.
       graph.load_config
       assert_includes(graph.excluded_paths, context.absolute_path_to("node_modules"))
     end


### PR DESCRIPTION
While Rubydex is a framework that can be used to build all sorts of tools, in most cases we want consistency in the base analysis.

For example, imagine you have an LSP and a linter based on Rubydex, but because they each configure the framework differently, you get different results in the editor vs in the CLI. That would be a pretty poor experience.

I believe we can provide an easy way to ensure consistency while still maintaining flexibility so that the odd case can load custom configuration files for a random tool.

## Implementation

I recommend reviewing per commit:

1. Allow loading configuration from a file. This adds the infrastructure to read, parse and apply a configuration file, hooking it up to the graph. See the example configuration file below for the format
2. Exposes `load_config` in the Ruby API
3. Adds `rubydex.toml` default configuration for this repo itself

```toml
# rubydex.toml
# Comments
single_value = true

multi_value = ["one", "two"]

[something.nested]
enabled = false
```