### PR TITLE
Expose resolved method calls as a CALLS edge

### DIFF
--- a/rust/rubydex/src/query/cypher/schema.rs
+++ b/rust/rubydex/src/query/cypher/schema.rs
@@ -21,13 +21,15 @@
 //! - `HAS_ANCESTOR`: `Declaration` → `Declaration` (linearized ancestor chain, incl. modules)
 //! - `HAS_DESCENDANT`: `Declaration` → `Declaration` (reverse of `HAS_ANCESTOR`)
 //! - `REFERENCES`: `Document` → `Declaration` (constant references)
+//! - `CALLS`: `Document` → `Declaration` (a `Method`; a constant-receiver method call like `Foo.bar`
+//!   resolved to its method declaration)
 
 use std::collections::{HashSet, VecDeque};
 
-use crate::model::declaration::Declaration;
+use crate::model::declaration::{Declaration, Namespace};
 use crate::model::definitions::{Definition, Mixin};
 use crate::model::graph::Graph;
-use crate::model::ids::{ConstantReferenceId, DeclarationId, DefinitionId, UriId};
+use crate::model::ids::{ConstantReferenceId, DeclarationId, DefinitionId, NameId, StringId, UriId};
 
 use cypher_parser::{CypherValue, GraphProvider};
 
@@ -71,6 +73,11 @@ pub enum RelType {
     HasDescendant,
     /// `Document` → `Declaration`: a constant reference in the file resolves to a declaration.
     References,
+    /// `Document` → `Declaration` (a `Method`): a method call whose receiver *type* is statically
+    /// known — a constant receiver (`Foo.bar`, resolved via the receiver's singleton-class ancestry)
+    /// or an implicit `self` call in a known scope — resolved to the method declaration. Calls with
+    /// a dynamic/unknown receiver carry no receiver and are not represented.
+    Calls,
 }
 
 /// Catalog metadata for a relationship type: the type itself, its canonical name, endpoint labels,
@@ -163,6 +170,13 @@ const REL_SCHEMAS: &[RelSchema] = &[
         from: "Document",
         to: "Declaration",
         description: "A file references a constant declaration",
+    },
+    RelSchema {
+        rel: RelType::Calls,
+        name: "CALLS",
+        from: "Document",
+        to: "Method",
+        description: "A file calls a method whose receiver type is statically known",
     },
 ];
 
@@ -564,7 +578,9 @@ fn document_property(graph: &Graph, id: UriId, prop: &str) -> CypherValue {
 #[must_use]
 pub fn rel_source_nodes(graph: &Graph, rel: RelType) -> Vec<NodeRef> {
     match rel {
-        RelType::Defines | RelType::References => graph.documents().keys().map(|id| NodeRef::Document(*id)).collect(),
+        RelType::Defines | RelType::References | RelType::Calls => {
+            graph.documents().keys().map(|id| NodeRef::Document(*id)).collect()
+        }
         RelType::Declares | RelType::Contains => {
             graph.definitions().keys().map(|id| NodeRef::Definition(*id)).collect()
         }
@@ -598,6 +614,7 @@ pub fn expand_out(graph: &Graph, node: NodeRef, rel: RelType) -> Vec<NodeRef> {
             })
             .unwrap_or_default(),
         (NodeRef::Document(uri_id), RelType::References) => document_references(graph, uri_id),
+        (NodeRef::Document(uri_id), RelType::Calls) => document_method_calls(graph, uri_id),
         (NodeRef::Definition(def_id), RelType::Declares) => graph
             .definitions()
             .get(&def_id)
@@ -631,6 +648,80 @@ fn document_references(graph: &Graph, uri_id: UriId) -> Vec<NodeRef> {
         }
     }
     targets
+}
+
+/// The method declarations reached by the constant-receiver method calls in a document.
+///
+/// Only calls whose receiver is a constant (e.g. `Foo.bar`) are statically resolvable, so calls
+/// with an implicit or non-constant receiver are skipped.
+fn document_method_calls(graph: &Graph, uri_id: UriId) -> Vec<NodeRef> {
+    let Some(document) = graph.documents().get(&uri_id) else {
+        return Vec::new();
+    };
+
+    let mut seen = HashSet::new();
+    let mut targets = Vec::new();
+    for ref_id in document.method_references() {
+        let Some(method_ref) = graph.method_references().get(ref_id) else {
+            continue;
+        };
+        let Some(receiver) = method_ref.receiver() else {
+            continue;
+        };
+        if let Some(decl_id) = resolve_method_call(graph, receiver, *method_ref.str())
+            && seen.insert(decl_id)
+        {
+            targets.push(NodeRef::Declaration(decl_id));
+        }
+    }
+    targets
+}
+
+/// Resolves a method call to its method declaration. `receiver` is the receiver *type*'s name as
+/// recorded by the indexer — the singleton class for a constant receiver (`Foo.bar`) or the
+/// enclosing type for an implicit `self` call — so the method is looked up directly along that
+/// declaration's ancestry, returning the first (most-derived) match. Calls whose receiver type is
+/// not statically known carry no receiver and never reach here.
+fn resolve_method_call(graph: &Graph, receiver: NameId, method_str: StringId) -> Option<DeclarationId> {
+    use crate::model::declaration::Ancestor;
+
+    // Call sites record the bare message (`bar`), while method declarations are keyed by
+    // `name()` in a namespace's members, so we match on the base name rather than the `StringId`.
+    let call_name = graph.strings().get(&method_str)?.as_str();
+
+    let receiver_decl_id = *graph.name_id_to_declaration_id(receiver)?;
+    let receiver_decl_id = resolve_to_namespace(graph, receiver_decl_id)?;
+    let namespace = graph.declarations().get(&receiver_decl_id)?.as_namespace()?;
+
+    for ancestor in namespace.ancestors() {
+        let Ancestor::Complete(ancestor_id) = ancestor else {
+            continue;
+        };
+        let Some(members) = graph
+            .declarations()
+            .get(ancestor_id)
+            .and_then(Declaration::as_namespace)
+            .map(Namespace::members)
+        else {
+            continue;
+        };
+
+        for (key, member_id) in members {
+            if graph
+                .declarations()
+                .get(member_id)
+                .is_some_and(|d| d.as_method().is_some())
+                && graph
+                    .strings()
+                    .get(key)
+                    .and_then(|name| name.as_str().strip_suffix("()"))
+                    == Some(call_name)
+            {
+                return Some(*member_id);
+            }
+        }
+    }
+    None
 }
 
 fn definition_children(graph: &Graph, def_id: DefinitionId) -> Vec<NodeRef> {

--- a/rust/rubydex/src/query/cypher/tests.rs
+++ b/rust/rubydex/src/query/cypher/tests.rs
@@ -226,3 +226,50 @@ fn document_uri_path_and_name_are_distinct() {
     #[cfg(windows)]
     assert_eq!(column_strings(&result, 1), vec!["file:///zoo.rb".to_string()]);
 }
+
+fn calls_graph() -> Graph {
+    let mut context = GraphTest::new();
+    context.index_uri(
+        "file:///m.rb",
+        "
+            class Foo
+              def self.bar; end
+            end
+
+            class Client
+              def run
+                Foo.bar       # constant receiver -> resolvable
+                helper        # implicit receiver -> not resolvable
+              end
+
+              def helper; end
+            end
+        ",
+    );
+    context.resolve();
+    context.into_graph()
+}
+
+#[test]
+fn calls_resolves_method_references_with_a_known_receiver() {
+    let graph = calls_graph();
+    let result = run(
+        &graph,
+        "MATCH (:Document)-[:CALLS]->(m:Method) RETURN m.unqualified_name",
+    );
+    // `Foo.bar` (constant receiver, class method) and `helper` (implicit self) both resolve.
+    assert_eq!(
+        column_strings(&result, 0),
+        vec!["bar()".to_string(), "helper()".to_string()]
+    );
+}
+
+#[test]
+fn calls_reverse_finds_callers_of_a_method() {
+    let graph = calls_graph();
+    let result = run(
+        &graph,
+        "MATCH (d:Document)-[:CALLS]->(m:Method {unqualified_name: 'bar()'}) RETURN d.name",
+    );
+    assert_eq!(column_strings(&result, 0), vec!["m.rb".to_string()]);
+}


### PR DESCRIPTION
## Goal

Expose **method calls** in the Cypher graph, resolved to the method declarations they target — so the graph can answer call-graph questions, not just definition/inheritance ones.

## What it adds

A new relationship type:

```
CALLS: Document → Declaration (a Method)
```

It maps a file's method references to the method declaration each one resolves to, for calls whose **receiver type is statically known**:

- a **constant receiver** (`Foo.bar`), resolved through the receiver's singleton-class ancestry (where class methods live), and
- an **implicit `self`** call in a known scope (e.g. calling a sibling method from inside an instance method).

```cypher
-- Everything a file calls (resolved)
MATCH (d:Document)-[:CALLS]->(m:Method) RETURN d.name, m.name

-- Callers of a specific method
MATCH (d:Document)-[:CALLS]->(m:Method {unqualified_name: 'bar()'}) RETURN d.name
```

## How it resolves

The indexer already records each call with the *receiver type's* name (the singleton-class name for `Foo.bar`, the enclosing type for a `self` call). The schema:

1. resolves that name to a declaration (the same way constant references resolve), then
2. looks the method up along that declaration's ancestry, matching on the base name — method members are keyed `name()` while call sites record the bare `name`, so a direct id match doesn't work.

## Scope / non-goals

Calls with a **dynamic or unknown receiver** (`foo.bar` on a local, a method-chain result, etc.) carry no receiver from the indexer and are **intentionally not represented** — resolving them would require type inference. This edge covers the statically-resolvable subset only; it's best-effort (first match in ancestry order) rather than a guaranteed runtime target.

The resolver currently lives in the cypher schema (consistent with how it already maps the graph); a future refactor could share a `Graph`-level method resolver with `query.rs`'s completion path.

## Verification

`cargo test -p rubydex query::cypher` (20 tests, incl. resolution + reverse "who calls this" + that dynamic-receiver calls are excluded); clippy + fmt clean; `--schema` lists `CALLS`; full gem suite green.
