### PR TITLE
Avoid id string allocations for references, definitions and names

### DIFF
--- a/rust/rubydex/src/model/definitions.rs
+++ b/rust/rubydex/src/model/definitions.rs
@@ -29,6 +29,7 @@ use crate::{
     assert_mem_size,
     model::{
         comment::Comment,
+        id::id_from_parts,
         ids::{self, ConstantReferenceId, DefinitionId, NameId, StringId, UriId},
         visibility::Visibility,
     },
@@ -673,12 +674,13 @@ impl ConstantAliasDefinition {
 
     #[must_use]
     pub fn id(&self) -> DefinitionId {
-        DefinitionId::from([
-            self.alias_constant.uri_id().get().to_le_bytes().as_slice(),
-            self.alias_constant.offset().start().to_le_bytes().as_slice(),
-            self.alias_constant.name_id().get().to_le_bytes().as_slice(),
-            self.target_name_id.get().to_le_bytes().as_slice(),
-        ])
+        id_from_parts!(
+            DefinitionId;
+            self.alias_constant.uri_id().get(),
+            self.alias_constant.offset().start(),
+            self.alias_constant.name_id().get(),
+            self.target_name_id.get(),
+        )
     }
 
     #[must_use]
@@ -756,11 +758,7 @@ impl ConstantVisibilityDefinition {
 
     #[must_use]
     pub fn id(&self) -> DefinitionId {
-        DefinitionId::from([
-            self.uri_id.get().to_le_bytes().as_slice(),
-            self.offset.start().to_le_bytes().as_slice(),
-            self.target.get().to_le_bytes().as_slice(),
-        ])
+        id_from_parts!(DefinitionId; self.uri_id.get(), self.offset.start(), self.target.get())
     }
 
     #[must_use]
@@ -840,12 +838,7 @@ impl MethodVisibilityDefinition {
 
     #[must_use]
     pub fn id(&self) -> DefinitionId {
-        DefinitionId::from([
-            self.uri_id.get().to_le_bytes().as_slice(),
-            self.offset.start().to_le_bytes().as_slice(),
-            self.str_id.get().to_le_bytes().as_slice(),
-            self.flags.bits().to_le_bytes().as_slice(),
-        ])
+        id_from_parts!(DefinitionId; self.uri_id.get(), self.offset.start(), self.str_id.get(), self.flags.bits())
     }
 
     #[must_use]
@@ -1131,11 +1124,7 @@ impl AttrAccessorDefinition {
 
     #[must_use]
     pub fn id(&self) -> DefinitionId {
-        DefinitionId::from([
-            self.uri_id.get().to_le_bytes().as_slice(),
-            self.offset.start().to_le_bytes().as_slice(),
-            self.str_id.get().to_le_bytes().as_slice(),
-        ])
+        id_from_parts!(DefinitionId; self.uri_id.get(), self.offset.start(), self.str_id.get())
     }
 
     #[must_use]
@@ -1216,11 +1205,7 @@ impl AttrReaderDefinition {
 
     #[must_use]
     pub fn id(&self) -> DefinitionId {
-        DefinitionId::from([
-            self.uri_id.get().to_le_bytes().as_slice(),
-            self.offset.start().to_le_bytes().as_slice(),
-            self.str_id.get().to_le_bytes().as_slice(),
-        ])
+        id_from_parts!(DefinitionId; self.uri_id.get(), self.offset.start(), self.str_id.get())
     }
 
     #[must_use]
@@ -1301,11 +1286,7 @@ impl AttrWriterDefinition {
 
     #[must_use]
     pub fn id(&self) -> DefinitionId {
-        DefinitionId::from([
-            self.uri_id.get().to_le_bytes().as_slice(),
-            self.offset.start().to_le_bytes().as_slice(),
-            self.str_id.get().to_le_bytes().as_slice(),
-        ])
+        id_from_parts!(DefinitionId; self.uri_id.get(), self.offset.start(), self.str_id.get())
     }
 
     #[must_use]
@@ -1383,11 +1364,7 @@ impl GlobalVariableDefinition {
 
     #[must_use]
     pub fn id(&self) -> DefinitionId {
-        DefinitionId::from([
-            self.uri_id.get().to_le_bytes().as_slice(),
-            self.offset.start().to_le_bytes().as_slice(),
-            self.str_id.get().to_le_bytes().as_slice(),
-        ])
+        id_from_parts!(DefinitionId; self.uri_id.get(), self.offset.start(), self.str_id.get())
     }
 
     #[must_use]
@@ -1460,11 +1437,7 @@ impl InstanceVariableDefinition {
 
     #[must_use]
     pub fn id(&self) -> DefinitionId {
-        DefinitionId::from([
-            self.uri_id.get().to_le_bytes().as_slice(),
-            self.offset.start().to_le_bytes().as_slice(),
-            self.str_id.get().to_le_bytes().as_slice(),
-        ])
+        id_from_parts!(DefinitionId; self.uri_id.get(), self.offset.start(), self.str_id.get())
     }
 
     #[must_use]
@@ -1537,11 +1510,7 @@ impl ClassVariableDefinition {
 
     #[must_use]
     pub fn id(&self) -> DefinitionId {
-        DefinitionId::from([
-            self.uri_id.get().to_le_bytes().as_slice(),
-            self.offset.start().to_le_bytes().as_slice(),
-            self.str_id.get().to_le_bytes().as_slice(),
-        ])
+        id_from_parts!(DefinitionId; self.uri_id.get(), self.offset.start(), self.str_id.get())
     }
 
     #[must_use]
@@ -1615,12 +1584,13 @@ impl MethodAliasDefinition {
 
     #[must_use]
     pub fn id(&self) -> DefinitionId {
-        DefinitionId::from([
-            self.uri_id.get().to_le_bytes().as_slice(),
-            self.offset.start().to_le_bytes().as_slice(),
-            self.new_name_str_id.get().to_le_bytes().as_slice(),
-            self.old_name_str_id.get().to_le_bytes().as_slice(),
-        ])
+        id_from_parts!(
+            DefinitionId;
+            self.uri_id.get(),
+            self.offset.start(),
+            self.new_name_str_id.get(),
+            self.old_name_str_id.get(),
+        )
     }
 
     #[must_use]
@@ -1700,12 +1670,13 @@ impl GlobalVariableAliasDefinition {
 
     #[must_use]
     pub fn id(&self) -> DefinitionId {
-        DefinitionId::from([
-            self.uri_id.get().to_le_bytes().as_slice(),
-            self.offset.start().to_le_bytes().as_slice(),
-            self.new_name_str_id.get().to_le_bytes().as_slice(),
-            self.old_name_str_id.get().to_le_bytes().as_slice(),
-        ])
+        id_from_parts!(
+            DefinitionId;
+            self.uri_id.get(),
+            self.offset.start(),
+            self.new_name_str_id.get(),
+            self.old_name_str_id.get(),
+        )
     }
 
     #[must_use]

--- a/rust/rubydex/src/model/definitions.rs
+++ b/rust/rubydex/src/model/definitions.rs
@@ -673,13 +673,12 @@ impl ConstantAliasDefinition {
 
     #[must_use]
     pub fn id(&self) -> DefinitionId {
-        DefinitionId::from(&format!(
-            "{}{}{}{}",
-            *self.alias_constant.uri_id(),
-            self.alias_constant.offset().start(),
-            *self.alias_constant.name_id(),
-            *self.target_name_id,
-        ))
+        DefinitionId::from([
+            self.alias_constant.uri_id().get().to_le_bytes().as_slice(),
+            self.alias_constant.offset().start().to_le_bytes().as_slice(),
+            self.alias_constant.name_id().get().to_le_bytes().as_slice(),
+            self.target_name_id.get().to_le_bytes().as_slice(),
+        ])
     }
 
     #[must_use]
@@ -757,7 +756,11 @@ impl ConstantVisibilityDefinition {
 
     #[must_use]
     pub fn id(&self) -> DefinitionId {
-        DefinitionId::from(&format!("{}{}{}", *self.uri_id, self.offset.start(), *self.target))
+        DefinitionId::from([
+            self.uri_id.get().to_le_bytes().as_slice(),
+            self.offset.start().to_le_bytes().as_slice(),
+            self.target.get().to_le_bytes().as_slice(),
+        ])
     }
 
     #[must_use]
@@ -837,16 +840,12 @@ impl MethodVisibilityDefinition {
 
     #[must_use]
     pub fn id(&self) -> DefinitionId {
-        // Flags are part of the hash because `module_function :bar` emits two
-        // `MethodVisibility` defs at the same source location, differing only
-        // in their `SINGLETON_METHOD_VISIBILITY` flag.
-        DefinitionId::from(&format!(
-            "{}{}{}{}",
-            *self.uri_id,
-            self.offset.start(),
-            *self.str_id,
-            self.flags.bits()
-        ))
+        DefinitionId::from([
+            self.uri_id.get().to_le_bytes().as_slice(),
+            self.offset.start().to_le_bytes().as_slice(),
+            self.str_id.get().to_le_bytes().as_slice(),
+            self.flags.bits().to_le_bytes().as_slice(),
+        ])
     }
 
     #[must_use]
@@ -1132,7 +1131,11 @@ impl AttrAccessorDefinition {
 
     #[must_use]
     pub fn id(&self) -> DefinitionId {
-        DefinitionId::from(&format!("{}{}{}", *self.uri_id, self.offset.start(), *self.str_id))
+        DefinitionId::from([
+            self.uri_id.get().to_le_bytes().as_slice(),
+            self.offset.start().to_le_bytes().as_slice(),
+            self.str_id.get().to_le_bytes().as_slice(),
+        ])
     }
 
     #[must_use]
@@ -1213,7 +1216,11 @@ impl AttrReaderDefinition {
 
     #[must_use]
     pub fn id(&self) -> DefinitionId {
-        DefinitionId::from(&format!("{}{}{}", *self.uri_id, self.offset.start(), *self.str_id))
+        DefinitionId::from([
+            self.uri_id.get().to_le_bytes().as_slice(),
+            self.offset.start().to_le_bytes().as_slice(),
+            self.str_id.get().to_le_bytes().as_slice(),
+        ])
     }
 
     #[must_use]
@@ -1294,7 +1301,11 @@ impl AttrWriterDefinition {
 
     #[must_use]
     pub fn id(&self) -> DefinitionId {
-        DefinitionId::from(&format!("{}{}{}", *self.uri_id, self.offset.start(), *self.str_id))
+        DefinitionId::from([
+            self.uri_id.get().to_le_bytes().as_slice(),
+            self.offset.start().to_le_bytes().as_slice(),
+            self.str_id.get().to_le_bytes().as_slice(),
+        ])
     }
 
     #[must_use]
@@ -1372,7 +1383,11 @@ impl GlobalVariableDefinition {
 
     #[must_use]
     pub fn id(&self) -> DefinitionId {
-        DefinitionId::from(&format!("{}{}{}", *self.uri_id, self.offset.start(), *self.str_id))
+        DefinitionId::from([
+            self.uri_id.get().to_le_bytes().as_slice(),
+            self.offset.start().to_le_bytes().as_slice(),
+            self.str_id.get().to_le_bytes().as_slice(),
+        ])
     }
 
     #[must_use]
@@ -1445,7 +1460,11 @@ impl InstanceVariableDefinition {
 
     #[must_use]
     pub fn id(&self) -> DefinitionId {
-        DefinitionId::from(&format!("{}{}{}", *self.uri_id, self.offset.start(), *self.str_id))
+        DefinitionId::from([
+            self.uri_id.get().to_le_bytes().as_slice(),
+            self.offset.start().to_le_bytes().as_slice(),
+            self.str_id.get().to_le_bytes().as_slice(),
+        ])
     }
 
     #[must_use]
@@ -1518,7 +1537,11 @@ impl ClassVariableDefinition {
 
     #[must_use]
     pub fn id(&self) -> DefinitionId {
-        DefinitionId::from(&format!("{}{}{}", *self.uri_id, self.offset.start(), *self.str_id))
+        DefinitionId::from([
+            self.uri_id.get().to_le_bytes().as_slice(),
+            self.offset.start().to_le_bytes().as_slice(),
+            self.str_id.get().to_le_bytes().as_slice(),
+        ])
     }
 
     #[must_use]
@@ -1592,13 +1615,12 @@ impl MethodAliasDefinition {
 
     #[must_use]
     pub fn id(&self) -> DefinitionId {
-        DefinitionId::from(&format!(
-            "{}{}{}{}",
-            *self.uri_id,
-            self.offset.start(),
-            *self.new_name_str_id,
-            *self.old_name_str_id,
-        ))
+        DefinitionId::from([
+            self.uri_id.get().to_le_bytes().as_slice(),
+            self.offset.start().to_le_bytes().as_slice(),
+            self.new_name_str_id.get().to_le_bytes().as_slice(),
+            self.old_name_str_id.get().to_le_bytes().as_slice(),
+        ])
     }
 
     #[must_use]
@@ -1678,13 +1700,12 @@ impl GlobalVariableAliasDefinition {
 
     #[must_use]
     pub fn id(&self) -> DefinitionId {
-        DefinitionId::from(&format!(
-            "{}{}{}{}",
-            *self.uri_id,
-            self.offset.start(),
-            *self.new_name_str_id,
-            *self.old_name_str_id,
-        ))
+        DefinitionId::from([
+            self.uri_id.get().to_le_bytes().as_slice(),
+            self.offset.start().to_le_bytes().as_slice(),
+            self.new_name_str_id.get().to_le_bytes().as_slice(),
+            self.old_name_str_id.get().to_le_bytes().as_slice(),
+        ])
     }
 
     #[must_use]

--- a/rust/rubydex/src/model/id.rs
+++ b/rust/rubydex/src/model/id.rs
@@ -70,6 +70,18 @@ impl<T> From<&String> for Id<T> {
     }
 }
 
+impl<T, const N: usize> From<[&[u8]; N]> for Id<T> {
+    fn from(parts: [&[u8]; N]) -> Self {
+        let mut hasher = xxh3::Xxh3Default::new();
+
+        for part in parts {
+            hasher.update(part);
+        }
+
+        Self::new(hasher.digest())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -77,6 +89,25 @@ mod tests {
     #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone, Copy)]
     pub struct Marker;
     pub type TestId = Id<Marker>;
+
+    #[test]
+    fn from_byte_slices_matches_concatenated_string() {
+        assert_eq!(
+            TestId::from("foobar"),
+            TestId::from([b"foo".as_slice(), b"bar".as_slice()]),
+        );
+    }
+
+    #[test]
+    fn from_byte_slices_is_deterministic() {
+        let parts: [&[u8]; 2] = [&[1, 2, 3], &[4, 5]];
+        assert_eq!(TestId::from(parts), TestId::from(parts));
+    }
+
+    #[test]
+    fn from_byte_slices_distinguishes_inputs() {
+        assert_ne!(TestId::from([b"foo".as_slice()]), TestId::from([b"bar".as_slice()]),);
+    }
 
     #[test]
     fn test_create_hash() {

--- a/rust/rubydex/src/model/id.rs
+++ b/rust/rubydex/src/model/id.rs
@@ -1,6 +1,14 @@
 use std::{marker::PhantomData, num::NonZeroU64, ops::Deref};
 use xxhash_rust::xxh3;
 
+/// Creates an ID by hashing fixed-width integer components in little-endian order.
+macro_rules! id_from_parts {
+    ($id:ty; $($part:expr),+ $(,)?) => {
+        <$id>::from([$(($part).to_le_bytes().as_slice()),+])
+    };
+}
+pub(crate) use id_from_parts;
+
 /// Maps a u64 hash to a `NonZeroU64` by replacing 0 with `u64::MAX`.
 /// The probability of a 64-bit hash being exactly 0 is 2^-64 (~5.4e-20),
 /// and remapping 0 → MAX just means those two inputs collide — the same
@@ -95,6 +103,22 @@ mod tests {
         assert_eq!(
             TestId::from("foobar"),
             TestId::from([b"foo".as_slice(), b"bar".as_slice()]),
+        );
+    }
+
+    #[test]
+    fn from_parts_matches_mixed_width_byte_slices() {
+        let id = 42_u64;
+        let offset = 7_u32;
+        let tag = 2_u8;
+
+        assert_eq!(
+            TestId::from([
+                id.to_le_bytes().as_slice(),
+                offset.to_le_bytes().as_slice(),
+                tag.to_le_bytes().as_slice(),
+            ]),
+            id_from_parts!(TestId; id, offset, tag),
         );
     }
 

--- a/rust/rubydex/src/model/ids.rs
+++ b/rust/rubydex/src/model/ids.rs
@@ -27,7 +27,11 @@ assert_mem_size!(DefinitionId, 8);
 
 #[must_use]
 pub fn namespace_definition_id(uri_id: UriId, offset: &Offset, name_id: NameId) -> DefinitionId {
-    DefinitionId::from(&format!("{}{}{}", *uri_id, offset.start(), *name_id))
+    DefinitionId::from([
+        uri_id.get().to_le_bytes().as_slice(),
+        offset.start().to_le_bytes().as_slice(),
+        name_id.get().to_le_bytes().as_slice(),
+    ])
 }
 
 #[must_use]
@@ -37,14 +41,25 @@ pub fn method_definition_id(
     str_id: StringId,
     receiver: Option<&Receiver>,
 ) -> DefinitionId {
-    let mut formatted_id = format!("{}{}{}", *uri_id, offset.start(), *str_id);
-    if let Some(receiver) = receiver {
-        match receiver {
-            Receiver::SelfReceiver(def_id) => formatted_id.push_str(&def_id.to_string()),
-            Receiver::ConstantReceiver(name_id) => formatted_id.push_str(&name_id.to_string()),
-        }
+    let uri_bytes = uri_id.get().to_le_bytes();
+    let offset_bytes = offset.start().to_le_bytes();
+    let str_bytes = str_id.get().to_le_bytes();
+
+    match receiver {
+        Some(Receiver::SelfReceiver(def_id)) => DefinitionId::from([
+            uri_bytes.as_slice(),
+            offset_bytes.as_slice(),
+            str_bytes.as_slice(),
+            def_id.get().to_le_bytes().as_slice(),
+        ]),
+        Some(Receiver::ConstantReceiver(name_id)) => DefinitionId::from([
+            uri_bytes.as_slice(),
+            offset_bytes.as_slice(),
+            str_bytes.as_slice(),
+            name_id.get().to_le_bytes().as_slice(),
+        ]),
+        None => DefinitionId::from([uri_bytes.as_slice(), offset_bytes.as_slice(), str_bytes.as_slice()]),
     }
-    DefinitionId::from(&formatted_id)
 }
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone, Copy)]

--- a/rust/rubydex/src/model/ids.rs
+++ b/rust/rubydex/src/model/ids.rs
@@ -1,6 +1,9 @@
 use crate::{
     assert_mem_size,
-    model::{definitions::Receiver, id::Id},
+    model::{
+        definitions::Receiver,
+        id::{Id, id_from_parts},
+    },
     offset::Offset,
 };
 
@@ -27,11 +30,7 @@ assert_mem_size!(DefinitionId, 8);
 
 #[must_use]
 pub fn namespace_definition_id(uri_id: UriId, offset: &Offset, name_id: NameId) -> DefinitionId {
-    DefinitionId::from([
-        uri_id.get().to_le_bytes().as_slice(),
-        offset.start().to_le_bytes().as_slice(),
-        name_id.get().to_le_bytes().as_slice(),
-    ])
+    id_from_parts!(DefinitionId; uri_id.get(), offset.start(), name_id.get())
 }
 
 #[must_use]
@@ -41,24 +40,22 @@ pub fn method_definition_id(
     str_id: StringId,
     receiver: Option<&Receiver>,
 ) -> DefinitionId {
-    let uri_bytes = uri_id.get().to_le_bytes();
-    let offset_bytes = offset.start().to_le_bytes();
-    let str_bytes = str_id.get().to_le_bytes();
-
     match receiver {
-        Some(Receiver::SelfReceiver(def_id)) => DefinitionId::from([
-            uri_bytes.as_slice(),
-            offset_bytes.as_slice(),
-            str_bytes.as_slice(),
-            def_id.get().to_le_bytes().as_slice(),
-        ]),
-        Some(Receiver::ConstantReceiver(name_id)) => DefinitionId::from([
-            uri_bytes.as_slice(),
-            offset_bytes.as_slice(),
-            str_bytes.as_slice(),
-            name_id.get().to_le_bytes().as_slice(),
-        ]),
-        None => DefinitionId::from([uri_bytes.as_slice(), offset_bytes.as_slice(), str_bytes.as_slice()]),
+        Some(Receiver::SelfReceiver(def_id)) => id_from_parts!(
+            DefinitionId;
+            uri_id.get(),
+            offset.start(),
+            str_id.get(),
+            def_id.get(),
+        ),
+        Some(Receiver::ConstantReceiver(name_id)) => id_from_parts!(
+            DefinitionId;
+            uri_id.get(),
+            offset.start(),
+            str_id.get(),
+            name_id.get(),
+        ),
+        None => id_from_parts!(DefinitionId; uri_id.get(), offset.start(), str_id.get()),
     }
 }
 

--- a/rust/rubydex/src/model/name.rs
+++ b/rust/rubydex/src/model/name.rs
@@ -2,7 +2,10 @@ use std::fmt::Display;
 
 use crate::{
     assert_mem_size,
-    model::ids::{DeclarationId, NameId, StringId},
+    model::{
+        id::id_from_parts,
+        ids::{DeclarationId, NameId, StringId},
+    },
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -127,27 +130,19 @@ impl Name {
 
     #[must_use]
     pub fn id(&self) -> NameId {
-        let str_bytes = self.str.get().to_le_bytes();
-
         // We need to include both the variant and the bytes of the parent scope when present
-        let (parent_tag, parent_bytes): (u8, [u8; 8]) = match self.parent_scope {
-            ParentScope::None => (0, [0; 8]),
-            ParentScope::TopLevel => (1, [0; 8]),
-            ParentScope::Some(id) => (2, id.get().to_le_bytes()),
-            ParentScope::Attached(id) => (3, id.get().to_le_bytes()),
+        let (parent_tag, parent_id): (u8, u64) = match self.parent_scope {
+            ParentScope::None => (0, 0),
+            ParentScope::TopLevel => (1, 0),
+            ParentScope::Some(id) => (2, id.get()),
+            ParentScope::Attached(id) => (3, id.get()),
         };
-        let (nesting_tag, nesting_bytes): (u8, [u8; 8]) = match self.nesting {
-            None => (0, [0; 8]),
-            Some(id) => (1, id.get().to_le_bytes()),
+        let (nesting_tag, nesting_id): (u8, u64) = match self.nesting {
+            None => (0, 0),
+            Some(id) => (1, id.get()),
         };
 
-        NameId::from([
-            str_bytes.as_slice(),
-            [parent_tag].as_slice(),
-            parent_bytes.as_slice(),
-            [nesting_tag].as_slice(),
-            nesting_bytes.as_slice(),
-        ])
+        id_from_parts!(NameId; self.str.get(), parent_tag, parent_id, nesting_tag, nesting_id)
     }
 }
 

--- a/rust/rubydex/src/model/name.rs
+++ b/rust/rubydex/src/model/name.rs
@@ -127,12 +127,27 @@ impl Name {
 
     #[must_use]
     pub fn id(&self) -> NameId {
-        NameId::from(&format!(
-            "{}{}{}",
-            self.str,
-            self.parent_scope,
-            self.nesting.map_or(String::from("None"), |id| id.to_string())
-        ))
+        let str_bytes = self.str.get().to_le_bytes();
+
+        // We need to include both the variant and the bytes of the parent scope when present
+        let (parent_tag, parent_bytes): (u8, [u8; 8]) = match self.parent_scope {
+            ParentScope::None => (0, [0; 8]),
+            ParentScope::TopLevel => (1, [0; 8]),
+            ParentScope::Some(id) => (2, id.get().to_le_bytes()),
+            ParentScope::Attached(id) => (3, id.get().to_le_bytes()),
+        };
+        let (nesting_tag, nesting_bytes): (u8, [u8; 8]) = match self.nesting {
+            None => (0, [0; 8]),
+            Some(id) => (1, id.get().to_le_bytes()),
+        };
+
+        NameId::from([
+            str_bytes.as_slice(),
+            [parent_tag].as_slice(),
+            parent_bytes.as_slice(),
+            [nesting_tag].as_slice(),
+            nesting_bytes.as_slice(),
+        ])
     }
 }
 
@@ -296,5 +311,23 @@ mod tests {
             Some(Name::new(StringId::from("Foo"), ParentScope::None, None).id()),
         );
         assert_eq!(name_7.id(), name_8.id());
+    }
+
+    #[test]
+    fn parent_scope_variants_are_distinct() {
+        let inner = Name::new(StringId::from("Foo"), ParentScope::None, None).id();
+
+        let ids = [
+            Name::new(StringId::from("Foo"), ParentScope::None, None).id(),
+            Name::new(StringId::from("Foo"), ParentScope::TopLevel, None).id(),
+            Name::new(StringId::from("Foo"), ParentScope::Some(inner), None).id(),
+            Name::new(StringId::from("Foo"), ParentScope::Attached(inner), None).id(),
+        ];
+
+        for (i, a) in ids.iter().enumerate() {
+            for b in &ids[i + 1..] {
+                assert_ne!(a, b);
+            }
+        }
     }
 }

--- a/rust/rubydex/src/model/references.rs
+++ b/rust/rubydex/src/model/references.rs
@@ -43,13 +43,12 @@ impl ConstantReference {
 
     #[must_use]
     pub fn id(&self) -> ConstantReferenceId {
-        ConstantReferenceId::from(&format!(
-            "{}:{}:{}-{}",
-            self.name_id,
-            self.uri_id,
-            self.offset.start(),
-            self.offset.end()
-        ))
+        ConstantReferenceId::from([
+            self.name_id.get().to_le_bytes().as_slice(),
+            self.uri_id.get().to_le_bytes().as_slice(),
+            self.offset.start().to_le_bytes().as_slice(),
+            self.offset.end().to_le_bytes().as_slice(),
+        ])
     }
 }
 
@@ -100,12 +99,11 @@ impl MethodRef {
 
     #[must_use]
     pub fn id(&self) -> MethodReferenceId {
-        MethodReferenceId::from(&format!(
-            "{}:{}:{}-{}",
-            self.str,
-            self.uri_id,
-            self.offset.start(),
-            self.offset.end()
-        ))
+        MethodReferenceId::from([
+            self.str.get().to_le_bytes().as_slice(),
+            self.uri_id.get().to_le_bytes().as_slice(),
+            self.offset.start().to_le_bytes().as_slice(),
+            self.offset.end().to_le_bytes().as_slice(),
+        ])
     }
 }

--- a/rust/rubydex/src/model/references.rs
+++ b/rust/rubydex/src/model/references.rs
@@ -1,6 +1,9 @@
 use crate::{
     assert_mem_size,
-    model::ids::{ConstantReferenceId, MethodReferenceId, NameId, StringId, UriId},
+    model::{
+        id::id_from_parts,
+        ids::{ConstantReferenceId, MethodReferenceId, NameId, StringId, UriId},
+    },
     offset::Offset,
 };
 
@@ -43,12 +46,13 @@ impl ConstantReference {
 
     #[must_use]
     pub fn id(&self) -> ConstantReferenceId {
-        ConstantReferenceId::from([
-            self.name_id.get().to_le_bytes().as_slice(),
-            self.uri_id.get().to_le_bytes().as_slice(),
-            self.offset.start().to_le_bytes().as_slice(),
-            self.offset.end().to_le_bytes().as_slice(),
-        ])
+        id_from_parts!(
+            ConstantReferenceId;
+            self.name_id.get(),
+            self.uri_id.get(),
+            self.offset.start(),
+            self.offset.end(),
+        )
     }
 }
 
@@ -99,11 +103,12 @@ impl MethodRef {
 
     #[must_use]
     pub fn id(&self) -> MethodReferenceId {
-        MethodReferenceId::from([
-            self.str.get().to_le_bytes().as_slice(),
-            self.uri_id.get().to_le_bytes().as_slice(),
-            self.offset.start().to_le_bytes().as_slice(),
-            self.offset.end().to_le_bytes().as_slice(),
-        ])
+        id_from_parts!(
+            MethodReferenceId;
+            self.str.get(),
+            self.uri_id.get(),
+            self.offset.start(),
+            self.offset.end(),
+        )
     }
 }


### PR DESCRIPTION
Another optimization inspired by #912

In almost every ID, we were producing an intermediate string for interpolation just to immediately use the bytes for hashing. That string allocation is not necessary in most cases.

I split the work by commit:

1. Implement `From` for an array of byte slices. This allows us to take an arbitrary number of byte slices to produce IDs, rather than strings
2. Stop allocating intermediate strings in references
3. Stop allocating intermediate strings in definitions
4. Stop allocating intermediate strings in names

With these 3 in place, the indexing performance is improved by ~5%. We can do the same thing for string interning in the local graph, but I'll put that in a separate PR.