### PR TITLE
Use Box<str> instead of String for immutable interned strings

### DIFF
--- a/rust/rubydex/src/model/declaration.rs
+++ b/rust/rubydex/src/model/declaration.rs
@@ -91,7 +91,7 @@ macro_rules! namespace_declaration {
         #[derive(Debug)]
         pub struct $name {
             /// The fully qualified name of this declaration
-            name: String,
+            name: Box<str>,
             /// The list of definition IDs that compose this declaration
             definition_ids: Vec<DefinitionId>,
             /// The set of references that are made to this declaration
@@ -116,7 +116,7 @@ macro_rules! namespace_declaration {
             #[must_use]
             pub fn new(name: String, owner_id: DeclarationId) -> Self {
                 Self {
-                    name,
+                    name: name.into_boxed_str(),
                     definition_ids: Vec::new(),
                     members: IdentityHashMap::default(),
                     references: IdentityHashSet::default(),
@@ -231,7 +231,7 @@ macro_rules! simple_declaration {
         #[derive(Debug)]
         pub struct $name {
             /// The fully qualified name of this declaration
-            name: String,
+            name: Box<str>,
             /// The list of definition IDs that compose this declaration
             definition_ids: Vec<DefinitionId>,
             /// The set of references that are made to this declaration
@@ -244,7 +244,7 @@ macro_rules! simple_declaration {
             #[must_use]
             pub fn new(name: String, owner_id: DeclarationId) -> Self {
                 Self {
-                    name,
+                    name: name.into_boxed_str(),
                     definition_ids: Vec::new(),
                     references: IdentityHashSet::default(),
                     owner_id,
@@ -608,25 +608,25 @@ impl Namespace {
 }
 
 namespace_declaration!(Class, ClassDeclaration);
-assert_mem_size!(ClassDeclaration, 192);
+assert_mem_size!(ClassDeclaration, 184);
 namespace_declaration!(Module, ModuleDeclaration);
-assert_mem_size!(ModuleDeclaration, 192);
+assert_mem_size!(ModuleDeclaration, 184);
 namespace_declaration!(SingletonClass, SingletonClassDeclaration);
-assert_mem_size!(SingletonClassDeclaration, 192);
+assert_mem_size!(SingletonClassDeclaration, 184);
 namespace_declaration!(Todo, TodoDeclaration);
-assert_mem_size!(TodoDeclaration, 192);
+assert_mem_size!(TodoDeclaration, 184);
 simple_declaration!(ConstantDeclaration, ConstantReferenceId);
-assert_mem_size!(ConstantDeclaration, 88);
+assert_mem_size!(ConstantDeclaration, 80);
 simple_declaration!(MethodDeclaration, MethodReferenceId);
-assert_mem_size!(MethodDeclaration, 88);
+assert_mem_size!(MethodDeclaration, 80);
 simple_declaration!(GlobalVariableDeclaration, GlobalVariableReferenceId);
-assert_mem_size!(GlobalVariableDeclaration, 88);
+assert_mem_size!(GlobalVariableDeclaration, 80);
 simple_declaration!(InstanceVariableDeclaration, InstanceVariableReferenceId);
-assert_mem_size!(InstanceVariableDeclaration, 88);
+assert_mem_size!(InstanceVariableDeclaration, 80);
 simple_declaration!(ClassVariableDeclaration, ClassVariableReferenceId);
-assert_mem_size!(ClassVariableDeclaration, 88);
+assert_mem_size!(ClassVariableDeclaration, 80);
 simple_declaration!(ConstantAliasDeclaration, ConstantReferenceId);
-assert_mem_size!(ConstantAliasDeclaration, 88);
+assert_mem_size!(ConstantAliasDeclaration, 80);
 
 #[cfg(test)]
 mod tests {

--- a/rust/rubydex/src/model/string_ref.rs
+++ b/rust/rubydex/src/model/string_ref.rs
@@ -9,15 +9,23 @@ use std::ops::Deref;
 /// graph when its count reaches zero.
 #[derive(Debug)]
 pub struct StringRef {
-    value: String,
+    value: Box<str>,
     ref_count: u32,
 }
-assert_mem_size!(StringRef, 32);
+assert_mem_size!(StringRef, 24);
 
 impl StringRef {
     #[must_use]
     pub fn new(value: String) -> Self {
-        Self { value, ref_count: 1 }
+        Self {
+            value: value.into_boxed_str(),
+            ref_count: 1,
+        }
+    }
+
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.value
     }
 
     #[must_use]
@@ -44,7 +52,7 @@ impl StringRef {
 }
 
 impl Deref for StringRef {
-    type Target = String;
+    type Target = str;
 
     fn deref(&self) -> &Self::Target {
         &self.value


### PR DESCRIPTION
In Rust `String` is simply a `Vec<u8>` (a vector or UTF-8 bytes), which consumes 24 bytes (pointer, capacity and length) + more memory for however long the string ends up being. The `String` object allows for mutation, you can push more content into the same string, which is why it needs to track capacity.

In our use cases, we never have a need to mutate an existing string pushed to the graph. We only ever create or discard, there's never a case where we would mutate a fully qualified name after having already computed it.

For these cases, we can use a `Box<str>`, which is basically an immutable string (we put the byte slice into a boxed pointer). Since the string cannot be mutated, we save the 8 bytes for capacity, reducing the amount of memory we use.

It's a modest reduction since the size of the strings still matter more than the container where they are stored, but it still amounts for about 100MB in Core and it's so simple to apply I figured we go forward with it.