### PR TITLE
Make `Config` a proper object

### DIFF
--- a/exe/rdx
+++ b/exe/rdx
@@ -56,8 +56,7 @@ end
 
 # Builds the workspace graph, sending progress messages to `progress_io`.
 def build_graph(progress_io)
-  graph = Rubydex::Graph.new
-  graph.load_config
+  graph = Rubydex::Graph.configure_for_workspace(Dir.pwd)
   with_timer(progress_io, "Indexing workspace...") { graph.index_workspace }
   with_timer(progress_io, "Resolving graph...") { graph.resolve }
   graph

--- a/ext/rubydex/config.c
+++ b/ext/rubydex/config.c
@@ -1,0 +1,78 @@
+#include "config.h"
+#include "rustbindings.h"
+#include "utils.h"
+
+static VALUE mRubydex;
+
+// Free function for Rubydex::Config: releases the parsed configuration allocated by Rust.
+static void config_free(void *ptr) {
+    if (ptr) {
+        rdx_config_free(ptr);
+    }
+}
+
+const rb_data_type_t config_type = {
+    .wrap_struct_name = "Rubydex::Config",
+    .function = {
+        .dmark = NULL,
+        .dfree = config_free,
+        .dsize = NULL,
+        .dcompact = NULL,
+    },
+    .parent = NULL,
+    .data = NULL,
+    .flags = RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_FROZEN_SHAREABLE,
+};
+
+/*
+ * call-seq:
+ *   Rubydex::Config.load(workspace_path) -> Rubydex::Config
+ *
+ * Loads the configuration of the workspace rooted at +workspace_path+, which is where its `rubydex.toml` is expected to
+ * be. A workspace without a configuration file gets an empty configuration. Raises Rubydex::ConfigError if the file
+ * exists, but cannot be read or is malformed.
+ */
+static VALUE rdxr_config_load(VALUE klass, VALUE workspace_path) {
+    Check_Type(workspace_path, T_STRING);
+
+    struct CConfigResult result = rdx_config_load(StringValueCStr(workspace_path));
+    if (result.error != NULL) {
+        VALUE message = rb_utf8_str_new_cstr(result.error);
+        free_c_string(result.error);
+
+        VALUE config_error = rb_const_get(mRubydex, rb_intern("ConfigError"));
+        rb_exc_raise(rb_exc_new_str(config_error, message));
+    }
+
+    return TypedData_Wrap_Struct(klass, &config_type, result.config);
+}
+
+/*
+ * call-seq:
+ *   workspace_path -> String
+ *
+ * Returns the root directory of the workspace this configuration was loaded for.
+ */
+static VALUE rdxr_config_workspace_path(VALUE self) {
+    const char *result = rdx_config_workspace_path(rdxi_config_from_object(self));
+    // A configuration always has a workspace, so there is no absent case to hand back to Ruby. NULL only means the
+    // conversion itself failed, which is why this raises instead of returning nil.
+    if (result == NULL) {
+        rb_raise(rb_eRuntimeError, "Converting workspace path to Ruby string failed");
+    }
+
+    return rdxi_owned_c_string_to_ruby(result);
+}
+
+void rdxi_initialize_config(VALUE moduleRubydex) {
+    mRubydex = moduleRubydex;
+
+    VALUE cConfig = rb_define_class_under(mRubydex, "Config", rb_cObject);
+    rb_undef_alloc_func(cConfig);
+
+    // A configuration can only be obtained through `load`; `new` would create an object with no Rust data behind it.
+    rb_undef_method(rb_singleton_class(cConfig), "new");
+
+    rb_define_singleton_method(cConfig, "load", rdxr_config_load, 1);
+    rb_define_method(cConfig, "workspace_path", rdxr_config_workspace_path, 0);
+}

--- a/ext/rubydex/config.h
+++ b/ext/rubydex/config.h
@@ -1,0 +1,16 @@
+#ifndef RUBYDEX_CONFIG_H
+#define RUBYDEX_CONFIG_H
+
+#include "ruby.h"
+
+extern const rb_data_type_t config_type;
+
+static inline void *rdxi_config_from_object(VALUE config_obj) {
+    void *config;
+    TypedData_Get_Struct(config_obj, void *, &config_type, config);
+    return config;
+}
+
+void rdxi_initialize_config(VALUE mRubydex);
+
+#endif // RUBYDEX_CONFIG_H

--- a/ext/rubydex/graph.c
+++ b/ext/rubydex/graph.c
@@ -1,4 +1,5 @@
 #include "graph.h"
+#include "config.h"
 #include "declaration.h"
 #include "diagnostic.h"
 #include "document.h"
@@ -872,52 +873,18 @@ static VALUE rdxr_graph_workspace_path(VALUE self) {
 
 /*
  * call-seq:
- *   workspace_path=(path) -> void
+ *   load_config(config) -> void
  *
- * Sets the root directory of the workspace being indexed.
+ * Applies a parsed Rubydex::Config to the graph.
  */
-static VALUE rdxr_graph_set_workspace_path(VALUE self, VALUE path) {
-    Check_Type(path, T_STRING);
-
-    void *graph;
-    TypedData_Get_Struct(self, void*, &graph_type, graph);
-
-    rdx_graph_set_workspace_path(graph, StringValueCStr(path));
-    return path;
-}
-
-/*
- * call-seq:
- *   load_config(config_path = nil) -> void
- *
- * Loads a configuration file for the graph. If `config_path` is nil, loads the default configuration file at
- * `workspace_path/rubydex.toml` if it exists. Will raise on malformed files or if an explicit path is given but the
- * file does not exist.
- */
-static VALUE rdxr_graph_load_config(int argc, VALUE *argv, VALUE self) {
-    VALUE config_path;
-    rb_scan_args(argc, argv, "01", &config_path);
-
+static VALUE rdxr_graph_load_config(VALUE self, VALUE config_obj) {
     void *graph;
     TypedData_Get_Struct(self, void *, &graph_type, graph);
 
-    const char *config_path_cstr = NULL;
+    void *config = rdxi_config_from_object(config_obj);
+    rdx_graph_load_config(graph, config);
 
-    if (!NIL_P(config_path)) {
-        Check_Type(config_path, T_STRING);
-        config_path_cstr = StringValueCStr(config_path);
-    }
-
-    const char *error = rdx_graph_load_config(graph, config_path_cstr);
-    if (error == NULL) {
-        return Qnil;
-    }
-
-    VALUE message = rb_utf8_str_new_cstr(error);
-    free_c_string(error);
-
-    VALUE config_error = rb_const_get(mRubydex, rb_intern("ConfigError"));
-    rb_exc_raise(rb_exc_new_str(config_error, message));
+    return Qnil;
 }
 
 /*
@@ -979,7 +946,6 @@ void rdxi_initialize_graph(VALUE moduleRubydex) {
     rb_define_method(cGraph, "exclude_patterns", rdxr_graph_exclude_patterns, 1);
     rb_define_method(cGraph, "excluded_patterns", rdxr_graph_excluded_patterns, 0);
     rb_define_method(cGraph, "workspace_path", rdxr_graph_workspace_path, 0);
-    rb_define_method(cGraph, "workspace_path=", rdxr_graph_set_workspace_path, 1);
-    rb_define_method(cGraph, "load_config", rdxr_graph_load_config, -1);
+    rb_define_method(cGraph, "load_config", rdxr_graph_load_config, 1);
     rb_define_method(cGraph, "keyword", rdxr_graph_keyword, 1);
 }

--- a/ext/rubydex/rubydex.c
+++ b/ext/rubydex/rubydex.c
@@ -1,3 +1,4 @@
+#include "config.h"
 #include "declaration.h"
 #include "definition.h"
 #include "diagnostic.h"
@@ -20,6 +21,7 @@ void Init_rubydex(void) {
      */
     mRubydex = rb_define_module("Rubydex");
     rdxi_initialize_graph(mRubydex);
+    rdxi_initialize_config(mRubydex);
     rdxi_initialize_query(mRubydex);
     rdxi_initialize_declaration(mRubydex);
     rdxi_initialize_document(mRubydex);

--- a/lib/rubydex/errors.rb
+++ b/lib/rubydex/errors.rb
@@ -6,6 +6,7 @@ module Rubydex
   # Raised when `MethodAliasDefinition#target` walks an alias chain that loops back on itself.
   class AliasCycleError < Error; end
 
-  # Raised by `Graph#load_config` when the requested config file does not exist, cannot be read, or is malformed
+  # Raised by `Config.load` when the workspace does not exist, or when its config file cannot be read or is malformed.
+  # A workspace with no config file at all is not an error.
   class ConfigError < Error; end
 end

--- a/lib/rubydex/graph.rb
+++ b/lib/rubydex/graph.rb
@@ -7,9 +7,16 @@ module Rubydex
   class Graph
     INDEXABLE_EXTENSIONS = [".rb", ".rake", ".rbs", ".ru"].freeze
 
-    #: (?workspace_path: String?) -> void
-    def initialize(workspace_path: nil)
-      self.workspace_path = workspace_path if workspace_path
+    class << self
+      # Creates a new graph with the loaded configuration. For use cases where the graph must be shared between
+      # different tools, do not use this. Create and own a `Config` object instead.
+      #
+      #: (String) -> instance
+      def configure_for_workspace(workspace_path)
+        graph = new
+        graph.load_config(Config.load(workspace_path))
+        graph
+      end
     end
 
     # Index all files and dependencies of the workspace that exists in `workspace_path`

--- a/lib/rubydex/mcp_server.rb
+++ b/lib/rubydex/mcp_server.rb
@@ -28,8 +28,7 @@ module Rubydex
       def initialize(root_path:, transport: nil)
         @root_path = root_path
         @transport = transport
-        @graph = Graph.new(workspace_path: @root_path)
-        @graph.load_config
+        @graph = Graph.configure_for_workspace(@root_path)
         @index_finished = false
         @incoming_queue = Thread::Queue.new
         @outgoing_queue = Thread::Queue.new

--- a/rbi/rubydex.rbi
+++ b/rbi/rubydex.rbi
@@ -354,6 +354,21 @@ class Rubydex::Error < StandardError; end
 class Rubydex::AliasCycleError < Rubydex::Error; end
 class Rubydex::ConfigError < Rubydex::Error; end
 
+# The configuration of a workspace, parsed from its `rubydex.toml`. It carries both the settings that are global to
+# every built-in tool, such as the workspace being analyzed, and the typed settings of each tool's own section (e.g.
+# `[graph]`, `[linter]`).
+class Rubydex::Config
+  class << self
+    # Loads the configuration file for `workspace_path/rubydex.toml` if it exists or uses the defaults.
+    sig { params(workspace_path: String).returns(Rubydex::Config) }
+    def load(workspace_path); end
+  end
+
+  # The configured workspace path, which is usually PWD, except for editors that spawn language servers outside of pwd.
+  sig { returns(String) }
+  def workspace_path; end
+end
+
 class Rubydex::Failure
   sig { params(message: String).void }
   def initialize(message); end
@@ -381,8 +396,12 @@ class Rubydex::Query
 end
 
 class Rubydex::Graph
-  sig { params(workspace_path: T.nilable(String)).void }
-  def initialize(workspace_path: nil); end
+  class << self
+    # Creates a new graph with the loaded configuration. For use cases where the graph must be shared between
+    # different tools, do not use this. Create and own a `Config` object instead.
+    sig { params(workspace_path: String).returns(T.attached_class) }
+    def configure_for_workspace(workspace_path); end
+  end
 
   sig { params(fully_qualified_name: String).returns(T.nilable(Rubydex::Declaration)) }
   def [](fully_qualified_name); end
@@ -419,12 +438,9 @@ class Rubydex::Graph
   sig { params(name: String).returns(T.nilable(Rubydex::Keyword)) }
   def keyword(name); end
 
-  # Loads configuration, merging its exclusion patterns into the graph's configuration (the workspace path is never
-  # overridden). With `config_path` (resolved relative to the workspace path), an explicitly named file that does not
-  # exist raises `Rubydex::ConfigError`. With no argument, the default `.rubydex` is loaded if present and ignored if
-  # missing. Raises `Rubydex::ConfigError` if a file cannot be read or is malformed.
-  sig { params(config_path: T.nilable(String)).void }
-  def load_config(config_path = nil); end
+  # Loads the configuration in the graph.
+  sig { params(config: Rubydex::Config).void }
+  def load_config(config); end
 
   sig { returns(T::Enumerable[Rubydex::MethodReference]) }
   def method_references; end
@@ -450,11 +466,9 @@ class Rubydex::Graph
   sig { params(encoding: String).void }
   def encoding=(encoding); end
 
+  # The root directory of the workspace being analyzed, which comes from the loaded `Rubydex::Config`
   sig { returns(String) }
   def workspace_path; end
-
-  sig { params(workspace_path: String).returns(String) }
-  def workspace_path=(workspace_path); end
 
   sig { returns(T::Array[String]) }
   def workspace_paths; end

--- a/rubydex.toml
+++ b/rubydex.toml
@@ -1,1 +1,2 @@
+[graph]
 exclude = ["docs", "ext", "rust", "target"]

--- a/rust/rubydex-sys/src/config_api.rs
+++ b/rust/rubydex-sys/src/config_api.rs
@@ -69,7 +69,7 @@ pub unsafe extern "C" fn rdx_config_load(workspace_path: *const c_char) -> CConf
 pub unsafe extern "C" fn rdx_config_workspace_path(config: ConfigPointer) -> *const c_char {
     let config = unsafe { &*config.cast::<Config>() };
 
-    CString::new(config.workspace_path().to_string_lossy().as_ref())
+    CString::new(utils::interop_path(config.workspace_path()))
         .map_or(ptr::null(), |c_string| c_string.into_raw().cast_const())
 }
 

--- a/rust/rubydex-sys/src/config_api.rs
+++ b/rust/rubydex-sys/src/config_api.rs
@@ -1,0 +1,91 @@
+use crate::utils;
+use libc::{c_char, c_void};
+use rubydex::config::Config;
+use rubydex::errors::Errors;
+use std::ffi::CString;
+use std::path::Path;
+use std::ptr;
+
+/// An opaque pointer to a loaded configuration
+pub type ConfigPointer = *mut c_void;
+
+/// The result of loading a configuration file, carrying either a parsed configuration or an error message.
+#[repr(C)]
+pub struct CConfigResult {
+    /// Non-null on success: a heap-allocated parsed configuration. Free with `rdx_config_free`.
+    pub config: ConfigPointer,
+    /// Non-null on error; null on success. Caller must free with `free_c_string`.
+    pub error: *const c_char,
+}
+
+impl CConfigResult {
+    fn success(config: Config) -> Self {
+        Self {
+            config: Box::into_raw(Box::new(config)).cast::<c_void>(),
+            error: ptr::null(),
+        }
+    }
+
+    fn error(message: &str) -> Self {
+        // Parse errors quote raw file content, which may contain NUL bytes that a C string cannot carry.
+        let message = message.replace('\0', "\u{FFFD}");
+
+        Self {
+            config: ptr::null_mut(),
+            error: utils::cstring_raw(&message),
+        }
+    }
+}
+
+/// Loads the configuration of the workspace rooted at `workspace_path`, which is where its `rubydex.toml` is expected
+/// to be. A workspace without a configuration file produces an empty configuration.
+///
+/// # Safety
+///
+/// - `workspace_path` must be a valid, null-terminated string.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rdx_config_load(workspace_path: *const c_char) -> CConfigResult {
+    if workspace_path.is_null() {
+        return CConfigResult::error("workspace path is required");
+    }
+
+    let Ok(workspace_path) = (unsafe { utils::convert_char_ptr_to_string(workspace_path) }) else {
+        return CConfigResult::error("workspace path is not valid UTF-8");
+    };
+
+    match Config::load(Path::new(&workspace_path)) {
+        Ok(config) => CConfigResult::success(config),
+        Err(Errors::ConfigError(message) | Errors::FileError(message)) => CConfigResult::error(&message),
+    }
+}
+
+/// Returns the root directory of the workspace the configuration was loaded for, as a C string. Caller must free with
+/// `free_c_string`.
+///
+/// # Safety
+///
+/// - `config` must be a valid `ConfigPointer` previously returned by `rdx_config_load`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rdx_config_workspace_path(config: ConfigPointer) -> *const c_char {
+    let config = unsafe { &*config.cast::<Config>() };
+
+    CString::new(config.workspace_path().to_string_lossy().as_ref())
+        .map_or(ptr::null(), |c_string| c_string.into_raw().cast_const())
+}
+
+/// Frees a configuration through its pointer. Does nothing when given NULL.
+///
+/// # Safety
+///
+/// - `config` must either be NULL or a valid `ConfigPointer` previously returned by `rdx_config_load` and must not
+///   be used afterwards. Any string pointer borrowed from it becomes invalid.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rdx_config_free(config: ConfigPointer) {
+    if config.is_null() {
+        return;
+    }
+
+    unsafe {
+        let _ = Box::from_raw(config.cast::<Config>());
+    }
+}

--- a/rust/rubydex-sys/src/graph_api.rs
+++ b/rust/rubydex-sys/src/graph_api.rs
@@ -218,14 +218,8 @@ pub unsafe extern "C" fn rdx_graph_excluded_patterns(
 
         let c_strings: Vec<*const c_char> = excluded
             .iter()
-            .filter_map(|path| {
-                // Normalize all paths to use forward slashes. Otherwise, you get mixed backslashes and forward slashes
-                // on Windows if a configuration file is using forward slashes. For example:
-                //
-                // C:\project/vendor/bundle
-                let normalized = path.replace(std::path::MAIN_SEPARATOR, "/");
-
-                CString::new(normalized)
+            .filter_map(|pattern| {
+                CString::new(pattern.as_ref())
                     .ok()
                     .map(|c_string| c_string.into_raw().cast_const())
             })
@@ -246,7 +240,7 @@ pub unsafe extern "C" fn rdx_graph_excluded_patterns(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rdx_graph_workspace_path(pointer: GraphPointer) -> *const c_char {
     with_graph(pointer, |graph| {
-        CString::new(graph.workspace_path().to_string_lossy().as_ref())
+        CString::new(utils::interop_path(graph.workspace_path()))
             .map_or(ptr::null(), |c_string| c_string.into_raw().cast_const())
     })
 }

--- a/rust/rubydex-sys/src/graph_api.rs
+++ b/rust/rubydex-sys/src/graph_api.rs
@@ -1,5 +1,6 @@
 //! This file provides the C API for the Graph object
 
+use crate::config_api::ConfigPointer;
 use crate::cypher_api::CQueryResult;
 use crate::declaration_api::CDeclaration;
 use crate::declaration_api::DeclarationsIter;
@@ -8,7 +9,7 @@ use crate::document_api::DocumentsIter;
 use crate::reference_api::{CConstantReference, CMethodReference, ConstantReferencesIter, MethodReferencesIter};
 use crate::{name_api, utils};
 use libc::{c_char, c_void};
-use rubydex::errors::Errors;
+use rubydex::config::Config;
 use rubydex::indexing::LanguageId;
 use rubydex::model::encoding::Encoding;
 use rubydex::model::graph::Graph;
@@ -21,7 +22,7 @@ use rubydex::query::{CompletionCandidate, CompletionContext, CompletionReceiver}
 use rubydex::resolution::Resolver;
 use rubydex::{indexing, integrity, listing, query};
 use std::ffi::CString;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::{mem, ptr, sync::RwLock};
 
 pub type GraphPointer = *mut c_void;
@@ -237,23 +238,6 @@ pub unsafe extern "C" fn rdx_graph_excluded_patterns(
     })
 }
 
-/// Sets the workspace path used as the root directory for indexing and relative path resolution. Silently ignores the
-/// call if the given path is not valid UTF-8, leaving the existing workspace path untouched (mirrors
-/// `rdx_graph_set_encoding`). This avoids unwinding across the FFI boundary on malformed input.
-///
-/// # Safety
-///
-/// - `pointer` must be a valid `GraphPointer` previously returned by this crate.
-/// - `path` must be a valid, null-terminated string.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn rdx_graph_set_workspace_path(pointer: GraphPointer, path: *const c_char) {
-    let Ok(path) = (unsafe { utils::convert_char_ptr_to_string(path) }) else {
-        return;
-    };
-
-    with_mut_graph(pointer, |graph| graph.set_workspace_path(PathBuf::from(path)));
-}
-
 /// Returns the workspace path as a C string. Caller must free with `free_c_string`.
 ///
 /// # Safety
@@ -267,37 +251,18 @@ pub unsafe extern "C" fn rdx_graph_workspace_path(pointer: GraphPointer) -> *con
     })
 }
 
-/// Loads configuration into the graph. A null `config_path` attempts to load the default configuration file.
-///
-/// Returns NULL on success. On failure returns an owned, null-terminated error message that the caller must free with
-/// `free_c_string`.
-///
-/// A `config_path` that is not valid UTF-8 is reported as an error message.
+/// Applies a parsed configuration file to the graph, which adopts the workspace it was loaded for along with the
+/// settings of its `[graph]` section. This is the only way to point the graph at a workspace other than the current
+/// directory, and it replaces any previously applied configuration. Tool-specific sections are ignored.
 ///
 /// # Safety
 ///
 /// - `pointer` must be a valid `GraphPointer` previously returned by this crate.
-/// - `config_path` must either be NULL or a valid, null-terminated string.
+/// - `config` must be a valid `ConfigPointer` previously returned by `rdx_config_load`.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn rdx_graph_load_config(pointer: GraphPointer, config_path: *const c_char) -> *const c_char {
-    let result = with_mut_graph(pointer, |graph| {
-        if config_path.is_null() {
-            graph.load_config(None)
-        } else {
-            match unsafe { utils::convert_char_ptr_to_string(config_path) } {
-                Ok(config_path) => graph.load_config(Some(Path::new(&config_path))),
-                Err(_) => Err(Errors::ConfigError("config file path is not valid UTF-8".to_string())),
-            }
-        }
-    });
-
-    match result {
-        Ok(()) => ptr::null(),
-        Err(error) => CString::new(error.to_string())
-            .unwrap_or_default()
-            .into_raw()
-            .cast_const(),
-    }
+pub unsafe extern "C" fn rdx_graph_load_config(pointer: GraphPointer, config: ConfigPointer) {
+    let config = unsafe { &*config.cast::<Config>() };
+    with_mut_graph(pointer, |graph| graph.load_config(config));
 }
 
 /// Indexes all given file paths in parallel using the provided Graph pointer.

--- a/rust/rubydex-sys/src/lib.rs
+++ b/rust/rubydex-sys/src/lib.rs
@@ -68,6 +68,7 @@ macro_rules! iterator {
     };
 }
 
+pub mod config_api;
 pub mod cypher_api;
 pub mod declaration_api;
 pub mod definition_api;

--- a/rust/rubydex-sys/src/utils.rs
+++ b/rust/rubydex-sys/src/utils.rs
@@ -1,5 +1,6 @@
 use libc::{c_char, size_t};
 use std::ffi::{CStr, CString};
+use std::path::Path;
 use std::slice;
 use std::str::Utf8Error;
 
@@ -78,4 +79,29 @@ pub unsafe extern "C" fn free_c_string_array(ptr: *const *const c_char, count: u
 #[must_use]
 pub fn cstring_raw(value: &str) -> *const c_char {
     CString::new(value).unwrap().into_raw().cast_const()
+}
+
+/// Rust uses backslashes as separators on Windows, but Ruby prefers forward slashes everywhere. We need to make sure
+/// we're maintaining the right separators at the boundary.
+#[must_use]
+pub fn interop_path(path: &Path) -> String {
+    path.to_string_lossy().replace(std::path::MAIN_SEPARATOR, "/")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(unix)]
+    #[test]
+    fn interop_path_leaves_a_unix_path_untouched() {
+        // A backslash is an ordinary character in a Unix file name, so rewriting it would name a different file.
+        assert_eq!(interop_path(Path::new(r"/tmp/we\ird")), r"/tmp/we\ird");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn interop_path_separates_a_windows_path_with_forward_slashes() {
+        assert_eq!(interop_path(Path::new(r"D:\a\_temp\project")), "D:/a/_temp/project");
+    }
 }

--- a/rust/rubydex/benches/graph_memory.rs
+++ b/rust/rubydex/benches/graph_memory.rs
@@ -3,6 +3,7 @@ mod imp {
     use std::time::Instant;
 
     use rubydex::{
+        config::Config,
         indexing::{self, IndexerBackend},
         listing,
         model::graph::Graph,
@@ -27,11 +28,8 @@ mod imp {
         assert!(workspace_path.is_dir(), "the workspace path must be a directory");
 
         let mut graph = Graph::new();
-        graph.set_workspace_path(workspace_path);
-
-        if let Err(error) = graph.load_config(None) {
-            eprintln!("{error}");
-        }
+        let config = Config::load(&workspace_path).expect("the workspace configuration must be valid");
+        graph.load_config(&config);
 
         let time = Instant::now();
 

--- a/rust/rubydex/src/config.rs
+++ b/rust/rubydex/src/config.rs
@@ -1,9 +1,10 @@
 use crate::assert_mem_size;
 use crate::errors::Errors;
+use crate::path_helpers;
 use std::collections::HashSet;
 use std::fs;
 use std::io::ErrorKind;
-use std::path::{Path, PathBuf};
+use std::path::{MAIN_SEPARATOR, Path, PathBuf};
 use toml::{Table, Value};
 
 const DEFAULT_EXCLUDED_DIRECTORIES: &[&str] = &[
@@ -104,7 +105,7 @@ impl Config {
     /// Returns [`Errors::ConfigError`] if `workspace_path` is not a directory, or if the configuration file exists but
     /// cannot be read or is invalid.
     pub fn load(workspace_path: &Path) -> Result<Self, Errors> {
-        let workspace_path = fs::canonicalize(workspace_path).map_err(|error| {
+        let workspace_path = path_helpers::resolved(workspace_path).map_err(|error| {
             Errors::ConfigError(format!(
                 "Failed to resolve workspace path `{}`: {error}",
                 workspace_path.display()
@@ -158,10 +159,11 @@ impl Config {
         self.graph
             .excluded_patterns()
             .map(|pattern| {
+                // We must replace the separator on Windows for forward slash to use in glob patterns.
                 self.workspace_path
                     .join(pattern)
                     .to_string_lossy()
-                    .into_owned()
+                    .replace(MAIN_SEPARATOR, "/")
                     .into_boxed_str()
             })
             .collect()
@@ -209,9 +211,13 @@ impl Config {
 mod tests {
     use super::*;
 
-    /// The path the exclusion pattern `entry` resolves to under `workspace_path`
+    /// The pattern the exclusion `entry` resolves to under `workspace_path`, spelled the way exclusions are
     fn exclusion(workspace_path: impl AsRef<Path>, entry: &str) -> String {
-        workspace_path.as_ref().join(entry).to_string_lossy().into_owned()
+        workspace_path
+            .as_ref()
+            .join(entry)
+            .to_string_lossy()
+            .replace(MAIN_SEPARATOR, "/")
     }
 
     fn workspace_exclusion(entry: &str) -> String {
@@ -247,6 +253,23 @@ mod tests {
     }
 
     #[test]
+    fn excluded_patterns_are_separated_by_forward_slashes() {
+        // Exclusions are glob patterns, and a glob pattern is written with forward slashes whatever the platform's own
+        // separator is. Joining them against the workspace path is what would otherwise introduce a backslash, so the
+        // invariant is asserted on the joined result. Vacuous where the separator already is a forward slash.
+        let mut config = parse("").expect("an empty config is valid");
+        config.exclude_patterns([Box::from("vendor/bundle")]);
+
+        let excluded = config.excluded_patterns();
+
+        assert!(!excluded.is_empty(), "expected the defaults at least");
+        assert!(
+            excluded.iter().all(|pattern| !pattern.contains('\\')),
+            "unexpected backslash in {excluded:?}"
+        );
+    }
+
+    #[test]
     fn parse_rejects_an_unknown_section() {
         let error = parse("[lintr]\n").expect_err("every section must be backed by typed settings structs");
         assert!(error.contains("unknown section `lintr`"), "unexpected error: {error}");
@@ -257,7 +280,7 @@ mod tests {
         let dir = tempfile::tempdir().expect("failed to create temp dir");
         let config = Config::load(dir.path()).expect("a missing rubydex.toml must not be an error");
 
-        assert_eq!(config.workspace_path(), fs::canonicalize(dir.path()).unwrap());
+        assert_eq!(config.workspace_path(), path_helpers::resolved(dir.path()).unwrap());
         assert_eq!(config.excluded_patterns().len(), DEFAULT_EXCLUDED_DIRECTORIES.len());
     }
 
@@ -269,7 +292,7 @@ mod tests {
         let config = Config::load(dir.path()).expect("expected rubydex.toml to load");
         let excluded = config.excluded_patterns();
 
-        let path = fs::canonicalize(dir.path()).unwrap();
+        let path = path_helpers::resolved(dir.path()).unwrap();
         assert_eq!(config.workspace_path(), path);
         assert!(excluded.contains(exclusion(&path, "vendor").as_str()));
         assert!(excluded.contains(exclusion(&path, ".git").as_str()));
@@ -284,7 +307,7 @@ mod tests {
 
         for workspace_path in [missing.as_path(), file.as_path()] {
             let error = Config::load(workspace_path).expect_err("a workspace must be a directory");
-            let named = fs::canonicalize(workspace_path).unwrap_or_else(|_| workspace_path.to_path_buf());
+            let named = path_helpers::resolved(workspace_path).unwrap_or_else(|_| workspace_path.to_path_buf());
 
             assert!(matches!(error, Errors::ConfigError(_)), "unexpected error: {error:?}");
             assert!(

--- a/rust/rubydex/src/config.rs
+++ b/rust/rubydex/src/config.rs
@@ -1,12 +1,12 @@
 use crate::assert_mem_size;
 use crate::errors::Errors;
-use serde::Deserialize;
 use std::collections::HashSet;
 use std::fs;
 use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
+use toml::{Table, Value};
 
-pub const DEFAULT_EXCLUDED_DIRECTORIES: &[&str] = &[
+const DEFAULT_EXCLUDED_DIRECTORIES: &[&str] = &[
     ".bundle",
     ".claude",
     ".git",
@@ -18,106 +18,114 @@ pub const DEFAULT_EXCLUDED_DIRECTORIES: &[&str] = &[
     "tmp",
 ];
 
-/// Configuration coming from a config file
-#[derive(Debug, Default, Deserialize)]
-struct ConfigFile {
-    /// Patterns to exclude from file discovery during indexing.
-    #[serde(default)]
-    exclude: Vec<Box<str>>,
+/// The graph's settings, read from the `[graph]` section of the configuration file
+#[derive(Debug, Clone)]
+pub struct GraphSettings {
+    /// Patterns to exclude from file discovery during indexing, on top of the built-in defaults. Stored as written and
+    /// only joined with the workspace path when read, so that a pattern cannot outlive the configuration it came from
+    /// and be silently re-rooted under another workspace.
+    excluded_patterns: HashSet<Box<str>>,
 }
 
-/// Project configuration
-#[derive(Debug)]
+impl Default for GraphSettings {
+    /// The settings of a workspace that configures nothing: the built-in exclusions and no more
+    fn default() -> Self {
+        Self {
+            excluded_patterns: DEFAULT_EXCLUDED_DIRECTORIES.iter().map(|&dir| Box::from(dir)).collect(),
+        }
+    }
+}
+
+impl GraphSettings {
+    /// Parses the `[graph]` section on top of the default exclusions
+    fn parse(mut table: Table) -> Result<Self, String> {
+        let exclude = match table.remove("exclude") {
+            None => Vec::new(),
+            Some(value) => value
+                .try_into::<Vec<Box<str>>>()
+                .map_err(|error| format!("invalid `graph.exclude` setting: {error}"))?,
+        };
+
+        if let Some(key) = table.keys().next() {
+            return Err(format!("unknown setting `graph.{key}`"));
+        }
+
+        let mut settings = Self::default();
+        settings.exclude_patterns(exclude);
+        Ok(settings)
+    }
+
+    /// Adds patterns to exclude from file discovery during indexing
+    fn exclude_patterns(&mut self, patterns: impl IntoIterator<Item = Box<str>>) {
+        self.excluded_patterns.extend(patterns);
+    }
+
+    /// Returns the exclusion patterns as written, without resolving them against any workspace
+    fn excluded_patterns(&self) -> impl Iterator<Item = &str> {
+        self.excluded_patterns.iter().map(|pattern| &**pattern)
+    }
+}
+
+/// The configuration of a workspace, parsed from its `rubydex.toml` and shared by all built-in tools. It carries both
+/// the settings that are global to every tool, such as the workspace being analyzed, and the typed settings of each
+/// tool's own section (e.g. `[graph]`). Every section is parsed eagerly, so that all validation happens at load time and
+/// unknown sections or settings are rejected. Load the file once and hand the configuration to each consumer, so that
+/// none of them has to read it again.
+#[derive(Debug, Clone)]
 pub struct Config {
-    /// Path to the workspace being analyzed
+    /// Root directory of the workspace being analyzed, which is where its configuration file lives. Global, and not
+    /// configurable through the file itself, since it is what says where that file is.
     workspace_path: Box<Path>,
-    /// Patterns to exclude from file discovery during indexing.
-    excluded_patterns: HashSet<Box<str>>,
+    graph: GraphSettings,
 }
 assert_mem_size!(Config, 64);
 
 impl Default for Config {
+    /// The configuration of the current working directory, with the default settings of every section, which is what a
+    /// graph is configured by until one is loaded for it. Guessing a root here rather than leaving it empty is what
+    /// keeps `Graph::new` infallible, since patterns are resolved against it; every other configuration comes from
+    /// [`Config::load`]. Cannot be derived, as `Box<Path>` has no default.
     fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl Config {
-    /// Creates a configuration whose workspace path defaults to the current working directory.
-    #[must_use]
-    pub fn new() -> Self {
         Self {
             workspace_path: std::env::current_dir()
                 .unwrap_or_else(|_| PathBuf::from("."))
                 .into_boxed_path(),
-            excluded_patterns: DEFAULT_EXCLUDED_DIRECTORIES.iter().map(|&dir| Box::from(dir)).collect(),
+            graph: GraphSettings::default(),
         }
     }
+}
 
-    /// Returns the root directory of the workspace being analyzed.
-    #[must_use]
-    pub fn workspace_path(&self) -> &Path {
-        &self.workspace_path
-    }
-
-    /// Sets the root directory of the workspace being analyzed.
-    pub fn set_workspace_path(&mut self, workspace_path: PathBuf) {
-        self.workspace_path = workspace_path.into_boxed_path();
-    }
-
-    /// Adds patterns to exclude from file discovery during indexing. Excluded directories will be skipped entirely during
-    /// directory traversal.
-    pub fn exclude_patterns(&mut self, patterns: impl IntoIterator<Item = Box<str>>) {
-        self.excluded_patterns.extend(patterns);
-    }
-
-    /// Returns the set of exclusion patterns resolved against the workspace path.
-    #[must_use]
-    pub fn excluded_patterns(&self) -> HashSet<Box<str>> {
-        self.excluded_patterns
-            .iter()
-            .map(|entry| {
-                self.workspace_path
-                    .join(&**entry)
-                    .to_string_lossy()
-                    .into_owned()
-                    .into_boxed_str()
-            })
-            .collect()
-    }
-
-    /// Merges the default `rubydex.toml` configuration file from the workspace root into this config, if present.
-    ///
-    /// The default config file is optional, so a missing `rubydex.toml` is silently ignored. Any other failure (an
-    /// unreadable or malformed file) is still reported.
+impl Config {
+    /// Loads the configuration of the workspace rooted at `workspace_path`, which is where its `rubydex.toml` is
+    /// expected to be. The configuration file itself is optional: a workspace without one gets the default settings.
     ///
     /// # Errors
     ///
-    /// Will error if the config file exists but cannot be read or has invalid syntax.
-    pub fn load_default(&mut self) -> Result<(), Errors> {
-        let config_path = self.workspace_path.join("rubydex.toml");
+    /// Returns [`Errors::ConfigError`] if `workspace_path` is not a directory, or if the configuration file exists but
+    /// cannot be read or is invalid.
+    pub fn load(workspace_path: &Path) -> Result<Self, Errors> {
+        let workspace_path = fs::canonicalize(workspace_path).map_err(|error| {
+            Errors::ConfigError(format!(
+                "Failed to resolve workspace path `{}`: {error}",
+                workspace_path.display()
+            ))
+        })?;
 
-        match self.load_file(&config_path) {
-            Err(Errors::ConfigNotFound(_)) => Ok(()),
-            other => other,
+        // Since loading a configuration is how a workspace is chosen, a root that cannot be analyzed has to be rejected
+        // here. Otherwise the mistake is only reported much later, by whatever first tries to walk it.
+        if !workspace_path.is_dir() {
+            return Err(Errors::ConfigError(format!(
+                "Workspace `{}` is not a directory",
+                workspace_path.display()
+            )));
         }
-    }
 
-    /// Merges the configuration at `config_path` into this config
-    ///
-    /// # Errors
-    ///
-    /// Returns [`Errors::ConfigNotFound`] if the file does not exist or [`Errors::ConfigError`] if it cannot otherwise
-    /// be read or has invalid syntax.
-    pub fn load_file(&mut self, config_path: &Path) -> Result<(), Errors> {
-        let content = match fs::read_to_string(config_path) {
+        let config_path = workspace_path.join("rubydex.toml");
+
+        let content = match fs::read_to_string(&config_path) {
             Ok(content) => content,
-            Err(error) if error.kind() == ErrorKind::NotFound => {
-                return Err(Errors::ConfigNotFound(format!(
-                    "Config file `{}` does not exist",
-                    config_path.display()
-                )));
-            }
+            // Configuring a workspace is optional, so a missing file is the same as an empty one
+            Err(error) if error.kind() == ErrorKind::NotFound => String::new(),
             Err(error) => {
                 return Err(Errors::ConfigError(format!(
                     "Failed to read config file `{}`: {error}",
@@ -126,33 +134,98 @@ impl Config {
             }
         };
 
-        let parsed = Self::parse(&content).map_err(|error| {
-            Errors::ConfigError(format!("Invalid config file `{}`: {error}", config_path.display()))
-        })?;
-
-        self.excluded_patterns.extend(parsed.exclude);
-        Ok(())
+        Self::parse(workspace_path, &content)
+            .map_err(|error| Errors::ConfigError(format!("Invalid config file `{}`: {error}", config_path.display())))
     }
 
-    /// Parses the content into a [`ConfigFile`]
-    fn parse(content: &str) -> Result<ConfigFile, toml::de::Error> {
-        toml::from_str(content)
+    /// Returns the root directory of the workspace this configuration belongs to
+    #[must_use]
+    pub fn workspace_path(&self) -> &Path {
+        &self.workspace_path
+    }
+
+    /// Adds patterns to exclude from file discovery during indexing. Excluded directories will be skipped entirely
+    /// during directory traversal.
+    pub fn exclude_patterns(&mut self, patterns: impl IntoIterator<Item = Box<str>>) {
+        self.graph.exclude_patterns(patterns);
+    }
+
+    /// Returns the set of exclusion patterns resolved against the workspace path. Resolving is the one thing that needs
+    /// both halves of the configuration, which is why it lives here rather than on the settings of the section the
+    /// patterns come from.
+    #[must_use]
+    pub fn excluded_patterns(&self) -> HashSet<Box<str>> {
+        self.graph
+            .excluded_patterns()
+            .map(|pattern| {
+                self.workspace_path
+                    .join(pattern)
+                    .to_string_lossy()
+                    .into_owned()
+                    .into_boxed_str()
+            })
+            .collect()
+    }
+
+    /// Parses the content of the configuration file of the workspace rooted at `workspace_path` into the typed
+    /// settings of each section
+    fn parse(workspace_path: PathBuf, content: &str) -> Result<Self, String> {
+        let mut sections: Table = toml::from_str(content).map_err(|error| error.to_string())?;
+
+        // Every top-level entry must be a section table. A non-table entry is most likely a typo, and an array of
+        // tables comes from `[[section]]` syntax, which is a section shape mistake rather than an unknown setting.
+        if let Some((key, value)) = sections.iter().find(|(_, value)| !value.is_table()) {
+            if value
+                .as_array()
+                .is_some_and(|array| !array.is_empty() && array.iter().all(Value::is_table))
+            {
+                return Err(format!(
+                    "section `{key}` must be a table; use `[{key}]` instead of `[[{key}]]`"
+                ));
+            }
+
+            return Err(format!("unknown setting `{key}`"));
+        }
+
+        // Non-table entries were rejected above, so every present section is always a table.
+        let graph = match sections.remove("graph") {
+            Some(Value::Table(table)) => GraphSettings::parse(table)?,
+            _ => GraphSettings::default(),
+        };
+
+        // Every section must be backed by a typed settings struct, so any leftover section is unknown.
+        if let Some(key) = sections.keys().next() {
+            return Err(format!("unknown section `{key}`"));
+        }
+
+        Ok(Self {
+            workspace_path: Box::from(workspace_path),
+            graph,
+        })
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::path::Path;
+
+    /// The path the exclusion pattern `entry` resolves to under `workspace_path`
+    fn exclusion(workspace_path: impl AsRef<Path>, entry: &str) -> String {
+        workspace_path.as_ref().join(entry).to_string_lossy().into_owned()
+    }
 
     fn workspace_exclusion(entry: &str) -> String {
-        PathBuf::from("/workspace").join(entry).to_string_lossy().into_owned()
+        exclusion("/workspace", entry)
+    }
+
+    /// Parses configuration content for an arbitrary workspace, for the tests that only care about the settings
+    fn parse(content: &str) -> Result<Config, String> {
+        Config::parse(PathBuf::from("/workspace"), content)
     }
 
     #[test]
     fn excluded_patterns_resolves_patterns_against_the_workspace_path() {
-        let mut config = Config::new();
-        config.set_workspace_path(PathBuf::from("/workspace"));
+        let mut config = parse("").expect("an empty config is valid");
         config.exclude_patterns([
             Box::from("vendor"),
             Box::from("**/fixtures"),
@@ -174,122 +247,132 @@ mod tests {
     }
 
     #[test]
-    fn new_seeds_the_default_excluded_directories() {
-        let config = Config::new();
+    fn parse_rejects_an_unknown_section() {
+        let error = parse("[lintr]\n").expect_err("every section must be backed by typed settings structs");
+        assert!(error.contains("unknown section `lintr`"), "unexpected error: {error}");
+    }
 
-        for default in DEFAULT_EXCLUDED_DIRECTORIES {
+    #[test]
+    fn load_returns_the_default_configuration_for_a_workspace_without_a_config_file() {
+        let dir = tempfile::tempdir().expect("failed to create temp dir");
+        let config = Config::load(dir.path()).expect("a missing rubydex.toml must not be an error");
+
+        assert_eq!(config.workspace_path(), fs::canonicalize(dir.path()).unwrap());
+        assert_eq!(config.excluded_patterns().len(), DEFAULT_EXCLUDED_DIRECTORIES.len());
+    }
+
+    #[test]
+    fn load_reads_the_config_file_under_the_workspace_path() {
+        let dir = tempfile::tempdir().expect("failed to create temp dir");
+        fs::write(dir.path().join("rubydex.toml"), "[graph]\nexclude = [\"vendor\"]\n").unwrap();
+
+        let config = Config::load(dir.path()).expect("expected rubydex.toml to load");
+        let excluded = config.excluded_patterns();
+
+        let path = fs::canonicalize(dir.path()).unwrap();
+        assert_eq!(config.workspace_path(), path);
+        assert!(excluded.contains(exclusion(&path, "vendor").as_str()));
+        assert!(excluded.contains(exclusion(&path, ".git").as_str()));
+    }
+
+    #[test]
+    fn load_errors_when_the_workspace_is_not_a_directory() {
+        let dir = tempfile::tempdir().expect("failed to create temp dir");
+        let missing = dir.path().join("typo");
+        let file = dir.path().join("file.rb");
+        fs::write(&file, "class Foo; end").unwrap();
+
+        for workspace_path in [missing.as_path(), file.as_path()] {
+            let error = Config::load(workspace_path).expect_err("a workspace must be a directory");
+            let named = fs::canonicalize(workspace_path).unwrap_or_else(|_| workspace_path.to_path_buf());
+
+            assert!(matches!(error, Errors::ConfigError(_)), "unexpected error: {error:?}");
             assert!(
-                config.excluded_patterns.contains(*default),
-                "expected `{default}` to be excluded by default"
+                error.to_string().contains(&named.display().to_string()),
+                "expected the error to name the workspace `{}`: {error}",
+                named.display()
             );
         }
     }
 
     #[test]
-    fn load_file_merges_excluded_patterns_and_leaves_the_workspace_path_untouched() {
+    fn load_errors_when_the_config_file_cannot_be_read() {
         let dir = tempfile::tempdir().expect("failed to create temp dir");
-        let config_path = dir.path().join("rubydex.toml");
-        fs::write(&config_path, "exclude = [\"vendor\", \"generated\"]\n").unwrap();
+        // A `rubydex.toml` that exists but cannot be read is a broken workspace, unlike one that has no configuration
+        // at all. Making it a directory is the portable way of making it unreadable.
+        fs::create_dir(dir.path().join("rubydex.toml")).unwrap();
 
-        let mut config = Config::new();
-        config.set_workspace_path(PathBuf::from("/workspace"));
+        let error = Config::load(dir.path()).expect_err("an unreadable config file must be an error");
 
-        config
-            .load_file(&config_path)
-            .expect("expected the config file to load");
-
-        let excluded = config.excluded_patterns();
-        // Entries from the file are merged in and resolved against the workspace path.
-        assert!(excluded.contains(workspace_exclusion("vendor").as_str()));
-        assert!(excluded.contains(workspace_exclusion("generated").as_str()));
-        // Defaults seeded at construction survive the merge.
-        assert!(excluded.contains(workspace_exclusion("node_modules").as_str()));
-        // A config file cannot override the programmatically-set workspace path.
-        assert_eq!(config.workspace_path(), Path::new("/workspace"));
-    }
-
-    #[test]
-    fn load_file_accumulates_exclusions_across_multiple_loads() {
-        let dir = tempfile::tempdir().expect("failed to create temp dir");
-        fs::write(dir.path().join("a.toml"), "exclude = [\"vendor\"]\n").unwrap();
-        fs::write(dir.path().join("b.toml"), "exclude = [\"generated\"]\n").unwrap();
-
-        let mut config = Config::new();
-        config.set_workspace_path(PathBuf::from("/workspace"));
-        config
-            .load_file(&dir.path().join("a.toml"))
-            .expect("expected the first file to load");
-        config
-            .load_file(&dir.path().join("b.toml"))
-            .expect("expected the second file to load");
-
-        let excluded = config.excluded_patterns();
-        assert!(excluded.contains(workspace_exclusion("vendor").as_str()));
-        assert!(excluded.contains(workspace_exclusion("generated").as_str()));
-    }
-
-    #[test]
-    fn load_file_errors_when_the_file_is_missing() {
-        let dir = tempfile::tempdir().expect("failed to create temp dir");
-        let mut config = Config::new();
-
-        let error = config
-            .load_file(&dir.path().join("does_not_exist.toml"))
-            .expect_err("an explicitly requested missing file must be an error");
-
+        assert!(matches!(error, Errors::ConfigError(_)), "unexpected error: {error:?}");
         assert!(
-            matches!(error, Errors::ConfigNotFound(_)),
-            "unexpected error: {error:?}"
+            error.to_string().contains("Failed to read config file"),
+            "unexpected error: {error}"
         );
     }
 
     #[test]
-    fn load_default_ignores_a_missing_config_file() {
+    fn load_propagates_malformed_config_errors() {
         let dir = tempfile::tempdir().expect("failed to create temp dir");
-        let mut config = Config::new();
-        config.set_workspace_path(dir.path().to_path_buf());
+        fs::write(dir.path().join("rubydex.toml"), "[graph]\nexclude = [\n").unwrap();
 
-        config
-            .load_default()
-            .expect("a missing rubydex.toml must not be an error");
-    }
-
-    #[test]
-    fn load_default_loads_an_existing_config_file() {
-        let dir = tempfile::tempdir().expect("failed to create temp dir");
-        fs::write(dir.path().join("rubydex.toml"), "exclude = [\"vendor\"]\n").unwrap();
-
-        let mut config = Config::new();
-        config.set_workspace_path(dir.path().to_path_buf());
-        config.load_default().expect("expected rubydex.toml to load");
-
-        let expected = dir.path().join("vendor").to_string_lossy().into_owned();
-        assert!(config.excluded_patterns().contains(expected.as_str()));
-    }
-
-    #[test]
-    fn load_default_propagates_malformed_config_errors() {
-        let dir = tempfile::tempdir().expect("failed to create temp dir");
-        fs::write(dir.path().join("rubydex.toml"), "exclude = [\n").unwrap();
-
-        let mut config = Config::new();
-        config.set_workspace_path(dir.path().to_path_buf());
-
-        let error = config
-            .load_default()
-            .expect_err("a malformed default config must still be an error");
+        let error = Config::load(dir.path()).expect_err("a malformed config file must be an error");
 
         assert!(matches!(error, Errors::ConfigError(_)), "unexpected error: {error:?}");
     }
 
     #[test]
-    fn parse_defaults_the_excluded_patterns_to_empty_when_the_key_is_absent() {
-        let file = Config::parse("").expect("an empty config is valid");
-        assert!(file.exclude.is_empty());
+    fn parse_accepts_an_empty_config() {
+        let config = parse("").expect("an empty config is valid");
+
+        // Nothing is configured, so the settings of every section are the default ones.
+        assert_eq!(config.excluded_patterns().len(), DEFAULT_EXCLUDED_DIRECTORIES.len());
     }
 
     #[test]
     fn parse_rejects_an_exclude_value_of_the_wrong_type() {
-        Config::parse("exclude = \"vendor\"").expect_err("exclude must be an array of strings, not a string");
+        let error =
+            parse("[graph]\nexclude = \"vendor\"").expect_err("exclude must be an array of strings, not a string");
+
+        assert!(error.contains("graph.exclude"), "unexpected error: {error}");
+    }
+
+    #[test]
+    fn parse_rejects_an_unknown_top_level_setting() {
+        let error = parse("excludes = [\"vendor\"]\n").expect_err("every top-level entry must be a tool section table");
+
+        assert!(
+            error.contains("unknown setting `excludes`"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn parse_rejects_an_unknown_graph_setting() {
+        let error = parse("[graph]\nexcludes = [\"vendor\"]\n")
+            .expect_err("the graph section is owned by Rubydex, so typos inside it must be rejected");
+
+        assert!(
+            error.contains("unknown setting `graph.excludes`"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn parse_rejects_a_graph_section_that_is_not_a_table() {
+        let error = parse("graph = \"yes\"\n").expect_err("the graph section must be a table");
+
+        assert!(error.contains("`graph`"), "unexpected error: {error}");
+    }
+
+    #[test]
+    fn parse_rejects_an_array_of_tables_section() {
+        let error =
+            parse("[[linter]]\nparallel = true\n").expect_err("array-of-tables syntax is not a valid tool section");
+
+        assert!(
+            error.contains("use `[linter]` instead of `[[linter]]`"),
+            "unexpected error: {error}"
+        );
     }
 }

--- a/rust/rubydex/src/errors.rs
+++ b/rust/rubydex/src/errors.rs
@@ -26,5 +26,4 @@ macro_rules! errors {
 errors!(
     FileError;
     ConfigError;
-    ConfigNotFound;
 );

--- a/rust/rubydex/src/lib.rs
+++ b/rust/rubydex/src/lib.rs
@@ -16,6 +16,7 @@ pub mod listing;
 pub mod model;
 pub mod offset;
 pub mod operation;
+pub(crate) mod path_helpers;
 pub mod position;
 pub mod query;
 pub mod resolution;

--- a/rust/rubydex/src/listing.rs
+++ b/rust/rubydex/src/listing.rs
@@ -1,6 +1,7 @@
 use crate::{
     errors::Errors,
     job_queue::{Job, JobQueue},
+    path_helpers,
 };
 use crossbeam_channel::{Sender, unbounded};
 use glob::Pattern;
@@ -129,7 +130,7 @@ pub fn collect_file_paths<S: BuildHasher>(
         Arc::new(excluded.iter().filter_map(|entry| Pattern::new(entry).ok()).collect());
 
     for path in paths {
-        let Ok(path) = std::path::absolute(&path) else {
+        let Ok(path) = std::path::absolute(&path).map(path_helpers::simplified) else {
             errors_tx
                 .send(Errors::FileError(format!("Failed to resolve path `{path}`")))
                 .expect("errors receiver dropped before run completion");
@@ -418,6 +419,30 @@ mod tests {
         // The requested root is traversed; files are indexed under the requested (symlink) path.
         let foo = PathBuf::from("link").join("foo.rb");
         assert_eq!(files, [foo.to_str().unwrap().to_string()]);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn collect_files_excludes_a_directory_below_a_verbatim_root() {
+        // Exclusions are joined onto the workspace path the configuration resolved, which is spelled plainly. A root
+        // given verbatim only matches them once it is spelled that way too.
+        let context = Context::new();
+        context.touch(&PathBuf::from("excluded").join("skipped.rb"));
+
+        let mut excluded = HashSet::new();
+        excluded.insert(
+            context
+                .absolute_path_to("excluded")
+                .to_string_lossy()
+                .replace('\\', "/")
+                .into_boxed_str(),
+        );
+
+        let (files, errors) =
+            collect_file_paths(vec![format!(r"\\?\{}", context.absolute_path().display())], &excluded);
+
+        assert!(errors.is_empty());
+        assert!(files.is_empty(), "expected the exclusion to apply: {files:?}");
     }
 
     #[test]

--- a/rust/rubydex/src/main.rs
+++ b/rust/rubydex/src/main.rs
@@ -2,6 +2,7 @@ use clap::{Parser, ValueEnum};
 use std::{fs, mem, path::PathBuf};
 
 use rubydex::{
+    config::Config,
     dot,
     indexing::{self, IndexerBackend},
     integrity, listing,
@@ -104,10 +105,12 @@ fn main() {
     let mut graph = Graph::new();
 
     if let Some(workspace_path) = workspace_path_for(&args.paths) {
-        graph.set_workspace_path(workspace_path);
-        if let Err(error) = graph.load_config(None) {
-            eprintln!("{error}");
-            std::process::exit(1);
+        match Config::load(&workspace_path) {
+            Ok(config) => graph.load_config(&config),
+            Err(error) => {
+                eprintln!("{error}");
+                std::process::exit(1);
+            }
         }
     }
 

--- a/rust/rubydex/src/model/graph.rs
+++ b/rust/rubydex/src/model/graph.rs
@@ -1,10 +1,9 @@
 use std::collections::HashSet;
 use std::collections::hash_map::Entry;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use crate::config::Config;
 use crate::diagnostic::Diagnostic;
-use crate::errors::Errors;
 use crate::indexing::local_graph::LocalGraph;
 use crate::model::built_in::{OBJECT_ID, add_built_in_data};
 use crate::model::declaration::{Ancestor, Declaration, Namespace};
@@ -110,7 +109,7 @@ impl Graph {
             position_encoding: Encoding::default(),
             name_dependents: IdentityHashMap::default(),
             pending_work: Vec::default(),
-            config: Config::new(),
+            config: Config::default(),
         };
 
         add_built_in_data(&mut graph);
@@ -147,25 +146,9 @@ impl Graph {
         self.config.workspace_path()
     }
 
-    /// Sets the root directory of the workspace being indexed.
-    pub fn set_workspace_path(&mut self, workspace_path: PathBuf) {
-        self.config.set_workspace_path(workspace_path);
-    }
-
-    /// Loads a configuration file. Pass `None` to load the default `rubydex.toml` configuration file if it exists
-    ///
-    /// # Errors
-    ///
-    /// Returns an [`Errors::ConfigNotFound`] if an explicitly requested file does not exist or an
-    /// [`Errors::ConfigError`] if a file cannot otherwise be read or its contents are malformed.
-    pub fn load_config(&mut self, config_path: Option<&Path>) -> Result<(), Errors> {
-        match config_path {
-            Some(path) => {
-                let path = self.config.workspace_path().join(path);
-                self.config.load_file(&path)
-            }
-            None => self.config.load_default(),
-        }
+    /// Loads a config for the graph
+    pub fn load_config(&mut self, config: &Config) {
+        self.config = config.clone();
     }
 
     /// # Panics

--- a/rust/rubydex/src/path_helpers.rs
+++ b/rust/rubydex/src/path_helpers.rs
@@ -1,0 +1,77 @@
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+
+/// Resolves `path` into the spelling rubydex knows a path by: absolute, with symlinks expanded and, on Windows, spelled
+/// plainly instead of verbatim.
+///
+/// # Errors
+///
+/// Returns an error if the path cannot be canonicalized, as for one that does not exist.
+pub(crate) fn resolved(path: &Path) -> io::Result<PathBuf> {
+    Ok(simplified(fs::canonicalize(path)?))
+}
+
+/// Only Windows spells a path verbatim, so everywhere else there is nothing to simplify.
+#[cfg(not(windows))]
+pub(crate) fn simplified(path: PathBuf) -> PathBuf {
+    path
+}
+
+/// Since we canonicalize paths, we must simplify Windows paths in order to use them correctly with glob patterns, like
+/// stripping the `\\?\` prefix.
+#[cfg(windows)]
+pub(crate) fn simplified(path: PathBuf) -> PathBuf {
+    use std::path::Component;
+    use std::path::Prefix;
+
+    let mut components = path.components();
+    let Some(Component::Prefix(prefix)) = components.next() else {
+        return path;
+    };
+
+    // Only a verbatim drive or share has a plain equivalent: `\\?\D:\dir` is `D:\dir`, and `\\?\UNC\server\share` is
+    // the share `\\server\share`. Any other verbatim prefix names a device, such as `\\?\pipe\name`, which has none.
+    let root = match prefix.kind() {
+        Prefix::VerbatimDisk(drive) => format!("{}:\\", char::from(drive)),
+        Prefix::VerbatimUNC(server, share) => {
+            format!(r"\\{}\{}\", server.to_string_lossy(), share.to_string_lossy())
+        }
+        _ => return path,
+    };
+
+    // The root already carries the separator that follows it, so the one spelled as its own component is dropped rather
+    // than pushed, which would otherwise reset the path back to the root it was just given.
+    let mut simplified = PathBuf::from(root);
+    simplified.extend(components.filter(|component| !matches!(component, Component::RootDir)));
+    simplified
+}
+
+#[cfg(all(test, windows))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn simplified_rewrites_a_verbatim_path_into_its_plain_spelling() {
+        assert_eq!(
+            simplified(PathBuf::from(r"\\?\D:\a\project")),
+            PathBuf::from(r"D:\a\project")
+        );
+    }
+
+    #[test]
+    fn simplified_keeps_a_verbatim_share_rooted_on_that_share() {
+        assert_eq!(
+            simplified(PathBuf::from(r"\\?\UNC\server\share\project")),
+            PathBuf::from(r"\\server\share\project")
+        );
+    }
+
+    #[test]
+    fn simplified_leaves_a_path_with_no_plain_equivalent_alone() {
+        // A device path is not addressable without the prefix, and a plain path has nothing to simplify.
+        for path in [r"\\?\pipe\rubydex", r"D:\a\project", r"\\server\share\project"] {
+            assert_eq!(simplified(PathBuf::from(path)), PathBuf::from(path));
+        }
+    }
+}

--- a/rust/rubydex/src/test_utils/context.rs
+++ b/rust/rubydex/src/test_utils/context.rs
@@ -1,4 +1,5 @@
 use super::normalize_indentation;
+use crate::path_helpers;
 use std::fs;
 use std::path::{Path, PathBuf};
 use tempfile::TempDir;
@@ -37,7 +38,7 @@ impl Context {
     #[must_use]
     pub fn new() -> Self {
         let root = tempfile::tempdir().expect("failed to create temp dir");
-        let absolute_path = fs::canonicalize(root.path()).unwrap();
+        let absolute_path = path_helpers::resolved(root.path()).unwrap();
         Self {
             _root: root,
             absolute_path,

--- a/rust/rubydex/tests/cli.rs
+++ b/rust/rubydex/tests/cli.rs
@@ -60,7 +60,7 @@ fn single_directory_argument_is_workspace_root_for_config() {
     with_context(|context| {
         context.write("included.rb", "class Included\nend\n");
         context.write("excluded/skipped.rb", "class Skipped\nend\n");
-        context.write("rubydex.toml", "exclude = [\"excluded\"]\n");
+        context.write("rubydex.toml", "[graph]\nexclude = [\"excluded\"]\n");
 
         rdx(&[context.absolute_path().to_str().unwrap()])
             .success()
@@ -74,7 +74,7 @@ fn first_directory_argument_is_workspace_root_for_config() {
     with_context(|context| {
         context.write("included/kept.rb", "class Included\nend\n");
         context.write("excluded/skipped.rb", "class Skipped\nend\n");
-        context.write("rubydex.toml", "exclude = [\"excluded\"]\n");
+        context.write("rubydex.toml", "[graph]\nexclude = [\"excluded\"]\n");
 
         rdx(&[
             context.absolute_path().to_str().unwrap(),
@@ -92,7 +92,7 @@ fn single_file_argument_is_not_used_as_workspace_root() {
     with_context(|context| {
         context.write("included.rb", "class Included\nend\n");
         context.write("excluded/skipped.rb", "class Skipped\nend\n");
-        context.write("rubydex.toml", "exclude = [\"excluded\"]\n");
+        context.write("rubydex.toml", "[graph]\nexclude = [\"excluded\"]\n");
 
         rdx(&[context.absolute_path_to("excluded/skipped.rb").to_str().unwrap()])
             .success()
@@ -106,7 +106,7 @@ fn first_file_argument_is_not_used_as_workspace_root() {
     with_context(|context| {
         context.write("included.rb", "class Included\nend\n");
         context.write("excluded/skipped.rb", "class Skipped\nend\n");
-        context.write("rubydex.toml", "exclude = [\"excluded\"]\n");
+        context.write("rubydex.toml", "[graph]\nexclude = [\"excluded\"]\n");
 
         rdx(&[
             context.absolute_path_to("included.rb").to_str().unwrap(),

--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "helpers/context"
+
+class ConfigTest < Minitest::Test
+  include Test::Helpers::WithContext
+
+  def test_load_returns_an_empty_configuration_for_a_workspace_without_a_config_file
+    with_context do |context|
+      config = Rubydex::Config.load(context.absolute_path)
+      assert_equal(context.absolute_path, config.workspace_path)
+    end
+  end
+
+  def test_load_raises_when_the_workspace_does_not_exist
+    with_context do |context|
+      error = assert_raises(Rubydex::ConfigError) do
+        Rubydex::Config.load(context.absolute_path_to("typo"))
+      end
+
+      assert_match(/typo/, error.message)
+    end
+  end
+
+  def test_load_raises_on_malformed_toml
+    with_context do |context|
+      context.write!("rubydex.toml", "exclude = [\n")
+
+      error = assert_raises(Rubydex::ConfigError) do
+        Rubydex::Config.load(context.absolute_path)
+      end
+
+      assert_match(/rubydex.toml/, error.message)
+    end
+  end
+
+  def test_load_raises_on_an_unknown_top_level_setting
+    with_context do |context|
+      context.write!("rubydex.toml", "excludes = [\"vendor\"]\n")
+
+      error = assert_raises(Rubydex::ConfigError) do
+        Rubydex::Config.load(context.absolute_path)
+      end
+
+      assert_match(/excludes/, error.message)
+    end
+  end
+
+  def test_load_raises_on_an_unknown_graph_setting
+    with_context do |context|
+      context.write!("rubydex.toml", "[graph]\nexcludes = [\"vendor\"]\n")
+
+      error = assert_raises(Rubydex::ConfigError) do
+        Rubydex::Config.load(context.absolute_path)
+      end
+
+      assert_match(/graph.excludes/, error.message)
+    end
+  end
+
+  def test_load_raises_when_the_path_is_not_a_string
+    assert_raises(TypeError) { Rubydex::Config.load(123) }
+  end
+end

--- a/test/graph_test.rb
+++ b/test/graph_test.rb
@@ -51,12 +51,11 @@ class GraphTest < Minitest::Test
     assert_match(/FileError: Path `.*not_found.rb` does not exist/, errors.first)
   end
 
-  def test_load_config_from_explicit_path_adds_exclusions
+  def test_load_config_adds_exclusions_resolved_against_the_workspace_path
     with_context do |context|
-      context.write!(".rubydex_custom", "exclude = [\"vendor\", \"generated\"]\n")
+      context.write!("rubydex.toml", "[graph]\nexclude = [\"vendor\", \"generated\"]\n")
 
-      graph = Rubydex::Graph.new(workspace_path: context.absolute_path)
-      graph.load_config(".rubydex_custom")
+      graph = graph_for(context)
 
       # Excluded paths are resolved against the workspace path.
       assert_includes(graph.excluded_patterns, context.absolute_path_to("vendor"))
@@ -65,37 +64,19 @@ class GraphTest < Minitest::Test
     end
   end
 
-  def test_load_config_without_argument_loads_the_default_rubydex
+  def test_load_config_with_an_empty_config_leaves_the_defaults_in_place
     with_context do |context|
-      context.write!("rubydex.toml", "exclude = [\"vendor\", \"generated\"]\n")
+      # A workspace with no `rubydex.toml` carries no exclusions of its own; the defaults remain in place.
+      graph = graph_for(context)
 
-      graph = Rubydex::Graph.new(workspace_path: context.absolute_path)
-      graph.load_config
-
-      assert_includes(graph.excluded_patterns, context.absolute_path_to("vendor"))
-      assert_includes(graph.excluded_patterns, context.absolute_path_to("generated"))
       assert_includes(graph.excluded_patterns, context.absolute_path_to("node_modules"))
     end
   end
 
-  def test_load_config_without_argument_ignores_a_missing_default_rubydex
-    with_context do |context|
-      graph = Rubydex::Graph.new(workspace_path: context.absolute_path)
-
-      # A missing default `rubydex.toml` is not an error; defaults remain in place.
-      graph.load_config
-      assert_includes(graph.excluded_patterns, context.absolute_path_to("node_modules"))
-    end
-  end
-
-  def test_load_config_raises_when_file_is_missing
-    graph = Rubydex::Graph.new
-    assert_raises(Rubydex::ConfigError) { graph.load_config(".rubydex_missing") }
-  end
-
-  def test_load_config_fails_if_argument_is_not_string
+  def test_load_config_fails_if_argument_is_not_a_config
     graph = Rubydex::Graph.new
     assert_raises(TypeError) { graph.load_config(123) }
+    assert_raises(TypeError) { graph.load_config("rubydex.toml") }
   end
 
   def test_indexing_with_parse_errors
@@ -309,18 +290,11 @@ class GraphTest < Minitest::Test
     assert_equal(Dir.pwd, File.expand_path(graph.workspace_path))
   end
 
-  def test_workspace_path_can_be_passed_to_initialize
+  def test_workspace_path_comes_from_the_loaded_configuration
     with_context do |context|
-      graph = Rubydex::Graph.new(workspace_path: context.absolute_path)
+      graph = graph_for(context)
       assert_equal(context.absolute_path, graph.workspace_path)
     end
-  end
-
-  def test_workspace_path_setter
-    graph = Rubydex::Graph.new
-    graph.workspace_path = "/some/workspace"
-
-    assert_equal("/some/workspace", graph.workspace_path)
   end
 
   def test_graph_encoding_setter
@@ -741,7 +715,7 @@ class GraphTest < Minitest::Test
       context.write!("top_level.rbs", "class TopLevelRbs; end")
       context.write!("config.ru", "class ConfigRu; end")
 
-      graph = Rubydex::Graph.new(workspace_path: context.absolute_path)
+      graph = graph_for(context)
       paths = graph.workspace_paths
 
       # Includes workspace directories
@@ -791,7 +765,7 @@ class GraphTest < Minitest::Test
         end
       RBS
 
-      graph = Rubydex::Graph.new(workspace_path: context.absolute_path)
+      graph = graph_for(context)
       graph.index_workspace
       graph.resolve
 
@@ -1473,7 +1447,7 @@ class GraphTest < Minitest::Test
       context.write!("vendor/gems/foo.rb", "class Foo; end")
       context.write!("vendor/bundle/bar.rb", "class Bar; end")
 
-      graph = Rubydex::Graph.new(workspace_path: context.absolute_path)
+      graph = graph_for(context)
       graph.exclude_patterns(["vendor/bundle"])
 
       assert_includes(graph.excluded_patterns, context.absolute_path_to("vendor/bundle"))
@@ -1509,7 +1483,7 @@ class GraphTest < Minitest::Test
       context.write!("tmp/in_tmp.rb", "class InTmp; end")
       context.write!("lib/foo.rb", "class Foo; end")
 
-      graph = Rubydex::Graph.new(workspace_path: context.absolute_path)
+      graph = graph_for(context)
       graph.index_all(graph.workspace_paths)
       graph.resolve
 
@@ -1874,6 +1848,15 @@ class GraphTest < Minitest::Test
     assert_raises(RuntimeError) { graph.clone }
   end
 
+  def test_configure_for_workspace_creates_graph_with_config_file
+    with_context do |context|
+      context.write!("rubydex.toml", "[graph]\nexclude = [\"vendor\"]\n")
+
+      graph = Rubydex::Graph.configure_for_workspace(context.absolute_path)
+      assert_includes(graph.excluded_patterns, context.absolute_path_to("vendor"))
+    end
+  end
+
   private
 
   def skip_unstable_windows_ractor
@@ -1892,5 +1875,9 @@ class GraphTest < Minitest::Test
       actual.sort_by { |d| [d.location, d.message] }
         .map { |d| { rule: d.rule, path: File.basename(d.location.to_file_path), message: d.message } },
     )
+  end
+
+  def graph_for(context)
+    Rubydex::Graph.configure_for_workspace(context.absolute_path)
   end
 end

--- a/test/mcp_server_base_tool_test.rb
+++ b/test/mcp_server_base_tool_test.rb
@@ -6,7 +6,8 @@ require "rubydex/mcp_server"
 
 class MCPServerBaseToolTest < Minitest::Test
   def setup
-    @tool = Rubydex::MCPServer::BaseTool.new(Rubydex::Graph.new(workspace_path: Dir.pwd))
+    graph = Rubydex::Graph.configure_for_workspace(Dir.pwd)
+    @tool = Rubydex::MCPServer::BaseTool.new(graph)
   end
 
   def test_file_path_for_uri_removes_windows_file_uri_leading_slash

--- a/test/mcp_server_tools_test.rb
+++ b/test/mcp_server_tools_test.rb
@@ -158,7 +158,7 @@ class MCPServerToolsTest < Minitest::Test
   end
 
   def indexed_graph(root_path, paths)
-    graph = Rubydex::Graph.new(workspace_path: root_path)
+    graph = Rubydex::Graph.configure_for_workspace(root_path)
     errors = graph.index_all(paths)
     graph.resolve
 


### PR DESCRIPTION
This PR makes `Config` a proper object with a Ruby equivalent and allows us to easily add more config sections for each new tool.

### Implementation

There are a few relevant points:

1. The config is now composed of global fields (like workspace_path) and tool-specific fields which correspond to a section in the config file. For example, `[graph] -> GraphSettings`, [linter] -> LinterSettings`
2. All tools need to know what is the workspace path they are operating on. In certain tools, the workspace path isn't always pwd (e.g.: language servers that are spawned somewhere different than the workspace by editors). So the workspace_path state moved into `Config` rather than being inside of `Graph`
3. We started out with more complexity than we really needed, supporting loading arbitrary config files. I believe that decision is premature and we should just support the default `workspace_path/rubydex.toml` for now
4. Loading the configuration is now performed independently and then loaded into the graph. We need an approach like this because the configuration is shared by both the analysis (Rust) and tools built on top of it (Ruby or Rust). We don't want each tool to re-parse and maintain another config in memory or need to add a toml parser as a dependency. This approach avoids all of those

Note: this PR doesn't yet include the parsing of the new `[linter]` section. I tried to minimize the changes for an easier review, but it's a rather large breaking change. I also recommend reviewing by commit.