### PR TITLE
Avoid duplicate namespace lookup

### DIFF
--- a/rust/rubydex/src/resolution.rs
+++ b/rust/rubydex/src/resolution.rs
@@ -994,14 +994,9 @@ impl<'a> Resolver<'a> {
 
             // Automatically track descendants as we recurse. This has to happen before checking the cache since we may have
             // already linearized the parent's ancestors, but it's the first time we're discovering the descendant
+            let namespace = declaration.as_namespace_mut().unwrap();
             for descendant in &context.descendants {
-                self.graph
-                    .declarations_mut()
-                    .get_mut(&declaration_id)
-                    .unwrap()
-                    .as_namespace_mut()
-                    .unwrap()
-                    .add_descendant(*descendant);
+                namespace.add_descendant(*descendant);
             }
         }
 


### PR DESCRIPTION
Micro-performance: we don't need to perform the hash lookup at all, much less for each dependent.