### PR TITLE
Include dependencies in graph memory bench

### DIFF
--- a/rust/rubydex/benches/graph_memory.rs
+++ b/rust/rubydex/benches/graph_memory.rs
@@ -1,6 +1,6 @@
 #[cfg(all(feature = "jemalloc", not(target_os = "windows")))]
 mod imp {
-    use std::collections::HashSet;
+    use std::time::Instant;
 
     use rubydex::{
         indexing::{self, IndexerBackend},
@@ -18,13 +18,31 @@ mod imp {
     }
 
     pub fn run() {
-        let paths: Vec<String> = std::env::args().skip(1).collect();
-        let paths = if paths.is_empty() { vec![".".to_string()] } else { paths };
-        let (file_paths, _) = listing::collect_file_paths(paths, &HashSet::new());
+        let mut args = std::env::args().skip(1);
+
+        let workspace = args
+            .next()
+            .expect("incorrect usage of cargo bench --bench graph_memory. Please use `utils/bench-graph-memory` instead of invoking this benchmark directly.");
+        let workspace_path = std::fs::canonicalize(&workspace).expect("the workspace path must exist");
+        assert!(workspace_path.is_dir(), "the workspace path must be a directory");
 
         let mut graph = Graph::new();
+        graph.set_workspace_path(workspace_path);
+
+        if let Err(error) = graph.load_config(None) {
+            eprintln!("{error}");
+        }
+
+        let time = Instant::now();
+
+        let (file_paths, _) = listing::collect_file_paths(args.collect(), &graph.excluded_patterns());
+        println!("Listing {:.2}s", time.elapsed().as_secs_f64());
+
         let _ = indexing::index_files(&mut graph, file_paths, IndexerBackend::RubyIndexer);
+        println!("Indexing {:.2}s", time.elapsed().as_secs_f64());
+
         Resolver::new(&mut graph).resolve();
+        println!("Resolution {:.2}s", time.elapsed().as_secs_f64());
 
         // Compare the total memory used in the allocator before and after dropping the graph
         let before_drop = allocated_bytes();

--- a/utils/bench-graph-memory
+++ b/utils/bench-graph-memory
@@ -33,8 +33,26 @@ case "$TARGET" in
     *) TARGET="$PROJECT_ROOT/$TARGET" ;;
 esac
 
+# Check if dependencies are installed, otherwise the benchmark can't run with dependencies
+if ! /bin/bash -lc 'cd "$1" && bundle check 2>/dev/null' bash "$TARGET"; then
+    echo "Error: dependencies are not installed for the target repo at $TARGET" >&2
+    echo "Please run 'bundle install' there and try again." >&2
+    exit 1
+fi
+
+# Collect RBS and dependency paths, so that the graph we're using to benchmark has complete ancestors. Otherwise, we
+# benchmark with missing declarations, like `Object`, which leads to ancestor chains never being completed and several
+# constant references never resolving.
+INDEX_PATHS=()
+while IFS= read -r line; do
+    [ -e "$line" ] && INDEX_PATHS+=("$line")
+done < <(/bin/bash -lc 'cd "$1" && bundle exec ruby -e "require \"rubydex\"; puts Rubydex::Graph.new.workspace_paths" 2>/dev/null' bash "$TARGET")
+
+# Print the path count. This helps identify if there's an obvious mistake and the number is too low
+echo "Benchmarking with ${#INDEX_PATHS[@]} paths"
+
 run_bench() {
-    cd "$RUST_DIR" && cargo bench --bench graph_memory -- "$TARGET"
+    cd "$RUST_DIR" && cargo bench --bench graph_memory -- "$TARGET" "${INDEX_PATHS[@]}"
 }
 
 if [ "$COMPARE" -eq 1 ]; then


### PR DESCRIPTION
I just realized that all of our benchmarks don't match the exact usage of Rubydex in real codebases. Because they are completely just benchmarking the Rust analysis, we miss RBS core definitions and dependencies.

That means that fundamental classes like `Object` and `BasicObject` are missing and so are all definitions that belong to gems. This means we never succeed in fully linearizing ancestor chains since the top of the chain is always missing and that we fail to resolve constants more often than we would in reality.

Those aspects can skew benchmark results and lead to sub-optimal decisions. For example, we're not interested in optimizing the analysis for the case where `Object` is missing, since we never want it to be missing.

This PR changes the `graph_memory` benchmark to include RBS core definitions and dependencies, so that the graph we produce is more realistic. I also added a super simplistic timer, so that we can see the execution time in the same run. Finally, I started loading the target project's configuration, so that the benchmark is closer to reality.

**Caveat**: in the bash script, we need to run some sub-commands with `bash -lc`. This is because we need those commands to login to the user's shell and load the version manager, otherwise we miss the right environment variables to find dependencies.