### PR TITLE
Enqueue retry if `Object` ancestors are incomplete

### DIFF
--- a/rust/rubydex/src/resolution.rs
+++ b/rust/rubydex/src/resolution.rs
@@ -1733,8 +1733,13 @@ impl<'a> Resolver<'a> {
             if is_module || chain_incomplete {
                 let object_outcome = self.search_ancestors(*OBJECT_ID, str_id);
 
-                if let Outcome::Resolved(decl_id) = object_outcome {
-                    return Outcome::Resolved(decl_id);
+                match object_outcome {
+                    // Found the constant through Object's ancestors.
+                    Outcome::Resolved(decl_id) => return Outcome::Resolved(decl_id),
+                    // Object's ancestor chain is still partial, so we need to retry later.
+                    Outcome::Retry { .. } => return object_outcome,
+                    // Object's chain is complete, so we indeed can't resolve this constant.
+                    Outcome::Unresolved => {}
                 }
             }
 

--- a/rust/rubydex/src/resolution_tests.rs
+++ b/rust/rubydex/src/resolution_tests.rs
@@ -2132,6 +2132,30 @@ mod object_ancestors_tests {
         assert_constant_reference_to!(context, "Kernel::FOUND_ME", "file:///foo.rb:11:3-11:11");
         assert_constant_reference_unresolved!(context, "FOUND_ME", "file:///foo.rb:14:6-14:14");
     }
+
+    #[test]
+    fn object_inherited_constant_inside_module_reordered() {
+        let mut context = graph_test();
+        context.index_uri("file:///foo.rb", {
+            r"
+            module Foo
+              # Accessible via Object inheritance
+              FOUND_ME
+            end
+
+            module Kernel
+              FOUND_ME = true
+            end
+
+            class Object
+              include Kernel
+            end
+            "
+        });
+        context.resolve();
+
+        assert_constant_reference_to!(context, "Kernel::FOUND_ME", "file:///foo.rb:3:3-3:11");
+    }
 }
 
 mod singleton_ancestors_tests {


### PR DESCRIPTION
We weren't enqueuing retries when `Object` ancestors were not yet fully linearized. We need to do it or else constants defined inside of `Kernel` or any part of the `Object` chain may be missed.