### PR TITLE
Load default config before CLI listing

### DIFF
--- a/rust/rubydex/src/main.rs
+++ b/rust/rubydex/src/main.rs
@@ -1,5 +1,5 @@
 use clap::{Parser, ValueEnum};
-use std::{collections::HashSet, mem};
+use std::{fs, mem, path::PathBuf};
 
 use rubydex::{
     dot,
@@ -17,7 +17,11 @@ use rubydex::{
 #[command(name = "rubydex_cli", about = "A Static Analysis Toolkit for Ruby", version)]
 #[allow(clippy::struct_excessive_bools)]
 struct Args {
-    #[arg(value_name = "PATHS", default_value = ".")]
+    #[arg(
+        value_name = "PATHS",
+        default_value = ".",
+        help = "Path(s) to index. If the first path is a directory, it is used as the workspace root for rubydex.toml"
+    )]
     paths: Vec<String>,
 
     #[arg(long = "stop-after", help = "Stop after the given stage")]
@@ -85,6 +89,11 @@ fn exit(print_stats: bool) {
     std::process::exit(0);
 }
 
+fn workspace_path_for(paths: &[String]) -> Option<PathBuf> {
+    let first_path = paths.first()?;
+    fs::canonicalize(first_path).ok().filter(|path| path.is_dir())
+}
+
 fn main() {
     let args = Args::parse();
 
@@ -92,9 +101,21 @@ fn main() {
         Timer::set_global_timer(Timer::new());
     }
 
+    let mut graph = Graph::new();
+
+    if let Some(workspace_path) = workspace_path_for(&args.paths) {
+        graph.set_workspace_path(workspace_path);
+        if let Err(error) = graph.load_config(None) {
+            eprintln!("{error}");
+            std::process::exit(1);
+        }
+    }
+
     // Listing
 
-    let (file_paths, errors) = time_it!(listing, { listing::collect_file_paths(args.paths, &HashSet::new()) });
+    let (file_paths, errors) = time_it!(listing, {
+        listing::collect_file_paths(args.paths, &graph.excluded_paths())
+    });
 
     for error in errors {
         eprintln!("{error}");
@@ -106,7 +127,6 @@ fn main() {
 
     // Indexing
 
-    let mut graph = Graph::new();
     let backend = IndexerBackend::from(&args.indexer);
     let errors = time_it!(indexing, { indexing::index_files(&mut graph, file_paths, backend) });
 

--- a/rust/rubydex/tests/cli.rs
+++ b/rust/rubydex/tests/cli.rs
@@ -19,6 +19,9 @@ fn prints_help() {
         .success()
         .stdout(predicate::str::contains("A Static Analysis Toolkit for Ruby"))
         .stdout(predicate::str::contains("Usage:"))
+        .stdout(predicate::str::contains(
+            "If the first path is a directory, it is used as the workspace root for rubydex.toml",
+        ))
         .stdout(predicate::str::contains("--stats"))
         .stdout(predicate::str::contains("--dot"))
         .stdout(predicate::str::contains("--stop-after"));
@@ -49,6 +52,69 @@ fn paths_argument_variants() {
         .success()
         .stderr(predicate::str::is_empty())
         .stdout(predicate::str::contains("Indexed 4 files"));
+    });
+}
+
+#[test]
+fn single_directory_argument_is_workspace_root_for_config() {
+    with_context(|context| {
+        context.write("included.rb", "class Included\nend\n");
+        context.write("excluded/skipped.rb", "class Skipped\nend\n");
+        context.write("rubydex.toml", "exclude = [\"excluded\"]\n");
+
+        rdx(&[context.absolute_path().to_str().unwrap()])
+            .success()
+            .stderr(predicate::str::is_empty())
+            .stdout(predicate::str::contains("Indexed 2 files"));
+    });
+}
+
+#[test]
+fn first_directory_argument_is_workspace_root_for_config() {
+    with_context(|context| {
+        context.write("included/kept.rb", "class Included\nend\n");
+        context.write("excluded/skipped.rb", "class Skipped\nend\n");
+        context.write("rubydex.toml", "exclude = [\"excluded\"]\n");
+
+        rdx(&[
+            context.absolute_path().to_str().unwrap(),
+            context.absolute_path_to("included").to_str().unwrap(),
+            context.absolute_path_to("excluded").to_str().unwrap(),
+        ])
+        .success()
+        .stderr(predicate::str::is_empty())
+        .stdout(predicate::str::contains("Indexed 2 files"));
+    });
+}
+
+#[test]
+fn single_file_argument_is_not_used_as_workspace_root() {
+    with_context(|context| {
+        context.write("included.rb", "class Included\nend\n");
+        context.write("excluded/skipped.rb", "class Skipped\nend\n");
+        context.write("rubydex.toml", "exclude = [\"excluded\"]\n");
+
+        rdx(&[context.absolute_path_to("excluded/skipped.rb").to_str().unwrap()])
+            .success()
+            .stderr(predicate::str::is_empty())
+            .stdout(predicate::str::contains("Indexed 2 files"));
+    });
+}
+
+#[test]
+fn first_file_argument_is_not_used_as_workspace_root() {
+    with_context(|context| {
+        context.write("included.rb", "class Included\nend\n");
+        context.write("excluded/skipped.rb", "class Skipped\nend\n");
+        context.write("rubydex.toml", "exclude = [\"excluded\"]\n");
+
+        rdx(&[
+            context.absolute_path_to("included.rb").to_str().unwrap(),
+            context.absolute_path_to("excluded").to_str().unwrap(),
+        ])
+        .success()
+        .stderr(predicate::str::is_empty())
+        .stdout(predicate::str::contains("Indexed 3 files"));
     });
 }
 


### PR DESCRIPTION
## Problems

- The CLI loaded files before initializing the graph config, so `rubydex.toml` exclusions were ignored during listing.

## Solutions

- Initialize the graph before listing, derive a workspace root for single-path invocations, and load the default config before collecting file paths.
- Pass `graph.excluded_paths()` into file discovery so configured exclusions are respected.
- Warn when multiple paths are passed because `rubydex.toml` is intentionally ignored in that mode.
- Add CLI coverage for both single-workspace config loading and the multi-path warning.
