### PR TITLE
Reduce duplicate ancestor work enqueueing

### DIFF
--- a/rust/rubydex/src/query.rs
+++ b/rust/rubydex/src/query.rs
@@ -2826,7 +2826,16 @@ mod tests {
                 self_decl_id: None,
                 nesting_name_id,
             },
-            ["Bar#@@bar_cvar"]
+            [
+                "Bar",
+                "Bar#@@bar_cvar",
+                "BasicObject",
+                "Class",
+                "Foo",
+                "Kernel",
+                "Module",
+                "Object"
+            ]
         );
     }
 

--- a/rust/rubydex/src/resolution.rs
+++ b/rust/rubydex/src/resolution.rs
@@ -28,7 +28,7 @@ enum Outcome {
     /// must be placed back in the queue and retried once we have progressed further. `partial` is `true` when the
     /// blocker was a still-partial ancestor chain (the member may appear once the chain completes); `false` when it was
     /// a plain missing dependency (an unresolved parent scope, alias, or lexical nesting).
-    Retry { partial: bool },
+    Retry { partial_ancestors: bool },
 }
 
 impl Outcome {
@@ -195,7 +195,9 @@ impl<'a> Resolver<'a> {
                         None => Outcome::Unresolved,
                     },
                     // Owning class not resolved yet — retry next pass
-                    None => Outcome::Retry { partial: false },
+                    None => Outcome::Retry {
+                        partial_ancestors: false,
+                    },
                 }
             }
             _ => panic!("Expected constant or singleton method definitions"),
@@ -1233,7 +1235,9 @@ impl<'a> Resolver<'a> {
             // `set_singleton_class_id`, not `add_member`, so a TODO receiver would never gain a
             // member. Emit Retry so the unit is preserved for a later resolve where the receiver
             // may exist.
-            Outcome::Unresolved if singleton => Outcome::Retry { partial: false },
+            Outcome::Unresolved if singleton => Outcome::Retry {
+                partial_ancestors: false,
+            },
             Outcome::Unresolved => Outcome::Resolved(self.create_todo_for_parent(name_id)),
             other => other,
         };
@@ -1320,7 +1324,9 @@ impl<'a> Resolver<'a> {
                 // The parent scope is genuinely unknown — not a circular alias or pending
                 // linearization, but a name that doesn't exist anywhere in the graph.
                 Outcome::Unresolved => Outcome::Unresolved,
-                Outcome::Retry { partial: false } if !preserve_retry => Outcome::Unresolved,
+                Outcome::Retry {
+                    partial_ancestors: false,
+                } if !preserve_retry => Outcome::Unresolved,
                 retry @ Outcome::Retry { .. } => retry,
             }
         } else if let Some(nesting_id) = name_ref.nesting()
@@ -1336,7 +1342,9 @@ impl<'a> Resolver<'a> {
                 NameRef::Unresolved(_) => {
                     // The only case where we wouldn't have the nesting resolved at this point is if it's available through
                     // inheritance or if it doesn't exist, so we need to retry later
-                    Outcome::Retry { partial: false }
+                    Outcome::Retry {
+                        partial_ancestors: false,
+                    }
                 }
             }
         } else {
@@ -1405,7 +1413,9 @@ impl<'a> Resolver<'a> {
 
         // Get the primary (first) resolved target
         let Some(&primary_id) = resolved_ids.first() else {
-            return Outcome::Retry { partial: false };
+            return Outcome::Retry {
+                partial_ancestors: false,
+            };
         };
 
         // Check if the primary result is still an unresolved alias
@@ -1413,7 +1423,9 @@ impl<'a> Resolver<'a> {
             self.graph.declarations().get(&primary_id),
             Some(Declaration::ConstantAlias(_))
         ) {
-            return Outcome::Retry { partial: false };
+            return Outcome::Retry {
+                partial_ancestors: false,
+            };
         }
 
         Outcome::Resolved(primary_id)
@@ -1439,7 +1451,9 @@ impl<'a> Resolver<'a> {
                     }
                     ParentScope::Attached(parent_scope_id) => {
                         let NameRef::Resolved(parent_scope) = self.graph.names().get(parent_scope_id).unwrap() else {
-                            return Outcome::Retry { partial: false };
+                            return Outcome::Retry {
+                                partial_ancestors: false,
+                            };
                         };
 
                         let mut target_decl_id = *parent_scope.declaration_id();
@@ -1453,7 +1467,9 @@ impl<'a> Resolver<'a> {
                             if resolved_ids.iter().any(|id| {
                                 matches!(self.graph.declarations().get(id), Some(Declaration::ConstantAlias(_)))
                             }) {
-                                return Outcome::Retry { partial: false };
+                                return Outcome::Retry {
+                                    partial_ancestors: false,
+                                };
                             }
 
                             let Some(&namespace_id) = resolved_ids.iter().find(|id| {
@@ -1487,7 +1503,9 @@ impl<'a> Resolver<'a> {
                     }
                     ParentScope::Some(parent_scope_id) => {
                         let NameRef::Resolved(parent_scope) = self.graph.names().get(parent_scope_id).unwrap() else {
-                            return Outcome::Retry { partial: false };
+                            return Outcome::Retry {
+                                partial_ancestors: false,
+                            };
                         };
 
                         // Resolve the namespace in case it's an alias (e.g., ALIAS::CONST where ALIAS = Foo)
@@ -1502,7 +1520,9 @@ impl<'a> Resolver<'a> {
                             match self.graph.declarations().get(&id) {
                                 Some(Declaration::ConstantAlias(_)) => {
                                     // Alias not fully resolved yet
-                                    return Outcome::Retry { partial: false };
+                                    return Outcome::Retry {
+                                        partial_ancestors: false,
+                                    };
                                 }
                                 Some(Declaration::Namespace(_)) => {
                                     found_namespace = true;
@@ -1512,11 +1532,15 @@ impl<'a> Resolver<'a> {
                                             self.graph.record_resolved_name(name_id, declaration_id);
                                             return Outcome::Resolved(declaration_id);
                                         }
-                                        Outcome::Retry { partial: true } => {
+                                        Outcome::Retry {
+                                            partial_ancestors: true,
+                                        } => {
                                             missing_partial = true;
                                         }
                                         Outcome::Unresolved => {}
-                                        Outcome::Retry { partial: false } => {
+                                        Outcome::Retry {
+                                            partial_ancestors: false,
+                                        } => {
                                             unreachable!("search_ancestors never returns a non-partial Retry")
                                         }
                                     }
@@ -1536,7 +1560,7 @@ impl<'a> Resolver<'a> {
                         // whether the miss was due to a still-partial ancestor chain, so the unit is re-checked once
                         // that chain completes.
                         Outcome::Retry {
-                            partial: missing_partial,
+                            partial_ancestors: missing_partial,
                         }
                     }
                 }
@@ -1620,7 +1644,9 @@ impl<'a> Resolver<'a> {
                     for &id in &resolved_ids {
                         match self.graph.declarations().get(&id) {
                             Some(Declaration::ConstantAlias(_)) => {
-                                result = Outcome::Retry { partial: false };
+                                result = Outcome::Retry {
+                                    partial_ancestors: false,
+                                };
                                 break;
                             }
                             Some(Declaration::Namespace(_)) => {
@@ -1634,7 +1660,12 @@ impl<'a> Resolver<'a> {
 
                     (result, decl_id)
                 }
-                NameRef::Unresolved(_) => (Outcome::Retry { partial: false }, None),
+                NameRef::Unresolved(_) => (
+                    Outcome::Retry {
+                        partial_ancestors: false,
+                    },
+                    None,
+                ),
             };
 
             if matches!(ancestor_outcome, Outcome::Resolved(..)) {
@@ -1649,7 +1680,12 @@ impl<'a> Resolver<'a> {
                     Some(Declaration::Namespace(Namespace::Module(_) | Namespace::Todo(_)))
                 )
             });
-            let chain_incomplete = matches!(ancestor_outcome, Outcome::Retry { partial: true });
+            let chain_incomplete = matches!(
+                ancestor_outcome,
+                Outcome::Retry {
+                    partial_ancestors: true
+                }
+            );
 
             if is_module || chain_incomplete {
                 let object_outcome = self.search_ancestors(*OBJECT_ID, str_id);
@@ -1695,7 +1731,9 @@ impl<'a> Resolver<'a> {
                             // Stop at unresolved ancestors to avoid resolving to a later one.
                             // Skip if the name matches what we're searching for.
                             if *self.graph.names().get(&name_id).unwrap().str() != str_id {
-                                return Outcome::Retry { partial: true };
+                                return Outcome::Retry {
+                                    partial_ancestors: true,
+                                };
                             }
                         }
                         Ancestor::Complete(ancestor_id) => {
@@ -1713,7 +1751,9 @@ impl<'a> Resolver<'a> {
                         }
                     }
                 }
-                Outcome::Retry { partial: true }
+                Outcome::Retry {
+                    partial_ancestors: true,
+                }
             }
         }
     }
@@ -1735,7 +1775,9 @@ impl<'a> Resolver<'a> {
 
                 current_name = nesting_name_ref.name();
             } else {
-                return Outcome::Retry { partial: false };
+                return Outcome::Retry {
+                    partial_ancestors: false,
+                };
             }
         }
 

--- a/rust/rubydex/src/resolution.rs
+++ b/rust/rubydex/src/resolution.rs
@@ -21,15 +21,13 @@ use crate::model::{
 enum Outcome {
     /// The constant was successfully resolved to the given declaration ID.
     Resolved(DeclarationId),
-    /// We had everything we needed to resolve this constant, but we couldn't find it. When `partial` is `true`, the
-    /// lookup stopped at a still-partial ancestor chain, so the member may yet appear once that chain completes and the
-    /// unit should be retried. When `false`, the lookup is definitive (all relevant ancestor chains are complete) and
-    /// the unit can be dropped.
-    Unresolved { partial: bool },
-    /// We couldn't resolve this constant right now because a dependency was missing (an unresolved parent scope, alias,
-    /// or lexical nesting), or because a relevant ancestor chain is still partial. The unit must be placed back in the
-    /// queue and retried once we have progressed further. `partial` is `true` when the blocker was a partial ancestor
-    /// chain (mirrors `Unresolved::partial`).
+    /// We had everything we needed to resolve this constant (all relevant ancestor chains are complete), but the member
+    /// isn't there. This is definitive: the unit can be dropped and a diagnostic emitted.
+    Unresolved,
+    /// We couldn't resolve this constant right now because a dependency was missing, so it may succeed later. The unit
+    /// must be placed back in the queue and retried once we have progressed further. `partial` is `true` when the
+    /// blocker was a still-partial ancestor chain (the member may appear once the chain completes); `false` when it was
+    /// a plain missing dependency (an unresolved parent scope, alias, or lexical nesting).
     Retry { partial: bool },
 }
 
@@ -141,7 +139,7 @@ impl<'a> Resolver<'a> {
     pub fn resolve_constant(&mut self, name_id: NameId) -> Option<DeclarationId> {
         match self.resolve_constant_internal(name_id) {
             Outcome::Resolved(id) => Some(id),
-            Outcome::Unresolved { .. } | Outcome::Retry { .. } => None,
+            Outcome::Unresolved | Outcome::Retry { .. } => None,
         }
     }
 
@@ -194,7 +192,7 @@ impl<'a> Resolver<'a> {
                             Outcome::Resolved(singleton_id)
                         }
                         // Owner is a non-promotable constant — method is orphaned
-                        None => Outcome::Unresolved { partial: false },
+                        None => Outcome::Unresolved,
                     },
                     // Owning class not resolved yet — retry next pass
                     None => Outcome::Retry { partial: false },
@@ -204,10 +202,10 @@ impl<'a> Resolver<'a> {
         };
 
         match outcome {
-            Outcome::Retry { .. } | Outcome::Unresolved { partial: true } => {
+            Outcome::Retry { .. } => {
                 self.unit_queue.push_back(unit_id);
             }
-            Outcome::Unresolved { partial: false } => {
+            Outcome::Unresolved => {
                 // We couldn't resolve this name. Emit a diagnostic
             }
             Outcome::Resolved(id) => {
@@ -228,8 +226,13 @@ impl<'a> Resolver<'a> {
                 self.graph.record_resolved_reference(id, declaration_id);
                 self.made_progress = true;
             }
-            Outcome::Retry { .. } | Outcome::Unresolved { .. } => {
+            Outcome::Retry { .. } => {
                 self.unit_queue.push_back(unit_id);
+            }
+            Outcome::Unresolved => {
+                // If we had everything we needed to resolve this constant and still failed, then remember it as work
+                // for the next incremental resolution pass, but avoid trying again in this cycle
+                self.graph.push_work(unit_id);
             }
         }
     }
@@ -1230,8 +1233,8 @@ impl<'a> Resolver<'a> {
             // `set_singleton_class_id`, not `add_member`, so a TODO receiver would never gain a
             // member. Emit Retry so the unit is preserved for a later resolve where the receiver
             // may exist.
-            Outcome::Unresolved { partial: false } if singleton => Outcome::Retry { partial: false },
-            Outcome::Unresolved { partial: false } => Outcome::Resolved(self.create_todo_for_parent(name_id)),
+            Outcome::Unresolved if singleton => Outcome::Retry { partial: false },
+            Outcome::Unresolved => Outcome::Resolved(self.create_todo_for_parent(name_id)),
             other => other,
         };
 
@@ -1263,7 +1266,7 @@ impl<'a> Resolver<'a> {
                 // Foo = 1
                 // class << Foo; end
                 if singleton && !owner_is_namespace {
-                    return Outcome::Unresolved { partial: false };
+                    return Outcome::Unresolved;
                 }
 
                 // We don't prefix declarations with `Object::`
@@ -1316,9 +1319,9 @@ impl<'a> Resolver<'a> {
                 Outcome::Resolved(id) => self.resolve_to_primary_namespace(id),
                 // The parent scope is genuinely unknown — not a circular alias or pending
                 // linearization, but a name that doesn't exist anywhere in the graph.
-                Outcome::Unresolved { partial: false } => Outcome::Unresolved { partial: false },
-                Outcome::Retry { partial: false } if !preserve_retry => Outcome::Unresolved { partial: false },
-                other => other,
+                Outcome::Unresolved => Outcome::Unresolved,
+                Outcome::Retry { partial: false } if !preserve_retry => Outcome::Unresolved,
+                retry @ Outcome::Retry { .. } => retry,
             }
         } else if let Some(nesting_id) = name_ref.nesting()
             && !name_ref.parent_scope().is_top_level()
@@ -1456,7 +1459,7 @@ impl<'a> Resolver<'a> {
                             let Some(&namespace_id) = resolved_ids.iter().find(|id| {
                                 matches!(self.graph.declarations().get(id), Some(Declaration::Namespace(_)))
                             }) else {
-                                return Outcome::Unresolved { partial: false };
+                                return Outcome::Unresolved;
                             };
 
                             target_decl_id = namespace_id;
@@ -1465,7 +1468,7 @@ impl<'a> Resolver<'a> {
                         // If we found a singleton reference with a resolved attached object parent scope, we
                         // automatically create the singleton class
                         let Some(singleton_id) = self.get_or_create_singleton_class(target_decl_id, false) else {
-                            return Outcome::Unresolved { partial: false };
+                            return Outcome::Unresolved;
                         };
                         self.graph.record_resolved_name(name_id, singleton_id);
                         // `get_or_create_singleton_class` already enqueued the singleton's ancestors on
@@ -1509,10 +1512,10 @@ impl<'a> Resolver<'a> {
                                             self.graph.record_resolved_name(name_id, declaration_id);
                                             return Outcome::Resolved(declaration_id);
                                         }
-                                        Outcome::Retry { partial: true } | Outcome::Unresolved { partial: true } => {
+                                        Outcome::Retry { partial: true } => {
                                             missing_partial = true;
                                         }
-                                        Outcome::Unresolved { partial: false } => {}
+                                        Outcome::Unresolved => {}
                                         Outcome::Retry { partial: false } => {
                                             unreachable!("search_ancestors never returns a non-partial Retry")
                                         }
@@ -1526,15 +1529,14 @@ impl<'a> Resolver<'a> {
 
                         // If no namespaces were found, this constant path can never resolve.
                         if !found_namespace {
-                            return Outcome::Unresolved { partial: false };
+                            return Outcome::Unresolved;
                         }
 
-                        // Member not found in any namespace yet - retry in case it's added later. If the miss was due
-                        // to a still-partial ancestor chain, mark it so the unit is re-checked once the chain completes.
-                        if missing_partial {
-                            Outcome::Unresolved { partial: true }
-                        } else {
-                            Outcome::Retry { partial: false }
+                        // Member not found in any namespace yet - retry in case it's added later. `partial` records
+                        // whether the miss was due to a still-partial ancestor chain, so the unit is re-checked once
+                        // that chain completes.
+                        Outcome::Retry {
+                            partial: missing_partial,
                         }
                     }
                 }
@@ -1612,7 +1614,7 @@ impl<'a> Resolver<'a> {
             let (ancestor_outcome, nesting_decl_id) = match self.graph.names().get(nesting).unwrap() {
                 NameRef::Resolved(nesting_name_ref) => {
                     let resolved_ids = self.resolve_alias_chains(*nesting_name_ref.declaration_id());
-                    let mut result = Outcome::Unresolved { partial: false };
+                    let mut result = Outcome::Unresolved;
                     let mut decl_id = None;
 
                     for &id in &resolved_ids {
@@ -1647,10 +1649,7 @@ impl<'a> Resolver<'a> {
                     Some(Declaration::Namespace(Namespace::Module(_) | Namespace::Todo(_)))
                 )
             });
-            let chain_incomplete = matches!(
-                ancestor_outcome,
-                Outcome::Retry { partial: true } | Outcome::Unresolved { partial: true }
-            );
+            let chain_incomplete = matches!(ancestor_outcome, Outcome::Retry { partial: true });
 
             if is_module || chain_incomplete {
                 let object_outcome = self.search_ancestors(*OBJECT_ID, str_id);
@@ -1688,7 +1687,7 @@ impl<'a> Resolver<'a> {
                         None
                     }
                 })
-                .unwrap_or(Outcome::Unresolved { partial: false }),
+                .unwrap_or(Outcome::Unresolved),
             Ancestors::Partial(ids) => {
                 for ancestor_id in ids {
                     match ancestor_id {
@@ -1714,7 +1713,7 @@ impl<'a> Resolver<'a> {
                         }
                     }
                 }
-                Outcome::Unresolved { partial: true }
+                Outcome::Retry { partial: true }
             }
         }
     }
@@ -1740,7 +1739,7 @@ impl<'a> Resolver<'a> {
             }
         }
 
-        Outcome::Unresolved { partial: false }
+        Outcome::Unresolved
     }
 
     /// Returns a complexity score for a given name, which is used to sort names for resolution. The complexity is based

--- a/rust/rubydex/src/resolution.rs
+++ b/rust/rubydex/src/resolution.rs
@@ -19,23 +19,23 @@ use crate::model::{
 };
 
 enum Outcome {
-    /// The constant was successfully resolved to the given declaration ID. The second optional tuple element is a
-    /// declaration that still needs to have its ancestors linearized
-    Resolved(DeclarationId, Option<DeclarationId>),
-    /// We had everything we needed to resolved this constant, but we couldn't find it. This means it's not defined (or
-    /// defined in a way that static analysis won't discover it). Failing to resolve a constant may also uncovered
-    /// ancestors that require linearization, which is the second element
-    Unresolved(Option<DeclarationId>),
-    /// We couldn't resolve this constant right now because certain dependencies were missing. For example, a constant
-    /// reference involved in computing ancestors (like an include) was found, but wasn't resolved yet. We need to place
-    /// this back in the queue to retry once we have progressed further. The optional declaration ID is an ancestor that
-    /// needs to be linearized before we can retry.
-    Retry(Option<DeclarationId>),
+    /// The constant was successfully resolved to the given declaration ID.
+    Resolved(DeclarationId),
+    /// We had everything we needed to resolve this constant, but we couldn't find it. When `partial` is `true`, the
+    /// lookup stopped at a still-partial ancestor chain, so the member may yet appear once that chain completes and the
+    /// unit should be retried. When `false`, the lookup is definitive (all relevant ancestor chains are complete) and
+    /// the unit can be dropped.
+    Unresolved { partial: bool },
+    /// We couldn't resolve this constant right now because a dependency was missing (an unresolved parent scope, alias,
+    /// or lexical nesting), or because a relevant ancestor chain is still partial. The unit must be placed back in the
+    /// queue and retried once we have progressed further. `partial` is `true` when the blocker was a partial ancestor
+    /// chain (mirrors `Unresolved::partial`).
+    Retry { partial: bool },
 }
 
 impl Outcome {
     fn is_resolved_or_retry(&self) -> bool {
-        matches!(self, Outcome::Resolved(_, _) | Outcome::Retry(_))
+        matches!(self, Outcome::Resolved(_) | Outcome::Retry { .. })
     }
 }
 
@@ -140,8 +140,8 @@ impl<'a> Resolver<'a> {
     /// the Ruby API
     pub fn resolve_constant(&mut self, name_id: NameId) -> Option<DeclarationId> {
         match self.resolve_constant_internal(name_id) {
-            Outcome::Resolved(id, _) => Some(id),
-            Outcome::Unresolved(_) | Outcome::Retry(_) => None,
+            Outcome::Resolved(id) => Some(id),
+            Outcome::Unresolved { .. } | Outcome::Retry { .. } => None,
         }
     }
 
@@ -191,26 +191,26 @@ impl<'a> Resolver<'a> {
                             self.create_declaration(str_id, id, singleton_id, |name| {
                                 Declaration::Method(Box::new(MethodDeclaration::new(name, singleton_id)))
                             });
-                            Outcome::Resolved(singleton_id, None)
+                            Outcome::Resolved(singleton_id)
                         }
                         // Owner is a non-promotable constant — method is orphaned
-                        None => Outcome::Unresolved(None),
+                        None => Outcome::Unresolved { partial: false },
                     },
                     // Owning class not resolved yet — retry next pass
-                    None => Outcome::Retry(None),
+                    None => Outcome::Retry { partial: false },
                 }
             }
             _ => panic!("Expected constant or singleton method definitions"),
         };
 
         match outcome {
-            Outcome::Retry(_) | Outcome::Unresolved(Some(_)) => {
+            Outcome::Retry { .. } | Outcome::Unresolved { partial: true } => {
                 self.unit_queue.push_back(unit_id);
             }
-            Outcome::Unresolved(None) => {
+            Outcome::Unresolved { partial: false } => {
                 // We couldn't resolve this name. Emit a diagnostic
             }
-            Outcome::Resolved(id, _) => {
+            Outcome::Resolved(id) => {
                 if needs_linearization {
                     self.unit_queue.push_back(Unit::Ancestors(id));
                 }
@@ -224,11 +224,11 @@ impl<'a> Resolver<'a> {
         let constant_ref = self.graph.constant_references().get(&id).unwrap();
 
         match self.resolve_constant_internal(*constant_ref.name_id()) {
-            Outcome::Resolved(declaration_id, _) => {
+            Outcome::Resolved(declaration_id) => {
                 self.graph.record_resolved_reference(id, declaration_id);
                 self.made_progress = true;
             }
-            Outcome::Retry(_) | Outcome::Unresolved(_) => {
+            Outcome::Retry { .. } | Outcome::Unresolved { .. } => {
                 self.unit_queue.push_back(unit_id);
             }
         }
@@ -1230,15 +1230,15 @@ impl<'a> Resolver<'a> {
             // `set_singleton_class_id`, not `add_member`, so a TODO receiver would never gain a
             // member. Emit Retry so the unit is preserved for a later resolve where the receiver
             // may exist.
-            Outcome::Unresolved(None) if singleton => Outcome::Retry(None),
-            Outcome::Unresolved(None) => Outcome::Resolved(self.create_todo_for_parent(name_id), None),
+            Outcome::Unresolved { partial: false } if singleton => Outcome::Retry { partial: false },
+            Outcome::Unresolved { partial: false } => Outcome::Resolved(self.create_todo_for_parent(name_id)),
             other => other,
         };
 
         // The name of the declaration is determined by the name of its owner, which may or may not require resolution
         // depending on whether the name has a parent scope
         match outcome {
-            Outcome::Resolved(owner_id, id_needing_linearization) => {
+            Outcome::Resolved(owner_id) => {
                 let mut fully_qualified_name = self.graph.strings().get(&str_id).unwrap().to_string();
 
                 // If the owner is a promotable constant and something is being defined inside it, promote it to a
@@ -1263,7 +1263,7 @@ impl<'a> Resolver<'a> {
                 // Foo = 1
                 // class << Foo; end
                 if singleton && !owner_is_namespace {
-                    return Outcome::Unresolved(None);
+                    return Outcome::Unresolved { partial: false };
                 }
 
                 // We don't prefix declarations with `Object::`
@@ -1293,7 +1293,7 @@ impl<'a> Resolver<'a> {
                 }
 
                 self.graph.record_resolved_name(name_id, declaration_id);
-                Outcome::Resolved(declaration_id, id_needing_linearization)
+                Outcome::Resolved(declaration_id)
             }
             other => other,
         }
@@ -1313,11 +1313,11 @@ impl<'a> Resolver<'a> {
             // If we have `A::B`, the owner of `B` is whatever `A` resolves to.
             // If `A` is an alias, resolve through to get the actual namespace.
             match self.resolve_constant_internal(parent_scope) {
-                Outcome::Resolved(id, linearization) => self.resolve_to_primary_namespace(id, linearization),
+                Outcome::Resolved(id) => self.resolve_to_primary_namespace(id),
                 // The parent scope is genuinely unknown — not a circular alias or pending
                 // linearization, but a name that doesn't exist anywhere in the graph.
-                Outcome::Unresolved(None) => Outcome::Unresolved(None),
-                Outcome::Retry(None) if !preserve_retry => Outcome::Unresolved(None),
+                Outcome::Unresolved { partial: false } => Outcome::Unresolved { partial: false },
+                Outcome::Retry { partial: false } if !preserve_retry => Outcome::Unresolved { partial: false },
                 other => other,
             }
         } else if let Some(nesting_id) = name_ref.nesting()
@@ -1329,16 +1329,16 @@ impl<'a> Resolver<'a> {
             //   end
             // If `ALIAS` points to `Outer`, `CONST` should be owned by `Outer::Target`, not `ALIAS::Target`.
             match self.graph.names().get(nesting_id).unwrap() {
-                NameRef::Resolved(resolved) => self.resolve_to_primary_namespace(*resolved.declaration_id(), None),
+                NameRef::Resolved(resolved) => self.resolve_to_primary_namespace(*resolved.declaration_id()),
                 NameRef::Unresolved(_) => {
                     // The only case where we wouldn't have the nesting resolved at this point is if it's available through
                     // inheritance or if it doesn't exist, so we need to retry later
-                    Outcome::Retry(None)
+                    Outcome::Retry { partial: false }
                 }
             }
         } else {
             // Any constants at the top level are owned by Object
-            Outcome::Resolved(*OBJECT_ID, None)
+            Outcome::Resolved(*OBJECT_ID)
         }
     }
 
@@ -1359,7 +1359,7 @@ impl<'a> Resolver<'a> {
         // promotes it correctly. Using nesting would incorrectly create `SomeModule::A`.
         let parent_owner_id = if parent_has_parent_scope {
             match self.name_owner_id(parent_scope, false) {
-                Outcome::Resolved(id, _) => id,
+                Outcome::Resolved(id) => id,
                 _ => self.create_todo_for_parent(parent_scope),
             }
         } else {
@@ -1367,8 +1367,8 @@ impl<'a> Resolver<'a> {
         };
 
         // Ensure we follow constant aliases if that's the parent
-        let parent_owner_id = match self.resolve_to_primary_namespace(parent_owner_id, None) {
-            Outcome::Resolved(id, _) => id,
+        let parent_owner_id = match self.resolve_to_primary_namespace(parent_owner_id) {
+            Outcome::Resolved(id) => id,
             _ => *OBJECT_ID,
         };
 
@@ -1397,16 +1397,12 @@ impl<'a> Resolver<'a> {
 
     /// Resolves a declaration ID through any alias chain to get the primary (first) namespace.
     /// Returns `Retry` if the primary alias target hasn't been resolved yet.
-    fn resolve_to_primary_namespace(
-        &self,
-        declaration_id: DeclarationId,
-        linearization: Option<DeclarationId>,
-    ) -> Outcome {
+    fn resolve_to_primary_namespace(&self, declaration_id: DeclarationId) -> Outcome {
         let resolved_ids = self.resolve_alias_chains(declaration_id);
 
         // Get the primary (first) resolved target
         let Some(&primary_id) = resolved_ids.first() else {
-            return Outcome::Retry(None);
+            return Outcome::Retry { partial: false };
         };
 
         // Check if the primary result is still an unresolved alias
@@ -1414,10 +1410,10 @@ impl<'a> Resolver<'a> {
             self.graph.declarations().get(&primary_id),
             Some(Declaration::ConstantAlias(_))
         ) {
-            return Outcome::Retry(None);
+            return Outcome::Retry { partial: false };
         }
 
-        Outcome::Resolved(primary_id, linearization)
+        Outcome::Resolved(primary_id)
     }
 
     /// Attempts to resolve a constant reference against the graph. Returns the fully qualified declaration ID that the
@@ -1432,7 +1428,7 @@ impl<'a> Resolver<'a> {
                     ParentScope::TopLevel => {
                         let result = self.search_ancestors(*OBJECT_ID, *name.str());
 
-                        if let Outcome::Resolved(declaration_id, _) = result {
+                        if let Outcome::Resolved(declaration_id) = result {
                             self.graph.record_resolved_name(name_id, declaration_id);
                         }
 
@@ -1440,7 +1436,7 @@ impl<'a> Resolver<'a> {
                     }
                     ParentScope::Attached(parent_scope_id) => {
                         let NameRef::Resolved(parent_scope) = self.graph.names().get(parent_scope_id).unwrap() else {
-                            return Outcome::Retry(None);
+                            return Outcome::Retry { partial: false };
                         };
 
                         let mut target_decl_id = *parent_scope.declaration_id();
@@ -1454,13 +1450,13 @@ impl<'a> Resolver<'a> {
                             if resolved_ids.iter().any(|id| {
                                 matches!(self.graph.declarations().get(id), Some(Declaration::ConstantAlias(_)))
                             }) {
-                                return Outcome::Retry(None);
+                                return Outcome::Retry { partial: false };
                             }
 
                             let Some(&namespace_id) = resolved_ids.iter().find(|id| {
                                 matches!(self.graph.declarations().get(id), Some(Declaration::Namespace(_)))
                             }) else {
-                                return Outcome::Unresolved(None);
+                                return Outcome::Unresolved { partial: false };
                             };
 
                             target_decl_id = namespace_id;
@@ -1469,18 +1465,18 @@ impl<'a> Resolver<'a> {
                         // If we found a singleton reference with a resolved attached object parent scope, we
                         // automatically create the singleton class
                         let Some(singleton_id) = self.get_or_create_singleton_class(target_decl_id, false) else {
-                            return Outcome::Unresolved(None);
+                            return Outcome::Unresolved { partial: false };
                         };
                         self.graph.record_resolved_name(name_id, singleton_id);
                         // `get_or_create_singleton_class` already enqueued the singleton's ancestors on
                         // creation, so there is nothing to hand back for re-enqueueing.
-                        Outcome::Resolved(singleton_id, None)
+                        Outcome::Resolved(singleton_id)
                     }
                     ParentScope::None => {
                         // Otherwise, it's a simple constant read and we can resolve it directly
                         let result = self.run_resolution(&name);
 
-                        if let Outcome::Resolved(declaration_id, _) = result {
+                        if let Outcome::Resolved(declaration_id) = result {
                             self.graph.record_resolved_name(name_id, declaration_id);
                         }
 
@@ -1488,7 +1484,7 @@ impl<'a> Resolver<'a> {
                     }
                     ParentScope::Some(parent_scope_id) => {
                         let NameRef::Resolved(parent_scope) = self.graph.names().get(parent_scope_id).unwrap() else {
-                            return Outcome::Retry(None);
+                            return Outcome::Retry { partial: false };
                         };
 
                         // Resolve the namespace in case it's an alias (e.g., ALIAS::CONST where ALIAS = Foo)
@@ -1496,29 +1492,30 @@ impl<'a> Resolver<'a> {
                         let resolved_ids = self.resolve_alias_chains(*parent_scope.declaration_id());
 
                         // Search each resolved target for the constant. Return early if found.
-                        let mut missing_linearization_id = None;
+                        let mut missing_partial = false;
                         let mut found_namespace = false;
 
                         for &id in &resolved_ids {
                             match self.graph.declarations().get(&id) {
                                 Some(Declaration::ConstantAlias(_)) => {
                                     // Alias not fully resolved yet
-                                    return Outcome::Retry(None);
+                                    return Outcome::Retry { partial: false };
                                 }
                                 Some(Declaration::Namespace(_)) => {
                                     found_namespace = true;
 
                                     match self.search_ancestors(id, *name.str()) {
-                                        Outcome::Resolved(declaration_id, missing_linearization_id) => {
+                                        Outcome::Resolved(declaration_id) => {
                                             self.graph.record_resolved_name(name_id, declaration_id);
-                                            return Outcome::Resolved(declaration_id, missing_linearization_id);
+                                            return Outcome::Resolved(declaration_id);
                                         }
-                                        Outcome::Retry(Some(needs_linearization_id))
-                                        | Outcome::Unresolved(Some(needs_linearization_id)) => {
-                                            missing_linearization_id.get_or_insert(needs_linearization_id);
+                                        Outcome::Retry { partial: true } | Outcome::Unresolved { partial: true } => {
+                                            missing_partial = true;
                                         }
-                                        Outcome::Unresolved(None) => {}
-                                        Outcome::Retry(_) => unreachable!("search_ancestors never returns Retry"),
+                                        Outcome::Unresolved { partial: false } => {}
+                                        Outcome::Retry { partial: false } => {
+                                            unreachable!("search_ancestors never returns a non-partial Retry")
+                                        }
                                     }
                                 }
                                 _ => {
@@ -1529,15 +1526,20 @@ impl<'a> Resolver<'a> {
 
                         // If no namespaces were found, this constant path can never resolve.
                         if !found_namespace {
-                            return Outcome::Unresolved(None);
+                            return Outcome::Unresolved { partial: false };
                         }
 
-                        // Member not found in any namespace yet - retry in case it's added later
-                        missing_linearization_id.map_or(Outcome::Retry(None), |id| Outcome::Unresolved(Some(id)))
+                        // Member not found in any namespace yet - retry in case it's added later. If the miss was due
+                        // to a still-partial ancestor chain, mark it so the unit is re-checked once the chain completes.
+                        if missing_partial {
+                            Outcome::Unresolved { partial: true }
+                        } else {
+                            Outcome::Retry { partial: false }
+                        }
                     }
                 }
             }
-            NameRef::Resolved(resolved) => Outcome::Resolved(*resolved.declaration_id(), None),
+            NameRef::Resolved(resolved) => Outcome::Resolved(*resolved.declaration_id()),
         }
     }
 
@@ -1610,13 +1612,13 @@ impl<'a> Resolver<'a> {
             let (ancestor_outcome, nesting_decl_id) = match self.graph.names().get(nesting).unwrap() {
                 NameRef::Resolved(nesting_name_ref) => {
                     let resolved_ids = self.resolve_alias_chains(*nesting_name_ref.declaration_id());
-                    let mut result = Outcome::Unresolved(None);
+                    let mut result = Outcome::Unresolved { partial: false };
                     let mut decl_id = None;
 
                     for &id in &resolved_ids {
                         match self.graph.declarations().get(&id) {
                             Some(Declaration::ConstantAlias(_)) => {
-                                result = Outcome::Retry(None);
+                                result = Outcome::Retry { partial: false };
                                 break;
                             }
                             Some(Declaration::Namespace(_)) => {
@@ -1630,7 +1632,7 @@ impl<'a> Resolver<'a> {
 
                     (result, decl_id)
                 }
-                NameRef::Unresolved(_) => (Outcome::Retry(None), None),
+                NameRef::Unresolved(_) => (Outcome::Retry { partial: false }, None),
             };
 
             if matches!(ancestor_outcome, Outcome::Resolved(..)) {
@@ -1645,18 +1647,16 @@ impl<'a> Resolver<'a> {
                     Some(Declaration::Namespace(Namespace::Module(_) | Namespace::Todo(_)))
                 )
             });
-            let chain_incomplete = matches!(ancestor_outcome, Outcome::Retry(Some(_)) | Outcome::Unresolved(Some(_)));
+            let chain_incomplete = matches!(
+                ancestor_outcome,
+                Outcome::Retry { partial: true } | Outcome::Unresolved { partial: true }
+            );
 
             if is_module || chain_incomplete {
                 let object_outcome = self.search_ancestors(*OBJECT_ID, str_id);
 
-                if let Outcome::Resolved(decl_id, _) = object_outcome {
-                    // Preserve the linearization ID so the chain gets re-checked once complete
-                    let linearization_id = match ancestor_outcome {
-                        Outcome::Retry(id) | Outcome::Unresolved(id) => id,
-                        Outcome::Resolved(..) => unreachable!("guarded by early return above"),
-                    };
-                    return Outcome::Resolved(decl_id, linearization_id);
+                if let Outcome::Resolved(decl_id) = object_outcome {
+                    return Outcome::Resolved(decl_id);
                 }
             }
 
@@ -1683,12 +1683,12 @@ impl<'a> Resolver<'a> {
                             .as_namespace()
                             .unwrap()
                             .member(&str_id)
-                            .map(|id| Outcome::Resolved(*id, None))
+                            .map(|id| Outcome::Resolved(*id))
                     } else {
                         None
                     }
                 })
-                .unwrap_or(Outcome::Unresolved(None)),
+                .unwrap_or(Outcome::Unresolved { partial: false }),
             Ancestors::Partial(ids) => {
                 for ancestor_id in ids {
                     match ancestor_id {
@@ -1696,7 +1696,7 @@ impl<'a> Resolver<'a> {
                             // Stop at unresolved ancestors to avoid resolving to a later one.
                             // Skip if the name matches what we're searching for.
                             if *self.graph.names().get(&name_id).unwrap().str() != str_id {
-                                return Outcome::Retry(Some(declaration_id));
+                                return Outcome::Retry { partial: true };
                             }
                         }
                         Ancestor::Complete(ancestor_id) => {
@@ -1709,12 +1709,12 @@ impl<'a> Resolver<'a> {
                                 .unwrap()
                                 .member(&str_id)
                             {
-                                return Outcome::Resolved(*id, Some(declaration_id));
+                                return Outcome::Resolved(*id);
                             }
                         }
                     }
                 }
-                Outcome::Unresolved(Some(declaration_id))
+                Outcome::Unresolved { partial: true }
             }
         }
     }
@@ -1731,16 +1731,16 @@ impl<'a> Resolver<'a> {
                     && let Some(namespace) = self.graph.declarations().get(&namespace_id).unwrap().as_namespace()
                     && let Some(member) = namespace.member(&str_id)
                 {
-                    return Outcome::Resolved(*member, None);
+                    return Outcome::Resolved(*member);
                 }
 
                 current_name = nesting_name_ref.name();
             } else {
-                return Outcome::Retry(None);
+                return Outcome::Retry { partial: false };
             }
         }
 
-        Outcome::Unresolved(None)
+        Outcome::Unresolved { partial: false }
     }
 
     /// Returns a complexity score for a given name, which is used to sort names for resolution. The complexity is based

--- a/rust/rubydex/src/resolution.rs
+++ b/rust/rubydex/src/resolution.rs
@@ -204,25 +204,16 @@ impl<'a> Resolver<'a> {
         };
 
         match outcome {
-            Outcome::Retry(None) => {
-                // There might be dependencies we haven't figured out yet, so we need to retry
+            Outcome::Retry(_) | Outcome::Unresolved(Some(_)) => {
                 self.unit_queue.push_back(unit_id);
             }
             Outcome::Unresolved(None) => {
                 // We couldn't resolve this name. Emit a diagnostic
             }
-            Outcome::Retry(Some(id_needing_linearization)) | Outcome::Unresolved(Some(id_needing_linearization)) => {
-                self.unit_queue.push_back(unit_id);
-                self.unit_queue.push_back(Unit::Ancestors(id_needing_linearization));
-            }
-            Outcome::Resolved(id, None) => {
+            Outcome::Resolved(id, _) => {
                 if needs_linearization {
                     self.unit_queue.push_back(Unit::Ancestors(id));
                 }
-                self.made_progress = true;
-            }
-            Outcome::Resolved(_, Some(id_needing_linearization)) => {
-                self.unit_queue.push_back(Unit::Ancestors(id_needing_linearization));
                 self.made_progress = true;
             }
         }
@@ -233,24 +224,12 @@ impl<'a> Resolver<'a> {
         let constant_ref = self.graph.constant_references().get(&id).unwrap();
 
         match self.resolve_constant_internal(*constant_ref.name_id()) {
-            Outcome::Retry(None) | Outcome::Unresolved(None) => {
-                // Retry: dependencies not resolved yet, or name genuinely unknown
-                // (which can be temporary during incremental invalidation when the
-                // parent namespace was deleted but will be re-added).
-                self.unit_queue.push_back(unit_id);
-            }
-            Outcome::Retry(Some(id_needing_linearization)) | Outcome::Unresolved(Some(id_needing_linearization)) => {
-                self.unit_queue.push_back(unit_id);
-                self.unit_queue.push_back(Unit::Ancestors(id_needing_linearization));
-            }
-            Outcome::Resolved(declaration_id, None) => {
+            Outcome::Resolved(declaration_id, _) => {
                 self.graph.record_resolved_reference(id, declaration_id);
                 self.made_progress = true;
             }
-            Outcome::Resolved(resolved_id, Some(id_needing_linearization)) => {
-                self.graph.record_resolved_reference(id, resolved_id);
-                self.made_progress = true;
-                self.unit_queue.push_back(Unit::Ancestors(id_needing_linearization));
+            Outcome::Retry(_) | Outcome::Unresolved(_) => {
+                self.unit_queue.push_back(unit_id);
             }
         }
     }
@@ -1493,7 +1472,9 @@ impl<'a> Resolver<'a> {
                             return Outcome::Unresolved(None);
                         };
                         self.graph.record_resolved_name(name_id, singleton_id);
-                        Outcome::Resolved(singleton_id, Some(singleton_id))
+                        // `get_or_create_singleton_class` already enqueued the singleton's ancestors on
+                        // creation, so there is nothing to hand back for re-enqueueing.
+                        Outcome::Resolved(singleton_id, None)
                     }
                     ParentScope::None => {
                         // Otherwise, it's a simple constant read and we can resolve it directly


### PR DESCRIPTION
Alternative to #905

The essence of the problem is that we were enqueueing the same ancestor units multiple times. The approach on this PR is to simply remove the duplicate enqueueing, so that we can reduce the size of the queue and still achieve the same results.

I recommend reviewing by commit:

1. Stop re-enqueuing ancestor linearization units on definitions and constant references outcomes. These ancestor units are already enqueued in other parts of the pipeline, which means we push the same work more than once
2. After 1, the concept of `id_pending_linearization` is no longer necessary. All we need to know is whether a resolution outcome is partial or not, which allows us to use a boolean and reduce the size of `AncestorOutcome`

On my machine, this reduces resolution time in Core from `74.770s` -> `28.159s` (x2.65 speed up). It also ended up fixing a bug that got surfaced in a query test.