### PR TITLE
Accept multiple queries in search and fuzzy search

### DIFF
--- a/ext/rubydex/graph.c
+++ b/ext/rubydex/graph.c
@@ -196,40 +196,54 @@ static VALUE rdxr_graph_yield_search_results(VALUE self, void *iter) {
 
 /*
  * call-seq:
- *   search(query) -> Enumerator[Rubydex::Declaration]
+ *   search(*queries) -> Enumerator[Rubydex::Declaration]
  *
- * Returns an enumerator that yields declarations matching the query exactly by substring.
+ * Returns an enumerator that yields declarations whose name matches any of the queries exactly by substring.
  */
-static VALUE rdxr_graph_search(VALUE self, VALUE query) {
-    Check_Type(query, T_STRING);
+static VALUE rdxr_graph_search(int argc, VALUE *argv, VALUE self) {
+    rb_check_arity(argc, 1, UNLIMITED_ARGUMENTS);
+    VALUE queries = rb_ary_new_from_values(argc, argv);
+    rdxi_check_array_of_strings(queries);
 
     if (!rb_block_given_p()) {
-        return rb_enumeratorize(self, rb_str_new2("search"), 1, &query);
+        return rb_enumeratorize(self, rb_str_new2("search"), argc, argv);
     }
 
     void *graph;
     TypedData_Get_Struct(self, void *, &graph_type, graph);
 
-    return rdxr_graph_yield_search_results(self, rdx_graph_declarations_search(graph, StringValueCStr(query)));
+    size_t length = (size_t)argc;
+    char **converted = rdxi_str_array_to_char(queries, length);
+    void *iter = rdx_graph_declarations_search(graph, (const char *const *)converted, length);
+    rdxi_free_str_array(converted, length);
+
+    return rdxr_graph_yield_search_results(self, iter);
 }
 
 /*
  * call-seq:
- *   fuzzy_search(query) -> Enumerator[Rubydex::Declaration]
+ *   fuzzy_search(*queries) -> Enumerator[Rubydex::Declaration]
  *
- * Returns an enumerator that yields declarations matching the query fuzzily.
+ * Returns an enumerator that yields declarations whose name matches any of the queries fuzzily.
  */
-static VALUE rdxr_graph_fuzzy_search(VALUE self, VALUE query) {
-    Check_Type(query, T_STRING);
+static VALUE rdxr_graph_fuzzy_search(int argc, VALUE *argv, VALUE self) {
+    rb_check_arity(argc, 1, UNLIMITED_ARGUMENTS);
+    VALUE queries = rb_ary_new_from_values(argc, argv);
+    rdxi_check_array_of_strings(queries);
 
     if (!rb_block_given_p()) {
-        return rb_enumeratorize(self, rb_str_new2("fuzzy_search"), 1, &query);
+        return rb_enumeratorize(self, rb_str_new2("fuzzy_search"), argc, argv);
     }
 
     void *graph;
     TypedData_Get_Struct(self, void *, &graph_type, graph);
 
-    return rdxr_graph_yield_search_results(self, rdx_graph_declarations_fuzzy_search(graph, StringValueCStr(query)));
+    size_t length = (size_t)argc;
+    char **converted = rdxi_str_array_to_char(queries, length);
+    void *iter = rdx_graph_declarations_fuzzy_search(graph, (const char *const *)converted, length);
+    rdxi_free_str_array(converted, length);
+
+    return rdxr_graph_yield_search_results(self, iter);
 }
 
 // Body function for rb_ensure in Graph#documents
@@ -942,8 +956,8 @@ void rdxi_initialize_graph(VALUE moduleRubydex) {
     rb_define_method(cGraph, "diagnostics", rdxr_graph_diagnostics, 0);
     rb_define_method(cGraph, "check_integrity", rdxr_graph_check_integrity, 0);
     rb_define_method(cGraph, "[]", rdxr_graph_aref, 1);
-    rb_define_method(cGraph, "search", rdxr_graph_search, 1);
-    rb_define_method(cGraph, "fuzzy_search", rdxr_graph_fuzzy_search, 1);
+    rb_define_method(cGraph, "search", rdxr_graph_search, -1);
+    rb_define_method(cGraph, "fuzzy_search", rdxr_graph_fuzzy_search, -1);
     rb_define_method(cGraph, "encoding=", rdxr_graph_set_encoding, 1);
     rb_define_method(cGraph, "resolve_require_path", rdxr_graph_resolve_require_path, 2);
     rb_define_method(cGraph, "require_paths", rdxr_graph_require_paths, 1);

--- a/rbi/rubydex.rbi
+++ b/rbi/rubydex.rbi
@@ -335,11 +335,11 @@ class Rubydex::Graph
   sig { params(require_path: String, load_paths: T::Array[String]).returns(T.nilable(Rubydex::Document)) }
   def resolve_require_path(require_path, load_paths); end
 
-  sig { params(query: String).returns(T::Enumerable[Rubydex::Declaration]) }
-  def search(query); end
+  sig { params(queries: String).returns(T::Enumerable[Rubydex::Declaration]) }
+  def search(*queries); end
 
-  sig { params(query: String).returns(T::Enumerable[Rubydex::Declaration]) }
-  def fuzzy_search(query); end
+  sig { params(queries: String).returns(T::Enumerable[Rubydex::Declaration]) }
+  def fuzzy_search(*queries); end
 
   sig { params(encoding: String).void }
   def encoding=(encoding); end

--- a/rust/rubydex-mcp/src/server.rs
+++ b/rust/rubydex-mcp/src/server.rs
@@ -241,7 +241,7 @@ impl RubydexServer {
                 .to_string();
             }
         };
-        let ids = rubydex::query::declaration_search(graph, &params.query, &match_mode);
+        let ids = rubydex::query::declaration_search(graph, &[params.query.as_str()], &match_mode);
 
         let limit = params.limit.filter(|&l| l > 0).unwrap_or(50).min(100); // default 50, max 100
         let offset = params.offset.unwrap_or(0);

--- a/rust/rubydex-sys/src/graph_api.rs
+++ b/rust/rubydex-sys/src/graph_api.rs
@@ -58,64 +58,75 @@ where
     result
 }
 
-/// Searches the graph using exact substring matching
+/// Searches the graph using exact substring matching, returning every declaration whose name matches any of the
+/// queries.
 ///
 /// # Safety
 ///
-/// Expects both the graph and the query pointers to be valid
+/// Expects `pointer` to be a valid graph and `c_queries` to point to an array of `count` valid, NUL-terminated C
+/// strings. Returns a null pointer when `count` is zero, `c_queries` is null, or any query is not valid UTF-8.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rdx_graph_declarations_search(
     pointer: GraphPointer,
-    c_query: *const c_char,
+    c_queries: *const *const c_char,
+    count: usize,
 ) -> *mut DeclarationsIter {
-    {
-        let Ok(query) = (unsafe { utils::convert_char_ptr_to_string(c_query) }) else {
-            return ptr::null_mut();
-        };
-
-        let entries = with_graph(pointer, |graph| {
-            query::declaration_search(graph, &query, &query::MatchMode::Exact)
-                .into_iter()
-                .filter_map(|id| {
-                    let decl = graph.declarations().get(&id)?;
-                    Some(CDeclaration::from_declaration(id, decl))
-                })
-                .collect::<Vec<CDeclaration>>()
-                .into_boxed_slice()
-        });
-
-        DeclarationsIter::new(entries)
+    if count == 0 || c_queries.is_null() {
+        return ptr::null_mut();
     }
+
+    let Ok(queries) = (unsafe { utils::convert_double_pointer_to_vec(c_queries, count) }) else {
+        return ptr::null_mut();
+    };
+    let query_refs: Vec<&str> = queries.iter().map(String::as_str).collect();
+
+    let entries = with_graph(pointer, |graph| {
+        query::declaration_search(graph, &query_refs, &query::MatchMode::Exact)
+            .into_iter()
+            .filter_map(|id| {
+                let decl = graph.declarations().get(&id)?;
+                Some(CDeclaration::from_declaration(id, decl))
+            })
+            .collect::<Vec<CDeclaration>>()
+            .into_boxed_slice()
+    });
+
+    DeclarationsIter::new(entries)
 }
 
-/// Searches the graph using fuzzy matching
+/// Searches the graph using fuzzy matching, returning every declaration whose name matches any of the queries.
 ///
 /// # Safety
 ///
-/// Expects both the graph and the query pointers to be valid
+/// Expects `pointer` to be a valid graph and `c_queries` to point to an array of `count` valid, NUL-terminated C
+/// strings. Returns a null pointer when `count` is zero, `c_queries` is null, or any query is not valid UTF-8.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rdx_graph_declarations_fuzzy_search(
     pointer: GraphPointer,
-    c_query: *const c_char,
+    c_queries: *const *const c_char,
+    count: usize,
 ) -> *mut DeclarationsIter {
-    {
-        let Ok(query) = (unsafe { utils::convert_char_ptr_to_string(c_query) }) else {
-            return ptr::null_mut();
-        };
-
-        let entries = with_graph(pointer, |graph| {
-            query::declaration_search(graph, &query, &query::MatchMode::Fuzzy)
-                .into_iter()
-                .filter_map(|id| {
-                    let decl = graph.declarations().get(&id)?;
-                    Some(CDeclaration::from_declaration(id, decl))
-                })
-                .collect::<Vec<CDeclaration>>()
-                .into_boxed_slice()
-        });
-
-        DeclarationsIter::new(entries)
+    if count == 0 || c_queries.is_null() {
+        return ptr::null_mut();
     }
+
+    let Ok(queries) = (unsafe { utils::convert_double_pointer_to_vec(c_queries, count) }) else {
+        return ptr::null_mut();
+    };
+    let query_refs: Vec<&str> = queries.iter().map(String::as_str).collect();
+
+    let entries = with_graph(pointer, |graph| {
+        query::declaration_search(graph, &query_refs, &query::MatchMode::Fuzzy)
+            .into_iter()
+            .filter_map(|id| {
+                let decl = graph.declarations().get(&id)?;
+                Some(CDeclaration::from_declaration(id, decl))
+            })
+            .collect::<Vec<CDeclaration>>()
+            .into_boxed_slice()
+    });
+
+    DeclarationsIter::new(entries)
 }
 
 /// # Panics

--- a/rust/rubydex/src/query.rs
+++ b/rust/rubydex/src/query.rs
@@ -27,12 +27,25 @@ pub enum MatchMode {
     Exact,
 }
 
+/// Searches all declarations in parallel based on fully qualified names. Accepts multiple queries in case the caller
+/// wants to find multiple patterns without having to re-traverse the graph and also accepts match mode.
+///
+/// Note: an empty query returns all declarations, so if any are included the rest of the queries will be ignored.
+///
 /// # Panics
 ///
 /// Will panic if any of the threads panic
-pub fn declaration_search(graph: &Graph, query: &str, match_mode: &MatchMode) -> Vec<DeclarationId> {
+pub fn declaration_search(graph: &Graph, queries: &[&str], match_mode: &MatchMode) -> Vec<DeclarationId> {
     let num_threads = thread::available_parallelism().map_or(4, std::num::NonZero::get);
     let declarations = graph.declarations();
+
+    // An empty query matches all declarations as per the LSP specification and is equivalent to fetching all of them
+    // directly. Since an empty query matches all, there's no point in checking the other queries or pay the price of
+    // spawning threads.
+    if queries.iter().any(|q| q.is_empty()) {
+        return declarations.keys().copied().collect();
+    }
+
     let ids: Vec<DeclarationId> = declarations.keys().copied().collect();
     let chunk_size = ids.len().div_ceil(num_threads);
 
@@ -48,16 +61,8 @@ pub fn declaration_search(graph: &Graph, query: &str, match_mode: &MatchMode) ->
                     chunk
                         .iter()
                         .filter(|id| {
-                            let declaration = declarations.get(id).unwrap();
-                            let name = declaration.name();
-                            match match_mode {
-                                MatchMode::Fuzzy => {
-                                    // When the query is empty, we return everything as per the LSP specification.
-                                    // Otherwise, we compute the match score and return anything with a score greater than zero
-                                    query.is_empty() || match_score(query, name) > 0
-                                }
-                                MatchMode::Exact => name.contains(query),
-                            }
+                            let name = declarations.get(id).unwrap().name();
+                            queries.iter().any(|query| matches_query(query, name, match_mode))
                         })
                         .copied()
                         .collect::<Vec<_>>()
@@ -67,6 +72,15 @@ pub fn declaration_search(graph: &Graph, query: &str, match_mode: &MatchMode) ->
 
         handles.into_iter().flat_map(|h| h.join().unwrap()).collect()
     })
+}
+
+/// Returns whether a single `query` matches `name` under the given [`MatchMode`].
+#[must_use]
+fn matches_query(query: &str, name: &str, match_mode: &MatchMode) -> bool {
+    match match_mode {
+        MatchMode::Fuzzy => match_score(query, name) > 0,
+        MatchMode::Exact => name.contains(query),
+    }
 }
 
 #[must_use]
@@ -836,7 +850,7 @@ mod tests {
             assert_results_eq!($context, $query, &MatchMode::default(), $expected);
         };
         ($context:expr, $query:expr, $match_mode:expr, $expected:expr) => {
-            let actual = declaration_search(&$context.graph(), $query, $match_mode);
+            let actual = declaration_search(&$context.graph(), &[$query], $match_mode);
             assert_eq!(
                 actual,
                 $expected
@@ -945,8 +959,8 @@ mod tests {
             "
         });
         context.resolve();
-        let exact_results = declaration_search(context.graph(), "", &MatchMode::Exact);
-        let fuzzy_results = declaration_search(context.graph(), "", &MatchMode::Fuzzy);
+        let exact_results = declaration_search(context.graph(), &[""], &MatchMode::Exact);
+        let fuzzy_results = declaration_search(context.graph(), &[""], &MatchMode::Fuzzy);
 
         assert_eq!(exact_results.len(), fuzzy_results.len());
         assert_eq!(context.graph().declarations().len(), exact_results.len());
@@ -970,6 +984,51 @@ mod tests {
 
         assert_results_eq!(context, "#Is_A?()", &MatchMode::Exact, Vec::<&str>::new());
         assert_results_eq!(context, "#Is_A?()", ["Foo#is_a_foo?()", "Bar#is_a?()"]);
+    }
+
+    #[test]
+    fn multiple_queries_return_union_of_matches() {
+        let mut context = GraphTest::new();
+        context.index_uri("file:///foo.rb", {
+            r"
+            class Foo
+              def foo_method; end
+              def bar_method; end
+              def other_method; end
+            end
+            "
+        });
+        context.resolve();
+
+        let results = declaration_search(context.graph(), &["#foo_method()", "#bar_method()"], &MatchMode::Exact);
+        let mut names: Vec<String> = results
+            .iter()
+            .map(|id| context.graph().declarations().get(id).unwrap().name().to_string())
+            .collect();
+        names.sort();
+
+        assert_eq!(names, ["Foo#bar_method()", "Foo#foo_method()"]);
+    }
+
+    #[test]
+    fn overlapping_queries_do_not_duplicate_results() {
+        let mut context = GraphTest::new();
+        context.index_uri("file:///foo.rb", {
+            r"
+            class Foo
+              def is_a_foo?; end
+            end
+            "
+        });
+        context.resolve();
+
+        let results = declaration_search(context.graph(), &["is_a", "foo?"], &MatchMode::Exact);
+        let matches = results
+            .iter()
+            .filter(|id| context.graph().declarations().get(id).unwrap().name() == "Foo#is_a_foo?()")
+            .count();
+
+        assert_eq!(matches, 1);
     }
 
     fn test_root() -> PathBuf {

--- a/test/graph_test.rb
+++ b/test/graph_test.rb
@@ -250,6 +250,37 @@ class GraphTest < Minitest::Test
     end
   end
 
+  def test_graph_search_matches_any_of_multiple_queries
+    with_context do |context|
+      context.write!("foo.rb", <<~RUBY)
+        class Foo
+          def is_a_foo?; end
+        end
+
+        class Bar
+          def is_a_bar?; end
+        end
+
+        class Baz
+          def something_else; end
+        end
+      RUBY
+
+      graph = Rubydex::Graph.new
+      graph.index_all(context.glob("**/*.rb"))
+      graph.resolve
+
+      results = graph.search("#is_a_foo?()", "#is_a_bar?()").map(&:name).sort
+      assert_equal(["Bar#is_a_bar?()", "Foo#is_a_foo?()"], results)
+    end
+  end
+
+  def test_graph_search_requires_at_least_one_query
+    graph = Rubydex::Graph.new
+    assert_raises(ArgumentError) { graph.search }
+    assert_raises(ArgumentError) { graph.fuzzy_search }
+  end
+
   def test_workspace_path_defaults_to_pwd
     graph = Rubydex::Graph.new
     assert_equal(Dir.pwd, File.expand_path(graph.workspace_path))


### PR DESCRIPTION
I noticed that in some use cases, we want to search the graph for more than one query. Invoking `graph.search` multiple times means traversing all declarations and spawning threads for each invocation.

This PR starts accepting multiple queries instead, which allows us to search the entire graph in one go.

I also noticed that our empty query matching (which returns all declarations) was happening inside of the parallel loop, but that's unnecessary work. Empty matches everything, so we just need to return early before we even spawn any threads.