### PR TITLE
Support glob patterns in the `exclude` config

### DIFF
--- a/ext/rubydex/graph.c
+++ b/ext/rubydex/graph.c
@@ -796,38 +796,38 @@ static VALUE rdxr_graph_complete_method_argument(int argc, VALUE *argv, VALUE se
 
 /*
  * call-seq:
- *   exclude_paths(paths) -> nil
+ *   exclude_patterns(patterns) -> nil
  *
- * Excludes the paths from file discovery during indexing.
+ * Excludes files matching the given glob patterns from discovery during indexing.
  */
-static VALUE rdxr_graph_exclude_paths(VALUE self, VALUE paths) {
-    Check_Type(paths, T_ARRAY);
-    rdxi_check_array_of_strings(paths);
+static VALUE rdxr_graph_exclude_patterns(VALUE self, VALUE patterns) {
+    Check_Type(patterns, T_ARRAY);
+    rdxi_check_array_of_strings(patterns);
 
-    size_t length = RARRAY_LEN(paths);
-    char **converted_paths = rdxi_str_array_to_char(paths, length);
+    size_t length = RARRAY_LEN(patterns);
+    char **converted_patterns = rdxi_str_array_to_char(patterns, length);
 
     void *graph;
     TypedData_Get_Struct(self, void*, &graph_type, graph);
 
-    rdx_graph_exclude_paths(graph, (const char **)converted_paths, length);
-    rdxi_free_str_array(converted_paths, length);
+    rdx_graph_exclude_patterns(graph, (const char **)converted_patterns, length);
+    rdxi_free_str_array(converted_patterns, length);
 
     return Qnil;
 }
 
 /*
  * call-seq:
- *   excluded_paths -> Array[String]
+ *   excluded_patterns -> Array[String]
  *
- * Returns the paths currently excluded from file discovery.
+ * Returns the glob patterns currently excluded from file discovery.
  */
-static VALUE rdxr_graph_excluded_paths(VALUE self) {
+static VALUE rdxr_graph_excluded_patterns(VALUE self) {
     void *graph;
     TypedData_Get_Struct(self, void*, &graph_type, graph);
 
     size_t out_count = 0;
-    const char *const *results = rdx_graph_excluded_paths(graph, &out_count);
+    const char *const *results = rdx_graph_excluded_patterns(graph, &out_count);
 
     if (results == NULL) {
         return rb_ary_new();
@@ -965,8 +965,8 @@ void rdxi_initialize_graph(VALUE moduleRubydex) {
     rb_define_method(cGraph, "complete_namespace_access", rdxr_graph_complete_namespace_access, -1);
     rb_define_method(cGraph, "complete_method_call", rdxr_graph_complete_method_call, -1);
     rb_define_method(cGraph, "complete_method_argument", rdxr_graph_complete_method_argument, -1);
-    rb_define_method(cGraph, "exclude_paths", rdxr_graph_exclude_paths, 1);
-    rb_define_method(cGraph, "excluded_paths", rdxr_graph_excluded_paths, 0);
+    rb_define_method(cGraph, "exclude_patterns", rdxr_graph_exclude_patterns, 1);
+    rb_define_method(cGraph, "excluded_patterns", rdxr_graph_excluded_patterns, 0);
     rb_define_method(cGraph, "workspace_path", rdxr_graph_workspace_path, 0);
     rb_define_method(cGraph, "workspace_path=", rdxr_graph_set_workspace_path, 1);
     rb_define_method(cGraph, "load_config", rdxr_graph_load_config, -1);

--- a/rbi/rubydex.rbi
+++ b/rbi/rubydex.rbi
@@ -313,7 +313,7 @@ class Rubydex::Graph
   sig { returns(T::Array[String]) }
   def index_workspace; end
 
-  # Loads configuration, merging its excluded paths into the graph's configuration (the workspace path is never
+  # Loads configuration, merging its exclusion patterns into the graph's configuration (the workspace path is never
   # overridden). With `config_path` (resolved relative to the workspace path), an explicitly named file that does not
   # exist raises `Rubydex::ConfigError`. With no argument, the default `.rubydex` is loaded if present and ignored if
   # missing. Raises `Rubydex::ConfigError` if a file cannot be read or is malformed.
@@ -418,11 +418,11 @@ class Rubydex::Graph
   sig { params(paths: T::Array[String]).void }
   def add_workspace_dependency_paths(paths); end
 
-  sig { params(paths: T::Array[String]).void }
-  def exclude_paths(paths); end
+  sig { params(patterns: T::Array[String]).void }
+  def exclude_patterns(patterns); end
 
   sig { returns(T::Array[String]) }
-  def excluded_paths; end
+  def excluded_patterns; end
 end
 
 class Rubydex::DisplayLocation < Rubydex::Location

--- a/rust/rubydex-sys/src/graph_api.rs
+++ b/rust/rubydex-sys/src/graph_api.rs
@@ -182,8 +182,8 @@ pub unsafe extern "C" fn rdx_graph_resolve_constant(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rdx_graph_exclude_paths(pointer: GraphPointer, paths: *const *const c_char, count: usize) {
     let paths: Vec<String> = unsafe { utils::convert_double_pointer_to_vec(paths, count).unwrap() };
-    let path_bufs: Vec<PathBuf> = paths.into_iter().map(PathBuf::from).collect();
-    with_mut_graph(pointer, |graph| graph.exclude_paths(path_bufs));
+    let entries: Vec<Box<str>> = paths.into_iter().map(String::into_boxed_str).collect();
+    with_mut_graph(pointer, |graph| graph.exclude_paths(entries));
 }
 
 /// Returns the currently excluded paths as an array of C strings. Writes the count to `out_count`. Returns NULL if no
@@ -213,7 +213,7 @@ pub unsafe extern "C" fn rdx_graph_excluded_paths(
                 // on Windows if a configuration file is using forward slashes. For example:
                 //
                 // C:\project/vendor/bundle
-                let normalized = path.to_string_lossy().replace(std::path::MAIN_SEPARATOR, "/");
+                let normalized = path.replace(std::path::MAIN_SEPARATOR, "/");
 
                 CString::new(normalized)
                     .ok()

--- a/rust/rubydex-sys/src/graph_api.rs
+++ b/rust/rubydex-sys/src/graph_api.rs
@@ -169,37 +169,41 @@ pub unsafe extern "C" fn rdx_graph_resolve_constant(
     })
 }
 
-/// Adds paths to exclude from file discovery during indexing.
+/// Adds glob patterns to exclude from file discovery during indexing.
 ///
 /// # Panics
 ///
-/// Will panic if the given array of C string paths cannot be converted to a `Vec<String>`.
+/// Will panic if the given array of C string patterns cannot be converted to a `Vec<String>`.
 ///
 /// # Safety
 ///
 /// - `pointer` must be a valid `GraphPointer` previously returned by this crate.
-/// - `paths` must be an array of `count` valid, null-terminated UTF-8 strings.
+/// - `patterns` must be an array of `count` valid, null-terminated UTF-8 strings.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn rdx_graph_exclude_paths(pointer: GraphPointer, paths: *const *const c_char, count: usize) {
-    let paths: Vec<String> = unsafe { utils::convert_double_pointer_to_vec(paths, count).unwrap() };
-    let entries: Vec<Box<str>> = paths.into_iter().map(String::into_boxed_str).collect();
-    with_mut_graph(pointer, |graph| graph.exclude_paths(entries));
+pub unsafe extern "C" fn rdx_graph_exclude_patterns(
+    pointer: GraphPointer,
+    patterns: *const *const c_char,
+    count: usize,
+) {
+    let patterns: Vec<String> = unsafe { utils::convert_double_pointer_to_vec(patterns, count).unwrap() };
+    let entries: Vec<Box<str>> = patterns.into_iter().map(String::into_boxed_str).collect();
+    with_mut_graph(pointer, |graph| graph.exclude_patterns(entries));
 }
 
-/// Returns the currently excluded paths as an array of C strings. Writes the count to `out_count`. Returns NULL if no
-/// paths are excluded. Caller must free with `free_c_string_array`.
+/// Returns the currently excluded glob patterns as an array of C strings. Writes the count to `out_count`. Returns NULL
+/// if no patterns are excluded. Caller must free with `free_c_string_array`.
 ///
 /// # Safety
 ///
 /// - `pointer` must be a valid `GraphPointer` previously returned by this crate.
 /// - `out_count` must be a valid, writable pointer.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn rdx_graph_excluded_paths(
+pub unsafe extern "C" fn rdx_graph_excluded_patterns(
     pointer: GraphPointer,
     out_count: *mut usize,
 ) -> *const *const c_char {
     with_graph(pointer, |graph| {
-        let excluded = graph.excluded_paths();
+        let excluded = graph.excluded_patterns();
 
         if excluded.is_empty() {
             unsafe { *out_count = 0 };
@@ -313,7 +317,7 @@ pub unsafe extern "C" fn rdx_index_all(
     let file_paths: Vec<String> = unsafe { utils::convert_double_pointer_to_vec(file_paths, count).unwrap() };
 
     with_mut_graph(pointer, |graph| {
-        let (file_paths, listing_errors) = listing::collect_file_paths(file_paths, &graph.excluded_paths());
+        let (file_paths, listing_errors) = listing::collect_file_paths(file_paths, &graph.excluded_patterns());
         let indexing_errors = indexing::index_files(graph, file_paths, indexing::IndexerBackend::RubyIndexer);
 
         let all_errors: Vec<String> = listing_errors

--- a/rust/rubydex/src/config.rs
+++ b/rust/rubydex/src/config.rs
@@ -23,7 +23,7 @@ pub const DEFAULT_EXCLUDED_DIRECTORIES: &[&str] = &[
 struct ConfigFile {
     /// Paths to exclude from file discovery during indexing.
     #[serde(default)]
-    exclude: Vec<PathBuf>,
+    exclude: Vec<Box<str>>,
 }
 
 /// Project configuration
@@ -32,7 +32,7 @@ pub struct Config {
     /// Path to the workspace being analyzed
     workspace_path: Box<Path>,
     /// Paths to exclude from file discovery during indexing.
-    excluded_paths: HashSet<PathBuf>,
+    excluded_paths: HashSet<Box<str>>,
 }
 assert_mem_size!(Config, 64);
 
@@ -50,7 +50,7 @@ impl Config {
             workspace_path: std::env::current_dir()
                 .unwrap_or_else(|_| PathBuf::from("."))
                 .into_boxed_path(),
-            excluded_paths: DEFAULT_EXCLUDED_DIRECTORIES.iter().map(PathBuf::from).collect(),
+            excluded_paths: DEFAULT_EXCLUDED_DIRECTORIES.iter().map(|&dir| Box::from(dir)).collect(),
         }
     }
 
@@ -67,16 +67,22 @@ impl Config {
 
     /// Adds paths to exclude from file discovery during indexing. Excluded directories will be skipped entirely during
     /// directory traversal.
-    pub fn exclude_paths(&mut self, paths: impl IntoIterator<Item = PathBuf>) {
+    pub fn exclude_paths(&mut self, paths: impl IntoIterator<Item = Box<str>>) {
         self.excluded_paths.extend(paths);
     }
 
     /// Returns the set of paths excluded from file discovery
     #[must_use]
-    pub fn excluded_paths(&self) -> HashSet<PathBuf> {
+    pub fn excluded_paths(&self) -> HashSet<Box<str>> {
         self.excluded_paths
             .iter()
-            .map(|path| self.workspace_path.join(path))
+            .map(|entry| {
+                self.workspace_path
+                    .join(&**entry)
+                    .to_string_lossy()
+                    .replace(std::path::MAIN_SEPARATOR, "/")
+                    .into_boxed_str()
+            })
             .collect()
     }
 
@@ -143,15 +149,15 @@ mod tests {
     fn excluded_paths_are_resolved_against_the_workspace_path() {
         let mut config = Config::new();
         config.set_workspace_path(PathBuf::from("/workspace"));
-        config.exclude_paths([PathBuf::from("vendor"), PathBuf::from("/absolute/path")]);
+        config.exclude_paths([Box::from("vendor"), Box::from("/absolute/path")]);
 
         let excluded = config.excluded_paths();
 
         // Relative entries (including the defaults) are joined with the workspace path.
-        assert!(excluded.contains(Path::new("/workspace/vendor")));
-        assert!(excluded.contains(Path::new("/workspace/.git")));
+        assert!(excluded.contains("/workspace/vendor"));
+        assert!(excluded.contains("/workspace/.git"));
         // Absolute entries pass through unchanged.
-        assert!(excluded.contains(Path::new("/absolute/path")));
+        assert!(excluded.contains("/absolute/path"));
     }
 
     #[test]
@@ -160,7 +166,7 @@ mod tests {
 
         for default in DEFAULT_EXCLUDED_DIRECTORIES {
             assert!(
-                config.excluded_paths.contains(Path::new(default)),
+                config.excluded_paths.contains(*default),
                 "expected `{default}` to be excluded by default"
             );
         }
@@ -181,10 +187,10 @@ mod tests {
 
         let excluded = config.excluded_paths();
         // Entries from the file are merged in and resolved against the workspace path.
-        assert!(excluded.contains(Path::new("/workspace/vendor")));
-        assert!(excluded.contains(Path::new("/workspace/generated")));
+        assert!(excluded.contains("/workspace/vendor"));
+        assert!(excluded.contains("/workspace/generated"));
         // Defaults seeded at construction survive the merge.
-        assert!(excluded.contains(Path::new("/workspace/node_modules")));
+        assert!(excluded.contains("/workspace/node_modules"));
         // A config file cannot override the programmatically-set workspace path.
         assert_eq!(config.workspace_path(), Path::new("/workspace"));
     }
@@ -205,8 +211,8 @@ mod tests {
             .expect("expected the second file to load");
 
         let excluded = config.excluded_paths();
-        assert!(excluded.contains(Path::new("/workspace/vendor")));
-        assert!(excluded.contains(Path::new("/workspace/generated")));
+        assert!(excluded.contains("/workspace/vendor"));
+        assert!(excluded.contains("/workspace/generated"));
     }
 
     #[test]
@@ -244,7 +250,12 @@ mod tests {
         config.set_workspace_path(dir.path().to_path_buf());
         config.load_default().expect("expected rubydex.toml to load");
 
-        assert!(config.excluded_paths().contains(&dir.path().join("vendor")));
+        let expected = dir
+            .path()
+            .join("vendor")
+            .to_string_lossy()
+            .replace(std::path::MAIN_SEPARATOR, "/");
+        assert!(config.excluded_paths().contains(expected.as_str()));
     }
 
     #[test]

--- a/rust/rubydex/src/config.rs
+++ b/rust/rubydex/src/config.rs
@@ -21,7 +21,7 @@ pub const DEFAULT_EXCLUDED_DIRECTORIES: &[&str] = &[
 /// Configuration coming from a config file
 #[derive(Debug, Default, Deserialize)]
 struct ConfigFile {
-    /// Paths to exclude from file discovery during indexing.
+    /// Patterns to exclude from file discovery during indexing.
     #[serde(default)]
     exclude: Vec<Box<str>>,
 }
@@ -31,7 +31,7 @@ struct ConfigFile {
 pub struct Config {
     /// Path to the workspace being analyzed
     workspace_path: Box<Path>,
-    /// Paths to exclude from file discovery during indexing.
+    /// Patterns to exclude from file discovery during indexing.
     excluded_paths: HashSet<Box<str>>,
 }
 assert_mem_size!(Config, 64);
@@ -65,13 +65,13 @@ impl Config {
         self.workspace_path = workspace_path.into_boxed_path();
     }
 
-    /// Adds paths to exclude from file discovery during indexing. Excluded directories will be skipped entirely during
+    /// Adds patterns to exclude from file discovery during indexing. Excluded directories will be skipped entirely during
     /// directory traversal.
     pub fn exclude_paths(&mut self, paths: impl IntoIterator<Item = Box<str>>) {
         self.excluded_paths.extend(paths);
     }
 
-    /// Returns the set of paths excluded from file discovery
+    /// Returns the set of exclusion patterns resolved against the workspace path.
     #[must_use]
     pub fn excluded_paths(&self) -> HashSet<Box<str>> {
         self.excluded_paths
@@ -80,7 +80,7 @@ impl Config {
                 self.workspace_path
                     .join(&**entry)
                     .to_string_lossy()
-                    .replace(std::path::MAIN_SEPARATOR, "/")
+                    .into_owned()
                     .into_boxed_str()
             })
             .collect()
@@ -145,19 +145,32 @@ mod tests {
     use super::*;
     use std::path::Path;
 
+    fn workspace_exclusion(entry: &str) -> String {
+        PathBuf::from("/workspace").join(entry).to_string_lossy().into_owned()
+    }
+
     #[test]
-    fn excluded_paths_are_resolved_against_the_workspace_path() {
+    fn excluded_paths_resolves_patterns_against_the_workspace_path() {
         let mut config = Config::new();
         config.set_workspace_path(PathBuf::from("/workspace"));
-        config.exclude_paths([Box::from("vendor"), Box::from("/absolute/path")]);
+        config.exclude_paths([
+            Box::from("vendor"),
+            Box::from("**/fixtures"),
+            Box::from("/absolute/path"),
+        ]);
 
         let excluded = config.excluded_paths();
 
-        // Relative entries (including the defaults) are joined with the workspace path.
-        assert!(excluded.contains("/workspace/vendor"));
-        assert!(excluded.contains("/workspace/.git"));
-        // Absolute entries pass through unchanged.
-        assert!(excluded.contains("/absolute/path"));
+        let vendor = workspace_exclusion("vendor");
+        let fixtures = workspace_exclusion("**/fixtures");
+        let absolute = PathBuf::from("/absolute/path").to_string_lossy().into_owned();
+        let git = workspace_exclusion(".git");
+
+        assert!(excluded.contains(vendor.as_str()));
+        assert!(excluded.contains(fixtures.as_str()));
+        assert!(excluded.contains(absolute.as_str()));
+        // Defaults are included and resolved as well.
+        assert!(excluded.contains(git.as_str()));
     }
 
     #[test]
@@ -187,10 +200,10 @@ mod tests {
 
         let excluded = config.excluded_paths();
         // Entries from the file are merged in and resolved against the workspace path.
-        assert!(excluded.contains("/workspace/vendor"));
-        assert!(excluded.contains("/workspace/generated"));
+        assert!(excluded.contains(workspace_exclusion("vendor").as_str()));
+        assert!(excluded.contains(workspace_exclusion("generated").as_str()));
         // Defaults seeded at construction survive the merge.
-        assert!(excluded.contains("/workspace/node_modules"));
+        assert!(excluded.contains(workspace_exclusion("node_modules").as_str()));
         // A config file cannot override the programmatically-set workspace path.
         assert_eq!(config.workspace_path(), Path::new("/workspace"));
     }
@@ -211,8 +224,8 @@ mod tests {
             .expect("expected the second file to load");
 
         let excluded = config.excluded_paths();
-        assert!(excluded.contains("/workspace/vendor"));
-        assert!(excluded.contains("/workspace/generated"));
+        assert!(excluded.contains(workspace_exclusion("vendor").as_str()));
+        assert!(excluded.contains(workspace_exclusion("generated").as_str()));
     }
 
     #[test]
@@ -250,11 +263,7 @@ mod tests {
         config.set_workspace_path(dir.path().to_path_buf());
         config.load_default().expect("expected rubydex.toml to load");
 
-        let expected = dir
-            .path()
-            .join("vendor")
-            .to_string_lossy()
-            .replace(std::path::MAIN_SEPARATOR, "/");
+        let expected = dir.path().join("vendor").to_string_lossy().into_owned();
         assert!(config.excluded_paths().contains(expected.as_str()));
     }
 

--- a/rust/rubydex/src/config.rs
+++ b/rust/rubydex/src/config.rs
@@ -32,7 +32,7 @@ pub struct Config {
     /// Path to the workspace being analyzed
     workspace_path: Box<Path>,
     /// Patterns to exclude from file discovery during indexing.
-    excluded_paths: HashSet<Box<str>>,
+    excluded_patterns: HashSet<Box<str>>,
 }
 assert_mem_size!(Config, 64);
 
@@ -50,7 +50,7 @@ impl Config {
             workspace_path: std::env::current_dir()
                 .unwrap_or_else(|_| PathBuf::from("."))
                 .into_boxed_path(),
-            excluded_paths: DEFAULT_EXCLUDED_DIRECTORIES.iter().map(|&dir| Box::from(dir)).collect(),
+            excluded_patterns: DEFAULT_EXCLUDED_DIRECTORIES.iter().map(|&dir| Box::from(dir)).collect(),
         }
     }
 
@@ -67,14 +67,14 @@ impl Config {
 
     /// Adds patterns to exclude from file discovery during indexing. Excluded directories will be skipped entirely during
     /// directory traversal.
-    pub fn exclude_paths(&mut self, paths: impl IntoIterator<Item = Box<str>>) {
-        self.excluded_paths.extend(paths);
+    pub fn exclude_patterns(&mut self, patterns: impl IntoIterator<Item = Box<str>>) {
+        self.excluded_patterns.extend(patterns);
     }
 
     /// Returns the set of exclusion patterns resolved against the workspace path.
     #[must_use]
-    pub fn excluded_paths(&self) -> HashSet<Box<str>> {
-        self.excluded_paths
+    pub fn excluded_patterns(&self) -> HashSet<Box<str>> {
+        self.excluded_patterns
             .iter()
             .map(|entry| {
                 self.workspace_path
@@ -130,7 +130,7 @@ impl Config {
             Errors::ConfigError(format!("Invalid config file `{}`: {error}", config_path.display()))
         })?;
 
-        self.excluded_paths.extend(parsed.exclude);
+        self.excluded_patterns.extend(parsed.exclude);
         Ok(())
     }
 
@@ -150,16 +150,16 @@ mod tests {
     }
 
     #[test]
-    fn excluded_paths_resolves_patterns_against_the_workspace_path() {
+    fn excluded_patterns_resolves_patterns_against_the_workspace_path() {
         let mut config = Config::new();
         config.set_workspace_path(PathBuf::from("/workspace"));
-        config.exclude_paths([
+        config.exclude_patterns([
             Box::from("vendor"),
             Box::from("**/fixtures"),
             Box::from("/absolute/path"),
         ]);
 
-        let excluded = config.excluded_paths();
+        let excluded = config.excluded_patterns();
 
         let vendor = workspace_exclusion("vendor");
         let fixtures = workspace_exclusion("**/fixtures");
@@ -179,14 +179,14 @@ mod tests {
 
         for default in DEFAULT_EXCLUDED_DIRECTORIES {
             assert!(
-                config.excluded_paths.contains(*default),
+                config.excluded_patterns.contains(*default),
                 "expected `{default}` to be excluded by default"
             );
         }
     }
 
     #[test]
-    fn load_file_merges_excluded_paths_and_leaves_the_workspace_path_untouched() {
+    fn load_file_merges_excluded_patterns_and_leaves_the_workspace_path_untouched() {
         let dir = tempfile::tempdir().expect("failed to create temp dir");
         let config_path = dir.path().join("rubydex.toml");
         fs::write(&config_path, "exclude = [\"vendor\", \"generated\"]\n").unwrap();
@@ -198,7 +198,7 @@ mod tests {
             .load_file(&config_path)
             .expect("expected the config file to load");
 
-        let excluded = config.excluded_paths();
+        let excluded = config.excluded_patterns();
         // Entries from the file are merged in and resolved against the workspace path.
         assert!(excluded.contains(workspace_exclusion("vendor").as_str()));
         assert!(excluded.contains(workspace_exclusion("generated").as_str()));
@@ -223,7 +223,7 @@ mod tests {
             .load_file(&dir.path().join("b.toml"))
             .expect("expected the second file to load");
 
-        let excluded = config.excluded_paths();
+        let excluded = config.excluded_patterns();
         assert!(excluded.contains(workspace_exclusion("vendor").as_str()));
         assert!(excluded.contains(workspace_exclusion("generated").as_str()));
     }
@@ -264,7 +264,7 @@ mod tests {
         config.load_default().expect("expected rubydex.toml to load");
 
         let expected = dir.path().join("vendor").to_string_lossy().into_owned();
-        assert!(config.excluded_paths().contains(expected.as_str()));
+        assert!(config.excluded_patterns().contains(expected.as_str()));
     }
 
     #[test]
@@ -283,7 +283,7 @@ mod tests {
     }
 
     #[test]
-    fn parse_defaults_the_excluded_paths_to_empty_when_the_key_is_absent() {
+    fn parse_defaults_the_excluded_patterns_to_empty_when_the_key_is_absent() {
         let file = Config::parse("").expect("an empty config is valid");
         assert!(file.exclude.is_empty());
     }

--- a/rust/rubydex/src/listing.rs
+++ b/rust/rubydex/src/listing.rs
@@ -16,7 +16,7 @@ pub struct FileDiscoveryJob {
     queue: Arc<JobQueue>,
     paths_tx: Sender<PathBuf>,
     errors_tx: Sender<Errors>,
-    excluded_paths: Arc<HashSet<PathBuf>>,
+    excluded_paths: Arc<HashSet<Box<str>>>,
 }
 
 impl FileDiscoveryJob {
@@ -26,7 +26,7 @@ impl FileDiscoveryJob {
         queue: Arc<JobQueue>,
         paths_tx: Sender<PathBuf>,
         errors_tx: Sender<Errors>,
-        excluded_paths: Arc<HashSet<PathBuf>>,
+        excluded_paths: Arc<HashSet<Box<str>>>,
     ) -> Self {
         Self {
             path,
@@ -43,8 +43,8 @@ fn is_indexable_file(path: &Path) -> bool {
         .is_some_and(|ext| ext == "rb" || ext == "rake" || ext == "rbs" || ext == "ru")
 }
 
-fn is_excluded(excluded_paths: &HashSet<PathBuf>, path: &Path) -> bool {
-    excluded_paths.contains(path)
+fn is_excluded(excluded_paths: &HashSet<Box<str>>, path: &Path) -> bool {
+    path.to_str().is_some_and(|path| excluded_paths.contains(path))
 }
 
 impl FileDiscoveryJob {
@@ -158,14 +158,20 @@ impl Job for FileDiscoveryJob {
 #[must_use]
 pub fn collect_file_paths<S: BuildHasher>(
     paths: Vec<String>,
-    excluded: &HashSet<PathBuf, S>,
+    excluded: &HashSet<Box<str>, S>,
 ) -> (Vec<PathBuf>, Vec<Errors>) {
     let queue = Arc::new(JobQueue::new());
     let (files_tx, files_rx) = unbounded();
     let (errors_tx, errors_rx) = unbounded();
 
     // Canonicalize the excluded paths since they may be symlinks
-    let excluded: Arc<HashSet<PathBuf>> = Arc::new(excluded.iter().filter_map(|p| fs::canonicalize(p).ok()).collect());
+    let excluded: Arc<HashSet<Box<str>>> = Arc::new(
+        excluded
+            .iter()
+            .filter_map(|entry| fs::canonicalize(&**entry).ok())
+            .map(|canonical| canonical.to_string_lossy().into())
+            .collect(),
+    );
 
     for path in paths {
         let Ok(canonicalized) = fs::canonicalize(&path) else {
@@ -209,7 +215,7 @@ mod tests {
     fn collect_document_paths_with_exclusions(
         context: &Context,
         paths: &[&str],
-        excluded: &HashSet<PathBuf>,
+        excluded: &HashSet<Box<str>>,
     ) -> (Vec<String>, Vec<Errors>) {
         let (files, errors) = collect_file_paths(
             paths
@@ -337,7 +343,7 @@ mod tests {
         context.touch(&excluded_file);
 
         let mut excluded = HashSet::new();
-        excluded.insert(context.absolute_path_to("excluded"));
+        excluded.insert(context.absolute_path_to("excluded").to_string_lossy().into());
 
         let (files, errors) = collect_document_paths_with_exclusions(&context, &["included", "excluded"], &excluded);
 
@@ -354,7 +360,7 @@ mod tests {
         context.touch(&nested);
 
         let mut excluded = HashSet::new();
-        excluded.insert(context.absolute_path_to("root/skip"));
+        excluded.insert(context.absolute_path_to("root/skip").to_string_lossy().into());
 
         let (files, errors) = collect_document_paths_with_exclusions(&context, &["root"], &excluded);
 
@@ -376,7 +382,7 @@ mod tests {
 
         // Excluding the real directory while requesting to index the symlink should properly exclude the link
         let mut excluded = HashSet::new();
-        excluded.insert(context.absolute_path_to("real_dir"));
+        excluded.insert(context.absolute_path_to("real_dir").to_string_lossy().into());
 
         let (files, errors) = collect_document_paths_with_exclusions(&context, &["included", "link"], &excluded);
 

--- a/rust/rubydex/src/listing.rs
+++ b/rust/rubydex/src/listing.rs
@@ -43,6 +43,10 @@ fn is_indexable_file(path: &Path) -> bool {
         .is_some_and(|ext| ext == "rb" || ext == "rake" || ext == "rbs" || ext == "ru")
 }
 
+fn is_excluded(excluded_paths: &HashSet<PathBuf>, path: &Path) -> bool {
+    excluded_paths.contains(path)
+}
+
 impl FileDiscoveryJob {
     fn handle_file(&self, path: &Path) {
         if is_indexable_file(path) {
@@ -62,7 +66,7 @@ impl FileDiscoveryJob {
             return;
         };
 
-        if self.excluded_paths.contains(&canonicalized) {
+        if is_excluded(&self.excluded_paths, &canonicalized) {
             return;
         }
 
@@ -107,7 +111,7 @@ impl Job for FileDiscoveryJob {
                 let kind = entry.file_type().unwrap();
 
                 if kind.is_dir() {
-                    if self.excluded_paths.contains(&entry.path()) {
+                    if is_excluded(&self.excluded_paths, &entry.path()) {
                         continue;
                     }
 
@@ -172,7 +176,7 @@ pub fn collect_file_paths<S: BuildHasher>(
             continue;
         };
 
-        if excluded.contains(&canonicalized) {
+        if is_excluded(&excluded, &canonicalized) {
             continue;
         }
 

--- a/rust/rubydex/src/listing.rs
+++ b/rust/rubydex/src/listing.rs
@@ -3,6 +3,7 @@ use crate::{
     job_queue::{Job, JobQueue},
 };
 use crossbeam_channel::{Sender, unbounded};
+use glob::Pattern;
 use std::{
     collections::HashSet,
     fs,
@@ -16,7 +17,7 @@ pub struct FileDiscoveryJob {
     queue: Arc<JobQueue>,
     paths_tx: Sender<PathBuf>,
     errors_tx: Sender<Errors>,
-    excluded_paths: Arc<HashSet<Box<str>>>,
+    excluded_patterns: Arc<Vec<Pattern>>,
 }
 
 impl FileDiscoveryJob {
@@ -26,14 +27,14 @@ impl FileDiscoveryJob {
         queue: Arc<JobQueue>,
         paths_tx: Sender<PathBuf>,
         errors_tx: Sender<Errors>,
-        excluded_paths: Arc<HashSet<Box<str>>>,
+        excluded_patterns: Arc<Vec<Pattern>>,
     ) -> Self {
         Self {
             path,
             queue,
             paths_tx,
             errors_tx,
-            excluded_paths,
+            excluded_patterns,
         }
     }
 }
@@ -43,8 +44,8 @@ fn is_indexable_file(path: &Path) -> bool {
         .is_some_and(|ext| ext == "rb" || ext == "rake" || ext == "rbs" || ext == "ru")
 }
 
-fn is_excluded(excluded_paths: &HashSet<Box<str>>, path: &Path) -> bool {
-    path.to_str().is_some_and(|path| excluded_paths.contains(path))
+fn is_excluded(excluded_patterns: &[Pattern], path: &Path) -> bool {
+    excluded_patterns.iter().any(|pattern| pattern.matches_path(path))
 }
 
 impl FileDiscoveryJob {
@@ -66,7 +67,7 @@ impl FileDiscoveryJob {
             return;
         };
 
-        if is_excluded(&self.excluded_paths, &canonicalized) {
+        if is_excluded(&self.excluded_patterns, &canonicalized) {
             return;
         }
 
@@ -75,7 +76,7 @@ impl FileDiscoveryJob {
             Arc::clone(&self.queue),
             self.paths_tx.clone(),
             self.errors_tx.clone(),
-            Arc::clone(&self.excluded_paths),
+            Arc::clone(&self.excluded_patterns),
         )));
     }
 
@@ -111,7 +112,7 @@ impl Job for FileDiscoveryJob {
                 let kind = entry.file_type().unwrap();
 
                 if kind.is_dir() {
-                    if is_excluded(&self.excluded_paths, &entry.path()) {
+                    if is_excluded(&self.excluded_patterns, &entry.path()) {
                         continue;
                     }
 
@@ -120,7 +121,7 @@ impl Job for FileDiscoveryJob {
                         Arc::clone(&self.queue),
                         self.paths_tx.clone(),
                         self.errors_tx.clone(),
-                        Arc::clone(&self.excluded_paths),
+                        Arc::clone(&self.excluded_patterns),
                     )));
                 } else if kind.is_file() {
                     self.handle_file(&entry.path());
@@ -164,12 +165,13 @@ pub fn collect_file_paths<S: BuildHasher>(
     let (files_tx, files_rx) = unbounded();
     let (errors_tx, errors_rx) = unbounded();
 
-    // Canonicalize the excluded paths since they may be symlinks
-    let excluded: Arc<HashSet<Box<str>>> = Arc::new(
+    // Canonicalize the excluded paths (they may be symlinks) and turn each into a pattern. Escaping keeps
+    // matching exact.
+    let excluded_patterns: Arc<Vec<Pattern>> = Arc::new(
         excluded
             .iter()
             .filter_map(|entry| fs::canonicalize(&**entry).ok())
-            .map(|canonical| canonical.to_string_lossy().into())
+            .filter_map(|canonical| Pattern::new(&Pattern::escape(&canonical.to_string_lossy())).ok())
             .collect(),
     );
 
@@ -182,7 +184,7 @@ pub fn collect_file_paths<S: BuildHasher>(
             continue;
         };
 
-        if is_excluded(&excluded, &canonicalized) {
+        if is_excluded(&excluded_patterns, &canonicalized) {
             continue;
         }
 
@@ -191,7 +193,7 @@ pub fn collect_file_paths<S: BuildHasher>(
             Arc::clone(&queue),
             files_tx.clone(),
             errors_tx.clone(),
-            Arc::clone(&excluded),
+            Arc::clone(&excluded_patterns),
         )));
     }
 

--- a/rust/rubydex/src/listing.rs
+++ b/rust/rubydex/src/listing.rs
@@ -6,7 +6,6 @@ use crossbeam_channel::{Sender, unbounded};
 use glob::Pattern;
 use std::{
     collections::HashSet,
-    fs,
     hash::BuildHasher,
     path::{Path, PathBuf},
     sync::Arc,
@@ -57,29 +56,6 @@ impl FileDiscoveryJob {
         }
     }
 
-    fn handle_symlink(&self, path: &PathBuf) {
-        let Ok(canonicalized) = fs::canonicalize(path) else {
-            self.send_error(Errors::FileError(format!(
-                "Failed to canonicalize symlink: `{}`",
-                path.display(),
-            )));
-
-            return;
-        };
-
-        if is_excluded(&self.excluded_patterns, &canonicalized) {
-            return;
-        }
-
-        self.queue.push(Box::new(FileDiscoveryJob::new(
-            canonicalized,
-            Arc::clone(&self.queue),
-            self.paths_tx.clone(),
-            self.errors_tx.clone(),
-            Arc::clone(&self.excluded_patterns),
-        )));
-    }
-
     fn send_error(&self, error: Errors) {
         self.errors_tx
             .send(error)
@@ -89,60 +65,46 @@ impl FileDiscoveryJob {
 
 impl Job for FileDiscoveryJob {
     fn run(&self) {
-        if self.path.is_dir() {
-            let Ok(read_dir) = self.path.read_dir() else {
+        let Ok(read_dir) = self.path.read_dir() else {
+            if self.path.is_file() {
+                self.handle_file(&self.path);
+            } else {
                 self.send_error(Errors::FileError(format!(
                     "Failed to read directory `{}`",
+                    self.path.display()
+                )));
+            }
+
+            return;
+        };
+
+        for result in read_dir {
+            let Ok(entry) = result else {
+                self.send_error(Errors::FileError(format!(
+                    "Failed to read directory `{}`: {result:?}",
                     self.path.display(),
                 )));
 
-                return;
+                continue;
             };
 
-            for result in read_dir {
-                let Ok(entry) = result else {
-                    self.send_error(Errors::FileError(format!(
-                        "Failed to read directory `{}`: {result:?}",
-                        self.path.display(),
-                    )));
+            let path = entry.path();
 
+            if entry.file_type().unwrap().is_dir() {
+                if is_excluded(&self.excluded_patterns, &path) {
                     continue;
-                };
-
-                let kind = entry.file_type().unwrap();
-
-                if kind.is_dir() {
-                    if is_excluded(&self.excluded_patterns, &entry.path()) {
-                        continue;
-                    }
-
-                    self.queue.push(Box::new(FileDiscoveryJob::new(
-                        entry.path(),
-                        Arc::clone(&self.queue),
-                        self.paths_tx.clone(),
-                        self.errors_tx.clone(),
-                        Arc::clone(&self.excluded_patterns),
-                    )));
-                } else if kind.is_file() {
-                    self.handle_file(&entry.path());
-                } else if kind.is_symlink() {
-                    self.handle_symlink(&entry.path());
-                } else {
-                    self.send_error(Errors::FileError(format!(
-                        "Path `{}` is not a file or directory",
-                        entry.path().display()
-                    )));
                 }
+
+                self.queue.push(Box::new(FileDiscoveryJob::new(
+                    path,
+                    Arc::clone(&self.queue),
+                    self.paths_tx.clone(),
+                    self.errors_tx.clone(),
+                    Arc::clone(&self.excluded_patterns),
+                )));
+            } else {
+                self.handle_file(&path);
             }
-        } else if self.path.is_file() {
-            self.handle_file(&self.path);
-        } else if self.path.is_symlink() {
-            self.handle_symlink(&self.path);
-        } else {
-            self.send_error(Errors::FileError(format!(
-                "Path `{}` is not a file or directory",
-                self.path.display()
-            )));
         }
     }
 }
@@ -165,39 +127,32 @@ pub fn collect_file_paths<S: BuildHasher>(
     let (files_tx, files_rx) = unbounded();
     let (errors_tx, errors_rx) = unbounded();
 
-    // Canonicalize concrete excluded paths (they may be symlinks) and escape them so they match exactly, not
-    // as globs. Globs are kept as written.
-    let excluded_patterns: Arc<Vec<Pattern>> = Arc::new(
-        excluded
-            .iter()
-            .filter_map(|entry| {
-                let entry: &str = entry;
-
-                if entry.contains(['*', '?', '[']) {
-                    Pattern::new(entry).ok()
-                } else {
-                    let canonical = fs::canonicalize(entry).ok()?;
-                    Pattern::new(&Pattern::escape(&canonical.to_string_lossy())).ok()
-                }
-            })
-            .collect(),
-    );
+    let excluded_patterns: Arc<Vec<Pattern>> =
+        Arc::new(excluded.iter().filter_map(|entry| Pattern::new(entry).ok()).collect());
 
     for path in paths {
-        let Ok(canonicalized) = fs::canonicalize(&path) else {
+        let Ok(path) = std::path::absolute(&path) else {
             errors_tx
-                .send(Errors::FileError(format!("Path `{path}` does not exist")))
+                .send(Errors::FileError(format!("Failed to resolve path `{path}`")))
                 .expect("errors receiver dropped before run completion");
 
             continue;
         };
 
-        if is_excluded(&excluded_patterns, &canonicalized) {
+        if !path.exists() {
+            errors_tx
+                .send(Errors::FileError(format!("Path `{}` does not exist", path.display())))
+                .expect("errors receiver dropped before run completion");
+
+            continue;
+        }
+
+        if is_excluded(&excluded_patterns, &path) {
             continue;
         }
 
         queue.push(Box::new(FileDiscoveryJob::new(
-            canonicalized,
+            path,
             Arc::clone(&queue),
             files_tx.clone(),
             errors_tx.clone(),
@@ -344,6 +299,31 @@ mod tests {
         );
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn collect_files_emits_absolute_paths_for_relative_roots() {
+        let context = Context::new();
+        context.touch(PathBuf::from("project").join("foo.rb"));
+
+        // Express the project directory as a path relative to the process working directory.
+        let working_directory = std::env::current_dir().unwrap();
+        let mut relative_root = PathBuf::new();
+        for _ in 0..working_directory.components().count() - 1 {
+            relative_root.push("..");
+        }
+        let project = context.absolute_path_to("project");
+        let relative_root = relative_root.join(project.strip_prefix("/").unwrap());
+
+        let (files, errors) = collect_file_paths(vec![relative_root.to_string_lossy().into_owned()], &HashSet::new());
+
+        assert!(errors.is_empty());
+        assert!(!files.is_empty());
+        assert!(
+            files.iter().all(|path| path.is_absolute()),
+            "expected only absolute paths, got {files:?}"
+        );
+    }
+
     #[test]
     fn collect_files_excludes_directories() {
         let context = Context::new();
@@ -370,7 +350,7 @@ mod tests {
         context.touch(&nested);
 
         let mut excluded = HashSet::new();
-        excluded.insert(context.absolute_path_to("root/skip").to_string_lossy().into());
+        excluded.insert("**/skip".into());
 
         let (files, errors) = collect_document_paths_with_exclusions(&context, &["root"], &excluded);
 
@@ -380,40 +360,65 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn collect_files_excludes_symlinked_directories() {
+    fn collect_files_indexes_symlinked_files_at_their_own_path() {
         let context = Context::new();
-        let included = PathBuf::from("included").join("foo.rb");
-        let excluded_file = PathBuf::from("real_dir").join("bar.rb");
-        context.touch(&included);
-        context.touch(&excluded_file);
+        let target = PathBuf::from("outside").join("real.rb");
+        context.touch(&target);
+        context.mkdir("project");
 
-        // Create a symlink: link -> real_dir
-        std::os::unix::fs::symlink(context.absolute_path_to("real_dir"), context.absolute_path_to("link")).unwrap();
+        // Create a symlink to a file outside the traversed tree: project/alias.rb -> outside/real.rb
+        std::os::unix::fs::symlink(
+            context.absolute_path_to("outside/real.rb"),
+            context.absolute_path_to("project/alias.rb"),
+        )
+        .unwrap();
 
-        // Excluding the real directory while requesting to index the symlink should properly exclude the link
-        let mut excluded = HashSet::new();
-        excluded.insert(context.absolute_path_to("real_dir").to_string_lossy().into());
-
-        let (files, errors) = collect_document_paths_with_exclusions(&context, &["included", "link"], &excluded);
+        let (files, errors) = collect_document_paths(&context, &["project"]);
 
         assert!(errors.is_empty());
-        assert_eq!(files, [included.to_str().unwrap().to_string()]);
+        // The symlink is indexed at its own path, not resolved to the target.
+        let alias = PathBuf::from("project").join("alias.rb");
+        assert_eq!(files, [alias.to_str().unwrap().to_string()]);
     }
 
+    #[cfg(unix)]
     #[test]
-    fn collect_files_excludes_glob_patterns() {
+    fn collect_files_does_not_follow_symlinked_directories() {
         let context = Context::new();
-        let kept = PathBuf::from("lib").join("foo.rb");
-        let nested = PathBuf::from("lib").join("test/fixtures").join("bar.rb");
+        let kept = PathBuf::from("project").join("foo.rb");
+        let outside = PathBuf::from("outside").join("bar.rb");
         context.touch(&kept);
-        context.touch(&nested);
+        context.touch(&outside);
 
-        let mut excluded = HashSet::new();
-        excluded.insert("**/fixtures".into());
+        // Create a symlink inside the traversed tree: project/link -> outside
+        std::os::unix::fs::symlink(
+            context.absolute_path_to("outside"),
+            context.absolute_path_to("project/link"),
+        )
+        .unwrap();
 
-        let (files, errors) = collect_document_paths_with_exclusions(&context, &["lib"], &excluded);
+        let (files, errors) = collect_document_paths(&context, &["project"]);
 
         assert!(errors.is_empty());
+        // The symlinked directory is not followed, so `outside/bar.rb` is never reached.
         assert_eq!(files, [kept.to_str().unwrap().to_string()]);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn collect_files_indexes_symlinked_directory_roots() {
+        let context = Context::new();
+        let target = PathBuf::from("real").join("foo.rb");
+        context.touch(&target);
+
+        // A symlink to a directory passed as an explicit root, as `Graph#workspace_paths` does via `File.directory?`.
+        std::os::unix::fs::symlink(context.absolute_path_to("real"), context.absolute_path_to("link")).unwrap();
+
+        let (files, errors) = collect_document_paths(&context, &["link"]);
+
+        assert!(errors.is_empty());
+        // The requested root is traversed; files are indexed under the requested (symlink) path.
+        let foo = PathBuf::from("link").join("foo.rb");
+        assert_eq!(files, [foo.to_str().unwrap().to_string()]);
     }
 }

--- a/rust/rubydex/src/listing.rs
+++ b/rust/rubydex/src/listing.rs
@@ -90,11 +90,11 @@ impl Job for FileDiscoveryJob {
 
             let path = entry.path();
 
-            if entry.file_type().unwrap().is_dir() {
-                if is_excluded(&self.excluded_patterns, &path) {
-                    continue;
-                }
+            if is_excluded(&self.excluded_patterns, &path) {
+                continue;
+            }
 
+            if entry.file_type().unwrap().is_dir() {
                 self.queue.push(Box::new(FileDiscoveryJob::new(
                     path,
                     Arc::clone(&self.queue),
@@ -420,5 +420,22 @@ mod tests {
         // The requested root is traversed; files are indexed under the requested (symlink) path.
         let foo = PathBuf::from("link").join("foo.rb");
         assert_eq!(files, [foo.to_str().unwrap().to_string()]);
+    }
+
+    #[test]
+    fn collect_files_excludes_nested_files_matching_globs() {
+        let context = Context::new();
+        let kept = PathBuf::from("lib").join("foo.rb");
+        let excluded_file = PathBuf::from("lib").join("version.rb");
+        context.touch(&kept);
+        context.touch(&excluded_file);
+
+        let mut excluded = HashSet::new();
+        excluded.insert("**/version.rb".into());
+
+        let (files, errors) = collect_document_paths_with_exclusions(&context, &["lib"], &excluded);
+
+        assert!(errors.is_empty());
+        assert_eq!(files, [kept.to_str().unwrap().to_string()]);
     }
 }

--- a/rust/rubydex/src/listing.rs
+++ b/rust/rubydex/src/listing.rs
@@ -165,13 +165,21 @@ pub fn collect_file_paths<S: BuildHasher>(
     let (files_tx, files_rx) = unbounded();
     let (errors_tx, errors_rx) = unbounded();
 
-    // Canonicalize the excluded paths (they may be symlinks) and turn each into a pattern. Escaping keeps
-    // matching exact.
+    // Canonicalize concrete excluded paths (they may be symlinks) and escape them so they match exactly, not
+    // as globs. Globs are kept as written.
     let excluded_patterns: Arc<Vec<Pattern>> = Arc::new(
         excluded
             .iter()
-            .filter_map(|entry| fs::canonicalize(&**entry).ok())
-            .filter_map(|canonical| Pattern::new(&Pattern::escape(&canonical.to_string_lossy())).ok())
+            .filter_map(|entry| {
+                let entry: &str = entry;
+
+                if entry.contains(['*', '?', '[']) {
+                    Pattern::new(entry).ok()
+                } else {
+                    let canonical = fs::canonicalize(entry).ok()?;
+                    Pattern::new(&Pattern::escape(&canonical.to_string_lossy())).ok()
+                }
+            })
             .collect(),
     );
 
@@ -390,5 +398,22 @@ mod tests {
 
         assert!(errors.is_empty());
         assert_eq!(files, [included.to_str().unwrap().to_string()]);
+    }
+
+    #[test]
+    fn collect_files_excludes_glob_patterns() {
+        let context = Context::new();
+        let kept = PathBuf::from("lib").join("foo.rb");
+        let nested = PathBuf::from("lib").join("test/fixtures").join("bar.rb");
+        context.touch(&kept);
+        context.touch(&nested);
+
+        let mut excluded = HashSet::new();
+        excluded.insert("**/fixtures".into());
+
+        let (files, errors) = collect_document_paths_with_exclusions(&context, &["lib"], &excluded);
+
+        assert!(errors.is_empty());
+        assert_eq!(files, [kept.to_str().unwrap().to_string()]);
     }
 }

--- a/rust/rubydex/src/main.rs
+++ b/rust/rubydex/src/main.rs
@@ -134,7 +134,7 @@ fn main() {
     // Listing
 
     let (file_paths, errors) = time_it!(listing, {
-        listing::collect_file_paths(args.paths, &graph.excluded_paths())
+        listing::collect_file_paths(args.paths, &graph.excluded_patterns())
     });
 
     for error in errors {

--- a/rust/rubydex/src/model/graph.rs
+++ b/rust/rubydex/src/model/graph.rs
@@ -130,13 +130,13 @@ impl Graph {
 
     /// Adds paths to exclude from file discovery during indexing. Excluded directories will be skipped entirely during
     /// directory traversal.
-    pub fn exclude_paths(&mut self, paths: Vec<PathBuf>) {
+    pub fn exclude_paths(&mut self, paths: Vec<Box<str>>) {
         self.config.exclude_paths(paths);
     }
 
     /// Returns the set of paths excluded from file discovery.
     #[must_use]
-    pub fn excluded_paths(&self) -> HashSet<PathBuf> {
+    pub fn excluded_paths(&self) -> HashSet<Box<str>> {
         self.config.excluded_paths()
     }
 

--- a/rust/rubydex/src/model/graph.rs
+++ b/rust/rubydex/src/model/graph.rs
@@ -128,16 +128,16 @@ impl Graph {
         &mut self.declarations
     }
 
-    /// Adds paths to exclude from file discovery during indexing. Excluded directories will be skipped entirely during
-    /// directory traversal.
-    pub fn exclude_paths(&mut self, paths: Vec<Box<str>>) {
-        self.config.exclude_paths(paths);
+    /// Adds glob patterns to exclude from file discovery during indexing. Excluded directories will be skipped entirely
+    /// during directory traversal.
+    pub fn exclude_patterns(&mut self, patterns: Vec<Box<str>>) {
+        self.config.exclude_patterns(patterns);
     }
 
-    /// Returns the set of paths excluded from file discovery.
+    /// Returns the set of exclusion patterns.
     #[must_use]
-    pub fn excluded_paths(&self) -> HashSet<Box<str>> {
-        self.config.excluded_paths()
+    pub fn excluded_patterns(&self) -> HashSet<Box<str>> {
+        self.config.excluded_patterns()
     }
 
     /// Returns the root directory of the workspace being indexed.

--- a/test/graph_test.rb
+++ b/test/graph_test.rb
@@ -58,9 +58,9 @@ class GraphTest < Minitest::Test
       graph.load_config(".rubydex_custom")
 
       # Excluded paths are resolved against the workspace path.
-      assert_includes(graph.excluded_paths, context.absolute_path_to("vendor"))
-      assert_includes(graph.excluded_paths, context.absolute_path_to("generated"))
-      assert_includes(graph.excluded_paths, context.absolute_path_to("node_modules"))
+      assert_includes(graph.excluded_patterns, context.absolute_path_to("vendor"))
+      assert_includes(graph.excluded_patterns, context.absolute_path_to("generated"))
+      assert_includes(graph.excluded_patterns, context.absolute_path_to("node_modules"))
     end
   end
 
@@ -71,9 +71,9 @@ class GraphTest < Minitest::Test
       graph = Rubydex::Graph.new(workspace_path: context.absolute_path)
       graph.load_config
 
-      assert_includes(graph.excluded_paths, context.absolute_path_to("vendor"))
-      assert_includes(graph.excluded_paths, context.absolute_path_to("generated"))
-      assert_includes(graph.excluded_paths, context.absolute_path_to("node_modules"))
+      assert_includes(graph.excluded_patterns, context.absolute_path_to("vendor"))
+      assert_includes(graph.excluded_patterns, context.absolute_path_to("generated"))
+      assert_includes(graph.excluded_patterns, context.absolute_path_to("node_modules"))
     end
   end
 
@@ -83,7 +83,7 @@ class GraphTest < Minitest::Test
 
       # A missing default `rubydex.toml` is not an error; defaults remain in place.
       graph.load_config
-      assert_includes(graph.excluded_paths, context.absolute_path_to("node_modules"))
+      assert_includes(graph.excluded_patterns, context.absolute_path_to("node_modules"))
     end
   end
 
@@ -1467,15 +1467,15 @@ class GraphTest < Minitest::Test
     end
   end
 
-  def test_exclude_paths_filters_nested_directories
+  def test_exclude_patterns_filters_nested_directories
     with_context do |context|
       context.write!("vendor/gems/foo.rb", "class Foo; end")
       context.write!("vendor/bundle/bar.rb", "class Bar; end")
 
       graph = Rubydex::Graph.new(workspace_path: context.absolute_path)
-      graph.exclude_paths(["vendor/bundle"])
+      graph.exclude_patterns(["vendor/bundle"])
 
-      assert_includes(graph.excluded_paths, context.absolute_path_to("vendor/bundle"))
+      assert_includes(graph.excluded_patterns, context.absolute_path_to("vendor/bundle"))
 
       # vendor itself should be included since only vendor/bundle is excluded
       paths = graph.workspace_paths
@@ -1490,15 +1490,15 @@ class GraphTest < Minitest::Test
     end
   end
 
-  def test_exclude_paths_with_invalid_arguments
+  def test_exclude_patterns_with_invalid_arguments
     graph = Rubydex::Graph.new
 
     assert_raises(TypeError) do
-      graph.exclude_paths(123)
+      graph.exclude_patterns(123)
     end
 
     assert_raises(TypeError) do
-      graph.exclude_paths(["/valid/path", 456])
+      graph.exclude_patterns(["/valid/path", 456])
     end
   end
 


### PR DESCRIPTION
This PR lets `exclude` entries be glob patterns (e.g. `**/fixtures`, `**/*_pb.rb`), not just literal paths. Every entry is compiled to a glob and matched during file discovery, against both directories and nested files.

A glob is not a real path and cannot be canonicalized, so matching compares paths as-is. Discovery does not canonicalize or resolve symlinks.

Two notes on symlinks:
 - A symlinked directory passed as a root is still traversed (the follow comes from `read_dir`), but its files are reported under the symlink path, not the resolved destination.
 - Nested symlinks are not followed: a symlinked directory is not descended, and a symlinked file is indexed at its own path.
 
 ## Breaking change (v0.3.0)

Exclude entries are now glob patterns rather than literal paths, so the API is renamed to match:
- `Graph#exclude_paths` becomes `Graph#exclude_patterns`
- `Graph#excluded_paths` becomes `Graph#excluded_patterns`

(along with the underlying config, `graph.rs`, and FFI names).

## Performance

No listing regression. Averaged over `utils/bench` runs:

| Ref | Listing average | Min | Max |
| --- | ---: | ---: | ---: |
| this branch | 0.676667s | 0.656s | 0.718s |
| `main` | 0.677333s | 0.674s | 0.683s |

Branch delta: -0.10% versus `main`.