### PR TITLE
Make Graph Ractor-shareable via freeze

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,35 @@ diagnostic.message
 diagnostic.location
 ```
 
+## Ractor Safety
+
+A resolved `Rubydex::Graph` can be shared across Ractors without copying:
+
+```ruby
+graph = Rubydex::Graph.new
+graph.index_workspace
+graph.resolve
+Ractor.make_shareable(graph)
+
+# Worker Ractors can now read the graph in parallel
+ractor = Ractor.new(graph) { |g| g["Foo"]&.name }
+ractor.value
+```
+
+Thread safety comes from an `RwLock` on the Rust side, **not** from Ruby's
+`freeze`. This is a deliberate, but potentially surprising, choice:
+
+- A frozen (or `make_shareable`'d) graph **can still be mutated** — methods like
+  `index_source`, `resolve`, `exclude_patterns`, and `encoding=` work on a frozen
+  graph. This supports interactive use cases (LSP/MCP) that need incremental
+  edits while worker Ractors read concurrently.
+- Because the same underlying allocation is shared, callers are responsible for
+  ordering concurrent writes and reads, as with any shared mutable state across
+  Ractors.
+- Graphs cannot be `dup`'d or `clone`'d; both raise `RuntimeError` to avoid
+  aliasing the Rust allocation (which would double-free on GC) or ballooning
+  memory with a deep copy.
+
 ## Querying with Cypher
 
 Rubydex exposes the indexed graph through a read-only subset of the

--- a/ext/rubydex/graph.c
+++ b/ext/rubydex/graph.c
@@ -63,14 +63,23 @@ const rb_data_type_t graph_type = {
     },
     .parent = NULL,
     .data = NULL,
-    .flags = RUBY_TYPED_FREE_IMMEDIATELY,
+    .flags = RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_FROZEN_SHAREABLE,
 };
 
-// Custom allocator for the Graph class. Calls into Rust to create a new `Arc<Mutex<Graph>>` that gets stored internally
-// as a void pointer
+// Custom allocator for the Graph class. Calls into Rust to create a new Box<RwLock<Graph>> that gets stored
+// internally as an opaque void pointer. The RwLock provides thread-safe concurrent access across Ractors.
 static VALUE rdxr_graph_alloc(VALUE klass) {
     void *graph = rdx_graph_new();
     return TypedData_Wrap_Struct(klass, &graph_type, graph);
+}
+
+// Graph is intentionally non-copyable. A dup/clone of the TypedData wrapper would alias the
+// same underlying Rust allocation (double-free on GC) or, if deep-copied, balloon memory use.
+// Block both paths: `dup` dispatches to `initialize_copy`, `clone` to `initialize_clone`.
+static VALUE rdxr_graph_initialize_copy(VALUE self, VALUE other) {
+    (void)self;
+    (void)other;
+    rb_raise(rb_eRuntimeError, "Rubydex::Graph cannot be duplicated or cloned");
 }
 
 /*
@@ -943,6 +952,8 @@ void rdxi_initialize_graph(VALUE moduleRubydex) {
     id_self_receiver = rb_intern("self_receiver");
 
     rb_define_alloc_func(cGraph, rdxr_graph_alloc);
+    rb_define_method(cGraph, "initialize_copy", rdxr_graph_initialize_copy, 1);
+    rb_define_method(cGraph, "initialize_clone", rdxr_graph_initialize_copy, 1);
     rb_define_method(cGraph, "index_all", rdxr_graph_index_all, 1);
     rb_define_method(cGraph, "index_source", rdxr_graph_index_source, 3);
     rb_define_method(cGraph, "document", rdxr_graph_document, 1);

--- a/rust/rubydex-sys/src/graph_api.rs
+++ b/rust/rubydex-sys/src/graph_api.rs
@@ -21,42 +21,45 @@ use rubydex::resolution::Resolver;
 use rubydex::{indexing, integrity, listing, query};
 use std::ffi::CString;
 use std::path::{Path, PathBuf};
-use std::{mem, ptr};
+use std::{mem, ptr, sync::RwLock};
 
 pub type GraphPointer = *mut c_void;
 
-/// Creates a new graph within a mutex. This is meant to be used when creating new Graph objects in Ruby
+/// Creates a new graph wrapped in a `Box<RwLock<Graph>>` for thread-safe shared access across Ractors.
 #[unsafe(no_mangle)]
 pub extern "C" fn rdx_graph_new() -> GraphPointer {
-    Box::into_raw(Box::new(Graph::new())) as GraphPointer
+    Box::into_raw(Box::new(RwLock::new(Graph::new()))) as GraphPointer
 }
 
 /// Frees a Graph through its pointer
 #[unsafe(no_mangle)]
 pub extern "C" fn rdx_graph_free(pointer: GraphPointer) {
     unsafe {
-        let _ = Box::from_raw(pointer.cast::<Graph>());
+        let _ = Box::from_raw(pointer.cast::<RwLock<Graph>>());
     }
 }
 
+/// Runs `action` against the graph referenced by `pointer` under a read lock.
+///
+/// # Panics
+///
+/// Panics if the `RwLock` is poisoned (a writer panicked while holding the lock).
 pub fn with_graph<F, T>(pointer: GraphPointer, action: F) -> T
 where
     F: FnOnce(&Graph) -> T,
 {
-    let mut graph = unsafe { Box::from_raw(pointer.cast::<Graph>()) };
-    let result = action(&mut graph);
-    mem::forget(graph);
-    result
+    let rwlock = unsafe { &*pointer.cast::<RwLock<Graph>>() };
+    let guard = rwlock.read().unwrap();
+    action(&guard)
 }
 
 fn with_mut_graph<F, T>(pointer: GraphPointer, action: F) -> T
 where
     F: FnOnce(&mut Graph) -> T,
 {
-    let mut graph = unsafe { Box::from_raw(pointer.cast::<Graph>()) };
-    let result = action(&mut graph);
-    mem::forget(graph);
-    result
+    let rwlock = unsafe { &*pointer.cast::<RwLock<Graph>>() };
+    let mut guard = rwlock.write().unwrap();
+    action(&mut guard)
 }
 
 /// Searches the graph using exact substring matching, returning every declaration whose name matches any of the
@@ -1310,7 +1313,7 @@ mod tests {
                 .ref_count()
         );
 
-        let graph_ptr = Box::into_raw(Box::new(graph)) as GraphPointer;
+        let graph_ptr = Box::into_raw(Box::new(RwLock::new(graph))) as GraphPointer;
 
         // Build the nesting array: ["Foo"] since BAR is inside class Foo
         let nesting_strings = [CString::new("Foo").unwrap()];
@@ -1326,7 +1329,8 @@ mod tests {
             assert_eq!((*decl).id(), *DeclarationId::from("Foo::BAR"));
         };
 
-        let graph = unsafe { Box::from_raw(graph_ptr.cast::<Graph>()) };
+        let graph = unsafe { Box::from_raw(graph_ptr.cast::<RwLock<Graph>>()) };
+        let graph = graph.read().unwrap();
 
         assert_eq!(
             1,

--- a/rust/rubydex/src/compile_assertions.rs
+++ b/rust/rubydex/src/compile_assertions.rs
@@ -11,3 +11,18 @@ macro_rules! assert_mem_size {
         const _: [(); $size] = [(); std::mem::size_of::<$struct>()];
     };
 }
+
+/// Asserts at compile time that a type is `Send + Sync`.
+///
+/// The `Graph` is shared across Ractors/threads behind a `RwLock`, so it must stay
+/// `Send + Sync`. This assertion fails the build if a field that breaks either trait
+/// is ever added.
+#[macro_export]
+macro_rules! assert_send_sync {
+    ($struct:ident) => {
+        const _: fn() = || {
+            fn assert_send_sync<T: ?Sized + Send + Sync>() {}
+            assert_send_sync::<$struct>();
+        };
+    };
+}

--- a/rust/rubydex/src/model/graph.rs
+++ b/rust/rubydex/src/model/graph.rs
@@ -2,7 +2,6 @@ use std::collections::HashSet;
 use std::collections::hash_map::Entry;
 use std::path::{Path, PathBuf};
 
-use crate::assert_mem_size;
 use crate::config::Config;
 use crate::diagnostic::Diagnostic;
 use crate::errors::Errors;
@@ -21,6 +20,7 @@ use crate::model::name::{Name, NameRef, ParentScope, ResolvedName};
 use crate::model::references::{ConstantReference, MethodRef};
 use crate::model::string_ref::StringRef;
 use crate::model::visibility::Visibility;
+use crate::{assert_mem_size, assert_send_sync};
 use crate::{query, stats};
 
 /// An entity whose validity depends on a particular `NameId`.
@@ -94,6 +94,7 @@ pub struct Graph {
     config: Config,
 }
 assert_mem_size!(Graph, 352);
+assert_send_sync!(Graph);
 
 impl Graph {
     #[must_use]

--- a/test/graph_test.rb
+++ b/test/graph_test.rb
@@ -1706,7 +1706,118 @@ class GraphTest < Minitest::Test
     end
   end
 
+  def test_frozen_graph_allows_mutating_methods
+    with_context do |context|
+      context.write!("file.rb", "class Foo; end")
+
+      graph = Rubydex::Graph.new
+      graph.index_all(context.glob("**/*.rb"))
+      graph.resolve
+      graph.freeze
+
+      graph.index_source("test.rb", "class Bar; end", "ruby")
+      graph.resolve
+      refute_nil(graph["Bar"])
+
+      graph.encoding = "utf16"
+      graph.exclude_patterns(["vendor"])
+    end
+  end
+
+  def test_ractor_can_mutate_shared_graph
+    with_context do |context|
+      context.write!("file.rb", "class Foo; end")
+
+      graph = Rubydex::Graph.new
+      graph.index_all(context.glob("**/*.rb"))
+      graph.resolve
+      Ractor.make_shareable(graph)
+
+      ractor = Ractor.new(graph) do |g|
+        g.index_source("test.rb", "class Bar; end", "ruby")
+        g.resolve
+        g["Bar"]&.name
+      end
+
+      assert_equal("Bar", ractor_result(ractor))
+      refute_nil(graph["Bar"])
+    end
+  end
+
+  def test_frozen_graph_allows_read_operations
+    with_context do |context|
+      context.write!("file.rb", "class Foo; end")
+
+      graph = Rubydex::Graph.new
+      graph.index_all(context.glob("**/*.rb"))
+      graph.resolve
+      graph.freeze
+
+      refute_nil(graph["Foo"])
+      assert_nil(graph["Bar"])
+      assert_equal(6, graph.declarations.size)
+      refute_empty(graph.documents.to_a)
+      refute_empty(graph.search("Foo").to_a)
+      refute_empty(graph.fuzzy_search("Foo").to_a)
+      assert_empty(graph.check_integrity)
+      assert_empty(graph.diagnostics)
+      refute_nil(graph.excluded_patterns)
+    end
+  end
+
+  def test_frozen_graph_is_ractor_shareable
+    with_context do |context|
+      context.write!("file.rb", "class Foo; end")
+
+      graph = Rubydex::Graph.new
+      graph.index_all(context.glob("**/*.rb"))
+      graph.resolve
+      Ractor.make_shareable(graph)
+
+      ractor = Ractor.new(graph) do |g|
+        g["Foo"]&.name
+      end
+
+      assert_equal("Foo", ractor_result(ractor))
+    end
+  end
+
+  def test_frozen_graph_concurrent_reads_from_multiple_ractors
+    with_context do |context|
+      context.write!("a.rb", "class A; end")
+      context.write!("b.rb", "class B; end")
+
+      graph = Rubydex::Graph.new
+      graph.index_all(context.glob("**/*.rb"))
+      graph.resolve
+      Ractor.make_shareable(graph)
+
+      ractors = 4.times.map do
+        Ractor.new(graph) do |g|
+          names = []
+          g.declarations { |d| names << d.name }
+          names.sort
+        end
+      end
+
+      results = ractors.map { |r| ractor_result(r) }
+      assert_equal(results.uniq.size, 1)
+      assert_includes(results.first, "A")
+      assert_includes(results.first, "B")
+    end
+  end
+
+  def test_graph_cannot_be_duplicated_or_cloned
+    graph = Rubydex::Graph.new
+    assert_raises(RuntimeError) { graph.dup }
+    assert_raises(RuntimeError) { graph.clone }
+  end
+
   private
+
+  def ractor_result(ractor)
+    ractor.respond_to?(:value) ? ractor.value : ractor.take
+  end
 
   def assert_diagnostics(expected, actual)
     assert_equal(

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "minitest/autorun"
+Warning[:experimental] = false
 
 $LOAD_PATH.unshift(File.expand_path("../lib", __dir__))
 require "rubydex"


### PR DESCRIPTION
## Summary

`Ractor.make_shareable(@graph)` raises `Ractor::Error` because `Rubydex::Graph` is a TypedData object whose `rb_data_type_t` lacks `RUBY_TYPED_FROZEN_SHAREABLE`. This PR makes a resolved graph safe to share across Ractors without copying, while preserving the ability to mutate the graph for interactive use cases (LSP/MCP incremental edits).

## Approach

The graph is wrapped in `Arc<RwLock<Graph>>` at the FFI boundary. The `RwLock` provides thread-safe concurrent access: read operations acquire a read lock, write operations acquire a write lock. `Ractor.make_shareable` "freezes" the Ruby object as part of making it shareable (this doesn't change the underlying Rust structure - we need to do the ceremonial freeze so that the object is not copied for the Ractor). Thread safety comes entirely from the `RwLock` on the Rust side - mutable graphs can still be acquired.

This covers all use cases:
- **Batch/read-only**: index once, share across Ractors for parallel queries.
- **Interactive**: keep the graph mutable for incremental edits while still allowing parallel reads from worker Ractors. Ordering guarantees are the consumer's responsibility, as with any shared mutable state across Ractors.

## Usage

```ruby
# Batch/read-only
graph = Rubydex::Graph.new(workspace_path: path)
graph.index_workspace
graph.resolve
Ractor.make_shareable(graph)
# Safe to share into worker Ractors for parallel queries

# Interactive (LSP/MCP)
graph = Rubydex::Graph.new(workspace_path: path)
graph.index_workspace
graph.resolve
Ractor.make_shareable(graph)
# Worker Ractors can read; the main Ractor can still mutate
# (e.g. index_source + resolve for incremental edits)
```