### PR TITLE
Eagerly compute name depths into `Name`

### DIFF
--- a/rust/rubydex-sys/src/name_api.rs
+++ b/rust/rubydex-sys/src/name_api.rs
@@ -1,8 +1,4 @@
-use rubydex::model::{
-    graph::Graph,
-    ids::NameId,
-    name::{Name, ParentScope},
-};
+use rubydex::model::{graph::Graph, ids::NameId, name::ParentScope};
 
 /// Takes a constant name and a nesting stack (e.g.: `["Foo", "Bar::Baz", "Qux"]`) and transforms it into a `NameId`,
 /// registering each required part in the graph. Returns the `NameId` and a list of name ids that need to be untracked
@@ -74,7 +70,7 @@ fn process_qualified_name(
         };
 
         let str_id = graph.intern_string(part.to_owned());
-        let name_id = graph.add_name(Name::new(str_id, parent_scope, nesting_for_part));
+        let name_id = graph.add_name(str_id, parent_scope, nesting_for_part);
         names_to_untrack.push(name_id);
         *current_name = ParentScope::Some(name_id);
     }

--- a/rust/rubydex/src/indexing/local_graph.rs
+++ b/rust/rubydex/src/indexing/local_graph.rs
@@ -6,7 +6,7 @@ use crate::model::document::Document;
 use crate::model::graph::NameDependent;
 use crate::model::identity_maps::IdentityHashMap;
 use crate::model::ids::{ConstantReferenceId, DefinitionId, MethodReferenceId, NameId, StringId, UriId};
-use crate::model::name::{Name, NameRef};
+use crate::model::name::{Name, NameRef, ParentScope};
 use crate::model::references::{ConstantReference, MethodRef};
 use crate::model::string_ref::StringRef;
 use crate::offset::Offset;
@@ -119,7 +119,13 @@ impl LocalGraph {
         &self.names
     }
 
-    pub fn add_name(&mut self, name: Name) -> NameId {
+    pub fn add_name(&mut self, str: StringId, parent_scope: ParentScope, nesting: Option<NameId>) -> NameId {
+        let name = Name::new(
+            str,
+            parent_scope,
+            nesting,
+            Name::name_depth(&self.names, parent_scope, nesting),
+        );
         let name_id = name.id();
 
         match self.names.entry(name_id) {
@@ -128,13 +134,13 @@ impl LocalGraph {
                 entry.get_mut().increment_ref_count(1);
             }
             Entry::Vacant(entry) => {
-                if let Some(&parent_scope) = name.parent_scope().as_ref() {
+                if let Some(&parent_scope_id) = parent_scope.as_ref() {
                     self.name_dependents
-                        .entry(parent_scope)
+                        .entry(parent_scope_id)
                         .or_default()
                         .push(NameDependent::ChildName(name_id));
                 }
-                if let Some(&nesting_id) = name.nesting().as_ref() {
+                if let Some(nesting_id) = nesting {
                     self.name_dependents
                         .entry(nesting_id)
                         .or_default()

--- a/rust/rubydex/src/indexing/local_graph.rs
+++ b/rust/rubydex/src/indexing/local_graph.rs
@@ -120,12 +120,7 @@ impl LocalGraph {
     }
 
     pub fn add_name(&mut self, str: StringId, parent_scope: ParentScope, nesting: Option<NameId>) -> NameId {
-        let name = Name::new(
-            str,
-            parent_scope,
-            nesting,
-            Name::name_depth(&self.names, parent_scope, nesting),
-        );
+        let name = Name::new(&self.names, str, parent_scope, nesting);
         let name_id = name.id();
 
         match self.names.entry(name_id) {

--- a/rust/rubydex/src/indexing/rbs_indexer.rs
+++ b/rust/rubydex/src/indexing/rbs_indexer.rs
@@ -17,7 +17,7 @@ use crate::model::definitions::{
 };
 use crate::model::document::Document;
 use crate::model::ids::{ConstantReferenceId, DefinitionId, NameId, StringId, UriId};
-use crate::model::name::{Name, ParentScope};
+use crate::model::name::ParentScope;
 use crate::model::references::ConstantReference;
 use crate::model::visibility::Visibility;
 use crate::offset::Offset;
@@ -102,8 +102,7 @@ impl<'a> RBSIndexer<'a> {
         nesting_name_id: Option<NameId>,
     ) -> NameId {
         let string_id = self.local_graph.intern_string(symbol.as_str().to_owned());
-        self.local_graph
-            .add_name(Name::new(string_id, parent_scope, nesting_name_id))
+        self.local_graph.add_name(string_id, parent_scope, nesting_name_id)
     }
 
     fn parent_lexical_scope_id(&self) -> Option<DefinitionId> {

--- a/rust/rubydex/src/indexing/ruby_indexer.rs
+++ b/rust/rubydex/src/indexing/ruby_indexer.rs
@@ -12,7 +12,7 @@ use crate::model::definitions::{
 };
 use crate::model::document::Document;
 use crate::model::ids::{DefinitionId, NameId, StringId, UriId};
-use crate::model::name::{Name, ParentScope};
+use crate::model::name::ParentScope;
 use crate::model::references::{ConstantReference, MethodRef};
 use crate::model::visibility::Visibility;
 use crate::offset::Offset;
@@ -482,11 +482,9 @@ impl<'a> RubyIndexer<'a> {
         let offset = Offset::from_prism_location(&location);
         let name = Self::location_to_string(&location);
         let string_id = self.local_graph.intern_string(name);
-        let name_id = self.local_graph.add_name(Name::new(
-            string_id,
-            parent_scope_id,
-            self.current_lexical_scope_name_id(),
-        ));
+        let name_id = self
+            .local_graph
+            .add_name(string_id, parent_scope_id, self.current_lexical_scope_name_id());
 
         if push_final_reference {
             self.local_graph
@@ -687,7 +685,7 @@ impl<'a> RubyIndexer<'a> {
                 .intern_string(format!("{}:{}<anonymous>", self.uri_id, offset.start()));
 
             (
-                Some(self.local_graph.add_name(Name::new(string_id, ParentScope::None, None))),
+                Some(self.local_graph.add_name(string_id, ParentScope::None, None)),
                 offset.clone(),
             )
         };
@@ -748,7 +746,7 @@ impl<'a> RubyIndexer<'a> {
                 .intern_string(format!("{}:{}<anonymous>", self.uri_id, offset.start()));
 
             (
-                Some(self.local_graph.add_name(Name::new(string_id, ParentScope::None, None))),
+                Some(self.local_graph.add_name(string_id, ParentScope::None, None)),
                 offset.clone(),
             )
         };
@@ -1125,7 +1123,7 @@ impl<'a> RubyIndexer<'a> {
                     }
                     None => {
                         let str_id = self.local_graph.intern_string("Object".into());
-                        Some(self.local_graph.add_name(Name::new(str_id, ParentScope::None, None)))
+                        Some(self.local_graph.add_name(str_id, ParentScope::None, None))
                     }
                 }
             }
@@ -1169,7 +1167,7 @@ impl<'a> RubyIndexer<'a> {
         let string_id = self.local_graph.intern_string(singleton_class_name);
         let new_name_id = self
             .local_graph
-            .add_name(Name::new(string_id, ParentScope::Attached(name_id), None));
+            .add_name(string_id, ParentScope::Attached(name_id), None);
 
         let location = receiver.map_or(fallback_location, ruby_prism::Node::location);
         let offset = Offset::from_prism_location(&location);
@@ -1650,7 +1648,7 @@ impl Visit<'_> for RubyIndexer<'_> {
         let nesting = self.current_lexical_scope_name_id();
         let name_id = self
             .local_graph
-            .add_name(Name::new(string_id, ParentScope::Attached(attached_target), nesting));
+            .add_name(string_id, ParentScope::Attached(attached_target), nesting);
 
         let definition = Definition::SingletonClass(Box::new(SingletonClassDefinition::new(
             name_id,

--- a/rust/rubydex/src/model/graph.rs
+++ b/rust/rubydex/src/model/graph.rs
@@ -540,7 +540,13 @@ impl Graph {
     /// Registers a name in the graph unless already registered. In regular indexing, this only happens in the local
     /// graph. This method is only used to back the `Graph#resolve_constant` Ruby API because every name must be
     /// registered in the graph to properly resolve
-    pub fn add_name(&mut self, name: Name) -> NameId {
+    pub fn add_name(&mut self, str: StringId, parent_scope: ParentScope, nesting: Option<NameId>) -> NameId {
+        let name = Name::new(
+            str,
+            parent_scope,
+            nesting,
+            Name::name_depth(&self.names, parent_scope, nesting),
+        );
         let name_id = name.id();
 
         match self.names.entry(name_id) {
@@ -2522,7 +2528,7 @@ mod tests {
         );
 
         // Delete bar.rb — the Bar name should be fully removed
-        let bar_name_id = Name::new(StringId::from("Bar"), ParentScope::None, None).id();
+        let bar_name_id = Name::new(StringId::from("Bar"), ParentScope::None, None, 0).id();
         context.index_uri("file:///bar.rb", "");
         context.resolve();
 

--- a/rust/rubydex/src/model/graph.rs
+++ b/rust/rubydex/src/model/graph.rs
@@ -541,12 +541,7 @@ impl Graph {
     /// graph. This method is only used to back the `Graph#resolve_constant` Ruby API because every name must be
     /// registered in the graph to properly resolve
     pub fn add_name(&mut self, str: StringId, parent_scope: ParentScope, nesting: Option<NameId>) -> NameId {
-        let name = Name::new(
-            str,
-            parent_scope,
-            nesting,
-            Name::name_depth(&self.names, parent_scope, nesting),
-        );
+        let name = Name::new(&self.names, str, parent_scope, nesting);
         let name_id = name.id();
 
         match self.names.entry(name_id) {
@@ -2528,7 +2523,7 @@ mod tests {
         );
 
         // Delete bar.rb — the Bar name should be fully removed
-        let bar_name_id = Name::new(StringId::from("Bar"), ParentScope::None, None, 0).id();
+        let bar_name_id = Name::new(context.graph().names(), StringId::from("Bar"), ParentScope::None, None).id();
         context.index_uri("file:///bar.rb", "");
         context.resolve();
 

--- a/rust/rubydex/src/model/name.rs
+++ b/rust/rubydex/src/model/name.rs
@@ -4,6 +4,7 @@ use crate::{
     assert_mem_size,
     model::{
         id::id_from_parts,
+        identity_maps::IdentityHashMap,
         ids::{DeclarationId, NameId, StringId},
     },
 };
@@ -93,29 +94,55 @@ pub struct Name {
     /// list of names to represent the nesting
     nesting: Option<NameId>,
     ref_count: u32,
+    /// The depth of the name, which combines the depths of the parent scope and nesting
+    depth: u16,
 }
+assert_mem_size!(Name, 40);
 
 impl PartialEq for Name {
     fn eq(&self, other: &Self) -> bool {
         self.str == other.str && self.parent_scope == other.parent_scope && self.nesting == other.nesting
     }
 }
-assert_mem_size!(Name, 40);
 
 impl Name {
     #[must_use]
-    pub fn new(str: StringId, parent_scope: ParentScope, nesting: Option<NameId>) -> Self {
+    pub fn new(str: StringId, parent_scope: ParentScope, nesting: Option<NameId>, depth: u16) -> Self {
         Self {
             str,
             parent_scope,
             nesting,
             ref_count: 1,
+            depth,
         }
+    }
+
+    #[must_use]
+    pub(crate) fn name_depth(
+        names: &IdentityHashMap<NameId, NameRef>,
+        parent_scope: ParentScope,
+        nesting: Option<NameId>,
+    ) -> u16 {
+        if parent_scope.is_top_level() {
+            return 1;
+        }
+
+        let parent_depth = parent_scope
+            .as_ref()
+            .map_or(0, |id| names.get(id).map_or(0, NameRef::depth));
+        let nesting_depth = nesting.map_or(0, |id| names.get(&id).map_or(0, NameRef::depth));
+
+        parent_depth.saturating_add(nesting_depth).saturating_add(1)
     }
 
     #[must_use]
     pub fn str(&self) -> &StringId {
         &self.str
+    }
+
+    #[must_use]
+    pub fn depth(&self) -> u16 {
+        self.depth
     }
 
     #[must_use]
@@ -227,6 +254,14 @@ impl NameRef {
         }
     }
 
+    #[must_use]
+    pub fn depth(&self) -> u16 {
+        match self {
+            NameRef::Unresolved(name) => name.depth(),
+            NameRef::Resolved(resolved_name) => resolved_name.name.depth(),
+        }
+    }
+
     /// # Panics
     ///
     /// Panics if we exceed the maximum size of the reference count
@@ -281,42 +316,44 @@ mod tests {
 
     #[test]
     fn same_parent_scope_and_nesting() {
-        let name_1 = Name::new(StringId::from("Foo"), ParentScope::None, None);
-        let name_2 = Name::new(StringId::from("Foo"), ParentScope::None, None);
+        let name_1 = Name::new(StringId::from("Foo"), ParentScope::None, None, 0);
+        let name_2 = Name::new(StringId::from("Foo"), ParentScope::None, None, 0);
         assert_eq!(name_1.id(), name_2.id());
 
-        let name_3 = Name::new(StringId::from("Foo"), ParentScope::Some(name_1.id()), None);
-        let name_4 = Name::new(StringId::from("Foo"), ParentScope::Some(name_2.id()), None);
+        let name_3 = Name::new(StringId::from("Foo"), ParentScope::Some(name_1.id()), None, 0);
+        let name_4 = Name::new(StringId::from("Foo"), ParentScope::Some(name_2.id()), None, 0);
         assert_eq!(name_3.id(), name_4.id());
 
-        let name_5 = Name::new(StringId::from("Foo"), ParentScope::None, Some(name_1.id()));
-        let name_6 = Name::new(StringId::from("Foo"), ParentScope::None, Some(name_2.id()));
+        let name_5 = Name::new(StringId::from("Foo"), ParentScope::None, Some(name_1.id()), 0);
+        let name_6 = Name::new(StringId::from("Foo"), ParentScope::None, Some(name_2.id()), 0);
         assert_eq!(name_5.id(), name_6.id());
         assert_ne!(name_3.id(), name_5.id());
         assert_ne!(name_4.id(), name_6.id());
 
         let name_7 = Name::new(
             StringId::from("Foo"),
-            ParentScope::Some(Name::new(StringId::from("Foo"), ParentScope::None, None).id()),
-            Some(Name::new(StringId::from("Foo"), ParentScope::None, None).id()),
+            ParentScope::Some(Name::new(StringId::from("Foo"), ParentScope::None, None, 0).id()),
+            Some(Name::new(StringId::from("Foo"), ParentScope::None, None, 0).id()),
+            0,
         );
         let name_8 = Name::new(
             StringId::from("Foo"),
-            ParentScope::Some(Name::new(StringId::from("Foo"), ParentScope::None, None).id()),
-            Some(Name::new(StringId::from("Foo"), ParentScope::None, None).id()),
+            ParentScope::Some(Name::new(StringId::from("Foo"), ParentScope::None, None, 0).id()),
+            Some(Name::new(StringId::from("Foo"), ParentScope::None, None, 0).id()),
+            0,
         );
         assert_eq!(name_7.id(), name_8.id());
     }
 
     #[test]
     fn parent_scope_variants_are_distinct() {
-        let inner = Name::new(StringId::from("Foo"), ParentScope::None, None).id();
+        let inner = Name::new(StringId::from("Foo"), ParentScope::None, None, 0).id();
 
         let ids = [
-            Name::new(StringId::from("Foo"), ParentScope::None, None).id(),
-            Name::new(StringId::from("Foo"), ParentScope::TopLevel, None).id(),
-            Name::new(StringId::from("Foo"), ParentScope::Some(inner), None).id(),
-            Name::new(StringId::from("Foo"), ParentScope::Attached(inner), None).id(),
+            Name::new(StringId::from("Foo"), ParentScope::None, None, 0).id(),
+            Name::new(StringId::from("Foo"), ParentScope::TopLevel, None, 0).id(),
+            Name::new(StringId::from("Foo"), ParentScope::Some(inner), None, 0).id(),
+            Name::new(StringId::from("Foo"), ParentScope::Attached(inner), None, 0).id(),
         ];
 
         for (i, a) in ids.iter().enumerate() {

--- a/rust/rubydex/src/model/name.rs
+++ b/rust/rubydex/src/model/name.rs
@@ -107,22 +107,23 @@ impl PartialEq for Name {
 
 impl Name {
     #[must_use]
-    pub fn new(str: StringId, parent_scope: ParentScope, nesting: Option<NameId>, depth: u16) -> Self {
+    pub fn new(
+        names: &IdentityHashMap<NameId, NameRef>,
+        str: StringId,
+        parent_scope: ParentScope,
+        nesting: Option<NameId>,
+    ) -> Self {
         Self {
             str,
             parent_scope,
             nesting,
             ref_count: 1,
-            depth,
+            depth: Self::name_depth(names, parent_scope, nesting),
         }
     }
 
     #[must_use]
-    pub(crate) fn name_depth(
-        names: &IdentityHashMap<NameId, NameRef>,
-        parent_scope: ParentScope,
-        nesting: Option<NameId>,
-    ) -> u16 {
+    fn name_depth(names: &IdentityHashMap<NameId, NameRef>, parent_scope: ParentScope, nesting: Option<NameId>) -> u16 {
         if parent_scope.is_top_level() {
             return 1;
         }
@@ -316,44 +317,47 @@ mod tests {
 
     #[test]
     fn same_parent_scope_and_nesting() {
-        let name_1 = Name::new(StringId::from("Foo"), ParentScope::None, None, 0);
-        let name_2 = Name::new(StringId::from("Foo"), ParentScope::None, None, 0);
+        let names = IdentityHashMap::default();
+
+        let name_1 = Name::new(&names, StringId::from("Foo"), ParentScope::None, None);
+        let name_2 = Name::new(&names, StringId::from("Foo"), ParentScope::None, None);
         assert_eq!(name_1.id(), name_2.id());
 
-        let name_3 = Name::new(StringId::from("Foo"), ParentScope::Some(name_1.id()), None, 0);
-        let name_4 = Name::new(StringId::from("Foo"), ParentScope::Some(name_2.id()), None, 0);
+        let name_3 = Name::new(&names, StringId::from("Foo"), ParentScope::Some(name_1.id()), None);
+        let name_4 = Name::new(&names, StringId::from("Foo"), ParentScope::Some(name_2.id()), None);
         assert_eq!(name_3.id(), name_4.id());
 
-        let name_5 = Name::new(StringId::from("Foo"), ParentScope::None, Some(name_1.id()), 0);
-        let name_6 = Name::new(StringId::from("Foo"), ParentScope::None, Some(name_2.id()), 0);
+        let name_5 = Name::new(&names, StringId::from("Foo"), ParentScope::None, Some(name_1.id()));
+        let name_6 = Name::new(&names, StringId::from("Foo"), ParentScope::None, Some(name_2.id()));
         assert_eq!(name_5.id(), name_6.id());
         assert_ne!(name_3.id(), name_5.id());
         assert_ne!(name_4.id(), name_6.id());
 
         let name_7 = Name::new(
+            &names,
             StringId::from("Foo"),
-            ParentScope::Some(Name::new(StringId::from("Foo"), ParentScope::None, None, 0).id()),
-            Some(Name::new(StringId::from("Foo"), ParentScope::None, None, 0).id()),
-            0,
+            ParentScope::Some(Name::new(&names, StringId::from("Foo"), ParentScope::None, None).id()),
+            Some(Name::new(&names, StringId::from("Foo"), ParentScope::None, None).id()),
         );
         let name_8 = Name::new(
+            &names,
             StringId::from("Foo"),
-            ParentScope::Some(Name::new(StringId::from("Foo"), ParentScope::None, None, 0).id()),
-            Some(Name::new(StringId::from("Foo"), ParentScope::None, None, 0).id()),
-            0,
+            ParentScope::Some(Name::new(&names, StringId::from("Foo"), ParentScope::None, None).id()),
+            Some(Name::new(&names, StringId::from("Foo"), ParentScope::None, None).id()),
         );
         assert_eq!(name_7.id(), name_8.id());
     }
 
     #[test]
     fn parent_scope_variants_are_distinct() {
-        let inner = Name::new(StringId::from("Foo"), ParentScope::None, None, 0).id();
+        let names = IdentityHashMap::default();
+        let inner = Name::new(&names, StringId::from("Foo"), ParentScope::None, None).id();
 
         let ids = [
-            Name::new(StringId::from("Foo"), ParentScope::None, None, 0).id(),
-            Name::new(StringId::from("Foo"), ParentScope::TopLevel, None, 0).id(),
-            Name::new(StringId::from("Foo"), ParentScope::Some(inner), None, 0).id(),
-            Name::new(StringId::from("Foo"), ParentScope::Attached(inner), None, 0).id(),
+            Name::new(&names, StringId::from("Foo"), ParentScope::None, None).id(),
+            Name::new(&names, StringId::from("Foo"), ParentScope::TopLevel, None).id(),
+            Name::new(&names, StringId::from("Foo"), ParentScope::Some(inner), None).id(),
+            Name::new(&names, StringId::from("Foo"), ParentScope::Attached(inner), None).id(),
         ];
 
         for (i, a) in ids.iter().enumerate() {

--- a/rust/rubydex/src/operation/ruby_builder.rs
+++ b/rust/rubydex/src/operation/ruby_builder.rs
@@ -154,7 +154,13 @@ impl<'a> RubyOperationBuilder<'a> {
         string_id
     }
 
-    fn add_name(&mut self, name: Name) -> NameId {
+    fn add_name(&mut self, str: StringId, parent_scope: ParentScope, nesting: Option<NameId>) -> NameId {
+        let name = Name::new(
+            str,
+            parent_scope,
+            nesting,
+            Name::name_depth(&self.names, parent_scope, nesting),
+        );
         let name_id = name.id();
 
         match self.names.entry(name_id) {
@@ -360,11 +366,7 @@ impl<'a> RubyOperationBuilder<'a> {
         let offset = Offset::from_prism_location(&location);
         let name = Self::location_to_string(&location);
         let string_id = self.intern_string(name);
-        let name_id = self.add_name(Name::new(
-            string_id,
-            parent_scope_id,
-            self.current_lexical_scope_name_id(),
-        ));
+        let name_id = self.add_name(string_id, parent_scope_id, self.current_lexical_scope_name_id());
 
         if push_final_reference {
             self.operations
@@ -443,7 +445,7 @@ impl<'a> RubyOperationBuilder<'a> {
                 }
                 None => {
                     let str_id = self.intern_string("Object".into());
-                    Some(self.add_name(Name::new(str_id, ParentScope::None, None)))
+                    Some(self.add_name(str_id, ParentScope::None, None))
                 }
             },
             Some(ruby_prism::Node::CallNode { .. }) => {
@@ -477,7 +479,7 @@ impl<'a> RubyOperationBuilder<'a> {
         };
 
         let string_id = self.intern_string(singleton_class_name);
-        let new_name_id = self.add_name(Name::new(string_id, ParentScope::Attached(name_id), None));
+        let new_name_id = self.add_name(string_id, ParentScope::Attached(name_id), None);
 
         let location = receiver.map_or(fallback_location, ruby_prism::Node::location);
         let offset = Offset::from_prism_location(&location);
@@ -689,10 +691,7 @@ impl<'a> RubyOperationBuilder<'a> {
             )
         } else {
             let string_id = self.intern_string(format!("{}:{}<anonymous>", self.uri_id, offset.start()));
-            (
-                Some(self.add_name(Name::new(string_id, ParentScope::None, None))),
-                offset.clone(),
-            )
+            (Some(self.add_name(string_id, ParentScope::None, None)), offset.clone())
         };
 
         if let Some(name_id) = name_id {
@@ -754,10 +753,7 @@ impl<'a> RubyOperationBuilder<'a> {
             )
         } else {
             let string_id = self.intern_string(format!("{}:{}<anonymous>", self.uri_id, offset.start()));
-            (
-                Some(self.add_name(Name::new(string_id, ParentScope::None, None))),
-                offset.clone(),
-            )
+            (Some(self.add_name(string_id, ParentScope::None, None)), offset.clone())
         };
 
         if let Some(name_id) = name_id {
@@ -1483,7 +1479,7 @@ impl Visit<'_> for RubyOperationBuilder<'_> {
 
         let string_id = self.intern_string(singleton_class_name);
         let nesting = self.current_lexical_scope_name_id();
-        let name_id = self.add_name(Name::new(string_id, ParentScope::Attached(attached_target), nesting));
+        let name_id = self.add_name(string_id, ParentScope::Attached(attached_target), nesting);
         self.operations
             .push(Operation::EnterSingletonClass(op::EnterSingletonClass {
                 name_id,

--- a/rust/rubydex/src/operation/ruby_builder.rs
+++ b/rust/rubydex/src/operation/ruby_builder.rs
@@ -155,12 +155,7 @@ impl<'a> RubyOperationBuilder<'a> {
     }
 
     fn add_name(&mut self, str: StringId, parent_scope: ParentScope, nesting: Option<NameId>) -> NameId {
-        let name = Name::new(
-            str,
-            parent_scope,
-            nesting,
-            Name::name_depth(&self.names, parent_scope, nesting),
-        );
+        let name = Name::new(&self.names, str, parent_scope, nesting);
         let name_id = name.id();
 
         match self.names.entry(name_id) {

--- a/rust/rubydex/src/query.rs
+++ b/rust/rubydex/src/query.rs
@@ -1173,7 +1173,7 @@ mod tests {
         );
         context.resolve();
 
-        let name_id = Name::new(StringId::from("Child"), ParentScope::None, None).id();
+        let name_id = Name::new(StringId::from("Child"), ParentScope::None, None, 0).id();
         assert_declaration_completion_eq!(
             context,
             CompletionReceiver::Expression {
@@ -1222,7 +1222,7 @@ mod tests {
         );
         context.resolve();
 
-        let name_id = Name::new(StringId::from("Child"), ParentScope::None, None).id();
+        let name_id = Name::new(StringId::from("Child"), ParentScope::None, None, 0).id();
         assert_declaration_completion_eq!(
             context,
             CompletionReceiver::Expression {
@@ -1271,7 +1271,7 @@ mod tests {
         );
         context.resolve();
 
-        let name_id = Name::new(StringId::from("Foo"), ParentScope::None, None).id();
+        let name_id = Name::new(StringId::from("Foo"), ParentScope::None, None, 0).id();
         assert_declaration_completion_eq!(
             context,
             CompletionReceiver::Expression {
@@ -1320,8 +1320,8 @@ mod tests {
         );
         context.resolve();
 
-        let foo_id = Name::new(StringId::from("Foo"), ParentScope::None, None).id();
-        let name_id = Name::new(StringId::from("<Foo>"), ParentScope::Attached(foo_id), Some(foo_id)).id();
+        let foo_id = Name::new(StringId::from("Foo"), ParentScope::None, None, 0).id();
+        let name_id = Name::new(StringId::from("<Foo>"), ParentScope::Attached(foo_id), Some(foo_id), 0).id();
         assert_declaration_completion_eq!(
             context,
             CompletionReceiver::Expression {
@@ -1341,7 +1341,7 @@ mod tests {
             ]
         );
 
-        let name_id = Name::new(StringId::from("Bar"), ParentScope::None, None).id();
+        let name_id = Name::new(StringId::from("Bar"), ParentScope::None, None, 0).id();
         assert_declaration_completion_eq!(
             context,
             CompletionReceiver::Expression {
@@ -1383,8 +1383,8 @@ mod tests {
         );
         context.resolve();
 
-        let foo_id = Name::new(StringId::from("Foo"), ParentScope::None, None).id();
-        let name_id = Name::new(StringId::from("<Foo>"), ParentScope::Attached(foo_id), Some(foo_id)).id();
+        let foo_id = Name::new(StringId::from("Foo"), ParentScope::None, None, 0).id();
+        let name_id = Name::new(StringId::from("<Foo>"), ParentScope::Attached(foo_id), Some(foo_id), 0).id();
 
         assert_declaration_completion_eq!(
             context,
@@ -1433,7 +1433,8 @@ mod tests {
         let name_id = Name::new(
             StringId::from("Bar"),
             ParentScope::TopLevel,
-            Some(Name::new(StringId::from("Foo"), ParentScope::None, None).id()),
+            Some(Name::new(StringId::from("Foo"), ParentScope::None, None, 0).id()),
+            0,
         )
         .id();
 
@@ -1457,7 +1458,7 @@ mod tests {
             ]
         );
 
-        let name_id = Name::new(StringId::from("Bar"), ParentScope::None, None).id();
+        let name_id = Name::new(StringId::from("Bar"), ParentScope::None, None, 0).id();
         assert_declaration_completion_eq!(
             context,
             CompletionReceiver::Expression {
@@ -1498,8 +1499,8 @@ mod tests {
         );
         context.resolve();
 
-        let foo_id = Name::new(StringId::from("Foo"), ParentScope::None, None).id();
-        let name_id = Name::new(StringId::from("Bar"), ParentScope::None, Some(foo_id)).id();
+        let foo_id = Name::new(StringId::from("Foo"), ParentScope::None, None, 0).id();
+        let name_id = Name::new(StringId::from("Bar"), ParentScope::None, Some(foo_id), 0).id();
         // Foo::CONST is reachable from Foo::Bar through lexical scoping, so it must appear as a completion candidate
         // when the user types the unqualified name CONST
         assert_declaration_completion_eq!(
@@ -1546,7 +1547,8 @@ mod tests {
         let name_id = Name::new(
             StringId::from("Bar"),
             ParentScope::None,
-            Some(Name::new(StringId::from("Foo"), ParentScope::None, None).id()),
+            Some(Name::new(StringId::from("Foo"), ParentScope::None, None, 0).id()),
+            0,
         )
         .id();
         assert_declaration_completion_eq!(
@@ -2078,7 +2080,7 @@ mod tests {
         );
         context.resolve();
 
-        let name_id = Name::new(StringId::from("Foo"), ParentScope::None, None).id();
+        let name_id = Name::new(StringId::from("Foo"), ParentScope::None, None, 0).id();
         assert_declaration_completion_eq!(
             context,
             CompletionReceiver::MethodArgument {
@@ -2119,7 +2121,7 @@ mod tests {
         );
         context.resolve();
 
-        let name_id = Name::new(StringId::from("Foo"), ParentScope::None, None).id();
+        let name_id = Name::new(StringId::from("Foo"), ParentScope::None, None, 0).id();
         assert_declaration_completion_eq!(
             context,
             CompletionReceiver::MethodArgument {
@@ -2156,7 +2158,7 @@ mod tests {
         );
         context.resolve();
 
-        let name_id = Name::new(StringId::from("Foo"), ParentScope::None, None).id();
+        let name_id = Name::new(StringId::from("Foo"), ParentScope::None, None, 0).id();
         assert_declaration_completion_eq!(
             context,
             CompletionReceiver::MethodArgument {
@@ -2182,7 +2184,7 @@ mod tests {
         );
         context.resolve();
 
-        let name_id = Name::new(StringId::from("Foo"), ParentScope::None, None).id();
+        let name_id = Name::new(StringId::from("Foo"), ParentScope::None, None, 0).id();
         assert_declaration_completion_eq!(
             context,
             CompletionReceiver::MethodArgument {
@@ -2226,7 +2228,7 @@ mod tests {
         );
         context.resolve();
 
-        let name_id = Name::new(StringId::from("Foo"), ParentScope::None, None).id();
+        let name_id = Name::new(StringId::from("Foo"), ParentScope::None, None, 0).id();
         assert_declaration_completion_eq!(
             context,
             CompletionReceiver::MethodArgument {
@@ -2254,7 +2256,7 @@ mod tests {
         context.index_uri("file:///foo.rb", "class Foo; end");
         context.resolve();
 
-        let name_id = Name::new(StringId::from("Foo"), ParentScope::None, None).id();
+        let name_id = Name::new(StringId::from("Foo"), ParentScope::None, None, 0).id();
         assert_completion_eq!(
             context,
             CompletionReceiver::Expression {
@@ -2319,7 +2321,7 @@ mod tests {
         context.index_uri("file:///foo.rb", "class Foo; def bar(name:); end; end");
         context.resolve();
 
-        let name_id = Name::new(StringId::from("Foo"), ParentScope::None, None).id();
+        let name_id = Name::new(StringId::from("Foo"), ParentScope::None, None, 0).id();
         assert_completion_eq!(
             context,
             CompletionReceiver::MethodArgument {
@@ -2440,7 +2442,7 @@ mod tests {
         );
         context.resolve();
 
-        let outer_name_id = Name::new(StringId::from("Outer"), ParentScope::None, None).id();
+        let outer_name_id = Name::new(StringId::from("Outer"), ParentScope::None, None, 0).id();
         assert_declaration_completion_eq!(
             context,
             CompletionReceiver::Expression {
@@ -2479,7 +2481,7 @@ mod tests {
         );
         context.resolve();
 
-        let name_id = Name::new(StringId::from("Outer"), ParentScope::None, None).id();
+        let name_id = Name::new(StringId::from("Outer"), ParentScope::None, None, 0).id();
         // `self_decl_id` points to the alias `Outer::MyAlias`, which is a `ConstantAlias` rather than a `Namespace`.
         // The completion should still collect members from the aliased namespace (`Outer::Original`) instead of
         // returning an error, so callers do not have to unwrap aliases themselves.
@@ -2525,7 +2527,7 @@ mod tests {
         );
         context.resolve();
 
-        let name_id = Name::new(StringId::from("Bar"), ParentScope::None, None).id();
+        let name_id = Name::new(StringId::from("Bar"), ParentScope::None, None, 0).id();
         assert_declaration_completion_eq!(
             context,
             CompletionReceiver::Expression {
@@ -2568,7 +2570,7 @@ mod tests {
         );
         context.resolve();
 
-        let name_id = Name::new(StringId::from("Bar"), ParentScope::None, None).id();
+        let name_id = Name::new(StringId::from("Bar"), ParentScope::None, None, 0).id();
         assert_declaration_completion_eq!(
             context,
             CompletionReceiver::Expression {
@@ -2613,7 +2615,7 @@ mod tests {
         );
         context.resolve();
 
-        let name_id = Name::new(StringId::from("Bar"), ParentScope::None, None).id();
+        let name_id = Name::new(StringId::from("Bar"), ParentScope::None, None, 0).id();
         assert_declaration_completion_eq!(
             context,
             CompletionReceiver::Expression {
@@ -2650,7 +2652,7 @@ mod tests {
         );
         context.resolve();
 
-        let name_id = Name::new(StringId::from("Object"), ParentScope::None, None).id();
+        let name_id = Name::new(StringId::from("Object"), ParentScope::None, None, 0).id();
         assert_declaration_completion_eq!(
             context,
             CompletionReceiver::Expression {
@@ -2677,7 +2679,7 @@ mod tests {
         );
         context.resolve();
 
-        let name_id = Name::new(StringId::from("Mod"), ParentScope::None, None).id();
+        let name_id = Name::new(StringId::from("Mod"), ParentScope::None, None, 0).id();
         assert_declaration_completion_eq!(
             context,
             CompletionReceiver::Expression {
@@ -2715,7 +2717,7 @@ mod tests {
         );
         context.resolve();
 
-        let name_id = Name::new(StringId::from("Mod"), ParentScope::None, None).id();
+        let name_id = Name::new(StringId::from("Mod"), ParentScope::None, None, 0).id();
         assert_declaration_completion_eq!(
             context,
             CompletionReceiver::Expression {
@@ -2750,7 +2752,7 @@ mod tests {
         );
         context.resolve();
 
-        let name_id = Name::new(StringId::from("Object"), ParentScope::None, None).id();
+        let name_id = Name::new(StringId::from("Object"), ParentScope::None, None, 0).id();
         assert_declaration_completion_eq!(
             context,
             CompletionReceiver::Expression {
@@ -2785,7 +2787,7 @@ mod tests {
         );
         context.resolve();
 
-        let name_id = Name::new(StringId::from("Bar"), ParentScope::None, None).id();
+        let name_id = Name::new(StringId::from("Bar"), ParentScope::None, None, 0).id();
         assert_declaration_completion_eq!(
             context,
             CompletionReceiver::Expression {
@@ -2818,9 +2820,15 @@ mod tests {
         );
         context.resolve();
 
-        let bar_id = Name::new(StringId::from("Bar"), ParentScope::None, None).id();
-        let foo_ref_id = Name::new(StringId::from("Foo"), ParentScope::None, Some(bar_id)).id();
-        let nesting_name_id = Name::new(StringId::from("<Foo>"), ParentScope::Attached(foo_ref_id), Some(bar_id)).id();
+        let bar_id = Name::new(StringId::from("Bar"), ParentScope::None, None, 0).id();
+        let foo_ref_id = Name::new(StringId::from("Foo"), ParentScope::None, Some(bar_id), 0).id();
+        let nesting_name_id = Name::new(
+            StringId::from("<Foo>"),
+            ParentScope::Attached(foo_ref_id),
+            Some(bar_id),
+            0,
+        )
+        .id();
 
         assert_declaration_completion_eq!(
             context,
@@ -2859,7 +2867,7 @@ mod tests {
         );
         context.resolve();
 
-        let name_id = Name::new(StringId::from("Mod"), ParentScope::None, None).id();
+        let name_id = Name::new(StringId::from("Mod"), ParentScope::None, None, 0).id();
         assert_declaration_completion_eq!(
             context,
             CompletionReceiver::Expression {
@@ -2897,8 +2905,8 @@ mod tests {
         );
         context.resolve();
 
-        let foo_ref_id = Name::new(StringId::from("Foo"), ParentScope::None, None).id();
-        let nesting_name_id = Name::new(StringId::from("<Foo>"), ParentScope::Attached(foo_ref_id), None).id();
+        let foo_ref_id = Name::new(StringId::from("Foo"), ParentScope::None, None, 0).id();
+        let nesting_name_id = Name::new(StringId::from("<Foo>"), ParentScope::Attached(foo_ref_id), None, 0).id();
 
         assert_declaration_completion_eq!(
             context,
@@ -2923,7 +2931,7 @@ mod tests {
         );
         context.resolve();
 
-        let name_id = Name::new(StringId::from("Foo"), ParentScope::None, None).id();
+        let name_id = Name::new(StringId::from("Foo"), ParentScope::None, None, 0).id();
         let result = completion_candidates(
             context.graph(),
             CompletionContext::new(CompletionReceiver::Expression {
@@ -2949,7 +2957,7 @@ mod tests {
         );
         context.resolve();
 
-        let name_id = Name::new(StringId::from("Foo"), ParentScope::None, None).id();
+        let name_id = Name::new(StringId::from("Foo"), ParentScope::None, None, 0).id();
         let result = completion_candidates(
             context.graph(),
             CompletionContext::new(CompletionReceiver::Expression {
@@ -2981,7 +2989,7 @@ mod tests {
         );
         context.resolve();
 
-        let name_id = Name::new(StringId::from("Outer"), ParentScope::None, None).id();
+        let name_id = Name::new(StringId::from("Outer"), ParentScope::None, None, 0).id();
         assert_declaration_completion_eq!(
             context,
             CompletionReceiver::Expression {
@@ -3024,7 +3032,7 @@ mod tests {
         );
         context.resolve();
 
-        let name_id = Name::new(StringId::from("Bar"), ParentScope::None, None).id();
+        let name_id = Name::new(StringId::from("Bar"), ParentScope::None, None, 0).id();
         assert_declaration_completion_eq!(
             context,
             CompletionReceiver::Expression {
@@ -3097,7 +3105,7 @@ mod tests {
         );
         context.resolve();
 
-        let foo_name_id = Name::new(StringId::from("Foo"), ParentScope::None, None).id();
+        let foo_name_id = Name::new(StringId::from("Foo"), ParentScope::None, None, 0).id();
         assert_declaration_completion_eq!(
             context,
             CompletionReceiver::Expression {
@@ -3117,7 +3125,7 @@ mod tests {
             ]
         );
 
-        let bar_name_id = Name::new(StringId::from("Bar"), ParentScope::None, None).id();
+        let bar_name_id = Name::new(StringId::from("Bar"), ParentScope::None, None, 0).id();
         assert_declaration_completion_eq!(
             context,
             CompletionReceiver::Expression {
@@ -3433,7 +3441,7 @@ mod tests {
         );
         context.resolve();
 
-        let foo_name_id = Name::new(StringId::from("Foo"), ParentScope::None, None).id();
+        let foo_name_id = Name::new(StringId::from("Foo"), ParentScope::None, None, 0).id();
         assert_declaration_completion_eq!(
             context,
             CompletionReceiver::Expression {

--- a/rust/rubydex/src/query.rs
+++ b/rust/rubydex/src/query.rs
@@ -1173,7 +1173,13 @@ mod tests {
         );
         context.resolve();
 
-        let name_id = Name::new(StringId::from("Child"), ParentScope::None, None, 0).id();
+        let name_id = Name::new(
+            context.graph().names(),
+            StringId::from("Child"),
+            ParentScope::None,
+            None,
+        )
+        .id();
         assert_declaration_completion_eq!(
             context,
             CompletionReceiver::Expression {
@@ -1222,7 +1228,13 @@ mod tests {
         );
         context.resolve();
 
-        let name_id = Name::new(StringId::from("Child"), ParentScope::None, None, 0).id();
+        let name_id = Name::new(
+            context.graph().names(),
+            StringId::from("Child"),
+            ParentScope::None,
+            None,
+        )
+        .id();
         assert_declaration_completion_eq!(
             context,
             CompletionReceiver::Expression {
@@ -1271,7 +1283,7 @@ mod tests {
         );
         context.resolve();
 
-        let name_id = Name::new(StringId::from("Foo"), ParentScope::None, None, 0).id();
+        let name_id = Name::new(context.graph().names(), StringId::from("Foo"), ParentScope::None, None).id();
         assert_declaration_completion_eq!(
             context,
             CompletionReceiver::Expression {
@@ -1320,8 +1332,14 @@ mod tests {
         );
         context.resolve();
 
-        let foo_id = Name::new(StringId::from("Foo"), ParentScope::None, None, 0).id();
-        let name_id = Name::new(StringId::from("<Foo>"), ParentScope::Attached(foo_id), Some(foo_id), 0).id();
+        let foo_id = Name::new(context.graph().names(), StringId::from("Foo"), ParentScope::None, None).id();
+        let name_id = Name::new(
+            context.graph().names(),
+            StringId::from("<Foo>"),
+            ParentScope::Attached(foo_id),
+            Some(foo_id),
+        )
+        .id();
         assert_declaration_completion_eq!(
             context,
             CompletionReceiver::Expression {
@@ -1341,7 +1359,7 @@ mod tests {
             ]
         );
 
-        let name_id = Name::new(StringId::from("Bar"), ParentScope::None, None, 0).id();
+        let name_id = Name::new(context.graph().names(), StringId::from("Bar"), ParentScope::None, None).id();
         assert_declaration_completion_eq!(
             context,
             CompletionReceiver::Expression {
@@ -1383,8 +1401,14 @@ mod tests {
         );
         context.resolve();
 
-        let foo_id = Name::new(StringId::from("Foo"), ParentScope::None, None, 0).id();
-        let name_id = Name::new(StringId::from("<Foo>"), ParentScope::Attached(foo_id), Some(foo_id), 0).id();
+        let foo_id = Name::new(context.graph().names(), StringId::from("Foo"), ParentScope::None, None).id();
+        let name_id = Name::new(
+            context.graph().names(),
+            StringId::from("<Foo>"),
+            ParentScope::Attached(foo_id),
+            Some(foo_id),
+        )
+        .id();
 
         assert_declaration_completion_eq!(
             context,
@@ -1431,10 +1455,10 @@ mod tests {
         context.resolve();
 
         let name_id = Name::new(
+            context.graph().names(),
             StringId::from("Bar"),
             ParentScope::TopLevel,
-            Some(Name::new(StringId::from("Foo"), ParentScope::None, None, 0).id()),
-            0,
+            Some(Name::new(context.graph().names(), StringId::from("Foo"), ParentScope::None, None).id()),
         )
         .id();
 
@@ -1458,7 +1482,7 @@ mod tests {
             ]
         );
 
-        let name_id = Name::new(StringId::from("Bar"), ParentScope::None, None, 0).id();
+        let name_id = Name::new(context.graph().names(), StringId::from("Bar"), ParentScope::None, None).id();
         assert_declaration_completion_eq!(
             context,
             CompletionReceiver::Expression {
@@ -1499,8 +1523,14 @@ mod tests {
         );
         context.resolve();
 
-        let foo_id = Name::new(StringId::from("Foo"), ParentScope::None, None, 0).id();
-        let name_id = Name::new(StringId::from("Bar"), ParentScope::None, Some(foo_id), 0).id();
+        let foo_id = Name::new(context.graph().names(), StringId::from("Foo"), ParentScope::None, None).id();
+        let name_id = Name::new(
+            context.graph().names(),
+            StringId::from("Bar"),
+            ParentScope::None,
+            Some(foo_id),
+        )
+        .id();
         // Foo::CONST is reachable from Foo::Bar through lexical scoping, so it must appear as a completion candidate
         // when the user types the unqualified name CONST
         assert_declaration_completion_eq!(
@@ -1545,10 +1575,10 @@ mod tests {
         context.resolve();
 
         let name_id = Name::new(
+            context.graph().names(),
             StringId::from("Bar"),
             ParentScope::None,
-            Some(Name::new(StringId::from("Foo"), ParentScope::None, None, 0).id()),
-            0,
+            Some(Name::new(context.graph().names(), StringId::from("Foo"), ParentScope::None, None).id()),
         )
         .id();
         assert_declaration_completion_eq!(
@@ -2080,7 +2110,7 @@ mod tests {
         );
         context.resolve();
 
-        let name_id = Name::new(StringId::from("Foo"), ParentScope::None, None, 0).id();
+        let name_id = Name::new(context.graph().names(), StringId::from("Foo"), ParentScope::None, None).id();
         assert_declaration_completion_eq!(
             context,
             CompletionReceiver::MethodArgument {
@@ -2121,7 +2151,7 @@ mod tests {
         );
         context.resolve();
 
-        let name_id = Name::new(StringId::from("Foo"), ParentScope::None, None, 0).id();
+        let name_id = Name::new(context.graph().names(), StringId::from("Foo"), ParentScope::None, None).id();
         assert_declaration_completion_eq!(
             context,
             CompletionReceiver::MethodArgument {
@@ -2158,7 +2188,7 @@ mod tests {
         );
         context.resolve();
 
-        let name_id = Name::new(StringId::from("Foo"), ParentScope::None, None, 0).id();
+        let name_id = Name::new(context.graph().names(), StringId::from("Foo"), ParentScope::None, None).id();
         assert_declaration_completion_eq!(
             context,
             CompletionReceiver::MethodArgument {
@@ -2184,7 +2214,7 @@ mod tests {
         );
         context.resolve();
 
-        let name_id = Name::new(StringId::from("Foo"), ParentScope::None, None, 0).id();
+        let name_id = Name::new(context.graph().names(), StringId::from("Foo"), ParentScope::None, None).id();
         assert_declaration_completion_eq!(
             context,
             CompletionReceiver::MethodArgument {
@@ -2228,7 +2258,7 @@ mod tests {
         );
         context.resolve();
 
-        let name_id = Name::new(StringId::from("Foo"), ParentScope::None, None, 0).id();
+        let name_id = Name::new(context.graph().names(), StringId::from("Foo"), ParentScope::None, None).id();
         assert_declaration_completion_eq!(
             context,
             CompletionReceiver::MethodArgument {
@@ -2256,7 +2286,7 @@ mod tests {
         context.index_uri("file:///foo.rb", "class Foo; end");
         context.resolve();
 
-        let name_id = Name::new(StringId::from("Foo"), ParentScope::None, None, 0).id();
+        let name_id = Name::new(context.graph().names(), StringId::from("Foo"), ParentScope::None, None).id();
         assert_completion_eq!(
             context,
             CompletionReceiver::Expression {
@@ -2321,7 +2351,7 @@ mod tests {
         context.index_uri("file:///foo.rb", "class Foo; def bar(name:); end; end");
         context.resolve();
 
-        let name_id = Name::new(StringId::from("Foo"), ParentScope::None, None, 0).id();
+        let name_id = Name::new(context.graph().names(), StringId::from("Foo"), ParentScope::None, None).id();
         assert_completion_eq!(
             context,
             CompletionReceiver::MethodArgument {
@@ -2442,7 +2472,13 @@ mod tests {
         );
         context.resolve();
 
-        let outer_name_id = Name::new(StringId::from("Outer"), ParentScope::None, None, 0).id();
+        let outer_name_id = Name::new(
+            context.graph().names(),
+            StringId::from("Outer"),
+            ParentScope::None,
+            None,
+        )
+        .id();
         assert_declaration_completion_eq!(
             context,
             CompletionReceiver::Expression {
@@ -2481,7 +2517,13 @@ mod tests {
         );
         context.resolve();
 
-        let name_id = Name::new(StringId::from("Outer"), ParentScope::None, None, 0).id();
+        let name_id = Name::new(
+            context.graph().names(),
+            StringId::from("Outer"),
+            ParentScope::None,
+            None,
+        )
+        .id();
         // `self_decl_id` points to the alias `Outer::MyAlias`, which is a `ConstantAlias` rather than a `Namespace`.
         // The completion should still collect members from the aliased namespace (`Outer::Original`) instead of
         // returning an error, so callers do not have to unwrap aliases themselves.
@@ -2527,7 +2569,7 @@ mod tests {
         );
         context.resolve();
 
-        let name_id = Name::new(StringId::from("Bar"), ParentScope::None, None, 0).id();
+        let name_id = Name::new(context.graph().names(), StringId::from("Bar"), ParentScope::None, None).id();
         assert_declaration_completion_eq!(
             context,
             CompletionReceiver::Expression {
@@ -2570,7 +2612,7 @@ mod tests {
         );
         context.resolve();
 
-        let name_id = Name::new(StringId::from("Bar"), ParentScope::None, None, 0).id();
+        let name_id = Name::new(context.graph().names(), StringId::from("Bar"), ParentScope::None, None).id();
         assert_declaration_completion_eq!(
             context,
             CompletionReceiver::Expression {
@@ -2615,7 +2657,7 @@ mod tests {
         );
         context.resolve();
 
-        let name_id = Name::new(StringId::from("Bar"), ParentScope::None, None, 0).id();
+        let name_id = Name::new(context.graph().names(), StringId::from("Bar"), ParentScope::None, None).id();
         assert_declaration_completion_eq!(
             context,
             CompletionReceiver::Expression {
@@ -2652,7 +2694,13 @@ mod tests {
         );
         context.resolve();
 
-        let name_id = Name::new(StringId::from("Object"), ParentScope::None, None, 0).id();
+        let name_id = Name::new(
+            context.graph().names(),
+            StringId::from("Object"),
+            ParentScope::None,
+            None,
+        )
+        .id();
         assert_declaration_completion_eq!(
             context,
             CompletionReceiver::Expression {
@@ -2679,7 +2727,7 @@ mod tests {
         );
         context.resolve();
 
-        let name_id = Name::new(StringId::from("Mod"), ParentScope::None, None, 0).id();
+        let name_id = Name::new(context.graph().names(), StringId::from("Mod"), ParentScope::None, None).id();
         assert_declaration_completion_eq!(
             context,
             CompletionReceiver::Expression {
@@ -2717,7 +2765,7 @@ mod tests {
         );
         context.resolve();
 
-        let name_id = Name::new(StringId::from("Mod"), ParentScope::None, None, 0).id();
+        let name_id = Name::new(context.graph().names(), StringId::from("Mod"), ParentScope::None, None).id();
         assert_declaration_completion_eq!(
             context,
             CompletionReceiver::Expression {
@@ -2752,7 +2800,13 @@ mod tests {
         );
         context.resolve();
 
-        let name_id = Name::new(StringId::from("Object"), ParentScope::None, None, 0).id();
+        let name_id = Name::new(
+            context.graph().names(),
+            StringId::from("Object"),
+            ParentScope::None,
+            None,
+        )
+        .id();
         assert_declaration_completion_eq!(
             context,
             CompletionReceiver::Expression {
@@ -2787,7 +2841,7 @@ mod tests {
         );
         context.resolve();
 
-        let name_id = Name::new(StringId::from("Bar"), ParentScope::None, None, 0).id();
+        let name_id = Name::new(context.graph().names(), StringId::from("Bar"), ParentScope::None, None).id();
         assert_declaration_completion_eq!(
             context,
             CompletionReceiver::Expression {
@@ -2820,13 +2874,19 @@ mod tests {
         );
         context.resolve();
 
-        let bar_id = Name::new(StringId::from("Bar"), ParentScope::None, None, 0).id();
-        let foo_ref_id = Name::new(StringId::from("Foo"), ParentScope::None, Some(bar_id), 0).id();
+        let bar_id = Name::new(context.graph().names(), StringId::from("Bar"), ParentScope::None, None).id();
+        let foo_ref_id = Name::new(
+            context.graph().names(),
+            StringId::from("Foo"),
+            ParentScope::None,
+            Some(bar_id),
+        )
+        .id();
         let nesting_name_id = Name::new(
+            context.graph().names(),
             StringId::from("<Foo>"),
             ParentScope::Attached(foo_ref_id),
             Some(bar_id),
-            0,
         )
         .id();
 
@@ -2867,7 +2927,7 @@ mod tests {
         );
         context.resolve();
 
-        let name_id = Name::new(StringId::from("Mod"), ParentScope::None, None, 0).id();
+        let name_id = Name::new(context.graph().names(), StringId::from("Mod"), ParentScope::None, None).id();
         assert_declaration_completion_eq!(
             context,
             CompletionReceiver::Expression {
@@ -2905,8 +2965,14 @@ mod tests {
         );
         context.resolve();
 
-        let foo_ref_id = Name::new(StringId::from("Foo"), ParentScope::None, None, 0).id();
-        let nesting_name_id = Name::new(StringId::from("<Foo>"), ParentScope::Attached(foo_ref_id), None, 0).id();
+        let foo_ref_id = Name::new(context.graph().names(), StringId::from("Foo"), ParentScope::None, None).id();
+        let nesting_name_id = Name::new(
+            context.graph().names(),
+            StringId::from("<Foo>"),
+            ParentScope::Attached(foo_ref_id),
+            None,
+        )
+        .id();
 
         assert_declaration_completion_eq!(
             context,
@@ -2931,7 +2997,7 @@ mod tests {
         );
         context.resolve();
 
-        let name_id = Name::new(StringId::from("Foo"), ParentScope::None, None, 0).id();
+        let name_id = Name::new(context.graph().names(), StringId::from("Foo"), ParentScope::None, None).id();
         let result = completion_candidates(
             context.graph(),
             CompletionContext::new(CompletionReceiver::Expression {
@@ -2957,7 +3023,7 @@ mod tests {
         );
         context.resolve();
 
-        let name_id = Name::new(StringId::from("Foo"), ParentScope::None, None, 0).id();
+        let name_id = Name::new(context.graph().names(), StringId::from("Foo"), ParentScope::None, None).id();
         let result = completion_candidates(
             context.graph(),
             CompletionContext::new(CompletionReceiver::Expression {
@@ -2989,7 +3055,13 @@ mod tests {
         );
         context.resolve();
 
-        let name_id = Name::new(StringId::from("Outer"), ParentScope::None, None, 0).id();
+        let name_id = Name::new(
+            context.graph().names(),
+            StringId::from("Outer"),
+            ParentScope::None,
+            None,
+        )
+        .id();
         assert_declaration_completion_eq!(
             context,
             CompletionReceiver::Expression {
@@ -3032,7 +3104,7 @@ mod tests {
         );
         context.resolve();
 
-        let name_id = Name::new(StringId::from("Bar"), ParentScope::None, None, 0).id();
+        let name_id = Name::new(context.graph().names(), StringId::from("Bar"), ParentScope::None, None).id();
         assert_declaration_completion_eq!(
             context,
             CompletionReceiver::Expression {
@@ -3105,7 +3177,7 @@ mod tests {
         );
         context.resolve();
 
-        let foo_name_id = Name::new(StringId::from("Foo"), ParentScope::None, None, 0).id();
+        let foo_name_id = Name::new(context.graph().names(), StringId::from("Foo"), ParentScope::None, None).id();
         assert_declaration_completion_eq!(
             context,
             CompletionReceiver::Expression {
@@ -3125,7 +3197,7 @@ mod tests {
             ]
         );
 
-        let bar_name_id = Name::new(StringId::from("Bar"), ParentScope::None, None, 0).id();
+        let bar_name_id = Name::new(context.graph().names(), StringId::from("Bar"), ParentScope::None, None).id();
         assert_declaration_completion_eq!(
             context,
             CompletionReceiver::Expression {
@@ -3441,7 +3513,7 @@ mod tests {
         );
         context.resolve();
 
-        let foo_name_id = Name::new(StringId::from("Foo"), ParentScope::None, None, 0).id();
+        let foo_name_id = Name::new(context.graph().names(), StringId::from("Foo"), ParentScope::None, None).id();
         assert_declaration_completion_eq!(
             context,
             CompletionReceiver::Expression {

--- a/rust/rubydex/src/resolution.rs
+++ b/rust/rubydex/src/resolution.rs
@@ -1829,9 +1829,15 @@ impl<'a> Resolver<'a> {
         Outcome::Unresolved
     }
 
-    /// Returns a complexity score for a given name, which is used to sort names for resolution. The complexity is based
-    /// on how many parent scopes are involved in a name's nesting. This is because simple names are always
-    /// straightforward to resolve no matter how deep the nesting is. For example:
+    /// Drains `pending_work` and classifies items into the resolution queue.
+    ///
+    /// Namespace definitions and constant references are sorted by their name's [depth](Name::depth) so that simpler
+    /// names are processed first, with the URI rank and offset breaking ties to keep the order deterministic.
+    /// Non-namespace definitions (methods, attrs, variables) are returned separately for
+    /// `handle_remaining_definitions`.
+    ///
+    /// Ordering by depth matters because a name's parts may need to be resolved before the name itself can be. Simple
+    /// names are always straightforward no matter how deeply they nest:
     ///
     /// ```ruby
     /// module Foo
@@ -1841,9 +1847,8 @@ impl<'a> Resolver<'a> {
     /// end
     /// ```
     ///
-    /// These are all simple names because they don't require resolution logic to determine the final name of each step.
-    /// We only have to ensure that they are ordered by nesting level. Names with parent scopes require that their parts
-    /// be resolved to determine what they refer to and so they must be sorted last.
+    /// Here `Foo`, `Bar` and `Baz` only have to be ordered by nesting level. Names with parent scopes, however, require
+    /// their parts to be resolved first, so they must sort last:
     ///
     /// ```ruby
     /// module Foo
@@ -1853,51 +1858,9 @@ impl<'a> Resolver<'a> {
     /// end
     /// ```
     ///
-    /// In this case, we need `Bar` to have already been processed so that we can resolve the `Bar` reference inside of
-    /// the `Foo` nesting, which then unblocks the resolution of `Baz` and finally `Qux`. Notice how `Qux` is a simple
-    /// name, but it's nested under a complex name so we have to sort it last. This is why we consider the number of
-    /// parent scopes in the entire nesting, not just for the name itself
-    ///
-    /// Compute the depth of a name in the graph by recursively summing the depths of its
-    /// `parent_scope` and `nesting` chains. Results are memoized in `cache` (`NameId` → depth)
-    /// so each name is computed at most once across all calls.
-    ///
-    /// Depth represents the total complexity of a name's position in the namespace hierarchy.
-    /// For example, in `module Foo; module Bar; class Baz; end; end; end`, Foo has depth 1
-    /// (top-level), Bar has depth 2, and Baz has depth 3.
-    ///
-    /// # Panics
-    ///
-    /// Will panic if there is inconsistent data in the graph
-    fn name_depth(
-        name_id: NameId,
-        names: &IdentityHashMap<NameId, NameRef>,
-        cache: &mut IdentityHashMap<NameId, u32>,
-    ) -> u32 {
-        if let Some(&depth) = cache.get(&name_id) {
-            return depth;
-        }
-
-        let name = names.get(&name_id).unwrap();
-
-        let depth = if name.parent_scope().is_top_level() {
-            1
-        } else {
-            let parent_depth = name.parent_scope().map_or(0, |id| Self::name_depth(*id, names, cache));
-
-            let nesting_depth = name.nesting().map_or(0, |id| Self::name_depth(id, names, cache));
-
-            parent_depth + nesting_depth + 1
-        };
-
-        cache.insert(name_id, depth);
-        depth
-    }
-
-    /// Drains `pending_work` and classifies items into the resolution queue.
-    /// Namespace definitions and constant references are sorted by name depth for deterministic
-    /// resolution order. Non-namespace definitions (methods, attrs, variables) are returned
-    /// separately for `handle_remaining_definitions`.
+    /// In this case `Bar` must already be processed so the `Bar` reference inside `Foo` resolves, which then unblocks
+    /// `Baz` and finally `Qux`. Notice how `Qux` is a simple name nested under a complex one, so it too sorts late —
+    /// which is why depth accounts for the parent scopes across the entire nesting, not just for the name itself.
     fn prepare_units(&mut self) -> Vec<DefinitionId> {
         let work = self.graph.take_pending_work();
         let estimated = work.len() / 2;
@@ -1907,16 +1870,13 @@ impl<'a> Resolver<'a> {
         let mut const_refs = Vec::new();
         let mut ancestors = vec![*BASIC_OBJECT_ID, *KERNEL_ID, *OBJECT_ID, *MODULE_ID, *CLASS_ID];
         let names = self.graph.names();
-        // Memoize name depths on demand for only the names referenced by the pending work. During incremental
-        // resolution this avoids walking every name in the graph just to sort the small subset of units below.
-        // A pending unit references at most one name, so `estimated` (bounded by the total number of names) is a
-        // reasonable capacity that avoids rehashing as depths accumulate.
-        let mut depths: IdentityHashMap<NameId, u32> =
-            IdentityHashMap::with_capacity_and_hasher(estimated.min(names.len()), IdentityHashBuilder);
+        // Every name captured its depth during indexing (see `Name::compute_depth`), so ordering the units below is a
+        // direct lookup rather than a recursive walk of the nesting chain.
+        let depth_of = |name_id: &NameId| names.get(name_id).unwrap().depth();
 
         // Precompute the lexicographic rank of every document URI. Definitions and references are sorted by
-        // (name depth, URI, offset) below; storing precomputed integer sort keys instead of looking up name
-        // depths and comparing URI strings on every comparison makes sorting substantially cheaper on large graphs.
+        // (name depth, URI, offset) below; storing a precomputed integer rank instead of comparing URI strings on
+        // every comparison makes sorting substantially cheaper on large graphs.
         let mut uris: Vec<(&str, UriId)> = self
             .graph
             .documents()
@@ -1950,23 +1910,23 @@ impl<'a> Resolver<'a> {
 
                     match definition {
                         Definition::Class(def) => {
-                            let depth = Self::name_depth(*def.name_id(), names, &mut depths);
+                            let depth = depth_of(def.name_id());
                             definitions.push((Unit::Definition(id), (depth, uri_rank, definition.offset())));
                         }
                         Definition::Module(def) => {
-                            let depth = Self::name_depth(*def.name_id(), names, &mut depths);
+                            let depth = depth_of(def.name_id());
                             definitions.push((Unit::Definition(id), (depth, uri_rank, definition.offset())));
                         }
                         Definition::Constant(def) => {
-                            let depth = Self::name_depth(*def.name_id(), names, &mut depths);
+                            let depth = depth_of(def.name_id());
                             definitions.push((Unit::Definition(id), (depth, uri_rank, definition.offset())));
                         }
                         Definition::ConstantAlias(def) => {
-                            let depth = Self::name_depth(*def.name_id(), names, &mut depths);
+                            let depth = depth_of(def.name_id());
                             definitions.push((Unit::Definition(id), (depth, uri_rank, definition.offset())));
                         }
                         Definition::SingletonClass(def) => {
-                            let depth = Self::name_depth(*def.name_id(), names, &mut depths);
+                            let depth = depth_of(def.name_id());
                             definitions.push((Unit::Definition(id), (depth, uri_rank, definition.offset())));
                         }
                         // SelfReceiver methods create singleton classes, which need
@@ -1989,7 +1949,7 @@ impl<'a> Resolver<'a> {
                         continue;
                     };
                     let uri_rank = *uri_ranks.get(&constant_ref.uri_id()).unwrap();
-                    let depth = Self::name_depth(*constant_ref.name_id(), names, &mut depths);
+                    let depth = depth_of(constant_ref.name_id());
                     const_refs.push((Unit::ConstantRef(id), (depth, uri_rank, constant_ref.offset())));
                 }
                 Unit::Ancestors(id) => {


### PR DESCRIPTION
Instead of computing name depths during resolution, we can actually cache it inside the `Name` structure during indexing. Because of struct alignment, we pay no memory price for adding the extra field and move a portion of the work to the parallelized indexing workers.

Additionally, computing the depths becomes easier because we can simply sum the depths of the dependent names.

This change gives us a 6% speedup for resolution and no significant differences in any other dimension.

```
BEFORE

Listing: 0.77
Indexing: 5.44
Resolution: 14.374
Total graph memory: 3889.036

AFTER

Listing: 0.796
Indexing: 5.366
Resolution: 13.53
Total graph memory: 3889.05
```