### PR TITLE
Remove declaration diagnostics

### DIFF
--- a/rust/rubydex/src/model/declaration.rs
+++ b/rust/rubydex/src/model/declaration.rs
@@ -1,5 +1,4 @@
 use crate::assert_mem_size;
-use crate::diagnostic::Diagnostic;
 use crate::model::ids::{
     ClassVariableReferenceId, GlobalVariableReferenceId, InstanceVariableReferenceId, MethodReferenceId,
 };
@@ -111,8 +110,6 @@ macro_rules! namespace_declaration {
             descendants: IdentityHashSet<DeclarationId>,
             /// The singleton class associated with this declaration
             singleton_class_id: Option<DeclarationId>,
-            /// Diagnostics associated with this declaration
-            diagnostics: Vec<Diagnostic>,
         }
 
         impl $name {
@@ -127,13 +124,11 @@ macro_rules! namespace_declaration {
                     ancestors: Ancestors::Partial(Vec::new()),
                     descendants: IdentityHashSet::default(),
                     singleton_class_id: None,
-                    diagnostics: Vec::new(),
                 }
             }
 
-            pub fn extend(&mut self, mut other: Declaration) {
+            pub fn extend(&mut self, other: Declaration) {
                 self.definition_ids.extend(other.definitions());
-                self.diagnostics.extend(other.take_diagnostics());
 
                 match other {
                     Declaration::Namespace(namespace) => {
@@ -243,8 +238,6 @@ macro_rules! simple_declaration {
             references: IdentityHashSet<$reference_type>,
             /// The ID of the owner of this declaration
             owner_id: DeclarationId,
-            /// Diagnostics associated with this declaration
-            diagnostics: Vec<Diagnostic>,
         }
 
         impl $name {
@@ -255,13 +248,11 @@ macro_rules! simple_declaration {
                     definition_ids: Vec::new(),
                     references: IdentityHashSet::default(),
                     owner_id,
-                    diagnostics: Vec::new(),
                 }
             }
 
-            pub fn extend(&mut self, mut other: $name) {
+            pub fn extend(&mut self, other: $name) {
                 self.definition_ids.extend(other.definitions());
-                self.diagnostics.extend(other.take_diagnostics());
                 self.references.extend(other.references());
             }
 
@@ -276,10 +267,6 @@ macro_rules! simple_declaration {
 
             pub fn remove_reference(&mut self, reference_id: &$reference_type) {
                 self.references.remove(reference_id);
-            }
-
-            pub fn take_diagnostics(&mut self) -> Vec<Diagnostic> {
-                std::mem::take(&mut self.diagnostics)
             }
 
             #[must_use]
@@ -437,23 +424,6 @@ impl Declaration {
     }
 
     #[must_use]
-    pub fn diagnostics(&self) -> &[Diagnostic] {
-        all_declarations!(self, it => &it.diagnostics)
-    }
-
-    pub fn take_diagnostics(&mut self) -> Vec<Diagnostic> {
-        all_declarations!(self, it => std::mem::take(&mut it.diagnostics))
-    }
-
-    pub fn add_diagnostic(&mut self, diagnostic: Diagnostic) {
-        all_declarations!(self, it => it.diagnostics.push(diagnostic));
-    }
-
-    pub fn clear_diagnostics(&mut self) {
-        all_declarations!(self, it => it.diagnostics.clear());
-    }
-
-    #[must_use]
     pub fn reference_count(&self) -> usize {
         all_declarations!(self, it => it.references.len())
     }
@@ -544,15 +514,6 @@ impl Namespace {
     #[must_use]
     pub fn members(&self) -> &IdentityHashMap<StringId, DeclarationId> {
         all_namespaces!(self, it => &it.members)
-    }
-
-    #[must_use]
-    pub fn diagnostics(&self) -> &[Diagnostic] {
-        all_namespaces!(self, it => &it.diagnostics)
-    }
-
-    pub fn take_diagnostics(&mut self) -> Vec<Diagnostic> {
-        all_namespaces!(self, it => std::mem::take(&mut it.diagnostics))
     }
 
     pub fn extend(&mut self, other: Declaration) {
@@ -647,25 +608,25 @@ impl Namespace {
 }
 
 namespace_declaration!(Class, ClassDeclaration);
-assert_mem_size!(ClassDeclaration, 216);
+assert_mem_size!(ClassDeclaration, 192);
 namespace_declaration!(Module, ModuleDeclaration);
-assert_mem_size!(ModuleDeclaration, 216);
+assert_mem_size!(ModuleDeclaration, 192);
 namespace_declaration!(SingletonClass, SingletonClassDeclaration);
-assert_mem_size!(SingletonClassDeclaration, 216);
+assert_mem_size!(SingletonClassDeclaration, 192);
 namespace_declaration!(Todo, TodoDeclaration);
-assert_mem_size!(TodoDeclaration, 216);
+assert_mem_size!(TodoDeclaration, 192);
 simple_declaration!(ConstantDeclaration, ConstantReferenceId);
-assert_mem_size!(ConstantDeclaration, 112);
+assert_mem_size!(ConstantDeclaration, 88);
 simple_declaration!(MethodDeclaration, MethodReferenceId);
-assert_mem_size!(MethodDeclaration, 112);
+assert_mem_size!(MethodDeclaration, 88);
 simple_declaration!(GlobalVariableDeclaration, GlobalVariableReferenceId);
-assert_mem_size!(GlobalVariableDeclaration, 112);
+assert_mem_size!(GlobalVariableDeclaration, 88);
 simple_declaration!(InstanceVariableDeclaration, InstanceVariableReferenceId);
-assert_mem_size!(InstanceVariableDeclaration, 112);
+assert_mem_size!(InstanceVariableDeclaration, 88);
 simple_declaration!(ClassVariableDeclaration, ClassVariableReferenceId);
-assert_mem_size!(ClassVariableDeclaration, 112);
+assert_mem_size!(ClassVariableDeclaration, 88);
 simple_declaration!(ConstantAliasDeclaration, ConstantReferenceId);
-assert_mem_size!(ConstantAliasDeclaration, 112);
+assert_mem_size!(ConstantAliasDeclaration, 88);
 
 #[cfg(test)]
 mod tests {

--- a/rust/rubydex/src/model/graph.rs
+++ b/rust/rubydex/src/model/graph.rs
@@ -498,10 +498,7 @@ impl Graph {
 
     #[must_use]
     pub fn all_diagnostics(&self) -> Vec<&Diagnostic> {
-        let document_diagnostics = self.documents.values().flat_map(Document::diagnostics);
-        let declaration_diagnostics = self.declarations.values().flat_map(Declaration::diagnostics);
-
-        document_diagnostics.chain(declaration_diagnostics).collect()
+        self.documents.values().flat_map(Document::diagnostics).collect()
     }
 
     /// Interns a string in the graph unless already interned. This method is only used to back the
@@ -1212,9 +1209,6 @@ impl Graph {
         if let Some(decl) = self.declarations.get_mut(&decl_id) {
             for def_id in detach_def_ids {
                 decl.remove_definition(def_id);
-            }
-            if !detach_def_ids.is_empty() {
-                decl.clear_diagnostics();
             }
         }
 

--- a/rust/rubydex/src/resolution.rs
+++ b/rust/rubydex/src/resolution.rs
@@ -710,18 +710,8 @@ impl<'a> Resolver<'a> {
                     offset,
                     format!("undefined method `{owner_name}#{method_name}` for visibility change"),
                 );
-                if is_singleton {
-                    // Document-scoped: the singleton class may be synthetic (created by this
-                    // visibility resolution) and won't be cleaned up on file delete, so attaching
-                    // the diagnostic to the declaration would leave it orphaned.
-                    self.graph.add_document_diagnostic(uri_id, diagnostic);
-                } else {
-                    self.graph
-                        .declarations_mut()
-                        .get_mut(&owner_id)
-                        .unwrap()
-                        .add_diagnostic(diagnostic);
-                }
+
+                self.graph.add_document_diagnostic(uri_id, diagnostic);
             }
         }
 


### PR DESCRIPTION
I think adding declaration level diagnostics was premature. In reality, diagnostics are always associated to a piece of code written in some URI and offset combination, even if conceptually the problem arises at the declaration layer.

We weren't really using this, so let's remove it for now.