### PR TITLE
Preserve singleton hierarchies when concretizing Todos

### DIFF
--- a/rust/rubydex/src/model/graph.rs
+++ b/rust/rubydex/src/model/graph.rs
@@ -206,7 +206,15 @@ impl Graph {
                 if should_promote {
                     let mut new_declaration = constructor(fully_qualified_name);
                     let removed_declaration = occupied_entry.remove();
-                    new_declaration.as_namespace_mut().unwrap().extend(removed_declaration);
+                    let singleton_class_id = removed_declaration
+                        .as_namespace()
+                        .and_then(Namespace::singleton_class)
+                        .copied();
+                    let new_namespace = new_declaration.as_namespace_mut().unwrap();
+                    new_namespace.extend(removed_declaration);
+                    if let Some(singleton_class_id) = singleton_class_id {
+                        new_namespace.set_singleton_class_id(singleton_class_id);
+                    }
                     new_declaration.add_definition(definition_id);
                     self.declarations.insert(declaration_id, new_declaration);
                 } else {

--- a/rust/rubydex/src/resolution.rs
+++ b/rust/rubydex/src/resolution.rs
@@ -228,10 +228,36 @@ impl<'a> Resolver<'a> {
             Outcome::Resolved(id) => {
                 if needs_linearization {
                     self.unit_queue.push_back(Unit::Ancestors(id));
+                    self.relinearize_singleton_hierarchy(id);
                 }
                 self.made_progress = true;
             }
         }
+    }
+
+    /// Clears and re-enqueues the ancestors of a declaration's singleton class and all of its higher-order singleton
+    /// classes. A later class or module definition can change their parent hierarchy.
+    fn relinearize_singleton_hierarchy(&mut self, declaration_id: DeclarationId) {
+        let Some(singleton_id) = self
+            .graph
+            .declarations()
+            .get(&declaration_id)
+            .and_then(|declaration| declaration.as_namespace())
+            .and_then(|namespace| namespace.singleton_class())
+            .copied()
+        else {
+            return;
+        };
+
+        self.graph
+            .declarations_mut()
+            .get_mut(&singleton_id)
+            .unwrap()
+            .as_namespace_mut()
+            .unwrap()
+            .clear_ancestors();
+        self.unit_queue.push_back(Unit::Ancestors(singleton_id));
+        self.relinearize_singleton_hierarchy(singleton_id);
     }
 
     /// Handles a unit of work for resolving a constant reference

--- a/rust/rubydex/src/resolution_tests.rs
+++ b/rust/rubydex/src/resolution_tests.rs
@@ -4653,6 +4653,104 @@ mod promotability_tests {
     }
 
     #[test]
+    fn singleton_on_todo_is_preserved_and_relinearized_when_promoted_to_class() {
+        let mut context = graph_test();
+        context.index_uri("file:///placeholder.rb", "class Foo::Placeholder; end");
+        context.resolve();
+
+        assert_declaration_kind_eq!(context, "Foo", "<TODO>");
+
+        context.index_uri("file:///value.rb", "Foo.call");
+        context.resolve();
+
+        assert_singleton_class_eq!(context, "Foo", "Foo::<Foo>");
+
+        context.index_uri("file:///class.rb", "class Foo; end");
+        context.resolve();
+
+        assert_declaration_kind_eq!(context, "Foo", "Class");
+        assert_singleton_class_eq!(context, "Foo", "Foo::<Foo>");
+        assert_ancestors_eq!(
+            context,
+            "Foo::<Foo>",
+            [
+                "Foo::<Foo>",
+                "Object::<Object>",
+                "BasicObject::<BasicObject>",
+                "Class",
+                "Module",
+                "Object",
+                "Kernel",
+                "BasicObject"
+            ]
+        );
+    }
+
+    #[test]
+    fn singleton_on_todo_is_preserved_when_promoted_to_module() {
+        let mut context = graph_test();
+        context.index_uri("file:///placeholder.rb", "class Bar::Placeholder; end");
+        context.resolve();
+
+        assert_declaration_kind_eq!(context, "Bar", "<TODO>");
+
+        context.index_uri("file:///value.rb", "Bar.call");
+        context.resolve();
+
+        assert_singleton_class_eq!(context, "Bar", "Bar::<Bar>");
+
+        context.index_uri("file:///module.rb", "module Bar; end");
+        context.resolve();
+
+        assert_declaration_kind_eq!(context, "Bar", "Module");
+        assert_singleton_class_eq!(context, "Bar", "Bar::<Bar>");
+        assert_ancestors_eq!(
+            context,
+            "Bar::<Bar>",
+            ["Bar::<Bar>", "Module", "Object", "Kernel", "BasicObject"]
+        );
+    }
+
+    #[test]
+    fn higher_order_singleton_on_todo_is_relinearized_when_promoted_to_class() {
+        let mut context = graph_test();
+        context.index_uri("file:///placeholder.rb", "class Foo::Placeholder; end");
+        context.resolve();
+
+        context.index_uri("file:///value.rb", {
+            r"
+            class << Foo
+              class << self
+              end
+            end
+            "
+        });
+        context.resolve();
+
+        context.index_uri("file:///class.rb", "class Foo; end");
+        context.resolve();
+
+        assert_ancestors_eq!(
+            context,
+            "Foo::<Foo>::<<Foo>>",
+            [
+                "Foo::<Foo>::<<Foo>>",
+                "Object::<Object>::<<Object>>",
+                "BasicObject::<BasicObject>::<<BasicObject>>",
+                "Class::<Class>",
+                "Module::<Module>",
+                "Object::<Object>",
+                "BasicObject::<BasicObject>",
+                "Class",
+                "Module",
+                "Object",
+                "Kernel",
+                "BasicObject"
+            ]
+        );
+    }
+
+    #[test]
     fn ivar_defined_inside_of_undefined_alias_namespace() {
         let mut context = graph_test();
         context.index_uri("file:///alias.rb", {


### PR DESCRIPTION
When a `Todo` namespace is later replaced by an explicit `class` or `module`, preserve its singleton hierarchy and relinearize ancestor chains.

This covers the direct singleton class and any higher-order singleton classes.