### PR TITLE
Add `Location#short_path`

### DIFF
--- a/lib/rubydex.rb
+++ b/lib/rubydex.rb
@@ -2,6 +2,7 @@
 
 require "bundler"
 require "uri"
+require "pathname"
 require "rubydex/version"
 require "rubydex/mixin"
 

--- a/lib/rubydex/location.rb
+++ b/lib/rubydex/location.rb
@@ -47,6 +47,15 @@ module Rubydex
       path
     end
 
+    # Returns the relative path for a file URI or the opaque for an untitled URI.
+    #
+    #: () -> String
+    def short_path
+      Pathname.new(to_file_path).relative_path_from(Dir.pwd).to_s
+    rescue Rubydex::Location::NotFileUriError
+      URI(@uri).opaque #: as !nil
+    end
+
     #: (other: BasicObject) -> Integer
     def <=>(other)
       return -1 unless other.is_a?(Location)

--- a/rbi/rubydex.rbi
+++ b/rbi/rubydex.rbi
@@ -494,6 +494,9 @@ class Rubydex::Location
   sig { returns(String) }
   def to_file_path; end
 
+  sig { returns(String) }
+  def short_path; end
+
   sig { returns(Integer) }
   def start_column; end
 

--- a/test/location_test.rb
+++ b/test/location_test.rb
@@ -94,6 +94,26 @@ class LocationTest < Minitest::Test
     assert_equal("#{loc.to_file_path}:1:4-6:11", loc.to_s)
   end
 
+  def test_short_path_returns_relative_path_for_file_uri
+    absolute_path = File.join(Dir.pwd, "some", "nested", "file.rb")
+    uri = Gem.win_platform? ? "file:///#{absolute_path}" : "file://#{absolute_path}"
+    loc = Rubydex::Location.new(uri: uri, start_line: 0, end_line: 0, start_column: 0, end_column: 0)
+
+    assert_equal("some/nested/file.rb", loc.short_path)
+  end
+
+  def test_short_path_returns_opaque_for_non_file_uri
+    loc = Rubydex::Location.new(
+      uri: "untitled:Untitled-1",
+      start_line: 0,
+      end_line: 0,
+      start_column: 0,
+      end_column: 0,
+    )
+
+    assert_equal("Untitled-1", loc.short_path)
+  end
+
   def test_display_location_equality
     a = Rubydex::DisplayLocation.new(uri: "file:///foo.rb", start_line: 1, end_line: 1, start_column: 1, end_column: 6)
     b = Rubydex::DisplayLocation.new(uri: "file:///foo.rb", start_line: 1, end_line: 1, start_column: 1, end_column: 6)


### PR DESCRIPTION
A small helper to return a "short path" (or maybe short name?) for a URI. When it's a file URI, we use the path relative to the PWD. If it's an `untitled` URI, we use the opaque (e.g.: `untitled:Untitled-1` -> `Untitled-1`).