### PR TITLE
Avoid invalidate a document when the file's content is not changed

### DIFF
--- a/rust/rubydex/src/model/document.rs
+++ b/rust/rubydex/src/model/document.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 
 use line_index::LineIndex;
 use url::Url;
+use xxhash_rust::xxh3::xxh3_64;
 
 use crate::assert_mem_size;
 use crate::diagnostic::Diagnostic;
@@ -17,8 +18,9 @@ pub struct Document {
     method_reference_ids: Vec<MethodReferenceId>,
     constant_reference_ids: Vec<ConstantReferenceId>,
     diagnostics: Vec<Diagnostic>,
+    content_hash: u64,
 }
-assert_mem_size!(Document, 176);
+assert_mem_size!(Document, 184);
 
 impl Document {
     #[must_use]
@@ -30,12 +32,18 @@ impl Document {
             method_reference_ids: Vec::new(),
             constant_reference_ids: Vec::new(),
             diagnostics: Vec::new(),
+            content_hash: xxh3_64(source.as_bytes()),
         }
     }
 
     #[must_use]
     pub fn uri(&self) -> &str {
         &self.uri
+    }
+
+    #[must_use]
+    pub fn content_hash(&self) -> u64 {
+        self.content_hash
     }
 
     #[must_use]

--- a/rust/rubydex/src/model/graph.rs
+++ b/rust/rubydex/src/model/graph.rs
@@ -1044,7 +1044,17 @@ impl Graph {
     /// 3. `extend` -- merges the new `LocalGraph` into the now-clean graph
     pub fn consume_document_changes(&mut self, other: LocalGraph) {
         let uri_id = other.uri_id();
-        let old_document = self.documents.remove(&uri_id);
+
+        let old_document = match self.documents.entry(uri_id) {
+            Entry::Occupied(entry) => {
+                // No changes to the document, skip invalidation and merging
+                if entry.get().content_hash() == other.document().content_hash() {
+                    return;
+                }
+                Some(entry.remove())
+            }
+            Entry::Vacant(_) => None,
+        };
 
         // Skip invalidation during boot indexing (no documents have been resolved yet)
         // or when the document is brand new (no old data to invalidate against).
@@ -4208,5 +4218,22 @@ mod incremental_resolution_tests {
                 "Kernel has stale descendant id {id:?} with no backing declaration"
             );
         }
+    }
+
+    #[test]
+    fn unchanged_document_does_not_trigger_invalidation() {
+        let mut context = GraphTest::new();
+        context.index_uri("file:///a.rb", "class Foo; end");
+        context.resolve();
+
+        // Re-indexing the same content should not trigger any invalidation or changes
+        context.index_uri("file:///a.rb", "class Foo; end");
+
+        let mut graph = context.into_graph();
+
+        assert!(
+            graph.take_pending_work().is_empty(),
+            "Graph should have no pending work after re-indexing unchanged document"
+        );
     }
 } // mod incremental_resolution_tests


### PR DESCRIPTION
If a document's content doesn't change, we don't need to invalidate and produce work for it. So in this PR, I added `content_hash` to `Document` and compare the value before invalidation happens, so we can skip unnecessary work.

This currently doesn't save much in a real-world scenario, but it will be the first layer of the layered invalidation we need when we start introducing cache or database storage.

Ideally we can skip file indexing if the content is the same as well. But because indexing happens in parallel and currently does not need to access the main graph, making such change will be architectural. Given that it won't give us much additional gain, I think we can defer that change for later.