### PR TITLE
Remove stale .mcp.json configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ rust/THIRD_PARTY_LICENSES.html
 lib/rubydex/*.dylib
 lib/rubydex/*.so
 lib/rubydex/bin/
+.mcp.json

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,7 +1,0 @@
-{
-  "mcpServers": {
-    "rubydex": {
-      "command": "${HOME}/.cargo/bin/rubydex_mcp"
-    }
-  }
-}


### PR DESCRIPTION
Remove the checked-in .mcp.json and add it to .gitignore so contributors can maintain their own local MCP configuration.