### PR TITLE
Materialize singleton classes

### DIFF
--- a/rust/rubydex-mcp/src/server.rs
+++ b/rust/rubydex-mcp/src/server.rs
@@ -1119,12 +1119,15 @@ mod tests {
         let res = parse(&s.codebase_stats());
 
         assert_eq!(res["files"], 3);
-        assert_json_int!(res, "declarations", 7);
+        // 7 declarations (Animal, Greetable, and 5 built-ins) plus a materialized rank-1 singleton
+        // class for each of them. Definitions do not include singletons.
+        assert_json_int!(res, "declarations", 14);
         assert_json_int!(res, "definitions", 7);
 
         let breakdown = &res["breakdown_by_kind"];
         assert_json_int!(breakdown, "Class", 5);
         assert_json_int!(breakdown, "Module", 2);
+        assert_json_int!(breakdown, "SingletonClass", 7);
     }
 
     // -- error states --

--- a/rust/rubydex/src/query.rs
+++ b/rust/rubydex/src/query.rs
@@ -928,7 +928,8 @@ mod tests {
             "
         });
         context.resolve();
-        assert_results_eq!(context, "Fo", ["Foo"]);
+        // `Foo::<Foo>` is materialized for every class, so the fuzzy query matches the singleton too.
+        assert_results_eq!(context, "Fo", ["Foo::<Foo>", "Foo"]);
     }
 
     #[test]

--- a/rust/rubydex/src/query.rs
+++ b/rust/rubydex/src/query.rs
@@ -956,7 +956,7 @@ mod tests {
         });
         context.resolve();
 
-        // A rank-1 singleton is materialized for every class...
+        // Every declared class has its singleton class automatically populated...
         assert!(
             context
                 .graph()

--- a/rust/rubydex/src/query.rs
+++ b/rust/rubydex/src/query.rs
@@ -43,7 +43,10 @@ pub fn declaration_search(graph: &Graph, queries: &[&str], match_mode: &MatchMod
     // directly. Since an empty query matches all, there's no point in checking the other queries or pay the price of
     // spawning threads.
     if queries.iter().any(|q| q.is_empty()) {
-        return declarations.keys().copied().collect();
+        return declarations
+            .iter()
+            .filter_map(|(id, declaration)| is_searchable_declaration(declaration).then_some(*id))
+            .collect();
     }
 
     let ids: Vec<DeclarationId> = declarations.keys().copied().collect();
@@ -61,7 +64,12 @@ pub fn declaration_search(graph: &Graph, queries: &[&str], match_mode: &MatchMod
                     chunk
                         .iter()
                         .filter(|id| {
-                            let name = declarations.get(id).unwrap().name();
+                            let declaration = declarations.get(id).unwrap();
+                            if !is_searchable_declaration(declaration) {
+                                return false;
+                            }
+
+                            let name = declaration.name();
                             queries.iter().any(|query| matches_query(query, name, match_mode))
                         })
                         .copied()
@@ -72,6 +80,12 @@ pub fn declaration_search(graph: &Graph, queries: &[&str], match_mode: &MatchMod
 
         handles.into_iter().flat_map(|h| h.join().unwrap()).collect()
     })
+}
+
+/// Returns whether a declaration should be surfaced by user-facing declaration search.
+#[must_use]
+fn is_searchable_declaration(declaration: &Declaration) -> bool {
+    !matches!(declaration, Declaration::Namespace(Namespace::SingletonClass(_)))
 }
 
 /// Returns whether a single `query` matches `name` under the given [`MatchMode`].
@@ -928,8 +942,32 @@ mod tests {
             "
         });
         context.resolve();
-        // `Foo::<Foo>` is materialized for every class, so the fuzzy query matches the singleton too.
-        assert_results_eq!(context, "Fo", ["Foo::<Foo>", "Foo"]);
+        assert_results_eq!(context, "Fo", ["Foo"]);
+    }
+
+    #[test]
+    fn search_excludes_singleton_classes() {
+        let mut context = GraphTest::new();
+        context.index_uri("file:///foo.rb", {
+            r"
+            class Foo
+            end
+            "
+        });
+        context.resolve();
+
+        // A rank-1 singleton is materialized for every class...
+        assert!(
+            context
+                .graph()
+                .declarations()
+                .contains_key(&DeclarationId::from("Foo::<Foo>")),
+            "expected `Foo::<Foo>` to be materialized"
+        );
+        // ...but it is internal and must not surface in search results, even when the query
+        // matches the singleton's name directly.
+        assert_results_eq!(context, "<Foo>", &MatchMode::Exact, Vec::<&str>::new());
+        assert_results_eq!(context, "Foo", ["Foo"]);
     }
 
     #[test]
@@ -963,8 +1001,17 @@ mod tests {
         let exact_results = declaration_search(context.graph(), &[""], &MatchMode::Exact);
         let fuzzy_results = declaration_search(context.graph(), &[""], &MatchMode::Fuzzy);
 
+        // An empty query returns every searchable declaration. Materialized singleton classes are
+        // excluded from search, so the expected count is all declarations minus the singletons.
+        let searchable = context
+            .graph()
+            .declarations()
+            .values()
+            .filter(|d| !matches!(d, Declaration::Namespace(Namespace::SingletonClass(_))))
+            .count();
+
         assert_eq!(exact_results.len(), fuzzy_results.len());
-        assert_eq!(context.graph().declarations().len(), exact_results.len());
+        assert_eq!(searchable, exact_results.len());
     }
 
     #[test]

--- a/rust/rubydex/src/resolution.rs
+++ b/rust/rubydex/src/resolution.rs
@@ -145,10 +145,9 @@ impl<'a> Resolver<'a> {
 
         self.handle_remaining_definitions(other_ids);
 
-        // Materialize a rank-1 singleton class for every class/module declaration. This runs after
-        // every site that creates singletons organically (the convergence loop and
-        // `handle_remaining_definitions`), so future rank-N passes — which only build singletons for
-        // already-materialized ones — can be appended here and still observe the complete set.
+        // Materialize singleton classes for every class/module declaration. This runs after the
+        // main singleton creation paths (the convergence loop and `handle_remaining_definitions`)
+        // so it only fills gaps in existing singleton-class ancestor/descendant chains.
         self.materialize_singleton_classes();
 
         // Descendants are derived from the finalized ancestor chains, so they must be updated after
@@ -156,52 +155,62 @@ impl<'a> Resolver<'a> {
         self.update_descendants();
     }
 
-    /// Materializes the singleton class hierarchy so that it is complete after resolution.
+    /// Materializes singleton classes needed for complete ancestor/descendant chains.
     ///
     /// During the convergence loop and [`Self::handle_remaining_definitions`], singleton classes are
     /// only created on demand: when a self-method, an `extend`, a `class << self`, or a class-level
-    /// instance variable forces one into existence. Many class and module objects therefore never
-    /// get a singleton even though every Ruby object has one. This pass fills the gaps. Ancestors are
-    /// linearized eagerly because the convergence queue is already drained at this point.
+    /// instance variable forces one into existence. That lazy behavior is correct for Ruby, but it
+    /// leaves holes in graph queries that expect singleton-class ancestors and descendants to be
+    /// explicit declarations.
     ///
-    /// The pass runs in two stages:
+    /// For example, if source creates `Foo::<Foo>` and `Bar < Foo`, then `Bar::<Bar>` must also
+    /// exist so `Foo::<Foo>` can be recorded as an ancestor of `Bar::<Bar>`. The same rule applies
+    /// to nested singleton classes:
     ///
-    /// 1. **rank-1**: ensure `Foo::<Foo>` exists for every class and module `Foo`.
-    /// 2. **rank-N**: climb the singleton ranks. A nested `class << self` produces an explicit
-    ///    rank-`N` singleton (e.g. `Foo::<Foo>::<<Foo>>`). When that happens, every subclass of
-    ///    `Foo` must also gain a rank-`N` singleton so the hierarchy stays complete. We materialize
-    ///    only the ranks reachable from an explicit (source-backed) singleton, descending the class
-    ///    inheritance tree from it — materializing *all* ranks for *all* classes would never
-    ///    terminate.
+    /// ```rb
+    /// class Foo
+    ///   class << self        # Foo::<Foo>, the singleton class of Foo
+    ///     class << self      # Foo::<Foo>::<<Foo>>, the singleton class of Foo::<Foo>
+    ///     end
+    ///   end
+    /// end
     ///
-    /// The rank-`N` stage relies on the invariant that an explicit rank-`N` singleton always has an
-    /// existing rank-`(N-1)` owner (no gaps): every path that creates a singleton takes the rank
-    /// `(N-1)` declaration as input, and a nested `class << self` is indexed level by level, so each
-    /// intermediate rank is itself a definition.
+    /// class Bar < Foo
+    /// end
+    /// ```
+    ///
+    /// Because the source explicitly opens the singleton class of `Foo::<Foo>`, this pass also
+    /// creates `Bar::<Bar>::<<Bar>>`, the corresponding singleton class of `Bar::<Bar>`.
+    ///
+    /// The work is intentionally bounded. The first stage creates the singleton class of every class
+    /// and module. The second stage creates deeper singleton classes only when there is a
+    /// source-backed singleton class at that depth, then descends from that owner through the class
+    /// inheritance tree. It does not keep creating singleton classes for every possible singleton of
+    /// every class.
     fn materialize_singleton_classes(&mut self) {
         // Scan all declarations once to collect every input both stages need:
         //
-        // - `attached_ids`: every class and module, for which Stage 1 materializes a rank-1
-        //   singleton. Ids are collected up front because `get_or_create_singleton_class` borrows the
-        //   graph mutably.
+        // - `attached_ids`: every class and module whose singleton class should exist. Ids are
+        //   collected up front because `get_or_create_singleton_class` borrows the graph mutably.
         // - `class_parents`: each class paired with its resolved direct superclass. We resolve it here
         //   while the declaration is in hand; Stage 2 translates these edges to singleton ids (which
         //   do not exist until Stage 1 runs) to seed the `children` map.
-        // - `seed_owners_by_rank`: the owners of every source-backed rank-`>= 2` singleton, grouped by
-        //   the rank of that owner. An owner at rank `R` seeds materialization of rank-`(R + 1)`
-        //   singletons for all of its descendants in Stage 2. A rank-`>= 2` singleton is source-backed
-        //   when it has its own definition (a nested `class << self`) or members (e.g. a `def self.x`
-        //   written inside `class << self`). Singletons with neither are pure linearization artifacts:
-        //   linearizing an explicit singleton creates the singletons of its ancestors (e.g.
-        //   `Object::<Object>::<<Object>>`), and seeding on those would descend the whole class tree.
+        // - `seed_owners_by_depth`: the owners of every source-backed nested singleton class, grouped
+        //   by the singleton depth of that owner. `Foo::<Foo>::<<Foo>>` is source-backed when it has
+        //   its own definition (a nested `class << self`) or members (for example, a `def self.x`
+        //   written inside `class << self`). Its owner, `Foo::<Foo>`, seeds materialization of the
+        //   corresponding singleton class for each descendant of `Foo::<Foo>`. Singletons with no
+        //   definition or members are pure linearization artifacts: linearizing an explicit singleton
+        //   creates the singletons of its ancestors (for example, `Object::<Object>::<<Object>>`), and
+        //   seeding on those would descend the whole class tree.
         //
-        // The seed set is fixed before this pass: explicit rank-`>= 2` singletons are created
-        // organically during resolution, and Stage 1 only adds rank-1 singletons, so it never adds or
-        // removes a seed. That is why everything can be collected in this single scan.
+        // The seed set is fixed before this pass: source-backed nested singletons are created
+        // organically during resolution, and Stage 1 only adds the first singleton layer, so it never
+        // adds or removes a seed. That is why everything can be collected in this single scan.
         let mut attached_ids: Vec<DeclarationId> = Vec::new();
         let mut class_parents: Vec<(DeclarationId, DeclarationId)> = Vec::new();
-        let mut seed_owners_by_rank: HashMap<usize, IdentityHashSet<DeclarationId>> = HashMap::new();
-        let mut max_rank = 1;
+        let mut seed_owners_by_depth: HashMap<usize, IdentityHashSet<DeclarationId>> = HashMap::new();
+        let mut max_singleton_depth = 1;
         for (declaration_id, declaration) in self.graph.declarations() {
             match declaration.as_namespace() {
                 Some(Namespace::Module(_)) => attached_ids.push(*declaration_id),
@@ -215,34 +224,33 @@ impl<'a> Resolver<'a> {
                 Some(namespace @ Namespace::SingletonClass(_))
                     if !namespace.definitions().is_empty() || !namespace.members().is_empty() =>
                 {
-                    let rank = self.singleton_rank(*declaration_id);
-                    if rank >= 2 {
-                        seed_owners_by_rank
-                            .entry(rank - 1)
+                    let depth = self.singleton_depth(*declaration_id);
+                    if depth >= 2 {
+                        seed_owners_by_depth
+                            .entry(depth - 1)
                             .or_default()
                             .insert(*namespace.owner_id());
-                        max_rank = max_rank.max(rank);
+                        max_singleton_depth = max_singleton_depth.max(depth);
                     }
                 }
                 _ => {}
             }
         }
 
-        // --- Stage 1: rank-1 singleton for every class and module ---
+        // --- Stage 1: singleton class for every class and module ---
         for attached_id in &attached_ids {
             // Idempotent: returns the existing singleton when one was already created on demand.
             let _ = self.get_or_create_singleton_class(*attached_id, SingletonAncestors::Eager);
         }
 
-        // --- Stage 2: rank-N singletons for descendants of explicit singletons ---
+        // --- Stage 2: deeper singleton classes for descendants of source-backed singletons ---
         //
         // `children` maps a singleton to the singletons of the *direct* subclasses of its attached
-        // object: for `class B < A`, `A::<A>`'s children contain `B::<B>`. It starts as the rank-1
+        // object: for `class B < A`, `A::<A>`'s children contain `B::<B>`. It starts as the first
         // layer (translating the `class_parents` edges collected above, now that Stage 1 has
-        // materialized every rank-1 singleton) and grows one rank at a time as we climb: building
+        // materialized every class singleton) and grows one singleton layer at a time: building
         // `B::<B>::<<B>>` records it as a child of `A::<A>::<<A>>` for the next iteration. This is a
-        // local map; the global `descendants` relation is recomputed later by
-        // [`Self::compute_descendants`].
+        // local map; the global `descendants` relation is updated later by [`Self::update_descendants`].
         let mut children: IdentityHashMap<DeclarationId, IdentityHashSet<DeclarationId>> = IdentityHashMap::default();
         for (child_class, parent_class) in &class_parents {
             if let (Some(child_singleton), Some(parent_singleton)) =
@@ -252,13 +260,12 @@ impl<'a> Resolver<'a> {
             }
         }
 
-        // Climb the ranks: at rank `R`, descend the class inheritance tree from each seed owner,
-        // materializing the rank-`(R + 1)` singleton of every node reached, and record the new
-        // rank-`(R + 1)` edges so the next iteration can descend them. Ranks are contiguous (an
-        // explicit rank-`(R + 1)` singleton implies an explicit rank-`R` owner), so every rank in
-        // `1..max_rank` has seeds.
-        for rank in 1..max_rank {
-            let Some(seed_owners) = seed_owners_by_rank.get(&rank) else {
+        // Climb one singleton layer at a time. At owner depth `D`, descend the inheritance tree from
+        // each seed owner, materialize the singleton class of every node reached, and record those new
+        // child edges so depth `D + 1` can use them. Nested singleton definitions are contiguous: to
+        // create the singleton class of `Foo::<Foo>`, the graph must already contain `Foo::<Foo>`.
+        for owner_depth in 1..max_singleton_depth {
+            let Some(seed_owners) = seed_owners_by_depth.get(&owner_depth) else {
                 continue;
             };
 
@@ -294,20 +301,20 @@ impl<'a> Resolver<'a> {
         }
     }
 
-    /// Returns the rank of a singleton class: how many singleton wrappers separate it from its
-    /// non-singleton attached object. A class declaration has rank `0`, `Foo::<Foo>` has rank `1`,
-    /// `Foo::<Foo>::<<Foo>>` has rank `2`, and so on. Computed by walking the owner chain so it does
-    /// not depend on how the name is spelled.
-    fn singleton_rank(&self, mut id: DeclarationId) -> usize {
-        let mut rank = 0;
+    /// Returns how many singleton-class owners separate this declaration from its attached class or
+    /// module. A class declaration has depth `0`, `Foo::<Foo>` has depth `1`, and the singleton class
+    /// of `Foo::<Foo>` has depth `2`. Computed by walking the owner chain so it does not depend on
+    /// how the name is spelled.
+    fn singleton_depth(&self, mut id: DeclarationId) -> usize {
+        let mut depth = 0;
         while let Some(declaration) = self.graph.declarations().get(&id) {
             let Some(namespace @ Namespace::SingletonClass(_)) = declaration.as_namespace() else {
                 break;
             };
-            rank += 1;
+            depth += 1;
             id = *namespace.owner_id();
         }
-        rank
+        depth
     }
 
     /// Returns the id of the singleton class of the given declaration, if one has been materialized.

--- a/rust/rubydex/src/resolution.rs
+++ b/rust/rubydex/src/resolution.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashSet, VecDeque, hash_map::Entry};
+use std::collections::{HashMap, HashSet, VecDeque, hash_map::Entry};
 
 use crate::diagnostic::{Diagnostic, Rule};
 use crate::model::{
@@ -156,33 +156,167 @@ impl<'a> Resolver<'a> {
         self.update_descendants();
     }
 
-    /// Materializes a rank-1 singleton class for every class and module declaration.
+    /// Materializes the singleton class hierarchy so that it is complete after resolution.
     ///
     /// During the convergence loop and [`Self::handle_remaining_definitions`], singleton classes are
     /// only created on demand: when a self-method, an `extend`, a `class << self`, or a class-level
     /// instance variable forces one into existence. Many class and module objects therefore never
-    /// get a singleton even though every Ruby object has one. This pass fills the gaps so the
-    /// singleton hierarchy is complete: for class `Foo` it ensures `Foo::<Foo>` exists. Ancestors are
+    /// get a singleton even though every Ruby object has one. This pass fills the gaps. Ancestors are
     /// linearized eagerly because the convergence queue is already drained at this point.
     ///
-    /// Singleton classes themselves (rank >= 2) are intentionally skipped here; a later rank-N pass
-    /// builds those on top of the singletons materialized here.
+    /// The pass runs in two stages:
+    ///
+    /// 1. **rank-1**: ensure `Foo::<Foo>` exists for every class and module `Foo`.
+    /// 2. **rank-N**: climb the singleton ranks. A nested `class << self` produces an explicit
+    ///    rank-`N` singleton (e.g. `Foo::<Foo>::<<Foo>>`). When that happens, every subclass of
+    ///    `Foo` must also gain a rank-`N` singleton so the hierarchy stays complete. We materialize
+    ///    only the ranks reachable from an explicit (source-backed) singleton, descending the class
+    ///    inheritance tree from it — materializing *all* ranks for *all* classes would never
+    ///    terminate.
+    ///
+    /// The rank-`N` stage relies on the invariant that an explicit rank-`N` singleton always has an
+    /// existing rank-`(N-1)` owner (no gaps): every path that creates a singleton takes the rank
+    /// `(N-1)` declaration as input, and a nested `class << self` is indexed level by level, so each
+    /// intermediate rank is itself a definition.
     fn materialize_singleton_classes(&mut self) {
-        // Collect the target ids first: `get_or_create_singleton_class` borrows the graph mutably.
+        // Scan all declarations once to collect every input both stages need:
+        //
+        // - `attached_ids`: every class and module, for which Stage 1 materializes a rank-1
+        //   singleton. Ids are collected up front because `get_or_create_singleton_class` borrows the
+        //   graph mutably.
+        // - `class_parents`: each class paired with its resolved direct superclass. We resolve it here
+        //   while the declaration is in hand; Stage 2 translates these edges to singleton ids (which
+        //   do not exist until Stage 1 runs) to seed the `children` map.
+        // - `seed_owners_by_rank`: the owners of every source-backed rank-`>= 2` singleton, grouped by
+        //   the rank of that owner. An owner at rank `R` seeds materialization of rank-`(R + 1)`
+        //   singletons for all of its descendants in Stage 2. A rank-`>= 2` singleton is source-backed
+        //   when it has its own definition (a nested `class << self`) or members (e.g. a `def self.x`
+        //   written inside `class << self`). Singletons with neither are pure linearization artifacts:
+        //   linearizing an explicit singleton creates the singletons of its ancestors (e.g.
+        //   `Object::<Object>::<<Object>>`), and seeding on those would descend the whole class tree.
+        //
+        // The seed set is fixed before this pass: explicit rank-`>= 2` singletons are created
+        // organically during resolution, and Stage 1 only adds rank-1 singletons, so it never adds or
+        // removes a seed. That is why everything can be collected in this single scan.
         let mut attached_ids: Vec<DeclarationId> = Vec::new();
+        let mut class_parents: Vec<(DeclarationId, DeclarationId)> = Vec::new();
+        let mut seed_owners_by_rank: HashMap<usize, IdentityHashSet<DeclarationId>> = HashMap::new();
+        let mut max_rank = 1;
         for (declaration_id, declaration) in self.graph.declarations() {
-            if matches!(
-                declaration,
-                Declaration::Namespace(Namespace::Class(_) | Namespace::Module(_))
-            ) {
-                attached_ids.push(*declaration_id);
+            match declaration.as_namespace() {
+                Some(Namespace::Module(_)) => attached_ids.push(*declaration_id),
+                Some(namespace @ Namespace::Class(_)) => {
+                    attached_ids.push(*declaration_id);
+                    // Only classes participate in the inheritance tree Stage 2 descends; a module's
+                    // singleton parent is always `Module`, and modules cannot be subclassed.
+                    let (parent_class, _) = self.get_parent_class(namespace.definitions());
+                    class_parents.push((*declaration_id, parent_class));
+                }
+                Some(namespace @ Namespace::SingletonClass(_))
+                    if !namespace.definitions().is_empty() || !namespace.members().is_empty() =>
+                {
+                    let rank = self.singleton_rank(*declaration_id);
+                    if rank >= 2 {
+                        seed_owners_by_rank
+                            .entry(rank - 1)
+                            .or_default()
+                            .insert(*namespace.owner_id());
+                        max_rank = max_rank.max(rank);
+                    }
+                }
+                _ => {}
             }
         }
 
-        for attached_id in attached_ids {
+        // --- Stage 1: rank-1 singleton for every class and module ---
+        for attached_id in &attached_ids {
             // Idempotent: returns the existing singleton when one was already created on demand.
-            let _ = self.get_or_create_singleton_class(attached_id, true);
+            let _ = self.get_or_create_singleton_class(*attached_id, SingletonAncestors::Eager);
         }
+
+        // --- Stage 2: rank-N singletons for descendants of explicit singletons ---
+        //
+        // `children` maps a singleton to the singletons of the *direct* subclasses of its attached
+        // object: for `class B < A`, `A::<A>`'s children contain `B::<B>`. It starts as the rank-1
+        // layer (translating the `class_parents` edges collected above, now that Stage 1 has
+        // materialized every rank-1 singleton) and grows one rank at a time as we climb: building
+        // `B::<B>::<<B>>` records it as a child of `A::<A>::<<A>>` for the next iteration. This is a
+        // local map; the global `descendants` relation is recomputed later by
+        // [`Self::compute_descendants`].
+        let mut children: IdentityHashMap<DeclarationId, IdentityHashSet<DeclarationId>> = IdentityHashMap::default();
+        for (child_class, parent_class) in &class_parents {
+            if let (Some(child_singleton), Some(parent_singleton)) =
+                (self.singleton_id_of(*child_class), self.singleton_id_of(*parent_class))
+            {
+                children.entry(parent_singleton).or_default().insert(child_singleton);
+            }
+        }
+
+        // Climb the ranks: at rank `R`, descend the class inheritance tree from each seed owner,
+        // materializing the rank-`(R + 1)` singleton of every node reached, and record the new
+        // rank-`(R + 1)` edges so the next iteration can descend them. Ranks are contiguous (an
+        // explicit rank-`(R + 1)` singleton implies an explicit rank-`R` owner), so every rank in
+        // `1..max_rank` has seeds.
+        for rank in 1..max_rank {
+            let Some(seed_owners) = seed_owners_by_rank.get(&rank) else {
+                continue;
+            };
+
+            let mut stack: Vec<DeclarationId> = seed_owners.iter().copied().collect();
+            let mut visited: IdentityHashSet<DeclarationId> = IdentityHashSet::default();
+            let mut next_edges: Vec<(DeclarationId, DeclarationId)> = Vec::new();
+
+            while let Some(parent) = stack.pop() {
+                if !visited.insert(parent) {
+                    continue;
+                }
+
+                let Some(parent_next) = self.get_or_create_singleton_class(parent, SingletonAncestors::Eager) else {
+                    continue;
+                };
+
+                let Some(child_singletons) = children.get(&parent).map(|set| set.iter().copied().collect::<Vec<_>>())
+                else {
+                    continue;
+                };
+
+                for child in child_singletons {
+                    if let Some(child_next) = self.get_or_create_singleton_class(child, SingletonAncestors::Eager) {
+                        next_edges.push((parent_next, child_next));
+                    }
+                    stack.push(child);
+                }
+            }
+
+            for (parent_next, child_next) in next_edges {
+                children.entry(parent_next).or_default().insert(child_next);
+            }
+        }
+    }
+
+    /// Returns the rank of a singleton class: how many singleton wrappers separate it from its
+    /// non-singleton attached object. A class declaration has rank `0`, `Foo::<Foo>` has rank `1`,
+    /// `Foo::<Foo>::<<Foo>>` has rank `2`, and so on. Computed by walking the owner chain so it does
+    /// not depend on how the name is spelled.
+    fn singleton_rank(&self, mut id: DeclarationId) -> usize {
+        let mut rank = 0;
+        while let Some(declaration) = self.graph.declarations().get(&id) {
+            let Some(namespace @ Namespace::SingletonClass(_)) = declaration.as_namespace() else {
+                break;
+            };
+            rank += 1;
+            id = *namespace.owner_id();
+        }
+        rank
+    }
+
+    /// Returns the id of the singleton class of the given declaration, if one has been materialized.
+    fn singleton_id_of(&self, attached_id: DeclarationId) -> Option<DeclarationId> {
+        self.graph
+            .declarations()
+            .get(&attached_id)
+            .and_then(Declaration::as_namespace)
+            .and_then(|namespace| namespace.singleton_class().copied())
     }
 
     /// Updates the `descendants` relation to match the finalized ancestor chains.

--- a/rust/rubydex/src/resolution.rs
+++ b/rust/rubydex/src/resolution.rs
@@ -145,9 +145,44 @@ impl<'a> Resolver<'a> {
 
         self.handle_remaining_definitions(other_ids);
 
+        // Materialize a rank-1 singleton class for every class/module declaration. This runs after
+        // every site that creates singletons organically (the convergence loop and
+        // `handle_remaining_definitions`), so future rank-N passes — which only build singletons for
+        // already-materialized ones — can be appended here and still observe the complete set.
+        self.materialize_singleton_classes();
+
         // Descendants are derived from the finalized ancestor chains, so they must be updated after
         // all linearization has settled.
         self.update_descendants();
+    }
+
+    /// Materializes a rank-1 singleton class for every class and module declaration.
+    ///
+    /// During the convergence loop and [`Self::handle_remaining_definitions`], singleton classes are
+    /// only created on demand: when a self-method, an `extend`, a `class << self`, or a class-level
+    /// instance variable forces one into existence. Many class and module objects therefore never
+    /// get a singleton even though every Ruby object has one. This pass fills the gaps so the
+    /// singleton hierarchy is complete: for class `Foo` it ensures `Foo::<Foo>` exists. Ancestors are
+    /// linearized eagerly because the convergence queue is already drained at this point.
+    ///
+    /// Singleton classes themselves (rank >= 2) are intentionally skipped here; a later rank-N pass
+    /// builds those on top of the singletons materialized here.
+    fn materialize_singleton_classes(&mut self) {
+        // Collect the target ids first: `get_or_create_singleton_class` borrows the graph mutably.
+        let mut attached_ids: Vec<DeclarationId> = Vec::new();
+        for (declaration_id, declaration) in self.graph.declarations() {
+            if matches!(
+                declaration,
+                Declaration::Namespace(Namespace::Class(_) | Namespace::Module(_))
+            ) {
+                attached_ids.push(*declaration_id);
+            }
+        }
+
+        for attached_id in attached_ids {
+            // Idempotent: returns the existing singleton when one was already created on demand.
+            let _ = self.get_or_create_singleton_class(attached_id, true);
+        }
     }
 
     /// Updates the `descendants` relation to match the finalized ancestor chains.

--- a/rust/rubydex/src/resolution_tests.rs
+++ b/rust/rubydex/src/resolution_tests.rs
@@ -2249,6 +2249,107 @@ mod singleton_ancestors_tests {
     }
 
     #[test]
+    fn materializes_rank_n_singletons_for_descendants_of_existing_singletons() {
+        let mut context = graph_test();
+        context.index_uri("file:///foo.rb", {
+            r"
+            class A
+              class << self
+                class << self
+                end
+              end
+            end
+
+            class B < A; end
+            "
+        });
+        context.resolve();
+
+        assert_no_diagnostics!(&context);
+
+        // The nested `class << self` materializes a rank-2 singleton for `A`.
+        assert_declaration_exists!(context, "A::<A>::<<A>>");
+
+        // `B` has no rank-2 trigger of its own, but because it is a descendant of `A`, its rank-2
+        // singleton must be materialized so the rank-2 hierarchy under `A::<A>::<<A>>` is complete.
+        assert_declaration_exists!(context, "B::<B>::<<B>>");
+
+        // The rank-2 ancestor chain follows the superclass chain of the rank-1 singletons.
+        assert_ancestors_eq!(
+            context,
+            "B::<B>::<<B>>",
+            [
+                "B::<B>::<<B>>",
+                "A::<A>::<<A>>",
+                "Object::<Object>::<<Object>>",
+                "BasicObject::<BasicObject>::<<BasicObject>>",
+                "Class::<Class>",
+                "Module::<Module>",
+                "Object::<Object>",
+                "BasicObject::<BasicObject>",
+                "Class",
+                "Module",
+                "Object",
+                "Kernel",
+                "BasicObject"
+            ]
+        );
+
+        // Descendants are the inverse of the rank-2 ancestor chains and are reflexive.
+        assert_descendants!(context, "A::<A>::<<A>>", ["A::<A>::<<A>>", "B::<B>::<<B>>"]);
+    }
+
+    #[test]
+    fn materializes_rank_n_singletons_when_explicit_singleton_only_has_members() {
+        let mut context = graph_test();
+        context.index_uri("file:///foo.rb", {
+            r"
+            class A
+              class << self
+                # `def self.bar` inside `class << self` attaches `bar` to the rank-2 singleton,
+                # creating `A::<A>::<<A>>` on demand. It has no definition of its own, only a member.
+                def self.bar; end
+              end
+            end
+
+            class B < A; end
+            "
+        });
+        context.resolve();
+
+        assert_no_diagnostics!(&context);
+
+        // The rank-2 singleton exists because of `def self.bar`, even without a nested `class << self`.
+        assert_declaration_exists!(context, "A::<A>::<<A>>");
+        assert_declaration_exists!(context, "A::<A>::<<A>>#bar()");
+
+        // A member-only rank-2 singleton must still seed materialization for descendants.
+        assert_declaration_exists!(context, "B::<B>::<<B>>");
+
+        assert_ancestors_eq!(
+            context,
+            "B::<B>::<<B>>",
+            [
+                "B::<B>::<<B>>",
+                "A::<A>::<<A>>",
+                "Object::<Object>::<<Object>>",
+                "BasicObject::<BasicObject>::<<BasicObject>>",
+                "Class::<Class>",
+                "Module::<Module>",
+                "Object::<Object>",
+                "BasicObject::<BasicObject>",
+                "Class",
+                "Module",
+                "Object",
+                "Kernel",
+                "BasicObject"
+            ]
+        );
+
+        assert_descendants!(context, "A::<A>::<<A>>", ["A::<A>::<<A>>", "B::<B>::<<B>>"]);
+    }
+
+    #[test]
     fn singleton_ancestors_for_modules() {
         let mut context = graph_test();
         context.index_uri("file:///foo.rb", {

--- a/rust/rubydex/src/resolution_tests.rs
+++ b/rust/rubydex/src/resolution_tests.rs
@@ -2206,6 +2206,49 @@ mod singleton_ancestors_tests {
     }
 
     #[test]
+    fn materializes_rank1_singletons_for_all_namespaces() {
+        let mut context = graph_test();
+        context.index_uri("file:///foo.rb", {
+            r"
+            class Foo; end
+            class Bar < Foo; end
+            module Baz; end
+            "
+        });
+        context.resolve();
+
+        assert_no_diagnostics!(&context);
+
+        // Rank-1 singletons exist even without self-methods, extends, or `class << self`.
+        assert_declaration_exists!(context, "Foo::<Foo>");
+        assert_declaration_exists!(context, "Bar::<Bar>");
+        assert_declaration_exists!(context, "Baz::<Baz>");
+        // Built-in classes are materialized too.
+        assert_declaration_exists!(context, "Object::<Object>");
+
+        // The singleton ancestor chain reflects the class hierarchy (#Bar < #Foo).
+        assert_ancestors_eq!(
+            context,
+            "Bar::<Bar>",
+            [
+                "Bar::<Bar>",
+                "Foo::<Foo>",
+                "Object::<Object>",
+                "BasicObject::<BasicObject>",
+                "Class",
+                "Module",
+                "Object",
+                "Kernel",
+                "BasicObject"
+            ]
+        );
+
+        // Descendants are the inverse of the singleton ancestor chains and are reflexive.
+        assert_descendants!(context, "Foo::<Foo>", ["Foo::<Foo>", "Bar::<Bar>"]);
+        assert_descendants!(context, "Object::<Object>", ["Foo::<Foo>", "Bar::<Bar>"]);
+    }
+
+    #[test]
     fn singleton_ancestors_for_modules() {
         let mut context = graph_test();
         context.index_uri("file:///foo.rb", {

--- a/rust/rubydex/tests/cli.rs
+++ b/rust/rubydex/tests/cli.rs
@@ -128,7 +128,9 @@ fn prints_index_metrics() {
             .success()
             .stderr(predicate::str::is_empty())
             .stdout(predicate::str::contains("Indexed 3 files"))
-            .stdout(predicate::str::contains("Found 7 names"))
+            // 7 declarations (FirstClass, SecondModule, and 5 built-ins) plus a materialized
+            // rank-1 singleton class for each of them. Definitions do not include singletons.
+            .stdout(predicate::str::contains("Found 14 names"))
             .stdout(predicate::str::contains("Found 7 definitions"));
     });
 }

--- a/test/declaration_test.rb
+++ b/test/declaration_test.rb
@@ -124,7 +124,7 @@ class DeclarationTest < Minitest::Test
       graph.index_all(context.glob("**/*.rb"))
       graph.resolve
 
-      assert_nil(graph["Foo"].singleton_class)
+      assert_equal("Foo::<Foo>", graph["Foo"].singleton_class.name)
 
       bar = graph["Foo::Bar"]
       assert_equal("Foo::Bar::<Bar>", bar.singleton_class.name)

--- a/test/graph_test.rb
+++ b/test/graph_test.rb
@@ -179,10 +179,10 @@ class GraphTest < Minitest::Test
 
       enumerator = graph.declarations
 
-      # Object, Class, Module, BasicObject, Kernel + the indexed files
-      assert_equal(7, enumerator.size)
-      assert_equal(7, enumerator.count)
-      assert_equal(7, enumerator.to_a.size)
+      # Object, Class, Module, BasicObject, Kernel + the indexed files, plus their singleton classes.
+      assert_equal(14, enumerator.size)
+      assert_equal(14, enumerator.count)
+      assert_equal(14, enumerator.to_a.size)
     end
   end
 
@@ -200,7 +200,7 @@ class GraphTest < Minitest::Test
         declarations << declaration
       end
 
-      assert_equal(7, declarations.size)
+      assert_equal(14, declarations.size)
     end
   end
 


### PR DESCRIPTION
## Summary

This PR materializes singleton class declarations during resolution.

- Materialize the singleton class of every class and module after the convergence loop and remaining definitions have settled.
- Materialize deeper singleton classes only for descendants of explicit/source-backed nested singleton classes, so nested `class << self` hierarchies stay complete for subclasses without trying to materialize every possible singleton class.
- Keep singleton classes out of declaration search/workspace-symbol results because they are internal declarations, while graph-level declaration enumeration and stats now include them.
- Update Rust, MCP/CLI, and Ruby expectations for the additional singleton class declarations.

## Why

Rubydex already creates singleton classes on demand for self methods, `extend`, `class << self`, and class-level instance variables. That lazy behavior is correct for Ruby, but it means singleton classes exist in the graph only when source happens to force them into existence.

This lazy graph shape leaves gaps in queries that need to walk through singleton-class ancestors and descendants:

- When a module is extended into a class/module object, consumers may need the descendants of that extended module through singleton-class ancestors.
- When starting from a leaf singleton class, consumers may want to call `find_member` and rely on the singleton ancestor chain being present.
- When subclasses inherit from a class that has explicit nested singleton classes, the corresponding singleton classes for those subclasses need to exist for ancestor/descendant queries to be complete.

For example:

```rb
class Foo
  class << self        # Foo::<Foo>, the singleton class of Foo
    class << self      # Foo::<Foo>::<<Foo>>, the singleton class of Foo::<Foo>
    end
  end
end

class Bar < Foo
end
```

The first stage makes sure both `Foo::<Foo>` and `Bar::<Bar>` exist, so `Foo::<Foo>` can be recorded as an ancestor of `Bar::<Bar>`. Because source explicitly opens the singleton class of `Foo::<Foo>`, the second stage also creates `Bar::<Bar>::<<Bar>>`, the corresponding singleton class of `Bar::<Bar>`.

This PR makes singleton class materialization eager after the main resolution work has settled. The additional declarations are internal and are filtered out of declaration search, so they do not become user-facing workspace symbols. In practice, the runtime and memory impact is negligible, so eager materialization removes these graph completeness gaps without a meaningful cost.

This PR is stacked on #892: singleton classes are materialized before descendants are recomputed, so the descendant relation is derived from the completed ancestor graph.

## Notes

The materialization pass is intentionally bounded.

The first stage creates the singleton class of every class and module. For `class Bar < Foo`, this creates `Foo::<Foo>` and `Bar::<Bar>` even if neither class had a singleton class in source.

The second stage creates deeper singleton classes only when source has already created a nested singleton class at that depth. In the example above, `Foo::<Foo>::<<Foo>>` is source-backed because it came from the nested `class << self`, so `Foo::<Foo>` seeds creation of the matching singleton class for descendants like `Bar::<Bar>`.

Pure singleton classes created only while linearizing ancestors are not used as seeds. For example, linearizing `Foo::<Foo>::<<Foo>>` may require `Object::<Object>::<<Object>>`, but that artifact should not cause Rubydex to create every possible singleton class under `Object`.

Declaration search filters out singleton classes so internal names like `Foo::<Foo>` do not surface as user-facing search results.

## Validation

- `cargo test -p rubydex`
- Ruby test expectations were updated for materialized singleton classes

<details>
<summary>Performance and memory comparison against main</summary>

Target: large Ruby codebase

Commits:

- `main`: `f50e21de`
- This PR: `848d5e5b`

Commands:

```sh
utils/mem-use rust/target/release/rubydex_cli [path] --stats
cargo bench --bench graph_memory -- [path]
```

| Metric | main | This PR | Delta |
| --- | ---: | ---: | ---: |
| Execution time | 25.47s | 22.79s | -2.68s (-10.5%) |
| `--stats` total time | 25.033s | 22.725s | -2.308s (-9.2%) |
| Resolution time | 18.214s | 15.975s | -2.239s (-12.3%) |
| Peak memory footprint | 5236.47 MB | 4994.45 MB | -242.02 MB (-4.6%) |
| Total graph memory | 4225.43 MB | 4251.15 MB | +25.72 MB (+0.6%) |
| Declarations | 1,102,491 | 1,120,349 | +17,858 (+1.6%) |

The process-level peak memory number is from `/usr/bin/time -l` and can be noisy. The graph-memory benchmark is more directly tied to Rubydex's graph allocation; it shows only a `+25.72 MB` (`+0.6%`) increase while materializing `17,858` additional singleton class declarations.

Because this PR is stacked, comparing the PR head against its immediate base branch can show different numbers than comparing the listed `main` commit against the PR head.

</details>
