### PR TITLE
Expose `Definition#document` in the Ruby API

### DIFF
--- a/ext/rubydex/definition.c
+++ b/ext/rubydex/definition.c
@@ -18,6 +18,7 @@ static VALUE mRubydex;
 static VALUE cInclude;
 static VALUE cPrepend;
 static VALUE cExtend;
+static VALUE cDocument;
 VALUE cComment;
 VALUE cDefinition;
 VALUE cClassDefinition;
@@ -261,6 +262,27 @@ static VALUE rdxr_definition_lexical_nesting(VALUE self) {
     return nesting;
 }
 
+/*
+ * call-seq:
+ *   document -> Rubydex::Document
+ *
+ * Returns the document this definition belongs to.
+ */
+static VALUE rdxr_definition_document(VALUE self) {
+    HandleData *data;
+    void *graph = rdxi_graph_from_handle(self, &data);
+
+    const uint64_t *uri_id = rdx_definition_document(graph, data->id);
+    if (uri_id == NULL) {
+        rb_raise(rb_eRuntimeError, "Definition not found");
+    }
+
+    VALUE argv[] = {data->graph_obj, ULL2NUM(*uri_id)};
+    free_u64(uri_id);
+
+    return rb_class_new_instance(2, argv, cDocument);
+}
+
 static VALUE rdxi_build_constant_reference(VALUE graph_obj, const CConstantReference *cref) {
     VALUE ref_class = (cref->declaration_id == 0)
         ? cUnresolvedConstantReference
@@ -397,6 +419,7 @@ void rdxi_initialize_definition(VALUE mod) {
     cInclude = rb_const_get(mRubydex, rb_intern("Include"));
     cPrepend = rb_const_get(mRubydex, rb_intern("Prepend"));
     cExtend = rb_const_get(mRubydex, rb_intern("Extend"));
+    cDocument = rb_const_get(mRubydex, rb_intern("Document"));
 
     cComment = rb_define_class_under(mRubydex, "Comment", rb_cObject);
 
@@ -412,6 +435,7 @@ void rdxi_initialize_definition(VALUE mod) {
     rb_define_method(cDefinition, "declaration", rdxr_definition_declaration, 0);
     rb_define_method(cDefinition, "lexical_owner", rdxr_definition_lexical_owner, 0);
     rb_define_method(cDefinition, "lexical_nesting", rdxr_definition_lexical_nesting, 0);
+    rb_define_method(cDefinition, "document", rdxr_definition_document, 0);
 
     cClassDefinition = rb_define_class_under(mRubydex, "ClassDefinition", cDefinition);
     rb_define_method(cClassDefinition, "superclass", rdxr_class_definition_superclass, 0);

--- a/rbi/rubydex.rbi
+++ b/rbi/rubydex.rbi
@@ -158,6 +158,9 @@ class Rubydex::Definition
   sig { returns(T::Array[Rubydex::Definition]) }
   def lexical_nesting; end
 
+  sig { returns(Rubydex::Document) }
+  def document; end
+
   class << self
     private
 

--- a/rust/rubydex-sys/src/definition_api.rs
+++ b/rust/rubydex-sys/src/definition_api.rs
@@ -493,6 +493,25 @@ pub unsafe extern "C" fn rdx_definition_mixins(pointer: GraphPointer, definition
     })
 }
 
+/// Returns a pointer to the URI ID of the document a definition belongs to, or
+/// NULL if the definition cannot be found. Caller must free the returned pointer
+/// with `free_u64`.
+///
+/// # Safety
+/// - `pointer` must be a valid pointer previously returned by `rdx_graph_new`.
+/// - `definition_id` must be a valid definition id.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rdx_definition_document(pointer: GraphPointer, definition_id: u64) -> *const u64 {
+    with_graph(pointer, |graph| {
+        let def_id = DefinitionId::new(definition_id);
+        if let Some(defn) = graph.definitions().get(&def_id) {
+            Box::into_raw(Box::new(**defn.uri_id())).cast_const()
+        } else {
+            ptr::null()
+        }
+    })
+}
+
 /// Status of a `MethodAliasDefinition#target` resolution.
 #[repr(u8)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/test/definition_test.rb
+++ b/test/definition_test.rb
@@ -114,6 +114,40 @@ class DefinitionTest < Minitest::Test
     end
   end
 
+  def test_definition_document
+    with_context do |context|
+      context.write!("file1.rb", "class A; end")
+
+      graph = Rubydex::Graph.new
+      graph.index_all(context.glob("**/*.rb"))
+
+      document = graph.documents.find { |doc| doc.uri == context.uri_to("file1.rb") }
+      definition = document.definitions.find { |defn| defn.name == "A" }
+      refute_nil(definition)
+
+      assert_instance_of(Rubydex::Document, definition.document)
+      assert_equal(context.uri_to("file1.rb"), definition.document.uri)
+    end
+  end
+
+  def test_definition_document_raises_when_definition_is_gone
+    with_context do |context|
+      context.write!("file1.rb", "class A; end")
+
+      graph = Rubydex::Graph.new
+      graph.index_all(context.glob("**/*.rb"))
+
+      document = graph.documents.find { |doc| doc.uri == context.uri_to("file1.rb") }
+      definition = document.definitions.find { |defn| defn.name == "A" }
+      refute_nil(definition)
+
+      graph.delete_document(context.uri_to("file1.rb"))
+
+      error = assert_raises(RuntimeError) { definition.document }
+      assert_equal("Definition not found", error.message)
+    end
+  end
+
   def test_definition_comments
     with_context do |context|
       context.write!("file1.rb", <<~RUBY)


### PR DESCRIPTION
This PR exposes `Definition#document`, which returns the `Rubydex::Document` a definition belongs to. 

A definition already stores its document's URI id, the public API just didn't expose it so callers had no direct path from a definition to its document. This moves the public API toward the internal representation, where the URI belongs to the `Document` and `Location` holds only line and column positions.

This change is part of the URI rework (#825). That issue is about the URI currently being represented as a plain `String` rather than a dedicated URI type. Changing the type is a later step. The current step replaces `location.uri` with `document.uri`, and this PR adds `document.uri` for definitions.
