### PR TITLE
Add linter configuration

### DIFF
--- a/ext/rubydex/config.c
+++ b/ext/rubydex/config.c
@@ -3,6 +3,11 @@
 #include "utils.h"
 
 static VALUE mRubydex;
+// Defined here so that the configuration can build them, but implemented in Ruby (`lib/rubydex/config.rb`), like the
+// other value objects handed back to Ruby.
+static VALUE cLinterConfig;
+static VALUE cRuleConfig;
+static ID id_linter;
 
 // Free function for Rubydex::Config: releases the parsed configuration allocated by Rust.
 static void config_free(void *ptr) {
@@ -64,8 +69,46 @@ static VALUE rdxr_config_workspace_path(VALUE self) {
     return rdxi_owned_c_string_to_ruby(result);
 }
 
+/*
+ * call-seq:
+ *   linter -> Rubydex::LinterConfig
+ *
+ * Returns the linter's settings, read from the `[linter]` section of the configuration file. The rules are keyed by
+ * name and empty when the section is absent.
+ */
+static VALUE rdxr_config_linter(VALUE self) {
+    // Return early if we already fetched the rule config from Rust and built the Ruby objects.
+    VALUE linter = rb_ivar_get(self, id_linter);
+
+    if (!NIL_P(linter)) {
+        return linter;
+    }
+
+    CLinterRuleArray rule_array = rdx_config_linter_rules(rdxi_config_from_object(self));
+    VALUE rules = rb_hash_new_capa((long)rule_array.len);
+
+    for (size_t i = 0; i < rule_array.len; i++) {
+        CLinterRule rule = rule_array.items[i];
+        VALUE rule_name = rb_str_freeze(rb_utf8_str_new(rule.name, (long)rule.name_length));
+        VALUE argv[] = { rule_name , rule.enabled ? Qtrue : Qfalse};
+
+        rb_hash_aset(rules, rule_name, rb_class_new_instance(2, argv, cRuleConfig));
+    }
+
+    rdx_config_linter_rules_free(rule_array);
+
+    linter = rb_class_new_instance(1, &rules, cLinterConfig);
+    rb_ivar_set(self, id_linter, linter);
+
+    return linter;
+}
+
 void rdxi_initialize_config(VALUE moduleRubydex) {
     mRubydex = moduleRubydex;
+
+    cLinterConfig = rb_define_class_under(mRubydex, "LinterConfig", rb_cObject);
+    cRuleConfig = rb_define_class_under(mRubydex, "RuleConfig", rb_cObject);
+    id_linter = rb_intern("@linter");
 
     VALUE cConfig = rb_define_class_under(mRubydex, "Config", rb_cObject);
     rb_undef_alloc_func(cConfig);
@@ -75,4 +118,5 @@ void rdxi_initialize_config(VALUE moduleRubydex) {
 
     rb_define_singleton_method(cConfig, "load", rdxr_config_load, 1);
     rb_define_method(cConfig, "workspace_path", rdxr_config_workspace_path, 0);
+    rb_define_method(cConfig, "linter", rdxr_config_linter, 0);
 }

--- a/ext/rubydex/config.c
+++ b/ext/rubydex/config.c
@@ -2,6 +2,11 @@
 #include "rustbindings.h"
 #include "utils.h"
 
+/*
+ * RDoc parser workaround for https://github.com/ruby/rdoc/issues/1744:
+ * mRubydex = rb_define_module("Rubydex")
+ */
+
 static VALUE mRubydex;
 // Defined here so that the configuration can build them, but implemented in Ruby (`lib/rubydex/config.rb`), like the
 // other value objects handed back to Ruby.
@@ -14,6 +19,37 @@ static void config_free(void *ptr) {
     if (ptr) {
         rdx_config_free(ptr);
     }
+}
+
+// Body function for rb_ensure while building a Rubydex::LinterConfig.
+static VALUE config_linter_build(VALUE opaque_rule_array) {
+    CLinterRuleArray *rule_array = (CLinterRuleArray *)(uintptr_t)opaque_rule_array;
+    VALUE rules = rb_hash_new_capa((long)rule_array->len);
+
+    for (size_t i = 0; i < rule_array->len; i++) {
+        CLinterRule rule = rule_array->items[i];
+        VALUE rule_name = rb_str_freeze(rb_utf8_str_new(rule.name, (long)rule.name_length));
+        VALUE argv[] = {rule_name, rule.enabled ? Qtrue : Qfalse};
+
+        rb_hash_aset(rules, rule_name, rb_class_new_instance(2, argv, cRuleConfig));
+    }
+
+    return rb_class_new_instance(1, &rules, cLinterConfig);
+}
+
+// Ensure function for rb_ensure while building a Rubydex::LinterConfig.
+static VALUE config_linter_ensure(VALUE opaque_rule_array) {
+    CLinterRuleArray *rule_array = (CLinterRuleArray *)(uintptr_t)opaque_rule_array;
+    rdx_config_linter_rules_free(*rule_array);
+
+    return Qnil;
+}
+
+static VALUE config_linter(VALUE config_obj) {
+    CLinterRuleArray rule_array = rdx_config_linter_rules(rdxi_config_from_object(config_obj));
+    VALUE opaque_rule_array = (VALUE)(uintptr_t)&rule_array;
+
+    return rb_ensure(config_linter_build, opaque_rule_array, config_linter_ensure, opaque_rule_array);
 }
 
 const rb_data_type_t config_type = {
@@ -49,7 +85,10 @@ static VALUE rdxr_config_load(VALUE klass, VALUE workspace_path) {
         rb_exc_raise(rb_exc_new_str(config_error, message));
     }
 
-    return TypedData_Wrap_Struct(klass, &config_type, result.config);
+    VALUE config = TypedData_Wrap_Struct(klass, &config_type, result.config);
+    rb_ivar_set(config, id_linter, config_linter(config));
+
+    return config;
 }
 
 /*
@@ -69,40 +108,6 @@ static VALUE rdxr_config_workspace_path(VALUE self) {
     return rdxi_owned_c_string_to_ruby(result);
 }
 
-/*
- * call-seq:
- *   linter -> Rubydex::LinterConfig
- *
- * Returns the linter's settings, read from the `[linter]` section of the configuration file. The rules are keyed by
- * name and empty when the section is absent.
- */
-static VALUE rdxr_config_linter(VALUE self) {
-    // Return early if we already fetched the rule config from Rust and built the Ruby objects.
-    VALUE linter = rb_ivar_get(self, id_linter);
-
-    if (!NIL_P(linter)) {
-        return linter;
-    }
-
-    CLinterRuleArray rule_array = rdx_config_linter_rules(rdxi_config_from_object(self));
-    VALUE rules = rb_hash_new_capa((long)rule_array.len);
-
-    for (size_t i = 0; i < rule_array.len; i++) {
-        CLinterRule rule = rule_array.items[i];
-        VALUE rule_name = rb_str_freeze(rb_utf8_str_new(rule.name, (long)rule.name_length));
-        VALUE argv[] = { rule_name , rule.enabled ? Qtrue : Qfalse};
-
-        rb_hash_aset(rules, rule_name, rb_class_new_instance(2, argv, cRuleConfig));
-    }
-
-    rdx_config_linter_rules_free(rule_array);
-
-    linter = rb_class_new_instance(1, &rules, cLinterConfig);
-    rb_ivar_set(self, id_linter, linter);
-
-    return linter;
-}
-
 void rdxi_initialize_config(VALUE moduleRubydex) {
     mRubydex = moduleRubydex;
 
@@ -118,5 +123,7 @@ void rdxi_initialize_config(VALUE moduleRubydex) {
 
     rb_define_singleton_method(cConfig, "load", rdxr_config_load, 1);
     rb_define_method(cConfig, "workspace_path", rdxr_config_workspace_path, 0);
-    rb_define_method(cConfig, "linter", rdxr_config_linter, 0);
+
+    /* Returns the linter settings read from the `[linter]` section. Its rules are empty when the section is absent. */
+    rb_define_attr(cConfig, "linter", true, false);
 }

--- a/lib/rubydex.rb
+++ b/lib/rubydex.rb
@@ -16,6 +16,7 @@ end
 
 require "rubydex/errors"
 require "rubydex/failures"
+require "rubydex/config"
 require "rubydex/location"
 require "rubydex/comment"
 require "rubydex/diagnostic"

--- a/lib/rubydex/config.rb
+++ b/lib/rubydex/config.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Rubydex
+  # The linter's settings, read from the `[linter]` section of the configuration file.
+  class LinterConfig
+    # The configured rules, keyed by rule name. Only rules the configuration file mentions appear here, so a rule that
+    # was never configured is absent rather than present with its defaults.
+    #
+    #: Hash[String, RuleConfig]
+    attr_reader :rules
+
+    #: (Hash[String, RuleConfig]) -> void
+    def initialize(rules)
+      @rules = rules
+      freeze
+    end
+  end
+
+  # The settings of a single linter rule, read from a `[linter.rules.RuleName]` table.
+  class RuleConfig
+    #: String
+    attr_reader :name
+
+    #: (String, bool) -> void
+    def initialize(name, enabled)
+      @name = name
+      @enabled = enabled
+    end
+
+    #: () -> bool
+    def enabled?
+      @enabled
+    end
+  end
+end

--- a/lib/rubydex/config.rb
+++ b/lib/rubydex/config.rb
@@ -11,7 +11,7 @@ module Rubydex
 
     #: (Hash[String, RuleConfig]) -> void
     def initialize(rules)
-      @rules = rules
+      @rules = rules.freeze
       freeze
     end
   end

--- a/rbi/rubydex.rbi
+++ b/rbi/rubydex.rbi
@@ -364,9 +364,36 @@ class Rubydex::Config
     def load(workspace_path); end
   end
 
+  # The linter's settings, read from the `[linter]` section.
+  sig { returns(Rubydex::LinterConfig) }
+  def linter; end
+
   # The configured workspace path, which is usually PWD, except for editors that spawn language servers outside of pwd.
   sig { returns(String) }
   def workspace_path; end
+end
+
+# The linter's settings, read from the `[linter]` section of the configuration file.
+class Rubydex::LinterConfig
+  # The configured rules, keyed by rule name. Only rules the configuration file mentions appear here, so a rule that
+  # was never configured is absent rather than present with its defaults.
+  sig { returns(T::Hash[String, Rubydex::RuleConfig]) }
+  attr_reader :rules
+
+  sig { params(rules: T::Hash[String, Rubydex::RuleConfig]).void }
+  def initialize(rules); end
+end
+
+# The settings of a single linter rule, read from a `[linter.rules.RuleName]` table.
+class Rubydex::RuleConfig
+  sig { returns(String) }
+  attr_reader :name
+
+  sig { params(name: String, enabled: T::Boolean).void }
+  def initialize(name, enabled); end
+
+  sig { returns(T::Boolean) }
+  def enabled?; end
 end
 
 class Rubydex::Failure

--- a/rust/rubydex-sys/src/config_api.rs
+++ b/rust/rubydex-sys/src/config_api.rs
@@ -1,6 +1,6 @@
 use crate::utils;
 use libc::{c_char, c_void};
-use rubydex::config::Config;
+use rubydex::config::{Config, Rule};
 use rubydex::errors::Errors;
 use std::ffi::CString;
 use std::path::Path;
@@ -87,5 +87,74 @@ pub unsafe extern "C" fn rdx_config_free(config: ConfigPointer) {
 
     unsafe {
         let _ = Box::from_raw(config.cast::<Config>());
+    }
+}
+
+/// C-compatible struct representing a single configured linter rule.
+#[repr(C)]
+#[derive(Debug)]
+pub struct CLinterRule {
+    pub name: *const c_char,
+    pub name_length: usize,
+    pub enabled: bool,
+}
+
+impl From<&Rule> for CLinterRule {
+    fn from(rule: &Rule) -> Self {
+        Self {
+            name: rule.name().as_ptr().cast::<c_char>(),
+            name_length: rule.name().len(),
+            enabled: rule.enabled(),
+        }
+    }
+}
+
+/// C-compatible array of configured linter rules.
+#[repr(C)]
+pub struct CLinterRuleArray {
+    pub items: *mut CLinterRule,
+    pub len: usize,
+}
+
+/// Returns the configured linter rules as an array. Caller must free it with `rdx_config_linter_rules_free`, while the
+/// configuration is still alive, since the rule names are borrowed from it.
+///
+/// # Safety
+///
+/// - `config` must be a valid `ConfigPointer` previously returned by `rdx_config_load`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rdx_config_linter_rules(config: ConfigPointer) -> CLinterRuleArray {
+    let config = unsafe { &*config.cast::<Config>() };
+    let rules = config.linter().rules();
+
+    if rules.is_empty() {
+        return CLinterRuleArray {
+            items: ptr::null_mut(),
+            len: 0,
+        };
+    }
+
+    let items = rules.iter().map(CLinterRule::from).collect::<Box<[CLinterRule]>>();
+
+    CLinterRuleArray {
+        len: items.len(),
+        items: Box::into_raw(items).cast::<CLinterRule>(),
+    }
+}
+
+/// Frees an array previously returned by `rdx_config_linter_rules`. The rule names it borrowed are left alone, since
+/// they belong to the configuration.
+///
+/// # Safety
+///
+/// - `rules` must have been returned by `rdx_config_linter_rules` and must not be used afterwards.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rdx_config_linter_rules_free(rules: CLinterRuleArray) {
+    if rules.items.is_null() {
+        return;
+    }
+
+    unsafe {
+        let _ = Box::from_raw(ptr::slice_from_raw_parts_mut(rules.items, rules.len));
     }
 }

--- a/rust/rubydex/src/config.rs
+++ b/rust/rubydex/src/config.rs
@@ -67,6 +67,86 @@ impl GraphSettings {
     }
 }
 
+/// The setting of a single linter rule, read from a `[linter.rules.RuleName]` table
+#[derive(Debug, Clone)]
+pub struct Rule {
+    name: Box<str>,
+    enabled: bool,
+}
+
+impl Rule {
+    #[must_use]
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    #[must_use]
+    pub fn enabled(&self) -> bool {
+        self.enabled
+    }
+
+    /// Parses a single `[linter.rules.{name}]` table
+    fn parse(name: &str, value: Value) -> Result<Self, String> {
+        let Value::Table(mut table) = value else {
+            return Err(format!("invalid `linter.rules.{name}` setting: expected a table"));
+        };
+
+        let enabled = match table.remove("enabled") {
+            Some(Value::Boolean(enabled)) => enabled,
+            Some(_) => {
+                return Err(format!(
+                    "invalid `linter.rules.{name}.enabled` setting: expected a boolean"
+                ));
+            }
+            None => return Err(format!("missing `linter.rules.{name}.enabled` setting")),
+        };
+
+        if let Some(key) = table.keys().next() {
+            return Err(format!("unknown setting `linter.rules.{name}.{key}`"));
+        }
+
+        Ok(Self {
+            name: Box::from(name),
+            enabled,
+        })
+    }
+}
+
+/// The linter's settings, read from the `[linter]` section of the configuration file
+#[derive(Debug, Clone, Default)]
+pub struct LinterSettings {
+    rules: Box<[Rule]>,
+}
+
+impl LinterSettings {
+    #[must_use]
+    pub fn rules(&self) -> &[Rule] {
+        &self.rules
+    }
+
+    /// Parses the `[linter]` section
+    fn parse(mut table: Table) -> Result<Self, String> {
+        let rules = match table.remove("rules") {
+            None => Box::default(),
+            Some(Value::Table(rules)) => rules
+                .into_iter()
+                .map(|(name, value)| Rule::parse(&name, value))
+                .collect::<Result<_, _>>()?,
+            Some(_) => {
+                return Err(String::from(
+                    "invalid `linter.rules` setting: expected a table of rules",
+                ));
+            }
+        };
+
+        if let Some(key) = table.keys().next() {
+            return Err(format!("unknown setting `linter.{key}`"));
+        }
+
+        Ok(Self { rules })
+    }
+}
+
 /// The configuration of a workspace, parsed from its `rubydex.toml` and shared by all built-in tools. It carries both
 /// the settings that are global to every tool, such as the workspace being analyzed, and the typed settings of each
 /// tool's own section (e.g. `[graph]`). Every section is parsed eagerly, so that all validation happens at load time and
@@ -78,8 +158,9 @@ pub struct Config {
     /// configurable through the file itself, since it is what says where that file is.
     workspace_path: Box<Path>,
     graph: GraphSettings,
+    linter: LinterSettings,
 }
-assert_mem_size!(Config, 64);
+assert_mem_size!(Config, 80);
 
 impl Default for Config {
     /// The configuration of the current working directory, with the default settings of every section, which is what a
@@ -92,6 +173,7 @@ impl Default for Config {
                 .unwrap_or_else(|_| PathBuf::from("."))
                 .into_boxed_path(),
             graph: GraphSettings::default(),
+            linter: LinterSettings::default(),
         }
     }
 }
@@ -169,6 +251,11 @@ impl Config {
             .collect()
     }
 
+    #[must_use]
+    pub fn linter(&self) -> &LinterSettings {
+        &self.linter
+    }
+
     /// Parses the content of the configuration file of the workspace rooted at `workspace_path` into the typed
     /// settings of each section
     fn parse(workspace_path: PathBuf, content: &str) -> Result<Self, String> {
@@ -195,6 +282,11 @@ impl Config {
             _ => GraphSettings::default(),
         };
 
+        let linter = match sections.remove("linter") {
+            Some(Value::Table(table)) => LinterSettings::parse(table)?,
+            _ => LinterSettings::default(),
+        };
+
         // Every section must be backed by a typed settings struct, so any leftover section is unknown.
         if let Some(key) = sections.keys().next() {
             return Err(format!("unknown section `{key}`"));
@@ -203,6 +295,7 @@ impl Config {
         Ok(Self {
             workspace_path: Box::from(workspace_path),
             graph,
+            linter,
         })
     }
 }
@@ -270,9 +363,116 @@ mod tests {
     }
 
     #[test]
+    fn load_parses_the_settings_of_every_section() {
+        let dir = tempfile::tempdir().expect("failed to create temp dir");
+        fs::write(
+            dir.path().join("rubydex.toml"),
+            "[graph]\nexclude = [\"vendor\"]\n\n[linter.rules.Something]\nenabled = true\n",
+        )
+        .unwrap();
+
+        let config = Config::load(dir.path()).expect("expected the config file to load");
+        let excluded = config.excluded_patterns();
+
+        let path = path_helpers::resolved(dir.path()).unwrap();
+        assert!(excluded.contains(exclusion(&path, "vendor").as_str()));
+
+        let rules = config.linter().rules();
+        assert_eq!(rules.len(), 1);
+        assert_eq!(rules[0].name(), "Something");
+        assert!(rules[0].enabled());
+    }
+
+    #[test]
+    fn parse_parses_every_linter_rule() {
+        let config = parse("[linter.rules.Something]\nenabled = true\n\n[linter.rules.Other]\nenabled = false\n")
+            .expect("expected the config to parse");
+
+        let rules = config.linter().rules();
+        assert_eq!(rules.len(), 2);
+
+        let something = rules.iter().find(|rule| rule.name() == "Something").unwrap();
+        assert!(something.enabled());
+
+        let other = rules.iter().find(|rule| rule.name() == "Other").unwrap();
+        assert!(!other.enabled());
+    }
+
+    #[test]
+    fn parse_accepts_an_empty_linter_section() {
+        let config = parse("[linter]\n").expect("an empty linter section is valid");
+        assert!(config.linter().rules().is_empty());
+
+        let config = parse("[linter.rules]\n").expect("an empty rules table is valid");
+        assert!(config.linter().rules().is_empty());
+    }
+
+    #[test]
     fn parse_rejects_an_unknown_section() {
         let error = parse("[lintr]\n").expect_err("every section must be backed by typed settings structs");
         assert!(error.contains("unknown section `lintr`"), "unexpected error: {error}");
+    }
+
+    #[test]
+    fn parse_rejects_an_unknown_linter_setting() {
+        let error = parse("[linter]\nparallel = true\n").expect_err("typos inside the linter section must be rejected");
+
+        assert!(
+            error.contains("unknown setting `linter.parallel`"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn parse_rejects_a_rules_setting_that_is_not_a_table() {
+        let error = parse("[linter]\nrules = true\n").expect_err("rules must be a table of rule tables");
+
+        assert!(
+            error.contains("invalid `linter.rules` setting"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn parse_rejects_a_rule_that_is_not_a_table() {
+        let error = parse("[linter.rules]\nSomething = true\n").expect_err("every rule setting must be a table");
+
+        assert!(
+            error.contains("invalid `linter.rules.Something` setting"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn parse_rejects_a_rule_without_enabled() {
+        let error =
+            parse("[linter.rules.Something]\n").expect_err("a rule setting must state whether the rule is enabled");
+
+        assert!(
+            error.contains("missing `linter.rules.Something.enabled` setting"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn parse_rejects_a_non_boolean_enabled_setting() {
+        let error = parse("[linter.rules.Something]\nenabled = \"yes\"\n").expect_err("enabled only accepts a boolean");
+
+        assert!(
+            error.contains("invalid `linter.rules.Something.enabled` setting"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn parse_rejects_an_unknown_rule_setting() {
+        let error = parse("[linter.rules.Something]\nenabled = true\nseverity = \"error\"\n")
+            .expect_err("rules only accept the enabled setting");
+
+        assert!(
+            error.contains("unknown setting `linter.rules.Something.severity`"),
+            "unexpected error: {error}"
+        );
     }
 
     #[test]
@@ -282,6 +482,7 @@ mod tests {
 
         assert_eq!(config.workspace_path(), path_helpers::resolved(dir.path()).unwrap());
         assert_eq!(config.excluded_patterns().len(), DEFAULT_EXCLUDED_DIRECTORIES.len());
+        assert!(config.linter().rules().is_empty());
     }
 
     #[test]
@@ -350,6 +551,7 @@ mod tests {
 
         // Nothing is configured, so the settings of every section are the default ones.
         assert_eq!(config.excluded_patterns().len(), DEFAULT_EXCLUDED_DIRECTORIES.len());
+        assert!(config.linter().rules().is_empty());
     }
 
     #[test]

--- a/rust/rubydex/src/model/graph.rs
+++ b/rust/rubydex/src/model/graph.rs
@@ -92,7 +92,7 @@ pub struct Graph {
     /// Project configuration
     config: Config,
 }
-assert_mem_size!(Graph, 352);
+assert_mem_size!(Graph, 368);
 assert_send_sync!(Graph);
 
 impl Graph {

--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -62,4 +62,33 @@ class ConfigTest < Minitest::Test
   def test_load_raises_when_the_path_is_not_a_string
     assert_raises(TypeError) { Rubydex::Config.load(123) }
   end
+
+  def test_linter_returns_the_configured_rules
+    with_context do |context|
+      context.write!("rubydex.toml", <<~TOML)
+        [linter.rules.Something]
+        enabled = true
+
+        [linter.rules.Other]
+        enabled = false
+      TOML
+
+      config = Rubydex::Config.load(context.absolute_path)
+      rules = config.linter.rules
+
+      assert_equal(["Other", "Something"], rules.keys.sort)
+      assert_predicate(rules.fetch("Something"), :enabled?)
+      refute_predicate(rules.fetch("Other"), :enabled?)
+    end
+  end
+
+  def test_linter_settings_are_built_once_per_configuration
+    with_context do |context|
+      context.write!("rubydex.toml", "[linter.rules.Something]\nenabled = true\n")
+
+      config = Rubydex::Config.load(context.absolute_path)
+      assert_same(config.linter, config.linter)
+      assert_same(config.linter.rules.fetch("Something"), config.linter.rules.fetch("Something"))
+    end
+  end
 end

--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -10,6 +10,7 @@ class ConfigTest < Minitest::Test
     with_context do |context|
       config = Rubydex::Config.load(context.absolute_path)
       assert_equal(context.absolute_path, config.workspace_path)
+      assert_empty(config.linter.rules)
     end
   end
 
@@ -77,18 +78,9 @@ class ConfigTest < Minitest::Test
       rules = config.linter.rules
 
       assert_equal(["Other", "Something"], rules.keys.sort)
+      assert_predicate(rules, :frozen?)
       assert_predicate(rules.fetch("Something"), :enabled?)
       refute_predicate(rules.fetch("Other"), :enabled?)
-    end
-  end
-
-  def test_linter_settings_are_built_once_per_configuration
-    with_context do |context|
-      context.write!("rubydex.toml", "[linter.rules.Something]\nenabled = true\n")
-
-      config = Rubydex::Config.load(context.absolute_path)
-      assert_same(config.linter, config.linter)
-      assert_same(config.linter.rules.fetch("Something"), config.linter.rules.fetch("Something"))
     end
   end
 end


### PR DESCRIPTION
I recommend reviewing per commit.

The first one starts parsing the `[linter]` section of the configuration file with all changes on the Rust core logic.

The second one exposes the linter configuration as a Ruby object. I went with proper objects to get nicer typing instead of just using a plain hash. Each rule has a `RuleConfig` that we can easily extend with more fields.