### PR TITLE
Fold split impl blocks

### DIFF
--- a/rust/rubydex/src/listing.rs
+++ b/rust/rubydex/src/listing.rs
@@ -36,18 +36,7 @@ impl FileDiscoveryJob {
             excluded_patterns,
         }
     }
-}
 
-fn is_indexable_file(path: &Path) -> bool {
-    path.extension()
-        .is_some_and(|ext| ext == "rb" || ext == "rake" || ext == "rbs" || ext == "ru")
-}
-
-fn is_excluded(excluded_patterns: &[Pattern], path: &Path) -> bool {
-    excluded_patterns.iter().any(|pattern| pattern.matches_path(path))
-}
-
-impl FileDiscoveryJob {
     fn handle_file(&self, path: &Path) {
         if is_indexable_file(path) {
             self.paths_tx
@@ -107,6 +96,15 @@ impl Job for FileDiscoveryJob {
             }
         }
     }
+}
+
+fn is_indexable_file(path: &Path) -> bool {
+    path.extension()
+        .is_some_and(|ext| ext == "rb" || ext == "rake" || ext == "rbs" || ext == "ru")
+}
+
+fn is_excluded(excluded_patterns: &[Pattern], path: &Path) -> bool {
+    excluded_patterns.iter().any(|pattern| pattern.matches_path(path))
 }
 
 /// Recursively collects all Ruby files for the given workspace and dependencies, returning a vector of document instances

--- a/rust/rubydex/src/operation/applier.rs
+++ b/rust/rubydex/src/operation/applier.rs
@@ -116,9 +116,7 @@ impl OperationApplier {
             _ => {}
         }
     }
-}
 
-impl OperationApplier {
     fn apply_operation(&mut self, op: Operation) {
         match op {
             Operation::EnterClass(op) => self.apply_enter_class(op),


### PR DESCRIPTION
While working in `listing.rs` I noticed `FileDiscoveryJob` had two `impl` blocks. I looked for other instances and found one more, `OperationApplier` in `applier.rs`.

`RubydexServer` also has two `impl` blocks, but the second has the attribute macro `#[tool_router]`, so I left it alone.