### PR TITLE
Distinguish public_constant from private_constant in diagnostics

### DIFF
--- a/rust/rubydex/src/diagnostic.rs
+++ b/rust/rubydex/src/diagnostic.rs
@@ -103,7 +103,7 @@ rules! {
     DynamicSingletonDefinition;
     DynamicAncestor;
     TopLevelMixinSelf;
-    InvalidPrivateConstant;
+    InvalidConstantVisibility;
     InvalidMethodVisibility;
 
     // Resolution

--- a/rust/rubydex/src/indexing/ruby_indexer.rs
+++ b/rust/rubydex/src/indexing/ruby_indexer.rs
@@ -1182,9 +1182,9 @@ impl<'a> RubyIndexer<'a> {
         let receiver = node.receiver();
         let call_name = String::from_utf8_lossy(node.name().as_slice());
 
-        let receiver_name_id = match receiver {
+        let receiver_name_id = match &receiver {
             Some(ruby_prism::Node::ConstantPathNode { .. } | ruby_prism::Node::ConstantReadNode { .. }) => {
-                self.index_constant_reference(&receiver.unwrap(), true)
+                self.index_constant_reference(receiver.as_ref().unwrap(), true)
             }
             Some(ruby_prism::Node::SelfNode { .. }) | None => match self.nesting_stack.last() {
                 Some(Nesting::Method(_)) => {
@@ -1202,10 +1202,10 @@ impl<'a> RubyIndexer<'a> {
                 }
                 _ => None,
             },
-            _ => {
+            Some(other) => {
                 self.local_graph.add_diagnostic(
                     Rule::InvalidConstantVisibility,
-                    Offset::from_prism_location(&node.location()),
+                    Offset::from_prism_location(&other.location()),
                     format!("Dynamic receiver for `{call_name}`"),
                 );
                 self.visit_call_node_parts(node);

--- a/rust/rubydex/src/indexing/ruby_indexer.rs
+++ b/rust/rubydex/src/indexing/ruby_indexer.rs
@@ -1180,6 +1180,7 @@ impl<'a> RubyIndexer<'a> {
 
     fn handle_constant_visibility(&mut self, node: &ruby_prism::CallNode, visibility: Visibility) {
         let receiver = node.receiver();
+        let call_name = String::from_utf8_lossy(node.name().as_slice());
 
         let receiver_name_id = match receiver {
             Some(ruby_prism::Node::ConstantPathNode { .. } | ruby_prism::Node::ConstantReadNode { .. }) => {
@@ -1194,7 +1195,7 @@ impl<'a> RubyIndexer<'a> {
                     self.local_graph.add_diagnostic(
                         Rule::InvalidPrivateConstant,
                         Offset::from_prism_location(&node.location()),
-                        "Private constant called at top level".to_string(),
+                        format!("`{call_name}` called at top level"),
                     );
                     self.visit_call_node_parts(node);
                     return;
@@ -1205,7 +1206,7 @@ impl<'a> RubyIndexer<'a> {
                 self.local_graph.add_diagnostic(
                     Rule::InvalidPrivateConstant,
                     Offset::from_prism_location(&node.location()),
-                    "Dynamic receiver for private constant".to_string(),
+                    format!("Dynamic receiver for `{call_name}`"),
                 );
                 self.visit_call_node_parts(node);
                 return;
@@ -1221,7 +1222,7 @@ impl<'a> RubyIndexer<'a> {
                 self.local_graph.add_diagnostic(
                     Rule::InvalidPrivateConstant,
                     Offset::from_prism_location(&argument.location()),
-                    "Private constant called with non-symbol argument".to_string(),
+                    format!("`{call_name}` called with a non-literal argument"),
                 );
                 self.visit(&argument);
                 continue;

--- a/rust/rubydex/src/indexing/ruby_indexer.rs
+++ b/rust/rubydex/src/indexing/ruby_indexer.rs
@@ -1193,7 +1193,7 @@ impl<'a> RubyIndexer<'a> {
                 }
                 None => {
                     self.local_graph.add_diagnostic(
-                        Rule::InvalidPrivateConstant,
+                        Rule::InvalidConstantVisibility,
                         Offset::from_prism_location(&node.location()),
                         format!("`{call_name}` called at top level"),
                     );
@@ -1204,7 +1204,7 @@ impl<'a> RubyIndexer<'a> {
             },
             _ => {
                 self.local_graph.add_diagnostic(
-                    Rule::InvalidPrivateConstant,
+                    Rule::InvalidConstantVisibility,
                     Offset::from_prism_location(&node.location()),
                     format!("Dynamic receiver for `{call_name}`"),
                 );
@@ -1220,7 +1220,7 @@ impl<'a> RubyIndexer<'a> {
         for argument in &arguments.arguments() {
             let Some((name, location)) = Self::extract_literal_name(&argument) else {
                 self.local_graph.add_diagnostic(
-                    Rule::InvalidPrivateConstant,
+                    Rule::InvalidConstantVisibility,
                     Offset::from_prism_location(&argument.location()),
                     format!("`{call_name}` called with a non-literal argument"),
                 );

--- a/rust/rubydex/src/indexing/ruby_indexer_tests.rs
+++ b/rust/rubydex/src/indexing/ruby_indexer_tests.rs
@@ -1772,11 +1772,11 @@ mod visibility_tests {
         assert_local_diagnostics_eq!(
             &context,
             vec![
-                "invalid-private-constant: `private_constant` called at top level (1:1-1:30)",
-                "invalid-private-constant: `private_constant` called at top level (2:1-2:35)",
-                "invalid-private-constant: Dynamic receiver for `private_constant` (3:1-3:34)",
-                "invalid-private-constant: `private_constant` called with a non-literal argument (6:20-6:31)",
-                "invalid-private-constant: `private_constant` called with a non-literal argument (6:33-6:44)",
+                "invalid-constant-visibility: `private_constant` called at top level (1:1-1:30)",
+                "invalid-constant-visibility: `private_constant` called at top level (2:1-2:35)",
+                "invalid-constant-visibility: Dynamic receiver for `private_constant` (3:1-3:34)",
+                "invalid-constant-visibility: `private_constant` called with a non-literal argument (6:20-6:31)",
+                "invalid-constant-visibility: `private_constant` called with a non-literal argument (6:33-6:44)",
             ]
         );
 
@@ -1809,11 +1809,11 @@ mod visibility_tests {
         assert_local_diagnostics_eq!(
             &context,
             vec![
-                "invalid-private-constant: `public_constant` called at top level (1:1-1:29)",
-                "invalid-private-constant: `public_constant` called at top level (2:1-2:34)",
-                "invalid-private-constant: Dynamic receiver for `public_constant` (3:1-3:33)",
-                "invalid-private-constant: `public_constant` called with a non-literal argument (6:19-6:30)",
-                "invalid-private-constant: `public_constant` called with a non-literal argument (6:32-6:43)",
+                "invalid-constant-visibility: `public_constant` called at top level (1:1-1:29)",
+                "invalid-constant-visibility: `public_constant` called at top level (2:1-2:34)",
+                "invalid-constant-visibility: Dynamic receiver for `public_constant` (3:1-3:33)",
+                "invalid-constant-visibility: `public_constant` called with a non-literal argument (6:19-6:30)",
+                "invalid-constant-visibility: `public_constant` called with a non-literal argument (6:32-6:43)",
             ]
         );
 

--- a/rust/rubydex/src/indexing/ruby_indexer_tests.rs
+++ b/rust/rubydex/src/indexing/ruby_indexer_tests.rs
@@ -1750,20 +1750,20 @@ mod visibility_tests {
     fn index_private_constant_calls_diagnostics() {
         let context = index_source({
             "
-            private_constant :NOT_INDEXED
-            self.private_constant :NOT_INDEXED
-            foo.private_constant :NOT_INDEXED # not indexed, dynamic receiver
+            private_constant :BAR # not indexed, called at top level
+            self.private_constant :BAR # not indexed, self receiver at top level
+            foo.private_constant :BAR # not indexed, dynamic receiver
 
             module Foo
-              private_constant NOT_INDEXED, not_indexed # not indexed, not a symbol
+              private_constant SomeConst, some_method # not indexed, non-literal arguments
               private_constant # not indexed, no arguments
 
               def self.qux
-                private_constant :Bar # not indexed, dynamic
+                private_constant :BAR # not indexed, inside a method
               end
 
               def foo
-                private_constant :Bar # not indexed, dynamic
+                private_constant :BAR # not indexed, inside a method
               end
             end
             "
@@ -1772,35 +1772,35 @@ mod visibility_tests {
         assert_local_diagnostics_eq!(
             &context,
             vec![
-                "invalid-constant-visibility: `private_constant` called at top level (1:1-1:30)",
-                "invalid-constant-visibility: `private_constant` called at top level (2:1-2:35)",
+                "invalid-constant-visibility: `private_constant` called at top level (1:1-1:22)",
+                "invalid-constant-visibility: `private_constant` called at top level (2:1-2:27)",
                 "invalid-constant-visibility: Dynamic receiver for `private_constant` (3:1-3:4)",
-                "invalid-constant-visibility: `private_constant` called with a non-literal argument (6:20-6:31)",
-                "invalid-constant-visibility: `private_constant` called with a non-literal argument (6:33-6:44)",
+                "invalid-constant-visibility: `private_constant` called with a non-literal argument (6:20-6:29)",
+                "invalid-constant-visibility: `private_constant` called with a non-literal argument (6:31-6:42)",
             ]
         );
 
-        assert_eq!(context.graph().definitions().len(), 3); // Foo, Foo::Qux, Foo#foo
+        assert_eq!(context.graph().definitions().len(), 3); // Foo, Foo.qux, Foo#foo
     }
 
     #[test]
     fn index_public_constant_calls_diagnostics() {
         let context = index_source({
             "
-            public_constant :NOT_INDEXED
-            self.public_constant :NOT_INDEXED
-            foo.public_constant :NOT_INDEXED # not indexed, dynamic receiver
+            public_constant :BAR # not indexed, called at top level
+            self.public_constant :BAR # not indexed, self receiver at top level
+            foo.public_constant :BAR # not indexed, dynamic receiver
 
             module Foo
-              public_constant NOT_INDEXED, not_indexed # not indexed, not a symbol
+              public_constant SomeConst, some_method # not indexed, non-literal arguments
               public_constant # not indexed, no arguments
 
               def self.qux
-                public_constant :Bar # not indexed, dynamic
+                public_constant :BAR # not indexed, inside a method
               end
 
               def foo
-                public_constant :Bar # not indexed, dynamic
+                public_constant :BAR # not indexed, inside a method
               end
             end
             "
@@ -1809,15 +1809,15 @@ mod visibility_tests {
         assert_local_diagnostics_eq!(
             &context,
             vec![
-                "invalid-constant-visibility: `public_constant` called at top level (1:1-1:29)",
-                "invalid-constant-visibility: `public_constant` called at top level (2:1-2:34)",
+                "invalid-constant-visibility: `public_constant` called at top level (1:1-1:21)",
+                "invalid-constant-visibility: `public_constant` called at top level (2:1-2:26)",
                 "invalid-constant-visibility: Dynamic receiver for `public_constant` (3:1-3:4)",
-                "invalid-constant-visibility: `public_constant` called with a non-literal argument (6:19-6:30)",
-                "invalid-constant-visibility: `public_constant` called with a non-literal argument (6:32-6:43)",
+                "invalid-constant-visibility: `public_constant` called with a non-literal argument (6:19-6:28)",
+                "invalid-constant-visibility: `public_constant` called with a non-literal argument (6:30-6:41)",
             ]
         );
 
-        assert_eq!(context.graph().definitions().len(), 3); // Foo, Foo::Qux, Foo#foo
+        assert_eq!(context.graph().definitions().len(), 3); // Foo, Foo.qux, Foo#foo
     }
 
     #[test]

--- a/rust/rubydex/src/indexing/ruby_indexer_tests.rs
+++ b/rust/rubydex/src/indexing/ruby_indexer_tests.rs
@@ -1772,11 +1772,48 @@ mod visibility_tests {
         assert_local_diagnostics_eq!(
             &context,
             vec![
-                "invalid-private-constant: Private constant called at top level (1:1-1:30)",
-                "invalid-private-constant: Private constant called at top level (2:1-2:35)",
-                "invalid-private-constant: Dynamic receiver for private constant (3:1-3:34)",
-                "invalid-private-constant: Private constant called with non-symbol argument (6:20-6:31)",
-                "invalid-private-constant: Private constant called with non-symbol argument (6:33-6:44)",
+                "invalid-private-constant: `private_constant` called at top level (1:1-1:30)",
+                "invalid-private-constant: `private_constant` called at top level (2:1-2:35)",
+                "invalid-private-constant: Dynamic receiver for `private_constant` (3:1-3:34)",
+                "invalid-private-constant: `private_constant` called with a non-literal argument (6:20-6:31)",
+                "invalid-private-constant: `private_constant` called with a non-literal argument (6:33-6:44)",
+            ]
+        );
+
+        assert_eq!(context.graph().definitions().len(), 3); // Foo, Foo::Qux, Foo#foo
+    }
+
+    #[test]
+    fn index_public_constant_calls_diagnostics() {
+        let context = index_source({
+            "
+            public_constant :NOT_INDEXED
+            self.public_constant :NOT_INDEXED
+            foo.public_constant :NOT_INDEXED # not indexed, dynamic receiver
+
+            module Foo
+              public_constant NOT_INDEXED, not_indexed # not indexed, not a symbol
+              public_constant # not indexed, no arguments
+
+              def self.qux
+                public_constant :Bar # not indexed, dynamic
+              end
+
+              def foo
+                public_constant :Bar # not indexed, dynamic
+              end
+            end
+            "
+        });
+
+        assert_local_diagnostics_eq!(
+            &context,
+            vec![
+                "invalid-private-constant: `public_constant` called at top level (1:1-1:29)",
+                "invalid-private-constant: `public_constant` called at top level (2:1-2:34)",
+                "invalid-private-constant: Dynamic receiver for `public_constant` (3:1-3:33)",
+                "invalid-private-constant: `public_constant` called with a non-literal argument (6:19-6:30)",
+                "invalid-private-constant: `public_constant` called with a non-literal argument (6:32-6:43)",
             ]
         );
 

--- a/rust/rubydex/src/indexing/ruby_indexer_tests.rs
+++ b/rust/rubydex/src/indexing/ruby_indexer_tests.rs
@@ -1774,7 +1774,7 @@ mod visibility_tests {
             vec![
                 "invalid-constant-visibility: `private_constant` called at top level (1:1-1:30)",
                 "invalid-constant-visibility: `private_constant` called at top level (2:1-2:35)",
-                "invalid-constant-visibility: Dynamic receiver for `private_constant` (3:1-3:34)",
+                "invalid-constant-visibility: Dynamic receiver for `private_constant` (3:1-3:4)",
                 "invalid-constant-visibility: `private_constant` called with a non-literal argument (6:20-6:31)",
                 "invalid-constant-visibility: `private_constant` called with a non-literal argument (6:33-6:44)",
             ]
@@ -1811,7 +1811,7 @@ mod visibility_tests {
             vec![
                 "invalid-constant-visibility: `public_constant` called at top level (1:1-1:29)",
                 "invalid-constant-visibility: `public_constant` called at top level (2:1-2:34)",
-                "invalid-constant-visibility: Dynamic receiver for `public_constant` (3:1-3:33)",
+                "invalid-constant-visibility: Dynamic receiver for `public_constant` (3:1-3:4)",
                 "invalid-constant-visibility: `public_constant` called with a non-literal argument (6:19-6:30)",
                 "invalid-constant-visibility: `public_constant` called with a non-literal argument (6:32-6:43)",
             ]

--- a/rust/rubydex/src/operation/ruby_builder.rs
+++ b/rust/rubydex/src/operation/ruby_builder.rs
@@ -889,9 +889,9 @@ impl<'a> RubyOperationBuilder<'a> {
         let receiver = node.receiver();
         let call_name = String::from_utf8_lossy(node.name().as_slice());
 
-        let receiver_name_id = match receiver {
+        let receiver_name_id = match &receiver {
             Some(ruby_prism::Node::ConstantPathNode { .. } | ruby_prism::Node::ConstantReadNode { .. }) => {
-                self.index_constant_reference(&receiver.unwrap(), true)
+                self.index_constant_reference(receiver.as_ref().unwrap(), true)
             }
             Some(ruby_prism::Node::SelfNode { .. }) | None => match self.nesting_stack.last() {
                 Some(Nesting::Method { .. }) => return,
@@ -905,10 +905,10 @@ impl<'a> RubyOperationBuilder<'a> {
                 }
                 _ => None,
             },
-            _ => {
+            Some(other) => {
                 self.add_diagnostic(
                     Rule::InvalidConstantVisibility,
-                    Offset::from_prism_location(&node.location()),
+                    Offset::from_prism_location(&other.location()),
                     format!("Dynamic receiver for `{call_name}`"),
                 );
                 return;

--- a/rust/rubydex/src/operation/ruby_builder.rs
+++ b/rust/rubydex/src/operation/ruby_builder.rs
@@ -897,7 +897,7 @@ impl<'a> RubyOperationBuilder<'a> {
                 Some(Nesting::Method { .. }) => return,
                 None => {
                     self.add_diagnostic(
-                        Rule::InvalidPrivateConstant,
+                        Rule::InvalidConstantVisibility,
                         Offset::from_prism_location(&node.location()),
                         format!("`{call_name}` called at top level"),
                     );
@@ -907,7 +907,7 @@ impl<'a> RubyOperationBuilder<'a> {
             },
             _ => {
                 self.add_diagnostic(
-                    Rule::InvalidPrivateConstant,
+                    Rule::InvalidConstantVisibility,
                     Offset::from_prism_location(&node.location()),
                     format!("Dynamic receiver for `{call_name}`"),
                 );
@@ -922,7 +922,7 @@ impl<'a> RubyOperationBuilder<'a> {
         for argument in &arguments.arguments() {
             let Some((name, location)) = Self::extract_literal_name(&argument) else {
                 self.add_diagnostic(
-                    Rule::InvalidPrivateConstant,
+                    Rule::InvalidConstantVisibility,
                     Offset::from_prism_location(&argument.location()),
                     format!("`{call_name}` called with a non-literal argument"),
                 );

--- a/rust/rubydex/src/operation/ruby_builder.rs
+++ b/rust/rubydex/src/operation/ruby_builder.rs
@@ -887,6 +887,7 @@ impl<'a> RubyOperationBuilder<'a> {
 
     fn handle_constant_visibility(&mut self, node: &ruby_prism::CallNode, visibility: Visibility) {
         let receiver = node.receiver();
+        let call_name = String::from_utf8_lossy(node.name().as_slice());
 
         let receiver_name_id = match receiver {
             Some(ruby_prism::Node::ConstantPathNode { .. } | ruby_prism::Node::ConstantReadNode { .. }) => {
@@ -898,7 +899,7 @@ impl<'a> RubyOperationBuilder<'a> {
                     self.add_diagnostic(
                         Rule::InvalidPrivateConstant,
                         Offset::from_prism_location(&node.location()),
-                        "Private constant called at top level".to_string(),
+                        format!("`{call_name}` called at top level"),
                     );
                     return;
                 }
@@ -908,7 +909,7 @@ impl<'a> RubyOperationBuilder<'a> {
                 self.add_diagnostic(
                     Rule::InvalidPrivateConstant,
                     Offset::from_prism_location(&node.location()),
-                    "Dynamic receiver for private constant".to_string(),
+                    format!("Dynamic receiver for `{call_name}`"),
                 );
                 return;
             }
@@ -923,7 +924,7 @@ impl<'a> RubyOperationBuilder<'a> {
                 self.add_diagnostic(
                     Rule::InvalidPrivateConstant,
                     Offset::from_prism_location(&argument.location()),
-                    "Private constant called with non-symbol argument".to_string(),
+                    format!("`{call_name}` called with a non-literal argument"),
                 );
                 continue;
             };


### PR DESCRIPTION
Part of #89, follows #783.

`private_constant` and `public_constant` are validated by the same handler, but its diagnostics hardcoded "private constant". A misused `public_constant` (top-level, dynamic receiver, or non-literal argument) triggered a diagnostic naming the wrong call. For example, `public_constant :FOO` at the top level produced "Private constant called at top level".

The messages now name the actual call, and the rejected-argument message says "non-literal" instead of the inaccurate "non-symbol" (strings are valid arguments too, matching the method-visibility diagnostics). The dynamic-receiver diagnostic now points at the receiver rather than the whole call, since the receiver is what is dynamic, and the rule id is renamed `invalid-constant-visibility` so it fits both calls. The same code is flagged, only the reporting changes.

Both indexer backends (`RubyIndexer` and `RubyOperationBuilder`) get the change, since they share the diagnostic test suite.