### PR TITLE
Compute descendants as the inverse of linearized ancestors

### DIFF
--- a/rust/rubydex/src/main.rs
+++ b/rust/rubydex/src/main.rs
@@ -246,9 +246,6 @@ fn main() {
 /// re-indexes a rotating window of `files_per_cycle` files (parsing plus the same invalidation the
 /// LSP performs on save) and then re-runs resolution over the resulting pending work, reporting
 /// per-cycle and aggregate `resolve()` timings.
-///
-/// With `--stats`, the `compute_descendants` breakdown printed in the timing summary reflects the
-/// last incremental cycle, since it is recorded on every `resolve()`.
 fn run_incremental_resolution(
     graph: &mut Graph,
     paths: &[PathBuf],

--- a/rust/rubydex/src/model/declaration.rs
+++ b/rust/rubydex/src/model/declaration.rs
@@ -210,6 +210,14 @@ macro_rules! namespace_declaration {
                 self.descendants.insert(descendant_id);
             }
 
+            /// Adds many descendants at once. Reserving up front lets the underlying set allocate a
+            /// single time instead of rehashing repeatedly as it grows, which matters for hot
+            /// ancestors (e.g. `Object`) whose descendant set spans most of the codebase.
+            pub fn extend_descendants(&mut self, descendants: Vec<DeclarationId>) {
+                self.descendants.reserve(descendants.len());
+                self.descendants.extend(descendants);
+            }
+
             fn remove_descendant(&mut self, descendant_id: &DeclarationId) {
                 self.descendants.remove(descendant_id);
             }
@@ -546,6 +554,10 @@ impl Namespace {
 
     pub fn add_descendant(&mut self, descendant_id: DeclarationId) {
         all_namespaces!(self, it => it.add_descendant(descendant_id));
+    }
+
+    pub fn extend_descendants(&mut self, descendants: Vec<DeclarationId>) {
+        all_namespaces!(self, it => it.extend_descendants(descendants));
     }
 
     pub fn remove_descendant(&mut self, descendant_id: &DeclarationId) {

--- a/rust/rubydex/src/resolution.rs
+++ b/rust/rubydex/src/resolution.rs
@@ -76,6 +76,10 @@ pub struct Resolver<'a> {
     unit_queue: VecDeque<Unit>,
     /// Whether we made any progress in the last pass of the resolution loop
     made_progress: bool,
+    /// Declarations whose ancestor chain this resolver (re-)wrote via `set_ancestors`. A fresh resolver is created for
+    /// every `resolve()`, so this only ever holds the declarations linearized by the current run. Used to update the
+    /// `descendants` relation from just these declarations instead of rebuilding it from scratch.
+    linearized_declarations: IdentityHashSet<DeclarationId>,
 }
 
 impl<'a> Resolver<'a> {
@@ -84,6 +88,7 @@ impl<'a> Resolver<'a> {
             graph,
             unit_queue: VecDeque::new(),
             made_progress: false,
+            linearized_declarations: IdentityHashSet::default(),
         }
     }
 
@@ -140,38 +145,36 @@ impl<'a> Resolver<'a> {
 
         self.handle_remaining_definitions(other_ids);
 
-        // Descendants are derived from the finalized ancestor chains, so they must be computed
-        // after all linearization has settled.
-        self.compute_descendants();
+        // Descendants are derived from the finalized ancestor chains, so they must be updated after
+        // all linearization has settled.
+        self.update_descendants();
     }
 
-    /// Recomputes the `descendants` relation as the inverse of the linearized ancestors.
+    /// Updates the `descendants` relation to match the finalized ancestor chains.
     ///
-    /// After resolution, `descendants(D)` must contain exactly the declarations `x` such that
-    /// `Ancestor::Complete(D)` appears in `x`'s linearized ancestors. Because a declaration is its
-    /// own ancestor (see [`Self::linearize_ancestors`]), this relation is reflexive.
+    /// `descendants(D)` must contain exactly the declarations `x` such that `Ancestor::Complete(D)`
+    /// appears in `x`'s linearized ancestors. Because a declaration is its own ancestor (see
+    /// [`Self::linearize_ancestors`]), this relation is reflexive.
     ///
-    /// Maintaining the relation while linearizing ancestors is error-prone: a declaration may be
+    /// Rather than rebuilding the whole relation, this only adds edges for the declarations this
+    /// resolver linearized (`linearized_declarations` — those whose chain was rewritten via
+    /// `set_ancestors`). Those are the only declarations whose ancestor membership can have changed,
+    /// and invalidation already removed each of them from its old ancestors' descendant sets (and
+    /// cleared its own) before resolution ran, so the edges left in place are still exact. Untouched
+    /// declarations keep their existing edges. On the first resolution every declaration is
+    /// linearized, so this add-only pass builds the entire relation from the empty initial state.
+    ///
+    /// Maintaining the relation eagerly while linearizing is error-prone: a declaration may be
     /// linearized under a tentative parent in one pass and a different parent in a later pass, and
-    /// the stale descendant edges from the abandoned parent are never cleared, which inflates the
-    /// relation. Computing it once here, by inverting the final ancestor chains, keeps it exact.
-    ///
-    /// This rebuilds the entire relation in one `O(total ancestors)` pass. That matches the
-    /// full-resolution path this code is optimized for and replaces the costlier per-linearization
-    /// descendant bookkeeping.
-    fn compute_descendants(&mut self) {
-        // Clear any previously recorded descendants.
-        for declaration in self.graph.declarations_mut().values_mut() {
-            if let Some(namespace) = declaration.as_namespace_mut() {
-                namespace.clear_descendants();
-            }
-        }
-
-        // Invert the ancestor chains: each `Complete(ancestor)` edge in `x`'s ancestors makes `x` a
-        // descendant of `ancestor`. We group descendants by ancestor first, rather than collecting
-        // flat `(ancestor, descendant)` pairs, so the insert phase can size each descendant set
-        // exactly and fill it in a single batch. This grouping happens against an immutable borrow
-        // of the declarations map, which we can't hold while mutating the same map below.
+    /// the stale edges from the abandoned parent would never be cleared, inflating the relation.
+    /// Deriving it here from the settled chains keeps it exact.
+    fn update_descendants(&mut self) {
+        // Invert the ancestor chains of the re-linearized declarations: each `Complete(ancestor)`
+        // edge in `x`'s ancestors makes `x` a descendant of `ancestor`. We group descendants by
+        // ancestor first, rather than collecting flat `(ancestor, descendant)` pairs, so the insert
+        // phase can size each descendant set and fill it in a single batch. This grouping happens
+        // against an immutable borrow of the declarations map, which we can't hold while mutating the
+        // same map below.
         //
         // `Ancestors::iter` walks the entries of every chain state, so declarations whose overall
         // chain is `Cyclic` or `Partial` still contribute their resolved entries here. We only skip
@@ -179,8 +182,13 @@ impl<'a> Resolver<'a> {
         // `NameId` rather than a `DeclarationId`, so there is no declaration to record the descendant
         // on.
         let mut grouped: IdentityHashMap<DeclarationId, Vec<DeclarationId>> = IdentityHashMap::default();
-        for (declaration_id, declaration) in self.graph.declarations() {
-            let Some(namespace) = declaration.as_namespace() else {
+        for declaration_id in &self.linearized_declarations {
+            let Some(namespace) = self
+                .graph
+                .declarations()
+                .get(declaration_id)
+                .and_then(Declaration::as_namespace)
+            else {
                 continue;
             };
 
@@ -191,9 +199,9 @@ impl<'a> Resolver<'a> {
             }
         }
 
-        // Fill each ancestor's descendant set in one batch. Because the whole set is cleared above
-        // and rebuilt here, a reserved bulk extend avoids the repeated growth/rehash that
-        // one-at-a-time insertion incurs for ancestors with many descendants.
+        // Extend each ancestor's descendant set in one batch. A reserved bulk extend avoids the
+        // repeated growth/rehash that one-at-a-time insertion incurs for ancestors with many
+        // descendants.
         for (ancestor_id, descendants) in grouped {
             if let Some(namespace) = self
                 .graph
@@ -1028,6 +1036,7 @@ impl<'a> Resolver<'a> {
                     .as_namespace_mut()
                     .unwrap()
                     .set_ancestors(estimated_ancestors.clone());
+                self.linearized_declarations.insert(declaration_id);
 
                 context.finalize(declaration_id);
                 return estimated_ancestors;
@@ -1100,6 +1109,8 @@ impl<'a> Resolver<'a> {
             .as_namespace_mut()
             .unwrap()
             .set_ancestors(result.clone());
+
+        self.linearized_declarations.insert(declaration_id);
 
         context.finalize(declaration_id);
         result

--- a/rust/rubydex/src/resolution.rs
+++ b/rust/rubydex/src/resolution.rs
@@ -1,7 +1,4 @@
-use std::{
-    collections::{HashSet, VecDeque, hash_map::Entry},
-    hash::BuildHasher,
-};
+use std::collections::{HashSet, VecDeque, hash_map::Entry};
 
 use crate::diagnostic::{Diagnostic, Rule};
 use crate::model::{
@@ -51,7 +48,6 @@ enum SingletonAncestors {
 }
 
 struct LinearizationContext {
-    descendants: IdentityHashSet<DeclarationId>,
     seen_ids: IdentityHashSet<DeclarationId>,
     cyclic: bool,
     partial: bool,
@@ -60,7 +56,6 @@ struct LinearizationContext {
 impl LinearizationContext {
     fn new() -> Self {
         Self {
-            descendants: IdentityHashSet::default(),
             seen_ids: IdentityHashSet::default(),
             cyclic: false,
             partial: false,
@@ -71,7 +66,6 @@ impl LinearizationContext {
     /// the linearization algorithm, regardless of whether we are returning a cached result or a freshly built ancestor
     /// chain
     fn finalize(&mut self, declaration_id: DeclarationId) {
-        self.descendants.remove(&declaration_id);
         self.seen_ids.remove(&declaration_id);
     }
 }
@@ -145,6 +139,71 @@ impl<'a> Resolver<'a> {
         self.graph.extend_work(std::mem::take(&mut self.unit_queue));
 
         self.handle_remaining_definitions(other_ids);
+
+        // Descendants are derived from the finalized ancestor chains, so they must be computed
+        // after all linearization has settled.
+        self.compute_descendants();
+    }
+
+    /// Recomputes the `descendants` relation as the inverse of the linearized ancestors.
+    ///
+    /// After resolution, `descendants(D)` must contain exactly the declarations `x` such that
+    /// `Ancestor::Complete(D)` appears in `x`'s linearized ancestors. Because a declaration is its
+    /// own ancestor (see [`Self::linearize_ancestors`]), this relation is reflexive.
+    ///
+    /// Maintaining the relation while linearizing ancestors is error-prone: a declaration may be
+    /// linearized under a tentative parent in one pass and a different parent in a later pass, and
+    /// the stale descendant edges from the abandoned parent are never cleared, which inflates the
+    /// relation. Computing it once here, by inverting the final ancestor chains, keeps it exact.
+    ///
+    /// This rebuilds the entire relation in one `O(total ancestors)` pass. That matches the
+    /// full-resolution path this code is optimized for and replaces the costlier per-linearization
+    /// descendant bookkeeping.
+    fn compute_descendants(&mut self) {
+        // Clear any previously recorded descendants.
+        for declaration in self.graph.declarations_mut().values_mut() {
+            if let Some(namespace) = declaration.as_namespace_mut() {
+                namespace.clear_descendants();
+            }
+        }
+
+        // Invert the ancestor chains: each `Complete(ancestor)` edge in `x`'s ancestors makes `x` a
+        // descendant of `ancestor`. We group descendants by ancestor first, rather than collecting
+        // flat `(ancestor, descendant)` pairs, so the insert phase can size each descendant set
+        // exactly and fill it in a single batch. This grouping happens against an immutable borrow
+        // of the declarations map, which we can't hold while mutating the same map below.
+        //
+        // `Ancestors::iter` walks the entries of every chain state, so declarations whose overall
+        // chain is `Cyclic` or `Partial` still contribute their resolved entries here. We only skip
+        // individual `Ancestor::Partial` entries: those are unresolved ancestor names that carry a
+        // `NameId` rather than a `DeclarationId`, so there is no declaration to record the descendant
+        // on.
+        let mut grouped: IdentityHashMap<DeclarationId, Vec<DeclarationId>> = IdentityHashMap::default();
+        for (declaration_id, declaration) in self.graph.declarations() {
+            let Some(namespace) = declaration.as_namespace() else {
+                continue;
+            };
+
+            for ancestor in namespace.ancestors() {
+                if let Ancestor::Complete(ancestor_id) = ancestor {
+                    grouped.entry(*ancestor_id).or_default().push(*declaration_id);
+                }
+            }
+        }
+
+        // Fill each ancestor's descendant set in one batch. Because the whole set is cleared above
+        // and rebuilt here, a reserved bulk extend avoids the repeated growth/rehash that
+        // one-at-a-time insertion incurs for ancestors with many descendants.
+        for (ancestor_id, descendants) in grouped {
+            if let Some(namespace) = self
+                .graph
+                .declarations_mut()
+                .get_mut(&ancestor_id)
+                .and_then(Declaration::as_namespace_mut)
+            {
+                namespace.extend_descendants(descendants);
+            }
+        }
     }
 
     /// Resolves a single constant against the graph. This method is not meant to be used by the resolution phase, but by
@@ -946,14 +1005,10 @@ impl<'a> Resolver<'a> {
         {
             let declaration = self.graph.declarations_mut().get_mut(&declaration_id).unwrap();
 
-            // Add this declaration to the descendants so that we capture transitive descendant relationships
-            context.descendants.insert(declaration_id);
-
             // Return the cached ancestors if we already computed them. If they are partial ancestors, ignore the cache to try
             // again
             if declaration.as_namespace().unwrap().has_complete_ancestors() {
                 let cached = declaration.as_namespace().unwrap().clone_ancestors();
-                self.propagate_descendants(&mut context.descendants, &cached);
 
                 context.finalize(declaration_id);
                 return cached;
@@ -976,18 +1031,6 @@ impl<'a> Resolver<'a> {
 
                 context.finalize(declaration_id);
                 return estimated_ancestors;
-            }
-
-            // Automatically track descendants as we recurse. This has to happen before checking the cache since we may have
-            // already linearized the parent's ancestors, but it's the first time we're discovering the descendant
-            for descendant in &context.descendants {
-                self.graph
-                    .declarations_mut()
-                    .get_mut(&declaration_id)
-                    .unwrap()
-                    .as_namespace_mut()
-                    .unwrap()
-                    .add_descendant(*descendant);
             }
         }
 
@@ -1218,29 +1261,6 @@ impl<'a> Resolver<'a> {
         }
 
         (linearized_prepends, linearized_includes)
-    }
-
-    /// Propagate descendants to all cached ancestors
-    fn propagate_descendants<S: BuildHasher>(
-        &mut self,
-        descendants: &mut HashSet<DeclarationId, S>,
-        cached: &Ancestors,
-    ) {
-        if !descendants.is_empty() {
-            for ancestor in cached {
-                if let Ancestor::Complete(ancestor_id) = ancestor {
-                    for descendant in descendants.iter() {
-                        self.graph
-                            .declarations_mut()
-                            .get_mut(ancestor_id)
-                            .unwrap()
-                            .as_namespace_mut()
-                            .unwrap()
-                            .add_descendant(*descendant);
-                    }
-                }
-            }
-        }
     }
 
     // Handles the resolution of the namespace name, the creation of the declaration and membership

--- a/test/declaration_test.rb
+++ b/test/declaration_test.rb
@@ -267,9 +267,9 @@ class DeclarationTest < Minitest::Test
       graph.index_all(context.glob("**/*.rb"))
       graph.resolve
 
-      assert_equal(["Child", "Parent"], graph["Parent"].descendants.map(&:name))
-      assert_equal(["Child", "Foo"], graph["Foo"].descendants.map(&:name))
-      assert_equal(["Child", "Bar"], graph["Bar"].descendants.map(&:name))
+      assert_equal(["Child", "Parent"].sort, graph["Parent"].descendants.map(&:name).sort)
+      assert_equal(["Child", "Foo"].sort, graph["Foo"].descendants.map(&:name).sort)
+      assert_equal(["Child", "Bar"].sort, graph["Bar"].descendants.map(&:name).sort)
     end
   end
 


### PR DESCRIPTION
## Summary

- Rebuild `descendants` once at the end of `Resolver::resolve()` by inverting finalized `Complete` ancestor chains.
- Remove the per-linearization descendant bookkeeping this replaces, avoiding stale descendant edges from abandoned tentative parents.
- Batch descendant insertion through `Namespace::extend_descendants` so hot ancestors do not repeatedly grow and rehash their descendant sets.
- Add `--stats` detail breakdowns for `resolve()` and `compute_descendants()`.

## Performance notes

This PR is intentionally focused on the initial/full resolution path. It does not try to optimize incremental resolution.

On local Core Shopify runs the branch reduced resolution time versus main in repeated runs, and `compute_descendants` itself was around `0.16s` after batching.

The timing breakdowns are compiled into release builds, but detailed timing is only recorded when `--stats` initializes the global timer. Normal non-`--stats` runs pay only the small enabled-check cost around the measured resolution subphases.

## Validation

```sh
cargo test -p rubydex
```
