### PR TITLE
Mark RBS constants as promotable

### DIFF
--- a/rust/rubydex/src/indexing/rbs_indexer.rs
+++ b/rust/rubydex/src/indexing/rbs_indexer.rs
@@ -495,7 +495,10 @@ impl Visit for RBSIndexer<'_> {
             self.uri_id,
             offset,
             comments,
-            Self::flags(&constant_node.annotations()),
+            // RBS establishes that the constant exists, but its value type is intentionally not
+            // represented in the graph. Treat it like a dynamic Ruby assignment so resolution
+            // may promote it when a namespace or singleton receiver is required.
+            Self::flags(&constant_node.annotations()) | DefinitionFlags::PROMOTABLE,
             lexical_nesting_id,
         )));
 

--- a/rust/rubydex/src/resolution_tests.rs
+++ b/rust/rubydex/src/resolution_tests.rs
@@ -4625,6 +4625,33 @@ mod promotability_tests {
     }
 
     #[test]
+    fn rbs_constant_is_promotable_for_singleton_call() {
+        let mut context = graph_test();
+        context.index_rbs_uri("file:///env.rbs", "ENV: untyped");
+        context.index_uri("file:///env.rb", {
+            r#"
+            ENV.fetch("FEATURE")
+            "#
+        });
+        context.resolve();
+
+        assert_no_diagnostics!(&context);
+        assert_declaration_exists!(context, "ENV::<ENV>");
+
+        let fetch = context
+            .graph()
+            .method_references()
+            .values()
+            .find(|method| *method.str() == "fetch".into())
+            .expect("ENV.fetch should be indexed");
+        let receiver_name_id = fetch.receiver().expect("ENV.fetch should have a receiver");
+        let NameRef::Resolved(receiver) = context.graph().names().get(&receiver_name_id).unwrap() else {
+            panic!("ENV.fetch receiver should resolve");
+        };
+        assert_eq!(*receiver.declaration_id(), DeclarationId::from("ENV::<ENV>"));
+    }
+
+    #[test]
     fn ivar_defined_inside_of_undefined_alias_namespace() {
         let mut context = graph_test();
         context.index_uri("file:///alias.rb", {


### PR DESCRIPTION
Resolving `ENV.fetch` left the synthetic `ENV::<ENV>` namespace unresolved. This occurs only for constants declared in RBS because they are not promotable.

This PR marks RBS constants as *promotable*, like dynamically assigned Ruby constants, so the namespace can be resolved.