### PR TITLE
Fix leaks after string array conversion

### DIFF
--- a/ext/rubydex/graph.c
+++ b/ext/rubydex/graph.c
@@ -492,6 +492,7 @@ static VALUE rdxr_graph_set_encoding(VALUE self, VALUE encoding) {
 static VALUE rdxr_graph_resolve_constant(VALUE self, VALUE const_name, VALUE nesting) {
     Check_Type(const_name, T_STRING);
     rdxi_check_array_of_strings(nesting);
+    const char *const_name_string = StringValueCStr(const_name);
 
     // Convert the given file paths into a char** array, so that we can pass to Rust
     size_t length = RARRAY_LEN(nesting);
@@ -501,7 +502,7 @@ static VALUE rdxr_graph_resolve_constant(VALUE self, VALUE const_name, VALUE nes
     TypedData_Get_Struct(self, void *, &graph_type, graph);
 
     const CDeclaration *decl =
-        rdx_graph_resolve_constant(graph, StringValueCStr(const_name), (const char **)converted_file_paths, length);
+        rdx_graph_resolve_constant(graph, const_name_string, (const char **)converted_file_paths, length);
 
     rdxi_free_str_array(converted_file_paths, length);
 
@@ -787,6 +788,7 @@ static VALUE rdxr_graph_complete_method_argument(int argc, VALUE *argv, VALUE se
 
     Check_Type(name, T_STRING);
     rdxi_check_array_of_strings(nesting);
+    const char *name_string = StringValueCStr(name);
 
     const char *self_receiver = extract_self_receiver(opts);
 
@@ -797,7 +799,7 @@ static VALUE rdxr_graph_complete_method_argument(int argc, VALUE *argv, VALUE se
     char **converted_nesting = rdxi_str_array_to_char(nesting, nesting_count);
 
     struct CompletionResult result = rdx_graph_complete_method_argument(
-        graph, StringValueCStr(name), (const char *const *)converted_nesting, nesting_count, self_receiver);
+        graph, name_string, (const char *const *)converted_nesting, nesting_count, self_receiver);
 
     rdxi_free_str_array(converted_nesting, nesting_count);
     return completion_result_to_ruby_array(result, self);

--- a/ext/rubydex/utils.c
+++ b/ext/rubydex/utils.c
@@ -4,16 +4,23 @@
 #include "rustbindings.h"
 
 // Convert a Ruby array of strings into a double char pointer so that we can pass that to Rust.
-// This copies the data so it must be freed
+// This copies the data so it must be freed.
 char **rdxi_str_array_to_char(VALUE array, size_t length) {
+    // Validate every element before allocating so StringValueCStr cannot strand a partially built array.
+    for (size_t i = 0; i < length; i++) {
+        VALUE item = rb_ary_entry(array, i);
+        Check_Type(item, T_STRING);
+        (void)StringValueCStr(item);
+    }
+
     char **converted_array = malloc(length * sizeof(char *));
 
     for (size_t i = 0; i < length; i++) {
         VALUE item = rb_ary_entry(array, i);
-        const char *string = StringValueCStr(item);
+        size_t string_length = (size_t)RSTRING_LEN(item);
 
-        converted_array[i] = malloc(strlen(string) + 1);
-        strcpy(converted_array[i], string);
+        converted_array[i] = malloc(string_length + 1);
+        memcpy(converted_array[i], RSTRING_PTR(item), string_length + 1);
     }
 
     return converted_array;

--- a/test/graph_test.rb
+++ b/test/graph_test.rb
@@ -415,6 +415,14 @@ class GraphTest < Minitest::Test
     assert_raises(TypeError) do
       graph.resolve_constant("CONST", "Not an array")
     end
+
+    assert_raises(ArgumentError) do
+      graph.resolve_constant("CONST", ["Foo", "Bar\0Baz"])
+    end
+
+    assert_raises(ArgumentError) do
+      graph.resolve_constant("CO\0NST", ["Foo"])
+    end
   end
 
   def test_graph_resolve_non_existing_constant
@@ -1439,6 +1447,7 @@ class GraphTest < Minitest::Test
     assert_raises(TypeError) { graph.complete_method_argument(123, [], self_receiver: nil) }
     assert_raises(TypeError) { graph.complete_method_argument("Foo#bar()", "not an array", self_receiver: nil) }
     assert_raises(TypeError) { graph.complete_method_argument("Foo#bar()", [123], self_receiver: nil) }
+    assert_raises(ArgumentError) { graph.complete_method_argument("Foo\0bar()", ["Foo"], self_receiver: nil) }
   end
 
   def test_completion_returns_empty_for_non_existent_declarations


### PR DESCRIPTION
Validate scalar string arguments with `StringValueCStr` before allocating converted nesting arrays in:

- `Graph#resolve_constant`
- `Graph#complete_method_argument`

This prevents an embedded-NUL exception from bypassing `rdxi_free_str_array` after ownership has returned to the caller.
