### PR TITLE
Promote promotable constants to Todo namespaces

### DIFF
--- a/rust/rubydex/src/resolution.rs
+++ b/rust/rubydex/src/resolution.rs
@@ -850,7 +850,7 @@ impl<'a> Resolver<'a> {
     /// Gets or creates a singleton class declaration for a given class/module declaration.  For class `Foo`, this
     /// returns the declaration for `Foo::<Foo>`.
     ///
-    /// If the declaration is a `Constant` with all-promotable definitions, it is automatically promoted to a `Class`
+    /// If the declaration is a `Constant` with all-promotable definitions, it is automatically promoted to an unknown
     /// namespace before creating the singleton. Returns `None` if the declaration is not a namespace and cannot be
     /// promoted (e.g., `FOO = 42`).
     /// `ancestors` controls how the singleton's ancestor chain is scheduled for linearization —
@@ -874,7 +874,7 @@ impl<'a> Resolver<'a> {
         if matches!(attached_decl, Declaration::Constant(_)) {
             if self.graph.all_definitions_promotable(attached_decl) {
                 self.graph.promote_constant_to_namespace(attached_id, |name, owner_id| {
-                    Declaration::Namespace(Namespace::Module(Box::new(ModuleDeclaration::new(name, owner_id))))
+                    Declaration::Namespace(Namespace::Todo(Box::new(TodoDeclaration::new(name, owner_id))))
                 });
 
                 self.schedule_singleton_ancestors(attached_id, mode);
@@ -1282,8 +1282,8 @@ impl<'a> Resolver<'a> {
             Outcome::Resolved(owner_id) => {
                 let mut fully_qualified_name = self.graph.strings().get(&str_id).unwrap().to_string();
 
-                // If the owner is a promotable constant and something is being defined inside it, promote it to a
-                // module
+                // If the owner is a promotable constant and something is being defined inside it, promote it to an
+                // unknown namespace. A later explicit class or module definition selects the concrete kind.
                 {
                     let owner = self.graph.declarations().get(&owner_id).unwrap();
                     let is_promotable_constant =
@@ -1291,7 +1291,7 @@ impl<'a> Resolver<'a> {
 
                     if is_promotable_constant {
                         self.graph.promote_constant_to_namespace(owner_id, |name, owner_id| {
-                            Declaration::Namespace(Namespace::Module(Box::new(ModuleDeclaration::new(name, owner_id))))
+                            Declaration::Namespace(Namespace::Todo(Box::new(TodoDeclaration::new(name, owner_id))))
                         });
                         self.unit_queue.push_back(Unit::Ancestors(owner_id));
                     }
@@ -2028,7 +2028,8 @@ impl<'a> Resolver<'a> {
         let decl = self.graph.declarations().get(&attached_id).unwrap();
 
         match decl {
-            Declaration::Namespace(Namespace::Module(_)) => (*MODULE_ID, false),
+            // Todo may later become a class or module. Until then, use Module as the singleton-parent fallback.
+            Declaration::Namespace(Namespace::Module(_) | Namespace::Todo(_)) => (*MODULE_ID, false),
             Declaration::Namespace(Namespace::SingletonClass(_)) => {
                 // For singleton classes, we keep recursively wrapping parents until we can reach the original attached
                 // object

--- a/rust/rubydex/src/resolution_tests.rs
+++ b/rust/rubydex/src/resolution_tests.rs
@@ -4484,6 +4484,7 @@ mod promotability_tests {
 
         context.resolve();
         assert_no_diagnostics!(&context);
+        assert_declaration_kind_eq!(context, "Qux", "<TODO>");
         assert_declaration_exists!(context, "Qux::<Qux>");
     }
 
@@ -4519,9 +4520,8 @@ mod promotability_tests {
 
     #[test]
     fn promoted_constant_has_correct_ancestors() {
-        // When a promotable constant is auto-promoted via singleton class access, we conservatively
-        // promote to a module (not a class) since we don't know what the call returns.
-        // Modules don't inherit from Object.
+        // When a promotable constant is auto-promoted via singleton class access, its kind remains unknown.
+        // Todos do not inherit from Object.
         let mut context = graph_test();
         context.index_uri("file:///foo.rb", {
             r"
@@ -4532,6 +4532,7 @@ mod promotability_tests {
 
         context.resolve();
         assert_no_diagnostics!(&context);
+        assert_declaration_kind_eq!(context, "Foo", "<TODO>");
         assert_ancestors_eq!(context, "Foo", ["Foo"]);
     }
 
@@ -4582,8 +4583,8 @@ mod promotability_tests {
         });
 
         context.resolve();
-        assert_declaration_kind_eq!(context, "Foo", "Module");
-        assert_declaration_kind_eq!(context, "Foo::Bar", "Module");
+        assert_declaration_kind_eq!(context, "Foo", "<TODO>");
+        assert_declaration_kind_eq!(context, "Foo::Bar", "<TODO>");
         assert_declaration_kind_eq!(context, "Foo::Bar::Baz", "Constant");
     }
 
@@ -4601,7 +4602,7 @@ mod promotability_tests {
         });
 
         context.resolve();
-        assert_declaration_kind_eq!(context, "Foo", "Module");
+        assert_declaration_kind_eq!(context, "Foo", "<TODO>");
         assert_declaration_exists!(context, "Foo::<Foo>#bar()");
     }
 


### PR DESCRIPTION
Promotable constants do not have a known class or module kind. When resolution needs a namespace or singleton receiver, promote them to a `Todo` namespace rather than assuming `Module`.

A later explicit `class` or `module` declaration can establish the concrete kind.