### PR TITLE
Emit constant references for RBS parent-scope segments

### DIFF
--- a/rust/rubydex/src/indexing/rbs_indexer.rs
+++ b/rust/rubydex/src/indexing/rbs_indexer.rs
@@ -80,7 +80,16 @@ impl<'a> RBSIndexer<'a> {
             let Node::Symbol(symbol) = path_node else {
                 continue;
             };
-            parent_scope = ParentScope::Some(self.intern_name(&symbol, parent_scope, nesting_name_id));
+            let name_id = self.intern_name(&symbol, parent_scope, nesting_name_id);
+
+            // Emit a constant reference for each parent-scope segment so it gets its own resolution
+            // unit, mirroring the Ruby indexer (see `index_constant_reference`). Otherwise the
+            // parent scope is an orphan name that never resolves, leaving qualified references stuck.
+            let offset = Offset::from_rbs_location(&symbol.location());
+            self.local_graph
+                .add_constant_reference(ConstantReference::new(name_id, self.uri_id, offset));
+
+            parent_scope = ParentScope::Some(name_id);
         }
 
         self.intern_name(&type_name.name(), parent_scope, nesting_name_id)

--- a/rust/rubydex/src/resolution_tests.rs
+++ b/rust/rubydex/src/resolution_tests.rs
@@ -4883,6 +4883,51 @@ mod rbs_tests {
     }
 
     #[test]
+    fn rbs_qualified_mixin_resolves_through_parent_scope() {
+        let mut context = graph_test();
+        context.index_rbs_uri("file:///minitest.rbs", {
+            r"
+            module Minitest
+              module Guard
+              end
+
+              module Assertions
+              end
+
+              class Runnable
+              end
+            end
+            "
+        });
+        context.index_rbs_uri("file:///minitest/test.rbs", {
+            r"
+            class Minitest::Test < ::Minitest::Runnable
+              include Minitest::Assertions
+              include Minitest::Guard
+              extend Minitest::Guard
+            end
+            "
+        });
+        context.resolve();
+
+        assert_no_diagnostics!(&context);
+
+        assert_ancestors_eq!(
+            context,
+            "Minitest::Test",
+            [
+                "Minitest::Test",
+                "Minitest::Guard",
+                "Minitest::Assertions",
+                "Minitest::Runnable",
+                "Object",
+                "Kernel",
+                "BasicObject"
+            ]
+        );
+    }
+
+    #[test]
     fn rbs_qualified_name_inside_nested_module() {
         let mut context = graph_test();
         context.index_rbs_uri("file:///foo.rbs", {

--- a/rust/rubydex/src/resolution_tests.rs
+++ b/rust/rubydex/src/resolution_tests.rs
@@ -4925,6 +4925,22 @@ mod rbs_tests {
                 "BasicObject"
             ]
         );
+        assert_ancestors_eq!(
+            context,
+            "Minitest::Test::<Test>",
+            [
+                "Minitest::Test::<Test>",
+                "Minitest::Guard",
+                "Minitest::Runnable::<Runnable>",
+                "Object::<Object>",
+                "BasicObject::<BasicObject>",
+                "Class",
+                "Module",
+                "Object",
+                "Kernel",
+                "BasicObject"
+            ]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The RBS indexer created a resolution unit only for the final segment of a
qualified name. Parent scopes (e.g. `Minitest` in `Minitest::Guard`) were
interned as names but had no resolution unit of their own, so they were never
resolved. Qualified mixin and superclass references in RBS therefore stayed
unresolved, and the affected ancestor chains stayed permanently partial — every
class using such a reference (directly or by inheritance) was re-linearized on
every resolution pass.

This mirrors what the Ruby indexer already does (`index_constant_reference`):
emit a constant reference for each parent-scope segment so each one gets its own
resolution unit.

## Changes

- `index_type_name` now adds a constant reference per parent-scope segment.
- Add an RBS resolution regression test.

## Impact

Beyond correctness, this removes a large class of references that could never
resolve, which cuts the work each incremental resolution pass repeats on
codebases that load RBS signatures.