### PR TITLE
Avoid cloning resolved names

### DIFF
--- a/rust/rubydex/src/resolution.rs
+++ b/rust/rubydex/src/resolution.rs
@@ -1468,139 +1468,139 @@ impl<'a> Resolver<'a> {
     /// resolved
     #[allow(clippy::too_many_lines)]
     fn resolve_constant_internal(&mut self, name_id: NameId) -> Outcome {
-        let name_ref = self.graph.names().get(&name_id).unwrap().clone();
+        let name = match self.graph.names().get(&name_id).unwrap() {
+            NameRef::Resolved(resolved) => return Outcome::Resolved(*resolved.declaration_id()),
+            NameRef::Unresolved(name) => name.as_ref().clone(),
+        };
 
-        match name_ref {
-            NameRef::Unresolved(name) => {
-                match name.parent_scope() {
-                    ParentScope::TopLevel => {
-                        let result = self.search_ancestors(*OBJECT_ID, *name.str());
+        match name.parent_scope() {
+            ParentScope::TopLevel => {
+                let result = self.search_ancestors(*OBJECT_ID, *name.str());
 
-                        if let Outcome::Resolved(declaration_id) = result {
-                            self.graph.record_resolved_name(name_id, declaration_id);
-                        }
+                if let Outcome::Resolved(declaration_id) = result {
+                    self.graph.record_resolved_name(name_id, declaration_id);
+                }
 
-                        result
+                result
+            }
+            ParentScope::Attached(parent_scope_id) => {
+                let NameRef::Resolved(parent_scope) = self.graph.names().get(parent_scope_id).unwrap() else {
+                    return Outcome::Retry {
+                        partial_ancestors: false,
+                    };
+                };
+
+                let mut target_decl_id = *parent_scope.declaration_id();
+                let target_decl = self.graph.declarations().get(&target_decl_id).unwrap();
+
+                // If the attached object is a constant alias, resolve it to the target namespace
+                // (e.g., ALIAS.bar where ALIAS = Foo should create the singleton class on Foo, not ALIAS)
+                if matches!(target_decl, Declaration::ConstantAlias(_)) {
+                    let resolved_ids = self.resolve_alias_chains(target_decl_id);
+
+                    if resolved_ids
+                        .iter()
+                        .any(|id| matches!(self.graph.declarations().get(id), Some(Declaration::ConstantAlias(_))))
+                    {
+                        return Outcome::Retry {
+                            partial_ancestors: false,
+                        };
                     }
-                    ParentScope::Attached(parent_scope_id) => {
-                        let NameRef::Resolved(parent_scope) = self.graph.names().get(parent_scope_id).unwrap() else {
+
+                    let Some(&namespace_id) = resolved_ids
+                        .iter()
+                        .find(|id| matches!(self.graph.declarations().get(id), Some(Declaration::Namespace(_))))
+                    else {
+                        return Outcome::Unresolved;
+                    };
+
+                    target_decl_id = namespace_id;
+                }
+
+                // If we found a singleton reference with a resolved attached object parent scope, we
+                // automatically create the singleton class
+                let Some(singleton_id) =
+                    self.get_or_create_singleton_class(target_decl_id, SingletonAncestors::Enqueue)
+                else {
+                    return Outcome::Unresolved;
+                };
+                self.graph.record_resolved_name(name_id, singleton_id);
+                // `get_or_create_singleton_class` already enqueued the singleton's ancestors on
+                // creation, so there is nothing to hand back for re-enqueueing.
+                Outcome::Resolved(singleton_id)
+            }
+            ParentScope::None => {
+                // Otherwise, it's a simple constant read and we can resolve it directly
+                let result = self.run_resolution(&name);
+
+                if let Outcome::Resolved(declaration_id) = result {
+                    self.graph.record_resolved_name(name_id, declaration_id);
+                }
+
+                result
+            }
+            ParentScope::Some(parent_scope_id) => {
+                let NameRef::Resolved(parent_scope) = self.graph.names().get(parent_scope_id).unwrap() else {
+                    return Outcome::Retry {
+                        partial_ancestors: false,
+                    };
+                };
+
+                // Resolve the namespace in case it's an alias (e.g., ALIAS::CONST where ALIAS = Foo)
+                // An alias can have multiple targets, so we try all of them in order.
+                let resolved_ids = self.resolve_alias_chains(*parent_scope.declaration_id());
+
+                // Search each resolved target for the constant. Return early if found.
+                let mut missing_partial = false;
+                let mut found_namespace = false;
+
+                for &id in &resolved_ids {
+                    match self.graph.declarations().get(&id) {
+                        Some(Declaration::ConstantAlias(_)) => {
+                            // Alias not fully resolved yet
                             return Outcome::Retry {
                                 partial_ancestors: false,
                             };
-                        };
+                        }
+                        Some(Declaration::Namespace(_)) => {
+                            found_namespace = true;
 
-                        let mut target_decl_id = *parent_scope.declaration_id();
-                        let target_decl = self.graph.declarations().get(&target_decl_id).unwrap();
-
-                        // If the attached object is a constant alias, resolve it to the target namespace
-                        // (e.g., ALIAS.bar where ALIAS = Foo should create the singleton class on Foo, not ALIAS)
-                        if matches!(target_decl, Declaration::ConstantAlias(_)) {
-                            let resolved_ids = self.resolve_alias_chains(target_decl_id);
-
-                            if resolved_ids.iter().any(|id| {
-                                matches!(self.graph.declarations().get(id), Some(Declaration::ConstantAlias(_)))
-                            }) {
-                                return Outcome::Retry {
+                            match self.search_ancestors(id, *name.str()) {
+                                Outcome::Resolved(declaration_id) => {
+                                    self.graph.record_resolved_name(name_id, declaration_id);
+                                    return Outcome::Resolved(declaration_id);
+                                }
+                                Outcome::Retry {
+                                    partial_ancestors: true,
+                                } => {
+                                    missing_partial = true;
+                                }
+                                Outcome::Unresolved => {}
+                                Outcome::Retry {
                                     partial_ancestors: false,
-                                };
-                            }
-
-                            let Some(&namespace_id) = resolved_ids.iter().find(|id| {
-                                matches!(self.graph.declarations().get(id), Some(Declaration::Namespace(_)))
-                            }) else {
-                                return Outcome::Unresolved;
-                            };
-
-                            target_decl_id = namespace_id;
-                        }
-
-                        // If we found a singleton reference with a resolved attached object parent scope, we
-                        // automatically create the singleton class
-                        let Some(singleton_id) =
-                            self.get_or_create_singleton_class(target_decl_id, SingletonAncestors::Enqueue)
-                        else {
-                            return Outcome::Unresolved;
-                        };
-                        self.graph.record_resolved_name(name_id, singleton_id);
-                        // `get_or_create_singleton_class` already enqueued the singleton's ancestors on
-                        // creation, so there is nothing to hand back for re-enqueueing.
-                        Outcome::Resolved(singleton_id)
-                    }
-                    ParentScope::None => {
-                        // Otherwise, it's a simple constant read and we can resolve it directly
-                        let result = self.run_resolution(&name);
-
-                        if let Outcome::Resolved(declaration_id) = result {
-                            self.graph.record_resolved_name(name_id, declaration_id);
-                        }
-
-                        result
-                    }
-                    ParentScope::Some(parent_scope_id) => {
-                        let NameRef::Resolved(parent_scope) = self.graph.names().get(parent_scope_id).unwrap() else {
-                            return Outcome::Retry {
-                                partial_ancestors: false,
-                            };
-                        };
-
-                        // Resolve the namespace in case it's an alias (e.g., ALIAS::CONST where ALIAS = Foo)
-                        // An alias can have multiple targets, so we try all of them in order.
-                        let resolved_ids = self.resolve_alias_chains(*parent_scope.declaration_id());
-
-                        // Search each resolved target for the constant. Return early if found.
-                        let mut missing_partial = false;
-                        let mut found_namespace = false;
-
-                        for &id in &resolved_ids {
-                            match self.graph.declarations().get(&id) {
-                                Some(Declaration::ConstantAlias(_)) => {
-                                    // Alias not fully resolved yet
-                                    return Outcome::Retry {
-                                        partial_ancestors: false,
-                                    };
-                                }
-                                Some(Declaration::Namespace(_)) => {
-                                    found_namespace = true;
-
-                                    match self.search_ancestors(id, *name.str()) {
-                                        Outcome::Resolved(declaration_id) => {
-                                            self.graph.record_resolved_name(name_id, declaration_id);
-                                            return Outcome::Resolved(declaration_id);
-                                        }
-                                        Outcome::Retry {
-                                            partial_ancestors: true,
-                                        } => {
-                                            missing_partial = true;
-                                        }
-                                        Outcome::Unresolved => {}
-                                        Outcome::Retry {
-                                            partial_ancestors: false,
-                                        } => {
-                                            unreachable!("search_ancestors never returns a non-partial Retry")
-                                        }
-                                    }
-                                }
-                                _ => {
-                                    // Not a namespace (e.g., a constant) - skip
+                                } => {
+                                    unreachable!("search_ancestors never returns a non-partial Retry")
                                 }
                             }
                         }
-
-                        // If no namespaces were found, this constant path can never resolve.
-                        if !found_namespace {
-                            return Outcome::Unresolved;
-                        }
-
-                        // Member not found in any namespace yet - retry in case it's added later. `partial` records
-                        // whether the miss was due to a still-partial ancestor chain, so the unit is re-checked once
-                        // that chain completes.
-                        Outcome::Retry {
-                            partial_ancestors: missing_partial,
+                        _ => {
+                            // Not a namespace (e.g., a constant) - skip
                         }
                     }
                 }
+
+                // If no namespaces were found, this constant path can never resolve.
+                if !found_namespace {
+                    return Outcome::Unresolved;
+                }
+
+                // Member not found in any namespace yet - retry in case it's added later. `partial` records
+                // whether the miss was due to a still-partial ancestor chain, so the unit is re-checked once
+                // that chain completes.
+                Outcome::Retry {
+                    partial_ancestors: missing_partial,
+                }
             }
-            NameRef::Resolved(resolved) => Outcome::Resolved(*resolved.declaration_id()),
         }
     }
 


### PR DESCRIPTION
A small optimization pulled from #912 (~2% faster)

We need to clone the name to avoid a double-borrow issue in the `Unresolved` branch. However, the clone is unnecessary for resolved names. By moving the `match` on `name_ref` up with an early return, we can avoid cloning for resolved names.

The diff looks larger than it actually is. Because the `match` was moved up, all lines below got dedented by 2 levels, but there are no code changes.