### PR TITLE
Expose `#document` on constant and method references in the Ruby API

### DIFF
--- a/ext/rubydex/reference.c
+++ b/ext/rubydex/reference.c
@@ -17,6 +17,8 @@ VALUE cUnresolvedConstantReference;
 VALUE cResolvedConstantReference;
 VALUE cMethodReference;
 
+static VALUE cDocument;
+
 /*
  * call-seq:
  *   name -> String
@@ -45,6 +47,27 @@ static VALUE rdxr_constant_reference_location(VALUE self) {
     VALUE location = rdxi_build_location_value(loc);
     rdx_location_free(loc);
     return location;
+}
+
+/*
+ * call-seq:
+ *   document -> Rubydex::Document
+ *
+ * Returns the document this constant reference belongs to.
+ */
+static VALUE rdxr_constant_reference_document(VALUE self) {
+    HandleData *data;
+    void *graph = rdxi_graph_from_handle(self, &data);
+
+    const uint64_t *uri_id = rdx_constant_reference_document(graph, data->id);
+    if (uri_id == NULL) {
+        rb_raise(rb_eRuntimeError, "Constant reference not found");
+    }
+
+    VALUE argv[] = {data->graph_obj, ULL2NUM(*uri_id)};
+    free_u64(uri_id);
+
+    return rb_class_new_instance(2, argv, cDocument);
 }
 
 /*
@@ -102,6 +125,27 @@ static VALUE rdxr_method_reference_receiver(VALUE self) {
 
 /*
  * call-seq:
+ *   document -> Rubydex::Document
+ *
+ * Returns the document this method reference belongs to.
+ */
+static VALUE rdxr_method_reference_document(VALUE self) {
+    HandleData *data;
+    void *graph = rdxi_graph_from_handle(self, &data);
+
+    const uint64_t *uri_id = rdx_method_reference_document(graph, data->id);
+    if (uri_id == NULL) {
+        rb_raise(rb_eRuntimeError, "Method reference not found");
+    }
+
+    VALUE argv[] = {data->graph_obj, ULL2NUM(*uri_id)};
+    free_u64(uri_id);
+
+    return rb_class_new_instance(2, argv, cDocument);
+}
+
+/*
+ * call-seq:
  *   declaration -> Rubydex::Declaration
  *
  * Returns the resolved declaration.
@@ -123,6 +167,8 @@ static VALUE rdxr_resolved_constant_reference_declaration(VALUE self) {
 }
 
 void rdxi_initialize_reference(VALUE mRubydex) {
+    cDocument = rb_const_get(mRubydex, rb_intern("Document"));
+
     cReference = rb_define_class_under(mRubydex, "Reference", rb_cObject);
     rb_define_alloc_func(cReference, rdxr_handle_alloc);
     rb_define_method(cReference, "initialize", rdxr_handle_initialize, 2);
@@ -132,6 +178,7 @@ void rdxi_initialize_reference(VALUE mRubydex) {
     rb_define_alloc_func(cConstantReference, rdxr_handle_alloc);
     rb_define_method(cConstantReference, "initialize", rdxr_handle_initialize, 2);
     rb_define_method(cConstantReference, "location", rdxr_constant_reference_location, 0);
+    rb_define_method(cConstantReference, "document", rdxr_constant_reference_document, 0);
     rb_funcall(rb_singleton_class(cConstantReference), rb_intern("private"), 1, ID2SYM(rb_intern("new")));
 
     cUnresolvedConstantReference = rb_define_class_under(mRubydex, "UnresolvedConstantReference", cConstantReference);
@@ -148,4 +195,5 @@ void rdxi_initialize_reference(VALUE mRubydex) {
     rb_define_method(cMethodReference, "name", rdxr_method_reference_name, 0);
     rb_define_method(cMethodReference, "location", rdxr_method_reference_location, 0);
     rb_define_method(cMethodReference, "receiver", rdxr_method_reference_receiver, 0);
+    rb_define_method(cMethodReference, "document", rdxr_method_reference_document, 0);
 }

--- a/rbi/rubydex.rbi
+++ b/rbi/rubydex.rbi
@@ -20,6 +20,9 @@ class Rubydex::ConstantReference < Rubydex::Reference
   sig { returns(Rubydex::Location) }
   def location; end
 
+  sig { returns(Rubydex::Document) }
+  def document; end
+
   class << self
     private
 
@@ -518,6 +521,9 @@ class Rubydex::MethodReference < Rubydex::Reference
 
   sig { returns(T.nilable(Rubydex::Declaration)) }
   def receiver; end
+
+  sig { returns(Rubydex::Document) }
+  def document; end
 end
 
 class Rubydex::Reference

--- a/rust/rubydex-sys/src/reference_api.rs
+++ b/rust/rubydex-sys/src/reference_api.rs
@@ -226,6 +226,25 @@ pub unsafe extern "C" fn rdx_resolved_constant_reference_declaration(
     })
 }
 
+/// Returns a pointer to the URI ID of the document a constant reference belongs
+/// to, or NULL if the reference cannot be found. Caller must free the returned
+/// pointer with `free_u64`.
+///
+/// # Safety
+/// - `pointer` must be a valid pointer previously returned by `rdx_graph_new`.
+/// - `reference_id` must be a valid reference id.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rdx_constant_reference_document(pointer: GraphPointer, reference_id: u64) -> *const u64 {
+    with_graph(pointer, |graph| {
+        let ref_id = ConstantReferenceId::new(reference_id);
+        if let Some(reference) = graph.constant_references().get(&ref_id) {
+            Box::into_raw(Box::new(*reference.uri_id())).cast_const()
+        } else {
+            ptr::null()
+        }
+    })
+}
+
 /// Returns the declaration of the resolved receiver for the given method reference. Returns NULL when the method
 /// reference has no tracked receiver or when the receiver could not be resolved. Caller must free with
 /// `free_c_declaration`.
@@ -285,6 +304,25 @@ pub unsafe extern "C" fn rdx_method_reference_location(pointer: GraphPointer, re
             .expect("Document should exist");
 
         create_location_for_uri_and_offset(graph, document, reference.offset())
+    })
+}
+
+/// Returns a pointer to the URI ID of the document a method reference belongs
+/// to, or NULL if the reference cannot be found. Caller must free the returned
+/// pointer with `free_u64`.
+///
+/// # Safety
+/// - `pointer` must be a valid pointer previously returned by `rdx_graph_new`.
+/// - `reference_id` must be a valid reference id.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rdx_method_reference_document(pointer: GraphPointer, reference_id: u64) -> *const u64 {
+    with_graph(pointer, |graph| {
+        let ref_id = MethodReferenceId::new(reference_id);
+        if let Some(reference) = graph.method_references().get(&ref_id) {
+            Box::into_raw(Box::new(*reference.uri_id())).cast_const()
+        } else {
+            ptr::null()
+        }
     })
 }
 

--- a/test/references_test.rb
+++ b/test/references_test.rb
@@ -217,6 +217,40 @@ class ReferencesTest < Minitest::Test
     end
   end
 
+  def test_constant_reference_document
+    with_context do |context|
+      context.write!("file1.rb", "class B < A; end")
+
+      graph = Rubydex::Graph.new
+      graph.index_all(context.glob("**/*.rb"))
+
+      file_uri = context.uri_to("file1.rb")
+      reference = graph.constant_references.find { |ref| ref.name == "A" }
+      refute_nil(reference)
+
+      assert_instance_of(Rubydex::Document, reference.document)
+      assert_equal(file_uri, reference.document.uri)
+    end
+  end
+
+  def test_constant_reference_document_raises_when_reference_is_gone
+    with_context do |context|
+      context.write!("file1.rb", "class B < A; end")
+
+      graph = Rubydex::Graph.new
+      graph.index_all(context.glob("**/*.rb"))
+
+      file_uri = context.uri_to("file1.rb")
+      reference = graph.constant_references.find { |ref| ref.name == "A" }
+      refute_nil(reference)
+
+      graph.delete_document(file_uri)
+
+      error = assert_raises(RuntimeError) { reference.document }
+      assert_equal("Constant reference not found", error.message)
+    end
+  end
+
   def test_graph_method_references_enumerator
     with_context do |context|
       context.write!("file1.rb", <<~RUBY)
@@ -409,6 +443,52 @@ class ReferencesTest < Minitest::Test
       receiver = method_ref.receiver
       assert_kind_of(Rubydex::SingletonClass, receiver)
       assert_equal("Bar::<Bar>", receiver.name)
+    end
+  end
+
+  def test_method_reference_document
+    with_context do |context|
+      context.write!("file1.rb", <<~RUBY)
+        class Foo
+          def bar
+            baz
+          end
+        end
+      RUBY
+
+      graph = Rubydex::Graph.new
+      graph.index_all(context.glob("**/*.rb"))
+
+      file_uri = context.uri_to("file1.rb")
+      reference = graph.method_references.find { |ref| ref.name == "baz" }
+      refute_nil(reference)
+
+      assert_instance_of(Rubydex::Document, reference.document)
+      assert_equal(file_uri, reference.document.uri)
+    end
+  end
+
+  def test_method_reference_document_raises_when_reference_is_gone
+    with_context do |context|
+      context.write!("file1.rb", <<~RUBY)
+        class Foo
+          def bar
+            baz
+          end
+        end
+      RUBY
+
+      graph = Rubydex::Graph.new
+      graph.index_all(context.glob("**/*.rb"))
+
+      file_uri = context.uri_to("file1.rb")
+      reference = graph.method_references.find { |ref| ref.name == "baz" }
+      refute_nil(reference)
+
+      graph.delete_document(file_uri)
+
+      error = assert_raises(RuntimeError) { reference.document }
+      assert_equal("Method reference not found", error.message)
     end
   end
 end


### PR DESCRIPTION
This PR mirrors #920, exposing `#document` on `ConstantReference` and `MethodReference`. It returns the `Rubydex::Document` the reference belongs to, so callers reach a reference's document in one call and read its URI as `reference.document.uri` instead of going through `location`. 

See #920 and #825 for more context.