### PR TITLE
Handle `extend` inside `class << self` for rank-N singletons

### DIFF
--- a/rust/rubydex-mcp/src/server.rs
+++ b/rust/rubydex-mcp/src/server.rs
@@ -1119,12 +1119,15 @@ mod tests {
         let res = parse(&s.codebase_stats());
 
         assert_eq!(res["files"], 3);
-        assert_json_int!(res, "declarations", 7);
+        // 7 declarations (Animal, Greetable, and 5 built-ins) plus a materialized rank-1 singleton
+        // class for each of them. Definitions do not include singletons.
+        assert_json_int!(res, "declarations", 14);
         assert_json_int!(res, "definitions", 7);
 
         let breakdown = &res["breakdown_by_kind"];
         assert_json_int!(breakdown, "Class", 5);
         assert_json_int!(breakdown, "Module", 2);
+        assert_json_int!(breakdown, "SingletonClass", 7);
     }
 
     // -- error states --

--- a/rust/rubydex/src/query.rs
+++ b/rust/rubydex/src/query.rs
@@ -914,7 +914,8 @@ mod tests {
             "
         });
         context.resolve();
-        assert_results_eq!(context, "Fo", ["Foo"]);
+        // `Foo::<Foo>` is materialized for every class, so the fuzzy query matches the singleton too.
+        assert_results_eq!(context, "Fo", ["Foo::<Foo>", "Foo"]);
     }
 
     #[test]

--- a/rust/rubydex/src/query.rs
+++ b/rust/rubydex/src/query.rs
@@ -49,6 +49,11 @@ pub fn declaration_search(graph: &Graph, query: &str, match_mode: &MatchMode) ->
                         .iter()
                         .filter(|id| {
                             let declaration = declarations.get(id).unwrap();
+                            // Singleton classes (e.g. `Foo::<Foo>`) are an internal representation,
+                            // not user-facing symbols, so they are never returned from search.
+                            if matches!(declaration, Declaration::Namespace(Namespace::SingletonClass(_))) {
+                                return false;
+                            }
                             let name = declaration.name();
                             match match_mode {
                                 MatchMode::Fuzzy => {
@@ -914,8 +919,32 @@ mod tests {
             "
         });
         context.resolve();
-        // `Foo::<Foo>` is materialized for every class, so the fuzzy query matches the singleton too.
-        assert_results_eq!(context, "Fo", ["Foo::<Foo>", "Foo"]);
+        assert_results_eq!(context, "Fo", ["Foo"]);
+    }
+
+    #[test]
+    fn search_excludes_singleton_classes() {
+        let mut context = GraphTest::new();
+        context.index_uri("file:///foo.rb", {
+            r"
+            class Foo
+            end
+            "
+        });
+        context.resolve();
+
+        // A rank-1 singleton is materialized for every class...
+        assert!(
+            context
+                .graph()
+                .declarations()
+                .contains_key(&DeclarationId::from("Foo::<Foo>")),
+            "expected `Foo::<Foo>` to be materialized"
+        );
+        // ...but it is internal and must not surface in search results, even when the query
+        // matches the singleton's name directly.
+        assert_results_eq!(context, "<Foo>", &MatchMode::Exact, Vec::<&str>::new());
+        assert_results_eq!(context, "Foo", ["Foo"]);
     }
 
     #[test]
@@ -949,8 +978,17 @@ mod tests {
         let exact_results = declaration_search(context.graph(), "", &MatchMode::Exact);
         let fuzzy_results = declaration_search(context.graph(), "", &MatchMode::Fuzzy);
 
+        // An empty query returns every searchable declaration. Materialized singleton classes are
+        // excluded from search, so the expected count is all declarations minus the singletons.
+        let searchable = context
+            .graph()
+            .declarations()
+            .values()
+            .filter(|d| !matches!(d, Declaration::Namespace(Namespace::SingletonClass(_))))
+            .count();
+
         assert_eq!(exact_results.len(), fuzzy_results.len());
-        assert_eq!(context.graph().declarations().len(), exact_results.len());
+        assert_eq!(searchable, exact_results.len());
     }
 
     #[test]

--- a/rust/rubydex/src/resolution.rs
+++ b/rust/rubydex/src/resolution.rs
@@ -171,13 +171,17 @@ impl<'a> Resolver<'a> {
         // - `class_parents`: each class paired with its resolved direct superclass. We resolve it here
         //   while the declaration is in hand; Stage 2 translates these edges to singleton ids (which
         //   do not exist until Stage 1 runs) to seed the `children` map.
-        // - `seed_owners_by_rank`: the owners of every source-backed rank-`>= 2` singleton, grouped by
-        //   the rank of that owner. An owner at rank `R` seeds materialization of rank-`(R + 1)`
-        //   singletons for all of its descendants in Stage 2. A rank-`>= 2` singleton is source-backed
-        //   when it has its own definition (a nested `class << self`) or members (e.g. a `def self.x`
-        //   written inside `class << self`). Singletons with neither are pure linearization artifacts:
-        //   linearizing an explicit singleton creates the singletons of its ancestors (e.g.
-        //   `Object::<Object>::<<Object>>`), and seeding on those would descend the whole class tree.
+        // - `seed_owners_by_rank`: the owners of every source-backed singleton, grouped by the rank of
+        //   that owner. An owner at rank `R` seeds materialization of rank-`(R + 1)` singletons for all
+        //   of its descendants in Stage 2. A singleton seeds the rank above it when it is source-backed,
+        //   which happens two ways: (a) the rank-`(R + 1)` singleton itself is explicit — it has its own
+        //   definition (a nested `class << self`) or members (e.g. a `def self.x` written inside
+        //   `class << self`) — so its rank-`R` owner is a seed; or (b) a rank-`R` singleton carries an
+        //   `extend M`, which mixes `M` into its rank-`(R + 1)` singleton, so that rank-`R` singleton is
+        //   itself the seed. A rank-`>= 2` singleton with neither a definition, members, nor an
+        //   incoming extend is a pure linearization artifact: linearizing an explicit singleton creates
+        //   the singletons of its ancestors (e.g. `Object::<Object>::<<Object>>`), and seeding on those
+        //   would descend the whole class tree.
         //
         // The seed set is fixed before this pass: explicit rank-`>= 2` singletons are created
         // organically during resolution, and Stage 1 only adds rank-1 singletons, so it never adds or
@@ -206,6 +210,15 @@ impl<'a> Resolver<'a> {
                             .or_default()
                             .insert(*namespace.owner_id());
                         max_rank = max_rank.max(rank);
+                    }
+                    // An `extend M` written inside this singleton's `class << self` mixes `M` into the
+                    // singleton's own singleton, i.e. the rank-`(rank + 1)` singleton. That singleton
+                    // carries `M` only as an ancestor (mixins are never members), so the checks above
+                    // miss it. Seed from this singleton so the rank-`(rank + 1)` singleton is
+                    // materialized for every subclass too, exactly as for an explicit `class << self`.
+                    if self.has_extend_mixin(namespace.definitions()) {
+                        seed_owners_by_rank.entry(rank).or_default().insert(*declaration_id);
+                        max_rank = max_rank.max(rank + 1);
                     }
                 }
                 _ => {}
@@ -1230,7 +1243,7 @@ impl<'a> Resolver<'a> {
         }
 
         // Ensure that we create the singleton and enqueue it for linearization if we see an extend
-        if has_extends && !is_singleton_class {
+        if has_extends {
             self.get_or_create_singleton_class(declaration_id, false);
         }
 
@@ -2258,6 +2271,16 @@ impl<'a> Resolver<'a> {
             Definition::Module(module) => Some(module.mixins().to_vec()),
             _ => None,
         }
+    }
+
+    /// Whether any of the given definitions carries an `extend` mixin. Used to detect that a
+    /// singleton spawns a higher-rank singleton (the extended module is mixed into it).
+    fn has_extend_mixin(&self, definition_ids: &[DefinitionId]) -> bool {
+        definition_ids
+            .iter()
+            .filter_map(|definition_id| self.mixins_of(*definition_id))
+            .flatten()
+            .any(|mixin| matches!(mixin, Mixin::Extend(_)))
     }
 }
 

--- a/rust/rubydex/src/resolution.rs
+++ b/rust/rubydex/src/resolution.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashSet, VecDeque, hash_map::Entry};
+use std::collections::{HashMap, HashSet, VecDeque, hash_map::Entry};
 
 use crate::diagnostic::{Diagnostic, Rule};
 use crate::model::{
@@ -140,33 +140,167 @@ impl<'a> Resolver<'a> {
         self.compute_descendants();
     }
 
-    /// Materializes a rank-1 singleton class for every class and module declaration.
+    /// Materializes the singleton class hierarchy so that it is complete after resolution.
     ///
     /// During the convergence loop and [`Self::handle_remaining_definitions`], singleton classes are
     /// only created on demand: when a self-method, an `extend`, a `class << self`, or a class-level
     /// instance variable forces one into existence. Many class and module objects therefore never
-    /// get a singleton even though every Ruby object has one. This pass fills the gaps so the
-    /// singleton hierarchy is complete: for class `Foo` it ensures `Foo::<Foo>` exists. Ancestors are
+    /// get a singleton even though every Ruby object has one. This pass fills the gaps. Ancestors are
     /// linearized eagerly because the convergence queue is already drained at this point.
     ///
-    /// Singleton classes themselves (rank >= 2) are intentionally skipped here; a later rank-N pass
-    /// builds those on top of the singletons materialized here.
+    /// The pass runs in two stages:
+    ///
+    /// 1. **rank-1**: ensure `Foo::<Foo>` exists for every class and module `Foo`.
+    /// 2. **rank-N**: climb the singleton ranks. A nested `class << self` produces an explicit
+    ///    rank-`N` singleton (e.g. `Foo::<Foo>::<<Foo>>`). When that happens, every subclass of
+    ///    `Foo` must also gain a rank-`N` singleton so the hierarchy stays complete. We materialize
+    ///    only the ranks reachable from an explicit (source-backed) singleton, descending the class
+    ///    inheritance tree from it — materializing *all* ranks for *all* classes would never
+    ///    terminate.
+    ///
+    /// The rank-`N` stage relies on the invariant that an explicit rank-`N` singleton always has an
+    /// existing rank-`(N-1)` owner (no gaps): every path that creates a singleton takes the rank
+    /// `(N-1)` declaration as input, and a nested `class << self` is indexed level by level, so each
+    /// intermediate rank is itself a definition.
     fn materialize_singleton_classes(&mut self) {
-        // Collect the target ids first: `get_or_create_singleton_class` borrows the graph mutably.
+        // Scan all declarations once to collect every input both stages need:
+        //
+        // - `attached_ids`: every class and module, for which Stage 1 materializes a rank-1
+        //   singleton. Ids are collected up front because `get_or_create_singleton_class` borrows the
+        //   graph mutably.
+        // - `class_parents`: each class paired with its resolved direct superclass. We resolve it here
+        //   while the declaration is in hand; Stage 2 translates these edges to singleton ids (which
+        //   do not exist until Stage 1 runs) to seed the `children` map.
+        // - `seed_owners_by_rank`: the owners of every source-backed rank-`>= 2` singleton, grouped by
+        //   the rank of that owner. An owner at rank `R` seeds materialization of rank-`(R + 1)`
+        //   singletons for all of its descendants in Stage 2. A rank-`>= 2` singleton is source-backed
+        //   when it has its own definition (a nested `class << self`) or members (e.g. a `def self.x`
+        //   written inside `class << self`). Singletons with neither are pure linearization artifacts:
+        //   linearizing an explicit singleton creates the singletons of its ancestors (e.g.
+        //   `Object::<Object>::<<Object>>`), and seeding on those would descend the whole class tree.
+        //
+        // The seed set is fixed before this pass: explicit rank-`>= 2` singletons are created
+        // organically during resolution, and Stage 1 only adds rank-1 singletons, so it never adds or
+        // removes a seed. That is why everything can be collected in this single scan.
         let mut attached_ids: Vec<DeclarationId> = Vec::new();
+        let mut class_parents: Vec<(DeclarationId, DeclarationId)> = Vec::new();
+        let mut seed_owners_by_rank: HashMap<usize, IdentityHashSet<DeclarationId>> = HashMap::new();
+        let mut max_rank = 1;
         for (declaration_id, declaration) in self.graph.declarations() {
-            if matches!(
-                declaration,
-                Declaration::Namespace(Namespace::Class(_) | Namespace::Module(_))
-            ) {
-                attached_ids.push(*declaration_id);
+            match declaration.as_namespace() {
+                Some(Namespace::Module(_)) => attached_ids.push(*declaration_id),
+                Some(namespace @ Namespace::Class(_)) => {
+                    attached_ids.push(*declaration_id);
+                    // Only classes participate in the inheritance tree Stage 2 descends; a module's
+                    // singleton parent is always `Module`, and modules cannot be subclassed.
+                    let (parent_class, _) = self.get_parent_class(namespace.definitions());
+                    class_parents.push((*declaration_id, parent_class));
+                }
+                Some(namespace @ Namespace::SingletonClass(_))
+                    if !namespace.definitions().is_empty() || !namespace.members().is_empty() =>
+                {
+                    let rank = self.singleton_rank(*declaration_id);
+                    if rank >= 2 {
+                        seed_owners_by_rank
+                            .entry(rank - 1)
+                            .or_default()
+                            .insert(*namespace.owner_id());
+                        max_rank = max_rank.max(rank);
+                    }
+                }
+                _ => {}
             }
         }
 
-        for attached_id in attached_ids {
+        // --- Stage 1: rank-1 singleton for every class and module ---
+        for attached_id in &attached_ids {
             // Idempotent: returns the existing singleton when one was already created on demand.
-            let _ = self.get_or_create_singleton_class(attached_id, true);
+            let _ = self.get_or_create_singleton_class(*attached_id, true);
         }
+
+        // --- Stage 2: rank-N singletons for descendants of explicit singletons ---
+        //
+        // `children` maps a singleton to the singletons of the *direct* subclasses of its attached
+        // object: for `class B < A`, `A::<A>`'s children contain `B::<B>`. It starts as the rank-1
+        // layer (translating the `class_parents` edges collected above, now that Stage 1 has
+        // materialized every rank-1 singleton) and grows one rank at a time as we climb: building
+        // `B::<B>::<<B>>` records it as a child of `A::<A>::<<A>>` for the next iteration. This is a
+        // local map; the global `descendants` relation is recomputed later by
+        // [`Self::compute_descendants`].
+        let mut children: IdentityHashMap<DeclarationId, IdentityHashSet<DeclarationId>> = IdentityHashMap::default();
+        for (child_class, parent_class) in &class_parents {
+            if let (Some(child_singleton), Some(parent_singleton)) =
+                (self.singleton_id_of(*child_class), self.singleton_id_of(*parent_class))
+            {
+                children.entry(parent_singleton).or_default().insert(child_singleton);
+            }
+        }
+
+        // Climb the ranks: at rank `R`, descend the class inheritance tree from each seed owner,
+        // materializing the rank-`(R + 1)` singleton of every node reached, and record the new
+        // rank-`(R + 1)` edges so the next iteration can descend them. Ranks are contiguous (an
+        // explicit rank-`(R + 1)` singleton implies an explicit rank-`R` owner), so every rank in
+        // `1..max_rank` has seeds.
+        for rank in 1..max_rank {
+            let Some(seed_owners) = seed_owners_by_rank.get(&rank) else {
+                continue;
+            };
+
+            let mut stack: Vec<DeclarationId> = seed_owners.iter().copied().collect();
+            let mut visited: IdentityHashSet<DeclarationId> = IdentityHashSet::default();
+            let mut next_edges: Vec<(DeclarationId, DeclarationId)> = Vec::new();
+
+            while let Some(parent) = stack.pop() {
+                if !visited.insert(parent) {
+                    continue;
+                }
+
+                let Some(parent_next) = self.get_or_create_singleton_class(parent, true) else {
+                    continue;
+                };
+
+                let Some(child_singletons) = children.get(&parent).map(|set| set.iter().copied().collect::<Vec<_>>())
+                else {
+                    continue;
+                };
+
+                for child in child_singletons {
+                    if let Some(child_next) = self.get_or_create_singleton_class(child, true) {
+                        next_edges.push((parent_next, child_next));
+                    }
+                    stack.push(child);
+                }
+            }
+
+            for (parent_next, child_next) in next_edges {
+                children.entry(parent_next).or_default().insert(child_next);
+            }
+        }
+    }
+
+    /// Returns the rank of a singleton class: how many singleton wrappers separate it from its
+    /// non-singleton attached object. A class declaration has rank `0`, `Foo::<Foo>` has rank `1`,
+    /// `Foo::<Foo>::<<Foo>>` has rank `2`, and so on. Computed by walking the owner chain so it does
+    /// not depend on how the name is spelled.
+    fn singleton_rank(&self, mut id: DeclarationId) -> usize {
+        let mut rank = 0;
+        while let Some(declaration) = self.graph.declarations().get(&id) {
+            let Some(namespace @ Namespace::SingletonClass(_)) = declaration.as_namespace() else {
+                break;
+            };
+            rank += 1;
+            id = *namespace.owner_id();
+        }
+        rank
+    }
+
+    /// Returns the id of the singleton class of the given declaration, if one has been materialized.
+    fn singleton_id_of(&self, attached_id: DeclarationId) -> Option<DeclarationId> {
+        self.graph
+            .declarations()
+            .get(&attached_id)
+            .and_then(Declaration::as_namespace)
+            .and_then(|namespace| namespace.singleton_class().copied())
     }
 
     /// Recomputes the `descendants` relation as the inverse of the linearized ancestors.

--- a/rust/rubydex/src/resolution.rs
+++ b/rust/rubydex/src/resolution.rs
@@ -129,9 +129,44 @@ impl<'a> Resolver<'a> {
 
         self.handle_remaining_definitions(other_ids);
 
+        // Materialize a rank-1 singleton class for every class/module declaration. This runs after
+        // every site that creates singletons organically (the convergence loop and
+        // `handle_remaining_definitions`), so future rank-N passes — which only build singletons for
+        // already-materialized ones — can be appended here and still observe the complete set.
+        self.materialize_singleton_classes();
+
         // Descendants are derived from the finalized ancestor chains, so they must be computed
         // after all linearization has settled.
         self.compute_descendants();
+    }
+
+    /// Materializes a rank-1 singleton class for every class and module declaration.
+    ///
+    /// During the convergence loop and [`Self::handle_remaining_definitions`], singleton classes are
+    /// only created on demand: when a self-method, an `extend`, a `class << self`, or a class-level
+    /// instance variable forces one into existence. Many class and module objects therefore never
+    /// get a singleton even though every Ruby object has one. This pass fills the gaps so the
+    /// singleton hierarchy is complete: for class `Foo` it ensures `Foo::<Foo>` exists. Ancestors are
+    /// linearized eagerly because the convergence queue is already drained at this point.
+    ///
+    /// Singleton classes themselves (rank >= 2) are intentionally skipped here; a later rank-N pass
+    /// builds those on top of the singletons materialized here.
+    fn materialize_singleton_classes(&mut self) {
+        // Collect the target ids first: `get_or_create_singleton_class` borrows the graph mutably.
+        let mut attached_ids: Vec<DeclarationId> = Vec::new();
+        for (declaration_id, declaration) in self.graph.declarations() {
+            if matches!(
+                declaration,
+                Declaration::Namespace(Namespace::Class(_) | Namespace::Module(_))
+            ) {
+                attached_ids.push(*declaration_id);
+            }
+        }
+
+        for attached_id in attached_ids {
+            // Idempotent: returns the existing singleton when one was already created on demand.
+            let _ = self.get_or_create_singleton_class(attached_id, true);
+        }
     }
 
     /// Recomputes the `descendants` relation as the inverse of the linearized ancestors.

--- a/rust/rubydex/src/resolution.rs
+++ b/rust/rubydex/src/resolution.rs
@@ -1,7 +1,4 @@
-use std::{
-    collections::{HashSet, VecDeque, hash_map::Entry},
-    hash::BuildHasher,
-};
+use std::collections::{HashSet, VecDeque, hash_map::Entry};
 
 use crate::diagnostic::{Diagnostic, Rule};
 use crate::model::{
@@ -40,7 +37,6 @@ impl Outcome {
 }
 
 struct LinearizationContext {
-    descendants: IdentityHashSet<DeclarationId>,
     seen_ids: IdentityHashSet<DeclarationId>,
     cyclic: bool,
     partial: bool,
@@ -49,7 +45,6 @@ struct LinearizationContext {
 impl LinearizationContext {
     fn new() -> Self {
         Self {
-            descendants: IdentityHashSet::default(),
             seen_ids: IdentityHashSet::default(),
             cyclic: false,
             partial: false,
@@ -60,7 +55,6 @@ impl LinearizationContext {
     /// the linearization algorithm, regardless of whether we are returning a cached result or a freshly built ancestor
     /// chain
     fn finalize(&mut self, declaration_id: DeclarationId) {
-        self.descendants.remove(&declaration_id);
         self.seen_ids.remove(&declaration_id);
     }
 }
@@ -134,6 +128,69 @@ impl<'a> Resolver<'a> {
         self.graph.extend_work(std::mem::take(&mut self.unit_queue));
 
         self.handle_remaining_definitions(other_ids);
+
+        // Descendants are derived from the finalized ancestor chains, so they must be computed
+        // after all linearization has settled.
+        self.compute_descendants();
+    }
+
+    /// Recomputes the `descendants` relation as the inverse of the linearized ancestors.
+    ///
+    /// After resolution, `descendants(D)` must contain exactly the declarations `x` such that
+    /// `Ancestor::Complete(D)` appears in `x`'s linearized ancestors. Because a declaration is its
+    /// own ancestor (see [`Self::linearize_ancestors`]), this relation is reflexive.
+    ///
+    /// Maintaining the relation incrementally during linearization is error-prone: a declaration
+    /// may be linearized under a tentative parent in one pass and a different parent in a later
+    /// pass, and the stale descendant edges from the abandoned parent are never cleared, which
+    /// inflates the relation. Computing it once here, by inverting the final ancestor chains, keeps
+    /// it exact. All existing descendants are cleared first so repeated `resolve()` calls
+    /// (incremental updates) converge on the same result.
+    ///
+    /// This rebuilds the entire relation on every `resolve()`, which is `O(total ancestors)`. That
+    /// is a clear win on full builds (it replaces the costlier per-linearization bookkeeping) but
+    /// adds a fixed cost to small incremental updates. Narrowing the rebuild to only the
+    /// declarations re-linearized in the current pass is a future optimization.
+    fn compute_descendants(&mut self) {
+        // Clear any previously recorded descendants.
+        for declaration in self.graph.declarations_mut().values_mut() {
+            if let Some(namespace) = declaration.as_namespace_mut() {
+                namespace.clear_descendants();
+            }
+        }
+
+        // Invert the ancestor chains: each `Complete(ancestor)` edge in `x`'s ancestors makes `x` a
+        // descendant of `ancestor`. Collect the edges first so we don't borrow the declarations map
+        // immutably and mutably at the same time.
+        //
+        // `Ancestors::iter` walks the entries of every chain state, so declarations whose overall
+        // chain is `Cyclic` or `Partial` still contribute their resolved entries here. We only skip
+        // individual `Ancestor::Partial` entries: those are unresolved ancestor names that carry a
+        // `NameId` rather than a `DeclarationId`, so there is no declaration to record the descendant
+        // on.
+        let mut edges: Vec<(DeclarationId, DeclarationId)> = Vec::new();
+        for (declaration_id, declaration) in self.graph.declarations() {
+            let Some(namespace) = declaration.as_namespace() else {
+                continue;
+            };
+
+            for ancestor in namespace.ancestors() {
+                if let Ancestor::Complete(ancestor_id) = ancestor {
+                    edges.push((*ancestor_id, *declaration_id));
+                }
+            }
+        }
+
+        for (ancestor_id, descendant_id) in edges {
+            if let Some(namespace) = self
+                .graph
+                .declarations_mut()
+                .get_mut(&ancestor_id)
+                .and_then(Declaration::as_namespace_mut)
+            {
+                namespace.add_descendant(descendant_id);
+            }
+        }
     }
 
     /// Resolves a single constant against the graph. This method is not meant to be used by the resolution phase, but by
@@ -940,14 +997,10 @@ impl<'a> Resolver<'a> {
         {
             let declaration = self.graph.declarations_mut().get_mut(&declaration_id).unwrap();
 
-            // Add this declaration to the descendants so that we capture transitive descendant relationships
-            context.descendants.insert(declaration_id);
-
             // Return the cached ancestors if we already computed them. If they are partial ancestors, ignore the cache to try
             // again
             if declaration.as_namespace().unwrap().has_complete_ancestors() {
                 let cached = declaration.as_namespace().unwrap().clone_ancestors();
-                self.propagate_descendants(&mut context.descendants, &cached);
 
                 context.finalize(declaration_id);
                 return cached;
@@ -970,18 +1023,6 @@ impl<'a> Resolver<'a> {
 
                 context.finalize(declaration_id);
                 return estimated_ancestors;
-            }
-
-            // Automatically track descendants as we recurse. This has to happen before checking the cache since we may have
-            // already linearized the parent's ancestors, but it's the first time we're discovering the descendant
-            for descendant in &context.descendants {
-                self.graph
-                    .declarations_mut()
-                    .get_mut(&declaration_id)
-                    .unwrap()
-                    .as_namespace_mut()
-                    .unwrap()
-                    .add_descendant(*descendant);
             }
         }
 
@@ -1212,29 +1253,6 @@ impl<'a> Resolver<'a> {
         }
 
         (linearized_prepends, linearized_includes)
-    }
-
-    /// Propagate descendants to all cached ancestors
-    fn propagate_descendants<S: BuildHasher>(
-        &mut self,
-        descendants: &mut HashSet<DeclarationId, S>,
-        cached: &Ancestors,
-    ) {
-        if !descendants.is_empty() {
-            for ancestor in cached {
-                if let Ancestor::Complete(ancestor_id) = ancestor {
-                    for descendant in descendants.iter() {
-                        self.graph
-                            .declarations_mut()
-                            .get_mut(ancestor_id)
-                            .unwrap()
-                            .as_namespace_mut()
-                            .unwrap()
-                            .add_descendant(*descendant);
-                    }
-                }
-            }
-        }
     }
 
     // Handles the resolution of the namespace name, the creation of the declaration and membership

--- a/rust/rubydex/src/resolution_tests.rs
+++ b/rust/rubydex/src/resolution_tests.rs
@@ -2350,6 +2350,99 @@ mod singleton_ancestors_tests {
     }
 
     #[test]
+    fn extend_inside_singleton_class_materializes_rank_2_singleton() {
+        let mut context = graph_test();
+        context.index_uri("file:///foo.rb", {
+            r"
+            module M; end
+
+            class A
+              class << self
+                extend M
+              end
+            end
+            "
+        });
+        context.resolve();
+
+        assert_no_diagnostics!(&context);
+
+        // `extend M` inside `class << self` extends the singleton of `A::<A>`, i.e. the rank-2
+        // singleton `A::<A>::<<A>>`. It must exist and carry `M` in its ancestors.
+        assert_declaration_exists!(context, "A::<A>::<<A>>");
+
+        assert_ancestors_eq!(
+            context,
+            "A::<A>::<<A>>",
+            [
+                "A::<A>::<<A>>",
+                "M",
+                "Object::<Object>::<<Object>>",
+                "BasicObject::<BasicObject>::<<BasicObject>>",
+                "Class::<Class>",
+                "Module::<Module>",
+                "Object::<Object>",
+                "BasicObject::<BasicObject>",
+                "Class",
+                "Module",
+                "Object",
+                "Kernel",
+                "BasicObject"
+            ]
+        );
+    }
+
+    #[test]
+    fn extend_inside_singleton_class_materializes_subclass_rank_2_singleton() {
+        let mut context = graph_test();
+        context.index_uri("file:///foo.rb", {
+            r"
+            module M; end
+
+            class A
+              class << self
+                extend M
+              end
+            end
+
+            class B < A; end
+            "
+        });
+        context.resolve();
+
+        assert_no_diagnostics!(&context);
+
+        // `extend M` inside `A`'s `class << self` produces the rank-2 singleton `A::<A>::<<A>>`.
+        // The subclass `B` must get its own rank-2 singleton `B::<B>::<<B>>`, which inherits the
+        // extended module `M` through `A::<A>::<<A>>`.
+        assert_declaration_exists!(context, "B::<B>::<<B>>");
+
+        assert_ancestors_eq!(
+            context,
+            "B::<B>::<<B>>",
+            [
+                "B::<B>::<<B>>",
+                "A::<A>::<<A>>",
+                "M",
+                "Object::<Object>::<<Object>>",
+                "BasicObject::<BasicObject>::<<BasicObject>>",
+                "Class::<Class>",
+                "Module::<Module>",
+                "Object::<Object>",
+                "BasicObject::<BasicObject>",
+                "Class",
+                "Module",
+                "Object",
+                "Kernel",
+                "BasicObject"
+            ]
+        );
+
+        // `M` is extended into `A::<A>::<<A>>`, so both rank-2 singletons are its descendants.
+        assert_descendants!(context, "M", ["M", "A::<A>::<<A>>", "B::<B>::<<B>>"]);
+    }
+
+    #[test]
     fn singleton_ancestors_for_modules() {
         let mut context = graph_test();
         context.index_uri("file:///foo.rb", {

--- a/rust/rubydex/src/resolution_tests.rs
+++ b/rust/rubydex/src/resolution_tests.rs
@@ -2249,6 +2249,107 @@ mod singleton_ancestors_tests {
     }
 
     #[test]
+    fn materializes_rank_n_singletons_for_descendants_of_existing_singletons() {
+        let mut context = graph_test();
+        context.index_uri("file:///foo.rb", {
+            r"
+            class A
+              class << self
+                class << self
+                end
+              end
+            end
+
+            class B < A; end
+            "
+        });
+        context.resolve();
+
+        assert_no_diagnostics!(&context);
+
+        // The nested `class << self` materializes a rank-2 singleton for `A`.
+        assert_declaration_exists!(context, "A::<A>::<<A>>");
+
+        // `B` has no rank-2 trigger of its own, but because it is a descendant of `A`, its rank-2
+        // singleton must be materialized so the rank-2 hierarchy under `A::<A>::<<A>>` is complete.
+        assert_declaration_exists!(context, "B::<B>::<<B>>");
+
+        // The rank-2 ancestor chain follows the superclass chain of the rank-1 singletons.
+        assert_ancestors_eq!(
+            context,
+            "B::<B>::<<B>>",
+            [
+                "B::<B>::<<B>>",
+                "A::<A>::<<A>>",
+                "Object::<Object>::<<Object>>",
+                "BasicObject::<BasicObject>::<<BasicObject>>",
+                "Class::<Class>",
+                "Module::<Module>",
+                "Object::<Object>",
+                "BasicObject::<BasicObject>",
+                "Class",
+                "Module",
+                "Object",
+                "Kernel",
+                "BasicObject"
+            ]
+        );
+
+        // Descendants are the inverse of the rank-2 ancestor chains and are reflexive.
+        assert_descendants!(context, "A::<A>::<<A>>", ["A::<A>::<<A>>", "B::<B>::<<B>>"]);
+    }
+
+    #[test]
+    fn materializes_rank_n_singletons_when_explicit_singleton_only_has_members() {
+        let mut context = graph_test();
+        context.index_uri("file:///foo.rb", {
+            r"
+            class A
+              class << self
+                # `def self.bar` inside `class << self` attaches `bar` to the rank-2 singleton,
+                # creating `A::<A>::<<A>>` on demand. It has no definition of its own, only a member.
+                def self.bar; end
+              end
+            end
+
+            class B < A; end
+            "
+        });
+        context.resolve();
+
+        assert_no_diagnostics!(&context);
+
+        // The rank-2 singleton exists because of `def self.bar`, even without a nested `class << self`.
+        assert_declaration_exists!(context, "A::<A>::<<A>>");
+        assert_declaration_exists!(context, "A::<A>::<<A>>#bar()");
+
+        // A member-only rank-2 singleton must still seed materialization for descendants.
+        assert_declaration_exists!(context, "B::<B>::<<B>>");
+
+        assert_ancestors_eq!(
+            context,
+            "B::<B>::<<B>>",
+            [
+                "B::<B>::<<B>>",
+                "A::<A>::<<A>>",
+                "Object::<Object>::<<Object>>",
+                "BasicObject::<BasicObject>::<<BasicObject>>",
+                "Class::<Class>",
+                "Module::<Module>",
+                "Object::<Object>",
+                "BasicObject::<BasicObject>",
+                "Class",
+                "Module",
+                "Object",
+                "Kernel",
+                "BasicObject"
+            ]
+        );
+
+        assert_descendants!(context, "A::<A>::<<A>>", ["A::<A>::<<A>>", "B::<B>::<<B>>"]);
+    }
+
+    #[test]
     fn singleton_ancestors_for_modules() {
         let mut context = graph_test();
         context.index_uri("file:///foo.rb", {

--- a/rust/rubydex/src/resolution_tests.rs
+++ b/rust/rubydex/src/resolution_tests.rs
@@ -2206,6 +2206,49 @@ mod singleton_ancestors_tests {
     }
 
     #[test]
+    fn materializes_rank1_singletons_for_all_namespaces() {
+        let mut context = graph_test();
+        context.index_uri("file:///foo.rb", {
+            r"
+            class Foo; end
+            class Bar < Foo; end
+            module Baz; end
+            "
+        });
+        context.resolve();
+
+        assert_no_diagnostics!(&context);
+
+        // Rank-1 singletons exist even without self-methods, extends, or `class << self`.
+        assert_declaration_exists!(context, "Foo::<Foo>");
+        assert_declaration_exists!(context, "Bar::<Bar>");
+        assert_declaration_exists!(context, "Baz::<Baz>");
+        // Built-in classes are materialized too.
+        assert_declaration_exists!(context, "Object::<Object>");
+
+        // The singleton ancestor chain reflects the class hierarchy (#Bar < #Foo).
+        assert_ancestors_eq!(
+            context,
+            "Bar::<Bar>",
+            [
+                "Bar::<Bar>",
+                "Foo::<Foo>",
+                "Object::<Object>",
+                "BasicObject::<BasicObject>",
+                "Class",
+                "Module",
+                "Object",
+                "Kernel",
+                "BasicObject"
+            ]
+        );
+
+        // Descendants are the inverse of the singleton ancestor chains and are reflexive.
+        assert_descendants!(context, "Foo::<Foo>", ["Foo::<Foo>", "Bar::<Bar>"]);
+        assert_descendants!(context, "Object::<Object>", ["Foo::<Foo>", "Bar::<Bar>"]);
+    }
+
+    #[test]
     fn singleton_ancestors_for_modules() {
         let mut context = graph_test();
         context.index_uri("file:///foo.rb", {

--- a/rust/rubydex/tests/cli.rs
+++ b/rust/rubydex/tests/cli.rs
@@ -62,7 +62,9 @@ fn prints_index_metrics() {
             .success()
             .stderr(predicate::str::is_empty())
             .stdout(predicate::str::contains("Indexed 3 files"))
-            .stdout(predicate::str::contains("Found 7 names"))
+            // 7 declarations (FirstClass, SecondModule, and 5 built-ins) plus a materialized
+            // rank-1 singleton class for each of them. Definitions do not include singletons.
+            .stdout(predicate::str::contains("Found 14 names"))
             .stdout(predicate::str::contains("Found 7 definitions"));
     });
 }


### PR DESCRIPTION
- Linearize: drop the `!is_singleton_class` guard so an `extend M` written inside a `class << self` always creates that singleton's own singleton (the rank-2 `Foo::<Foo>::<<Foo>>`), with `M` mixed in as an ancestor. It was previously skipped for singleton classes.
- Seed rank-N materialization from any singleton whose own `class << self` carries an `extend`: the extend mixes the module into that singleton's own singleton as an ancestor (mixins are never members), so the definition/member checks that detect explicit singletons miss it. Seeding here materializes the rank-`(N + 1)` singleton for every subclass too.
- Add tests: rank-2 singleton for the extended class itself, and for a subclass.