### PR TITLE
Move existing singleton check earlier

### DIFF
--- a/rust/rubydex/src/resolution.rs
+++ b/rust/rubydex/src/resolution.rs
@@ -877,6 +877,10 @@ impl<'a> Resolver<'a> {
     ) -> Option<DeclarationId> {
         let attached_decl = self.graph.declarations().get(&attached_id).unwrap();
 
+        if let Some(singleton_id) = attached_decl.as_namespace().and_then(|d| d.singleton_class()) {
+            return Some(*singleton_id);
+        }
+
         // If the attached object is a constant alias, follow the alias chain to find the actual namespace
         if matches!(attached_decl, Declaration::ConstantAlias(_)) {
             return match self.resolve_to_namespace(attached_id) {
@@ -903,10 +907,6 @@ impl<'a> Resolver<'a> {
         let namespace_decl = attached_decl
             .as_namespace_mut()
             .expect("constants are handled above; all other callers pass namespace declarations");
-
-        if let Some(singleton_id) = namespace_decl.singleton_class() {
-            return Some(*singleton_id);
-        }
 
         let decl_id = DeclarationId::from(&fully_qualified_name);
         namespace_decl.set_singleton_class_id(decl_id);


### PR DESCRIPTION
A micro performance change with good impact: our check for an existing singleton class was not early enough in the method, which means we performed unnecessary work before returning.

By moving the check a few lines above, we save about 12% resolution time.