### PR TITLE
Link to API documentation from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 This project is a high-performance static analysis toolkit for the Ruby language. The goal is to be a solid
 foundation to power a variety of tools, such as type checkers, linters, language servers and more.
 
+[Ruby API Documentation](https://shopify.github.io/rubydex/)
+
 ## Usage
 
 Both Ruby and Rust APIs are made available through a gem and a crate, respectively. Here's a simple example


### PR DESCRIPTION
Putting the documentation link in readme allows both developers and AI agents find them more easily.