### PR TITLE
Return NULL for missing entities in required FFI accessors

### DIFF
--- a/ext/rubydex/declaration.c
+++ b/ext/rubydex/declaration.c
@@ -236,7 +236,7 @@ static VALUE rdxr_declaration_owner(VALUE self) {
     const CDeclaration *decl = rdx_declaration_owner(graph, data->id);
 
     if (decl == NULL) {
-        rb_raise(rb_eRuntimeError, "owner can never be nil for any declarations");
+        rb_raise(rb_eRuntimeError, "Declaration must exist for a valid id");
     }
 
     VALUE decl_class = rdxi_declaration_class_for_kind(decl->kind);

--- a/ext/rubydex/definition.c
+++ b/ext/rubydex/definition.c
@@ -89,6 +89,9 @@ static VALUE rdxr_definition_location(VALUE self) {
     void *graph = rdxi_graph_from_handle(self, &data);
 
     Location *loc = rdx_definition_location(graph, data->id);
+    if (loc == NULL) {
+        rb_raise(rb_eRuntimeError, "Definition must exist for a valid id");
+    }
     VALUE location = rdxi_build_location_value(loc);
     rdx_location_free(loc);
 
@@ -106,10 +109,11 @@ static VALUE rdxr_definition_comments(VALUE self) {
     void *graph = rdxi_graph_from_handle(self, &data);
 
     CommentArray *arr = rdx_definition_comments(graph, data->id);
-    if (arr == NULL || arr->len == 0) {
-        if (arr != NULL) {
-            rdx_definition_comments_free(arr);
-        }
+    if (arr == NULL) {
+        rb_raise(rb_eRuntimeError, "Definition must exist for a valid id");
+    }
+    if (arr->len == 0) {
+        rdx_definition_comments_free(arr);
         return rb_ary_new();
     }
 

--- a/ext/rubydex/reference.c
+++ b/ext/rubydex/reference.c
@@ -104,6 +104,9 @@ static VALUE rdxr_method_reference_location(VALUE self) {
     void *graph = rdxi_graph_from_handle(self, &data);
 
     Location *loc = rdx_method_reference_location(graph, data->id);
+    if (loc == NULL) {
+        rb_raise(rb_eRuntimeError, "Method reference must exist for a valid id");
+    }
     VALUE location = rdxi_build_location_value(loc);
     rdx_location_free(loc);
     return location;

--- a/ext/rubydex/reference.c
+++ b/ext/rubydex/reference.c
@@ -30,6 +30,9 @@ static VALUE rdxr_constant_reference_name(VALUE self) {
     void *graph = rdxi_graph_from_handle(self, &data);
 
     const char *name = rdx_constant_reference_name(graph, data->id);
+    if (name == NULL) {
+        rb_raise(rb_eRuntimeError, "Constant reference must exist for a valid id");
+    }
     return rdxi_owned_c_string_to_ruby(name);
 }
 

--- a/ext/rubydex/reference.c
+++ b/ext/rubydex/reference.c
@@ -47,6 +47,9 @@ static VALUE rdxr_constant_reference_location(VALUE self) {
     void *graph = rdxi_graph_from_handle(self, &data);
 
     Location *loc = rdx_constant_reference_location(graph, data->id);
+    if (loc == NULL) {
+        rb_raise(rb_eRuntimeError, "Constant reference must exist for a valid id");
+    }
     VALUE location = rdxi_build_location_value(loc);
     rdx_location_free(loc);
     return location;

--- a/ext/rubydex/reference.c
+++ b/ext/rubydex/reference.c
@@ -84,6 +84,9 @@ static VALUE rdxr_method_reference_name(VALUE self) {
     void *graph = rdxi_graph_from_handle(self, &data);
 
     const char *name = rdx_method_reference_name(graph, data->id);
+    if (name == NULL) {
+        rb_raise(rb_eRuntimeError, "Method reference must exist for a valid id");
+    }
     return rdxi_owned_c_string_to_ruby(name);
 }
 

--- a/rust/rubydex-sys/src/declaration_api.rs
+++ b/rust/rubydex-sys/src/declaration_api.rs
@@ -291,7 +291,8 @@ pub unsafe extern "C" fn rdx_declaration_singleton_class(pointer: GraphPointer, 
     })
 }
 
-/// Returns the owner of the declaration (attached object in the case of singleton classes)
+/// Returns the owner of the declaration (attached object in the case of singleton classes), or NULL if the declaration
+/// cannot be found.
 ///
 /// # Safety
 ///
@@ -299,11 +300,13 @@ pub unsafe extern "C" fn rdx_declaration_singleton_class(pointer: GraphPointer, 
 ///
 /// # Panics
 ///
-/// Will panic if invoked on a non-existing or non-namespace declaration
+/// This function will panic if the owner declaration cannot be found.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rdx_declaration_owner(pointer: GraphPointer, decl_id: u64) -> *const CDeclaration {
     with_graph(pointer, |graph| {
-        let declaration = graph.declarations().get(&DeclarationId::new(decl_id)).unwrap();
+        let Some(declaration) = graph.declarations().get(&DeclarationId::new(decl_id)) else {
+            return ptr::null();
+        };
         let owner_id = *declaration.owner_id();
         Box::into_raw(Box::new(CDeclaration::from_declaration(
             owner_id,

--- a/rust/rubydex-sys/src/definition_api.rs
+++ b/rust/rubydex-sys/src/definition_api.rs
@@ -156,21 +156,22 @@ pub struct CommentArray {
     pub len: usize,
 }
 
-/// Returns a newly allocated array of comments (string and location) for the given definition id.
-/// Caller must free the returned pointer with `rdx_definition_comments_free` and each inner string with `free_c_string` if needed.
+/// Returns a newly allocated array of comments (string and location) for the given definition id, or NULL if the
+/// definition cannot be found. Caller must free the returned pointer and its contents with
+/// `rdx_definition_comments_free`.
 ///
 /// # Safety
 /// - `pointer` must be a valid pointer previously returned by `rdx_graph_new`.
 /// - `definition_id` must be a valid definition id.
 ///
 /// # Panics
-/// This function will panic if a definition or document cannot be found.
+/// This function will panic if the definition's document cannot be found.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rdx_definition_comments(pointer: GraphPointer, definition_id: u64) -> *mut CommentArray {
     with_graph(pointer, |graph| {
         let def_id = DefinitionId::new(definition_id);
         let Some(defn) = graph.definitions().get(&def_id) else {
-            panic!("Definition not found: {definition_id:?}");
+            return ptr::null_mut();
         };
 
         let uri_id = *defn.uri_id();
@@ -229,7 +230,7 @@ pub unsafe extern "C" fn rdx_definition_comments_free(ptr: *mut CommentArray) {
     // arr is dropped here
 }
 
-/// Returns a newly allocated `Location` for the given definition id.
+/// Returns a newly allocated `Location` for the given definition id, or NULL if the definition cannot be found.
 /// Caller must free the returned pointer with `rdx_location_free`.
 ///
 /// # Safety
@@ -238,13 +239,13 @@ pub unsafe extern "C" fn rdx_definition_comments_free(ptr: *mut CommentArray) {
 ///
 /// # Panics
 ///
-/// This function will panic if a definition or document cannot be found.
+/// This function will panic if the definition's document cannot be found.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rdx_definition_location(pointer: GraphPointer, definition_id: u64) -> *mut Location {
     with_graph(pointer, |graph| {
         let def_id = DefinitionId::new(definition_id);
         let Some(defn) = graph.definitions().get(&def_id) else {
-            panic!("Definition not found: {definition_id:?}");
+            return ptr::null_mut();
         };
 
         let document = graph.documents().get(defn.uri_id()).expect("document should exist");

--- a/rust/rubydex-sys/src/reference_api.rs
+++ b/rust/rubydex-sys/src/reference_api.rs
@@ -288,7 +288,7 @@ pub unsafe extern "C" fn rdx_method_reference_receiver_declaration(
     })
 }
 
-/// Returns a newly allocated `Location` for the given method reference id.
+/// Returns a newly allocated `Location` for the given method reference id, or NULL if the reference cannot be found.
 /// Caller must free the returned pointer with `rdx_location_free`.
 ///
 /// # Safety
@@ -298,12 +298,14 @@ pub unsafe extern "C" fn rdx_method_reference_receiver_declaration(
 ///
 /// # Panics
 ///
-/// This function will panic if a reference or document cannot be found.
+/// This function will panic if the reference's document cannot be found.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rdx_method_reference_location(pointer: GraphPointer, reference_id: u64) -> *mut Location {
     with_graph(pointer, |graph| {
         let ref_id = MethodReferenceId::new(reference_id);
-        let reference = graph.method_references().get(&ref_id).expect("Reference not found");
+        let Some(reference) = graph.method_references().get(&ref_id) else {
+            return ptr::null_mut();
+        };
         let document = graph
             .documents()
             .get(&reference.uri_id())

--- a/rust/rubydex-sys/src/reference_api.rs
+++ b/rust/rubydex-sys/src/reference_api.rs
@@ -120,7 +120,7 @@ pub unsafe extern "C" fn rdx_method_references_iter_free(iter: *mut MethodRefere
     unsafe { MethodReferencesIter::free(iter) }
 }
 
-/// Returns the UTF-8 name string for a constant reference id.
+/// Returns the UTF-8 name string for a constant reference id, or NULL if the reference cannot be found.
 /// Caller must free with `free_c_string`.
 ///
 /// # Safety
@@ -129,12 +129,14 @@ pub unsafe extern "C" fn rdx_method_references_iter_free(iter: *mut MethodRefere
 ///
 /// # Panics
 ///
-/// This function will panic if the reference cannot be found.
+/// This function will panic if the reference's name cannot be found.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rdx_constant_reference_name(pointer: GraphPointer, reference_id: u64) -> *const c_char {
     with_graph(pointer, |graph| {
         let ref_id = ConstantReferenceId::new(reference_id);
-        let reference = graph.constant_references().get(&ref_id).expect("Reference not found");
+        let Some(reference) = graph.constant_references().get(&ref_id) else {
+            return ptr::null();
+        };
         let name = graph.names().get(reference.name_id()).expect("Name ID should exist");
 
         let name_string = graph

--- a/rust/rubydex-sys/src/reference_api.rs
+++ b/rust/rubydex-sys/src/reference_api.rs
@@ -174,7 +174,7 @@ pub unsafe extern "C" fn rdx_method_reference_name(pointer: GraphPointer, refere
     })
 }
 
-/// Returns a newly allocated `Location` for the given constant reference id.
+/// Returns a newly allocated `Location` for the given constant reference id, or NULL if the reference cannot be found.
 /// Caller must free the returned pointer with `rdx_location_free`.
 ///
 /// # Safety
@@ -184,12 +184,14 @@ pub unsafe extern "C" fn rdx_method_reference_name(pointer: GraphPointer, refere
 ///
 /// # Panics
 ///
-/// This function will panic if a reference or document cannot be found.
+/// This function will panic if the reference's document cannot be found.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rdx_constant_reference_location(pointer: GraphPointer, reference_id: u64) -> *mut Location {
     with_graph(pointer, |graph| {
         let ref_id = ConstantReferenceId::new(reference_id);
-        let reference = graph.constant_references().get(&ref_id).expect("Reference not found");
+        let Some(reference) = graph.constant_references().get(&ref_id) else {
+            return ptr::null_mut();
+        };
         let document = graph
             .documents()
             .get(&reference.uri_id())

--- a/rust/rubydex-sys/src/reference_api.rs
+++ b/rust/rubydex-sys/src/reference_api.rs
@@ -148,7 +148,7 @@ pub unsafe extern "C" fn rdx_constant_reference_name(pointer: GraphPointer, refe
     })
 }
 
-/// Returns the UTF-8 name string for a method reference id.
+/// Returns the UTF-8 name string for a method reference id, or NULL if the reference cannot be found.
 /// Caller must free with `free_c_string`.
 ///
 /// # Safety
@@ -157,12 +157,14 @@ pub unsafe extern "C" fn rdx_constant_reference_name(pointer: GraphPointer, refe
 ///
 /// # Panics
 ///
-/// This function will panic if the reference cannot be found.
+/// This function will panic if the reference's name cannot be found.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rdx_method_reference_name(pointer: GraphPointer, reference_id: u64) -> *const c_char {
     with_graph(pointer, |graph| {
         let ref_id = MethodReferenceId::new(reference_id);
-        let reference = graph.method_references().get(&ref_id).expect("Reference not found");
+        let Some(reference) = graph.method_references().get(&ref_id) else {
+            return ptr::null();
+        };
         let name = graph
             .strings()
             .get(reference.str())

--- a/test/declaration_test.rb
+++ b/test/declaration_test.rb
@@ -154,6 +154,27 @@ class DeclarationTest < Minitest::Test
     end
   end
 
+  def test_declaration_owner_raises_when_source_document_is_deleted
+    with_context do |context|
+      context.write!("file1.rb", <<~RUBY)
+        class Foo
+          class Bar; end
+        end
+      RUBY
+      graph = Rubydex::Graph.new
+      graph.index_all(context.glob("**/*.rb"))
+      graph.resolve
+
+      declaration = graph["Foo::Bar"]
+      refute_nil(declaration)
+
+      graph.delete_document(context.uri_to("file1.rb"))
+
+      error = assert_raises(RuntimeError) { declaration.owner }
+      assert_equal("Declaration must exist for a valid id", error.message)
+    end
+  end
+
   def test_singleton_class_attached_class_aliases_owner
     with_context do |context|
       context.write!("file1.rb", <<~RUBY)

--- a/test/definition_test.rb
+++ b/test/definition_test.rb
@@ -148,6 +148,31 @@ class DefinitionTest < Minitest::Test
     end
   end
 
+  def test_definition_comments_and_location_raise_when_definition_is_gone
+    with_context do |context|
+      context.write!("file1.rb", <<~RUBY)
+        # Class comment
+        class Foo
+        end
+      RUBY
+
+      graph = Rubydex::Graph.new
+      graph.index_all(context.glob("**/*.rb"))
+
+      document = graph.documents.find { |doc| doc.uri == context.uri_to("file1.rb") }
+      definition = document.definitions.find { |defn| defn.name == "Foo" }
+      refute_nil(definition)
+
+      graph.delete_document(context.uri_to("file1.rb"))
+
+      error = assert_raises(RuntimeError) { definition.comments }
+      assert_equal("Definition must exist for a valid id", error.message)
+
+      error = assert_raises(RuntimeError) { definition.location }
+      assert_equal("Definition must exist for a valid id", error.message)
+    end
+  end
+
   def test_definition_comments
     with_context do |context|
       context.write!("file1.rb", <<~RUBY)

--- a/test/references_test.rb
+++ b/test/references_test.rb
@@ -251,6 +251,24 @@ class ReferencesTest < Minitest::Test
     end
   end
 
+  def test_constant_reference_name_raises_when_source_document_is_deleted
+    with_context do |context|
+      context.write!("file1.rb", "class B < A; end")
+
+      graph = Rubydex::Graph.new
+      graph.index_all(context.glob("**/*.rb"))
+
+      file_uri = context.uri_to("file1.rb")
+      reference = graph.constant_references.find { |r| r.document.uri == file_uri }
+      refute_nil(reference)
+
+      graph.delete_document(file_uri)
+
+      error = assert_raises(RuntimeError) { reference.name }
+      assert_equal("Constant reference must exist for a valid id", error.message)
+    end
+  end
+
   def test_graph_method_references_enumerator
     with_context do |context|
       context.write!("file1.rb", <<~RUBY)

--- a/test/references_test.rb
+++ b/test/references_test.rb
@@ -269,6 +269,24 @@ class ReferencesTest < Minitest::Test
     end
   end
 
+  def test_constant_reference_location_raises_when_source_document_is_deleted
+    with_context do |context|
+      context.write!("file1.rb", "class B < A; end")
+
+      graph = Rubydex::Graph.new
+      graph.index_all(context.glob("**/*.rb"))
+
+      file_uri = context.uri_to("file1.rb")
+      reference = graph.constant_references.find { |r| r.document.uri == file_uri }
+      refute_nil(reference)
+
+      graph.delete_document(file_uri)
+
+      error = assert_raises(RuntimeError) { reference.location }
+      assert_equal("Constant reference must exist for a valid id", error.message)
+    end
+  end
+
   def test_method_reference_name_raises_when_source_document_is_deleted
     with_context do |context|
       context.write!("file1.rb", <<~RUBY)

--- a/test/references_test.rb
+++ b/test/references_test.rb
@@ -311,6 +311,30 @@ class ReferencesTest < Minitest::Test
     end
   end
 
+  def test_method_reference_location_raises_when_source_document_is_deleted
+    with_context do |context|
+      context.write!("file1.rb", <<~RUBY)
+        class Foo
+          def bar
+            baz
+          end
+        end
+      RUBY
+
+      graph = Rubydex::Graph.new
+      graph.index_all(context.glob("**/*.rb"))
+
+      file_uri = context.uri_to("file1.rb")
+      reference = graph.method_references.find { |r| r.document.uri == file_uri }
+      refute_nil(reference)
+
+      graph.delete_document(file_uri)
+
+      error = assert_raises(RuntimeError) { reference.location }
+      assert_equal("Method reference must exist for a valid id", error.message)
+    end
+  end
+
   def test_graph_method_references_enumerator
     with_context do |context|
       context.write!("file1.rb", <<~RUBY)

--- a/test/references_test.rb
+++ b/test/references_test.rb
@@ -269,6 +269,30 @@ class ReferencesTest < Minitest::Test
     end
   end
 
+  def test_method_reference_name_raises_when_source_document_is_deleted
+    with_context do |context|
+      context.write!("file1.rb", <<~RUBY)
+        class Foo
+          def bar
+            baz
+          end
+        end
+      RUBY
+
+      graph = Rubydex::Graph.new
+      graph.index_all(context.glob("**/*.rb"))
+
+      file_uri = context.uri_to("file1.rb")
+      reference = graph.method_references.find { |r| r.document.uri == file_uri }
+      refute_nil(reference)
+
+      graph.delete_document(file_uri)
+
+      error = assert_raises(RuntimeError) { reference.name }
+      assert_equal("Method reference must exist for a valid id", error.message)
+    end
+  end
+
   def test_graph_method_references_enumerator
     with_context do |context|
       context.write!("file1.rb", <<~RUBY)


### PR DESCRIPTION
This PR follows up on a review comment from https://github.com/Shopify/rubydex/pull/920#discussion_r3559481317.

A Ruby object can outlive the graph entity it references. Accessing that stale object caused Rust to panic inside `extern "C"`. Since Rust cannot unwind through C, that aborted the Ruby process.

The affected FFI accessors now return `NULL` when the entity is missing. Ruby turns that result into an entity-specific `RuntimeError`.

This applies to definition comments and locations, constant and method reference names and locations, and declaration owners. Accessors where `NULL` or `false` already has a valid meaning need a different result type, so they remain follow-up work.