### PR TITLE
Improve linter infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,11 @@ Thread safety comes from an `RwLock` on the Rust side, **not** from Ruby's
   aliasing the Rust allocation (which would double-free on GC) or ballooning
   memory with a deep copy.
 
-## Querying with Cypher
+## Tools
+
+All built-in tools are experimental. These tools can change without deprecation warnings.
+
+### `rdx query`
 
 Rubydex exposes the indexed graph through a read-only subset of the
 [Cypher](https://opencypher.org/) query language. Only read clauses (`MATCH`,
@@ -145,12 +149,32 @@ puts query.render(graph, "json")
 puts Rubydex::Query.schema("table")
 ```
 
-## MCP Server (Experimental)
+### `rdx lint`
+
+Put rule files under `rubydex_linter/rules`. Each rule must inherit from `Rubydex::Linter::Rule`.
+
+Run the linter:
+
+```bash
+bundle exec rdx lint [PATH]
+```
+
+If you omit `PATH`, Rubydex uses the current directory.
+
+Configure a rule in `rubydex.toml`:
+
+```toml
+[linter.rules.<Rule name>]
+enabled = true
+exclude = ["path_to_skip/**"]
+```
+
+### `rdx mcp`
 
 Rubydex can run as an MCP (Model Context Protocol) server, enabling AI assistants
 like Claude to semantically query your Ruby codebase.
 
-### Setup
+#### Setup
 
 1. Add Rubydex to the Ruby project you want to index:
    ```ruby
@@ -178,7 +202,7 @@ like Claude to semantically query your Ruby codebase.
    the project at startup and provides semantic code intelligence tools through
    the tools below.
 
-### Available MCP Tools
+#### Available MCP Tools
 
 | Tool | Description |
 |------|-------------|

--- a/ext/rubydex/config.c
+++ b/ext/rubydex/config.c
@@ -1,4 +1,5 @@
 #include "config.h"
+#include "diagnostic.h"
 #include "rustbindings.h"
 #include "utils.h"
 
@@ -29,9 +30,19 @@ static VALUE config_linter_build(VALUE opaque_rule_array) {
     for (size_t i = 0; i < rule_array->len; i++) {
         CLinterRule rule = rule_array->items[i];
         VALUE rule_name = rb_str_freeze(rb_utf8_str_new(rule.name, (long)rule.name_length));
-        VALUE argv[] = {rule_name, rule.enabled ? Qtrue : Qfalse};
+        VALUE exclude_patterns = rb_ary_new_capa((long)rule.exclude_patterns_length);
+        for (size_t j = 0; j < rule.exclude_patterns_length; j++) {
+            CConfigString pattern = rule.exclude_patterns[j];
+            rb_ary_push(exclude_patterns, rb_str_freeze(rb_utf8_str_new(pattern.data, (long)pattern.length)));
+        }
+        rb_obj_freeze(exclude_patterns);
 
-        rb_hash_aset(rules, rule_name, rb_class_new_instance(2, argv, cRuleConfig));
+        VALUE severity = rule.severity == NULL
+            ? Qnil
+            : rdxi_build_diagnostic_severity_value(mRubydex, *rule.severity);
+        VALUE argv[] = {rule_name, rule.enabled ? Qtrue : Qfalse, exclude_patterns, severity};
+
+        rb_hash_aset(rules, rule_name, rb_class_new_instance(4, argv, cRuleConfig));
     }
 
     return rb_class_new_instance(1, &rules, cLinterConfig);

--- a/lib/rubydex/cli/command/lint.rb
+++ b/lib/rubydex/cli/command/lint.rb
@@ -32,7 +32,12 @@ module Rubydex
 
           graph = build_graph($stderr, workspace_path:, config:, fail_on_index_errors: true)
           result = Rubydex::Linter::Runner.new(graph, rules:, config: config.linter).run
-          result.diagnostics.each { |diagnostic| puts(format_linter_diagnostic(diagnostic)) }
+          if result.diagnostics.empty?
+            print_summary(graph.documents.count, result.diagnostics)
+            return
+          end
+
+          print_offenses(result.diagnostics, graph)
           exit(1) unless result.success?
         end
 
@@ -70,28 +75,94 @@ module Rubydex
           Rubydex::Linter::Rule.subclasses - existing_rules
         end
 
-        #: (Location location) -> String
-        def format_linter_location(location)
-          display_location = location.to_display
-          path = begin
-            display_location.to_file_path
-          rescue Rubydex::Location::NotFileUriError
-            display_location.uri
+        #: (Array[Diagnostic] diagnostics, Graph graph) -> void
+        def print_offenses(diagnostics, graph)
+          puts("Offenses:")
+          puts
+
+          diagnostics.each do |diagnostic|
+            puts(format_linter_diagnostic(diagnostic, workspace_path: graph.workspace_path))
+            print_source_excerpt(diagnostic.location)
+            puts
           end
+
+          print_summary(graph.documents.count, diagnostics)
+        end
+
+        #: (Location location, workspace_path: String) -> String
+        def format_linter_location(location, workspace_path:)
+          display_location = location.to_display
+          path = Rubydex::Linter::Helpers::PathHelpers.display_path(display_location, workspace: workspace_path)
 
           "#{path}:#{display_location.start_line}:#{display_location.start_column}"
         end
 
-        #: (Diagnostic diagnostic) -> String
-        def format_linter_diagnostic(diagnostic)
-          content = +"#{format_linter_location(diagnostic.location)}: " \
+        #: (Diagnostic diagnostic, workspace_path: String) -> String
+        def format_linter_diagnostic(diagnostic, workspace_path:)
+          content = +"#{format_linter_location(diagnostic.location, workspace_path:)}: " \
             "#{diagnostic.severity.value}: #{diagnostic.rule}: #{diagnostic.message}"
 
           diagnostic.related_information.each do |information|
-            content << "\n  #{format_linter_location(information.location)}: #{information.message}"
+            content << "\n  #{format_linter_location(information.location, workspace_path:)}: #{information.message}"
           end
 
           content
+        end
+
+        #: (Location location) -> void
+        def print_source_excerpt(location)
+          line = source_line_for(location)
+          return unless line
+
+          end_column = location.end_line == location.start_line ? location.end_column : line.length
+          carets = "^" * [end_column - location.start_column, 1].max
+
+          puts
+          puts(line)
+          puts("#{" " * location.start_column}#{carets}")
+        end
+
+        #: (Location location) -> String?
+        def source_line_for(location)
+          source_lines_for(location.to_file_path)[location.start_line]
+        rescue Errno::ENOENT, Errno::EACCES, Rubydex::Location::NotFileUriError
+          nil
+        end
+
+        #: (String path) -> Array[String]
+        def source_lines_for(path)
+          @source_lines_cache ||= {} #: Hash[String, Array[String]]?
+          @source_lines_cache[path] ||= File.readlines(path, chomp: true)
+        end
+
+        #: (Integer file_count, Array[Diagnostic] diagnostics) -> void
+        def print_summary(file_count, diagnostics)
+          if diagnostics.empty?
+            puts("#{file_count} #{pluralize("file", file_count)} inspected, no offenses detected")
+            return
+          end
+
+          severity_counts = diagnostics.map(&:severity).tally
+          offense_count = diagnostics.length
+          error_count = severity_counts.fetch(Rubydex::Severity::Error, 0)
+          warning_count = severity_counts.fetch(Rubydex::Severity::Warning, 0)
+          hint_count = severity_counts.fetch(Rubydex::Severity::Hint, 0)
+          severity_summary = [
+            "#{error_count} #{pluralize("error", error_count)}",
+            "#{warning_count} #{pluralize("warning", warning_count)}",
+            "#{severity_counts.fetch(Rubydex::Severity::Information, 0)} info",
+            "#{hint_count} #{pluralize("hint", hint_count)}",
+          ].join(", ")
+
+          puts(
+            "#{file_count} #{pluralize("file", file_count)} inspected, " \
+              "#{offense_count} #{pluralize("offense", offense_count)} detected: #{severity_summary}",
+          )
+        end
+
+        #: (String word, Integer count) -> String
+        def pluralize(word, count)
+          count == 1 ? word : "#{word}s"
         end
       end
     end

--- a/lib/rubydex/cli/command/lint.rb
+++ b/lib/rubydex/cli/command/lint.rb
@@ -7,8 +7,6 @@ module Rubydex
     # `rdx lint [PATH]` — discovers project and dependency rules and runs them against a workspace.
     class Command
       class Lint < Command
-        RULE_GLOB = "rubydex_linter/rules/**/*.rb" #: String
-
         command "lint"
         arguments "[PATH]"
         summary "Run semantic lint rules against a workspace"
@@ -56,23 +54,11 @@ module Rubydex
           )
         end
 
-        #: (String workspace_path) -> Array[singleton(Linter::Rule)]
+        #: (String workspace_path) -> Array[singleton(Rubydex::Linter::Rule)]
         def load_linter_rules(workspace_path)
-          existing_rules = Rubydex::Linter::Rule.subclasses
-          rule_files = Dir.glob(RULE_GLOB, base: workspace_path).map do |rule_file|
-            File.expand_path(rule_file, workspace_path)
-          end
-          if ENV["BUNDLE_GEMFILE"]
-            rule_files.concat(Gem.find_latest_files(RULE_GLOB))
-          end
-
-          rule_files.each do |rule_file|
-            require rule_file
-          rescue LoadError, SyntaxError => error
-            abort("Unable to load linter rules from #{rule_file}: #{error.message}")
-          end
-
-          Rubydex::Linter::Rule.subclasses - existing_rules
+          Rubydex::Linter::RuleLoader.load(workspace_path)
+        rescue Rubydex::Linter::RuleLoadError => error
+          abort(error.message)
         end
 
         #: (Array[Diagnostic] diagnostics, Graph graph) -> void

--- a/lib/rubydex/config.rb
+++ b/lib/rubydex/config.rb
@@ -20,6 +20,16 @@ module Rubydex
       rule = @rules[rule_class.rule_name]
       !rule || rule.enabled?
     end
+
+    #: (singleton(Linter::Rule) rule_class) -> Array[String]
+    def excludes_for(rule_class)
+      @rules[rule_class.rule_name]&.exclude_patterns || []
+    end
+
+    #: (singleton(Linter::Rule) rule_class, default: singleton(Severity::Base)) -> singleton(Severity::Base)
+    def severity_for(rule_class, default:)
+      @rules[rule_class.rule_name]&.severity || default
+    end
   end
 
   # The settings of a single linter rule, read from a `[linter.rules.RuleName]` table.
@@ -27,10 +37,18 @@ module Rubydex
     #: String
     attr_reader :name
 
-    #: (String, bool) -> void
-    def initialize(name, enabled)
+    #: Array[String]
+    attr_reader :exclude_patterns
+
+    #: singleton(Severity::Base)?
+    attr_reader :severity
+
+    #: (String, bool, ?Array[String], ?singleton(Severity::Base)?) -> void
+    def initialize(name, enabled, exclude_patterns = [], severity = nil)
       @name = name
       @enabled = enabled
+      @exclude_patterns = exclude_patterns
+      @severity = severity
     end
 
     #: () -> bool

--- a/lib/rubydex/linter.rb
+++ b/lib/rubydex/linter.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require "rubydex"
+require "rubydex/linter/helpers/path_helpers"
+require "rubydex/linter/helpers/source_access_helpers"
 require "rubydex/linter/result"
 require "rubydex/linter/rule"
 require "rubydex/linter/runner"

--- a/lib/rubydex/linter.rb
+++ b/lib/rubydex/linter.rb
@@ -5,6 +5,7 @@ require "rubydex/linter/helpers/path_helpers"
 require "rubydex/linter/helpers/source_access_helpers"
 require "rubydex/linter/result"
 require "rubydex/linter/rule"
+require "rubydex/linter/rule_loader"
 require "rubydex/linter/runner"
 
 module Rubydex

--- a/lib/rubydex/linter/helpers/path_helpers.rb
+++ b/lib/rubydex/linter/helpers/path_helpers.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require "pathname"
+require "uri"
+
+module Rubydex
+  module Linter
+    module Helpers
+      # @requires_ancestor: Rubydex::Linter::Rule
+      module PathHelpers
+        RUBOCOP_EXCLUDE_FNMATCH_FLAGS =
+          File::FNM_PATHNAME | File::FNM_EXTGLOB | File::FNM_DOTMATCH #: Integer
+        TEST_PATHS = ["test/**", "**/test/**", "**/*_test.rb"].freeze
+
+        class << self
+          #: (String, Array[String], workspace: String, ?flags: Integer) -> bool
+          def path_matches_patterns?(path, patterns, workspace:, flags: 0)
+            return false unless path == workspace || path.start_with?("#{workspace}/")
+
+            relative_path = path.delete_prefix("#{workspace}/")
+            patterns.any? { |pattern| File.fnmatch?(pattern, relative_path, flags) }
+          end
+
+          # Returns the path to show users for a location: relative to the workspace for files inside it, the absolute
+          # path for files outside it (dependencies, for example) and the URI opaque for non file URIs, so that
+          # `untitled:Untitled-1` displays as `Untitled-1`.
+          #
+          #: (Location, workspace: String) -> String
+          def display_path(location, workspace:)
+            path = location.to_file_path
+            return path unless path == workspace || path.start_with?("#{workspace}/")
+
+            Pathname.new(path).relative_path_from(workspace).to_s
+          rescue Location::NotFileUriError
+            URI(location.uri).opaque || location.uri
+          end
+        end
+
+        #: (Enumerable[Rubydex::Definition], Array[String]) -> Array[Rubydex::Definition]
+        def reject_definitions_in_paths(definitions, excluded_patterns)
+          workspace = graph.workspace_path
+
+          definitions.reject do |definition|
+            path = path_for_definition(definition)
+            path.nil? || (path != workspace && !path.start_with?("#{workspace}/")) ||
+              path_matches_patterns?(path, excluded_patterns)
+          end
+        end
+
+        #: (Enumerable[Rubydex::Definition], Array[String]) -> Array[Rubydex::Definition]
+        def select_definitions_in_paths(definitions, patterns)
+          definitions.select do |definition|
+            path = path_for_definition(definition)
+            path && path_matches_patterns?(path, patterns)
+          end
+        end
+
+        private
+
+        #: (String, Array[String]) -> bool
+        def path_matches_patterns?(path, patterns)
+          PathHelpers.path_matches_patterns?(path, patterns, workspace: graph.workspace_path)
+        end
+
+        #: (String) -> bool
+        def test_path?(path)
+          path_matches_patterns?(path, TEST_PATHS)
+        end
+
+        #: (Rubydex::Definition) -> String?
+        def path_for_definition(definition)
+          definition.location.to_file_path
+        rescue Location::NotFileUriError
+          nil
+        end
+      end
+    end
+  end
+end

--- a/lib/rubydex/linter/helpers/source_access_helpers.rb
+++ b/lib/rubydex/linter/helpers/source_access_helpers.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Rubydex
+  module Linter
+    module Helpers
+      # File and URI access for linter rules.
+      module SourceAccessHelpers
+        #: (String) -> Location
+        def file_location(uri)
+          Location.new(uri: uri, start_line: 0, end_line: 0, start_column: 0, end_column: 0)
+        end
+
+        #: (String) -> String
+        def path_for_uri(uri)
+          file_location(uri).to_file_path
+        rescue Location::NotFileUriError
+          uri
+        end
+
+        private
+
+        #: (Location) -> String?
+        def source_for_location(location)
+          File.read(location.to_file_path)
+        rescue Errno::ENOENT
+          nil
+        end
+      end
+    end
+  end
+end

--- a/lib/rubydex/linter/rule.rb
+++ b/lib/rubydex/linter/rule.rb
@@ -8,7 +8,8 @@ module Rubydex
       class << self
         #: () -> String
         def rule_name
-          name.split("::").last
+          name #: as !nil
+            .split("::").last #: as !nil
         end
       end
 
@@ -40,6 +41,44 @@ module Rubydex
         raise NotImplementedError, "Subclasses must implement the lint method"
       end
 
+      # Anchors a diagnostic on a definition's name token, falling back to its full range when no name location exists.
+      #: (Definition) -> Location
+      def diagnostic_location(definition)
+        definition.name_location || definition.location
+      end
+
+      # Returns every class inheriting from +base_name+, excluding the base class itself.
+      #: (String) -> Enumerable[Rubydex::Class]
+      def child_classes(base_name)
+        required_namespace(base_name).descendants.lazy.filter_map do |child_declaration|
+          next unless child_declaration.is_a?(Rubydex::Class)
+          next if child_declaration.name == base_name
+
+          child_declaration
+        end
+      end
+
+      #: (String) -> Namespace
+      def required_namespace(name)
+        declaration = graph[name]
+        return declaration if declaration.is_a?(Namespace)
+
+        raise MissingGraphDependencyError.new(rule_name, "`#{name}`")
+      end
+
+      #: (Namespace, String) -> Rubydex::Method
+      def required_method(namespace, method_name)
+        method = namespace.find_member(method_name)
+        return method if method.is_a?(Rubydex::Method)
+
+        raise MissingGraphDependencyError.new(rule_name, "`#{namespace.name}##{method_name}`")
+      end
+
+      #: () -> String
+      def rule_name
+        self.class.rule_name
+      end
+
       protected
 
       #: (
@@ -54,6 +93,17 @@ module Rubydex
           location: location,
           severity: severity,
           related_information: related_information,
+        )
+      end
+    end
+
+    class MissingGraphDependencyError < StandardError
+      #: (String, String) -> void
+      def initialize(rule_name, dependency)
+        super(
+          "Rubydex linter rule `#{rule_name}` requires #{dependency} to exist in the Rubydex graph. " \
+            "This is a rule setup error, not a clean lint result; ensure the source that defines " \
+            "the dependency is indexed and Rubydex can resolve it.",
         )
       end
     end

--- a/lib/rubydex/linter/rule.rb
+++ b/lib/rubydex/linter/rule.rb
@@ -27,12 +27,18 @@ module Rubydex
         @graph = graph
         @config = config
         @diagnostics = [] #: Array[Diagnostic]
+        @verified_severity = nil #: singleton(Severity::Base)?
       end
 
       # @abstract
       #: () -> singleton(Severity::Base)
       def severity
         raise NotImplementedError, "Subclasses must implement the severity method"
+      end
+
+      #: () -> singleton(Severity::Base)
+      def verified_severity
+        @verified_severity ||= config.severity_for(self.class, default: severity)
       end
 
       # @abstract
@@ -91,7 +97,7 @@ module Rubydex
           rule: self.class.rule_name,
           message: message,
           location: location,
-          severity: severity,
+          severity: verified_severity,
           related_information: related_information,
         )
       end

--- a/lib/rubydex/linter/rule_loader.rb
+++ b/lib/rubydex/linter/rule_loader.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Rubydex
+  module Linter
+    # Loads project and bundled-gem rules using the Rubydex linter path convention.
+    class RuleLoader
+      RULE_GLOB = "rubydex_linter/rules/**/*.rb" #: String
+
+      class << self
+        #: (String workspace_path) -> Array[singleton(Rule)]
+        def load(workspace_path)
+          existing_rules = Rule.subclasses
+          rule_files = Dir.glob(RULE_GLOB, base: workspace_path).map do |rule_file|
+            File.expand_path(rule_file, workspace_path)
+          end
+          if ENV["BUNDLE_GEMFILE"]
+            rule_files.concat(Gem.find_latest_files(RULE_GLOB))
+          end
+
+          rule_files.each do |rule_file|
+            require rule_file
+          rescue LoadError, SyntaxError => error
+            raise RuleLoadError, "Unable to load linter rules from #{rule_file}: #{error.message}", cause: error
+          end
+
+          Rule.subclasses - existing_rules
+        end
+      end
+    end
+
+    class RuleLoadError < StandardError; end
+  end
+end

--- a/lib/rubydex/linter/runner.rb
+++ b/lib/rubydex/linter/runner.rb
@@ -18,6 +18,7 @@ module Rubydex
         @graph = graph
         @config = config
         @rules = rules.select { |rule| config.rule_enabled?(rule) }.sort_by { |rule| rule.name.to_s }
+        @dependency_paths = Gem.path #: Array[String]
       end
 
       #: () -> Result
@@ -25,7 +26,7 @@ module Rubydex
         rule_diagnostics = @rules.flat_map do |rule_class|
           rule = rule_class.new(@graph, config: @config)
           rule.lint
-          rule.diagnostics
+          filter_diagnostics(rule.diagnostics, @config.excludes_for(rule_class))
         end
 
         diagnostics = (@graph.diagnostics + rule_diagnostics).select do |diagnostic|
@@ -47,6 +48,30 @@ module Rubydex
       end
 
       private
+
+      #: (Array[Diagnostic], Array[String]) -> Array[Diagnostic]
+      def filter_diagnostics(diagnostics, exclude_patterns)
+        diagnostics.reject do |diagnostic|
+          location_excluded?(diagnostic.location, exclude_patterns)
+        end
+      end
+
+      #: (Location, Array[String]) -> bool
+      def location_excluded?(location, patterns)
+        path = location.to_file_path
+        return true if @dependency_paths.any? do |dependency_path|
+          path == dependency_path || path.start_with?("#{dependency_path}/")
+        end
+
+        Helpers::PathHelpers.path_matches_patterns?(
+          path,
+          patterns,
+          workspace: @graph.workspace_path,
+          flags: Helpers::PathHelpers::RUBOCOP_EXCLUDE_FNMATCH_FLAGS,
+        )
+      rescue Location::NotFileUriError
+        false
+      end
 
       #: (Diagnostic) -> bool
       def diagnostic_in_workspace?(diagnostic)

--- a/lib/rubydex/linter/runner.rb
+++ b/lib/rubydex/linter/runner.rb
@@ -50,7 +50,7 @@ module Rubydex
 
       #: (Diagnostic) -> bool
       def diagnostic_in_workspace?(diagnostic)
-        path = URI::RFC2396_PARSER.unescape(diagnostic.location.to_file_path)
+        path = diagnostic.location.to_file_path
         workspace_path = Pathname.new(File.expand_path(@graph.workspace_path))
         relative_path = Pathname.new(File.expand_path(path)).relative_path_from(workspace_path)
 

--- a/lib/rubydex/location.rb
+++ b/lib/rubydex/location.rb
@@ -42,6 +42,9 @@ module Rubydex
       raise NotFileUriError, "URI is not a file:// URI: #{@uri}" unless uri.scheme == "file"
 
       path = uri.path
+      raise NotFileUriError, "URI has no file path: #{@uri}" if path.nil? || path.empty?
+
+      path = URI.decode_uri_component(path)
       # TODO: This has to go away once we have a proper URI abstraction
       path.delete_prefix!("/") if Gem.win_platform?
       path

--- a/rbi/rubydex.rbi
+++ b/rbi/rubydex.rbi
@@ -487,6 +487,15 @@ class Rubydex::Linter::MissingGraphDependencyError < StandardError
   def initialize(rule_name, dependency); end
 end
 
+class Rubydex::Linter::RuleLoadError < StandardError; end
+
+class Rubydex::Linter::RuleLoader
+  RULE_GLOB = T.let(T.unsafe(nil), String)
+
+  sig { params(workspace_path: String).returns(T::Array[T.class_of(Rubydex::Linter::Rule)]) }
+  def self.load(workspace_path); end
+end
+
 class Rubydex::Linter::Runner
   sig do
     params(

--- a/rbi/rubydex.rbi
+++ b/rbi/rubydex.rbi
@@ -357,6 +357,70 @@ class Rubydex::Diagnostic
 end
 
 module Rubydex::Linter; end
+module Rubydex::Linter::Helpers; end
+
+module Rubydex::Linter::Helpers::PathHelpers
+  extend T::Helpers
+
+  requires_ancestor { Rubydex::Linter::Rule }
+
+  RUBOCOP_EXCLUDE_FNMATCH_FLAGS = T.let(T.unsafe(nil), Integer)
+  TEST_PATHS = T.let(T.unsafe(nil), T::Array[String])
+
+  sig do
+    params(
+      path: String,
+      patterns: T::Array[String],
+      workspace: String,
+      flags: Integer,
+    ).returns(T::Boolean)
+  end
+  def self.path_matches_patterns?(path, patterns, workspace:, flags: 0); end
+
+  sig { params(location: Rubydex::Location, workspace: String).returns(String) }
+  def self.display_path(location, workspace:); end
+
+  sig do
+    params(
+      definitions: T::Enumerable[Rubydex::Definition],
+      excluded_patterns: T::Array[String],
+    ).returns(T::Array[Rubydex::Definition])
+  end
+  def reject_definitions_in_paths(definitions, excluded_patterns); end
+
+  sig do
+    params(
+      definitions: T::Enumerable[Rubydex::Definition],
+      patterns: T::Array[String],
+    ).returns(T::Array[Rubydex::Definition])
+  end
+  def select_definitions_in_paths(definitions, patterns); end
+
+  private
+
+  sig { params(path: String, patterns: T::Array[String]).returns(T::Boolean) }
+  def path_matches_patterns?(path, patterns); end
+
+  sig { params(path: String).returns(T::Boolean) }
+  def test_path?(path); end
+
+  sig { params(definition: Rubydex::Definition).returns(T.nilable(String)) }
+  def path_for_definition(definition); end
+
+end
+
+module Rubydex::Linter::Helpers::SourceAccessHelpers
+  sig { params(uri: String).returns(Rubydex::Location) }
+  def file_location(uri); end
+
+  sig { params(uri: String).returns(String) }
+  def path_for_uri(uri); end
+
+  private
+
+  sig { params(location: Rubydex::Location).returns(T.nilable(String)) }
+  def source_for_location(location); end
+end
 
 class Rubydex::Linter::Rule
   abstract!
@@ -376,6 +440,26 @@ class Rubydex::Linter::Rule
   sig { returns(T::Array[Rubydex::Diagnostic]) }
   def diagnostics; end
 
+  sig { params(definition: Rubydex::Definition).returns(Rubydex::Location) }
+  def diagnostic_location(definition); end
+
+  sig { params(base_name: String).returns(T::Enumerable[Rubydex::Class]) }
+  def child_classes(base_name); end
+
+  sig { params(name: String).returns(Rubydex::Namespace) }
+  def required_namespace(name); end
+
+  sig do
+    params(
+      namespace: Rubydex::Namespace,
+      method_name: String,
+    ).returns(Rubydex::Method)
+  end
+  def required_method(namespace, method_name); end
+
+  sig { returns(String) }
+  def rule_name; end
+
   sig { abstract.returns(T.class_of(Rubydex::Severity::Base)) }
   def severity; end
 
@@ -392,6 +476,12 @@ class Rubydex::Linter::Rule
     ).void
   end
   def add_diagnostic(message, location, related_information: []); end
+
+end
+
+class Rubydex::Linter::MissingGraphDependencyError < StandardError
+  sig { params(rule_name: String, dependency: String).void }
+  def initialize(rule_name, dependency); end
 end
 
 class Rubydex::Linter::Runner

--- a/rbi/rubydex.rbi
+++ b/rbi/rubydex.rbi
@@ -463,6 +463,9 @@ class Rubydex::Linter::Rule
   sig { abstract.returns(T.class_of(Rubydex::Severity::Base)) }
   def severity; end
 
+  sig { returns(T.class_of(Rubydex::Severity::Base)) }
+  def verified_severity; end
+
   sig { abstract.void }
   def lint; end
 
@@ -586,6 +589,17 @@ class Rubydex::LinterConfig
 
   sig { params(rule_class: T.class_of(Rubydex::Linter::Rule)).returns(T::Boolean) }
   def rule_enabled?(rule_class); end
+
+  sig { params(rule_class: T.class_of(Rubydex::Linter::Rule)).returns(T::Array[String]) }
+  def excludes_for(rule_class); end
+
+  sig do
+    params(
+      rule_class: T.class_of(Rubydex::Linter::Rule),
+      default: T.class_of(Rubydex::Severity::Base),
+    ).returns(T.class_of(Rubydex::Severity::Base))
+  end
+  def severity_for(rule_class, default:); end
 end
 
 # The settings of a single linter rule, read from a `[linter.rules.RuleName]` table.
@@ -593,8 +607,21 @@ class Rubydex::RuleConfig
   sig { returns(String) }
   attr_reader :name
 
-  sig { params(name: String, enabled: T::Boolean).void }
-  def initialize(name, enabled); end
+  sig { returns(T::Array[String]) }
+  attr_reader :exclude_patterns
+
+  sig { returns(T.nilable(T.class_of(Rubydex::Severity::Base))) }
+  attr_reader :severity
+
+  sig do
+    params(
+      name: String,
+      enabled: T::Boolean,
+      exclude_patterns: T::Array[String],
+      severity: T.nilable(T.class_of(Rubydex::Severity::Base)),
+    ).void
+  end
+  def initialize(name, enabled, exclude_patterns = [], severity = nil); end
 
   sig { returns(T::Boolean) }
   def enabled?; end

--- a/rust/rubydex-sys/src/config_api.rs
+++ b/rust/rubydex-sys/src/config_api.rs
@@ -1,3 +1,4 @@
+use crate::diagnostic_api::DiagnosticSeverity;
 use crate::utils;
 use libc::{c_char, c_void};
 use rubydex::config::{Config, Rule};
@@ -90,6 +91,14 @@ pub unsafe extern "C" fn rdx_config_free(config: ConfigPointer) {
     }
 }
 
+/// Borrowed string bytes exposed while building Ruby configuration values.
+#[repr(C)]
+#[derive(Debug)]
+pub struct CConfigString {
+    pub data: *const c_char,
+    pub length: usize,
+}
+
 /// C-compatible struct representing a single configured linter rule.
 #[repr(C)]
 #[derive(Debug)]
@@ -97,14 +106,38 @@ pub struct CLinterRule {
     pub name: *const c_char,
     pub name_length: usize,
     pub enabled: bool,
+    pub exclude_patterns: *const CConfigString,
+    pub exclude_patterns_length: usize,
+    pub severity: *const DiagnosticSeverity,
 }
 
 impl From<&Rule> for CLinterRule {
     fn from(rule: &Rule) -> Self {
+        let exclude_patterns = rule
+            .exclude_patterns()
+            .iter()
+            .map(|pattern| CConfigString {
+                data: pattern.as_ptr().cast::<c_char>(),
+                length: pattern.len(),
+            })
+            .collect::<Box<[CConfigString]>>();
+        let exclude_patterns_length = exclude_patterns.len();
+        let exclude_patterns = if exclude_patterns.is_empty() {
+            ptr::null()
+        } else {
+            Box::into_raw(exclude_patterns).cast::<CConfigString>().cast_const()
+        };
+        let severity = rule.severity().map_or(ptr::null(), |severity| {
+            Box::into_raw(Box::new(DiagnosticSeverity::from(severity))).cast_const()
+        });
+
         Self {
             name: rule.name().as_ptr().cast::<c_char>(),
             name_length: rule.name().len(),
             enabled: rule.enabled(),
+            exclude_patterns,
+            exclude_patterns_length,
+            severity,
         }
     }
 }
@@ -155,6 +188,18 @@ pub unsafe extern "C" fn rdx_config_linter_rules_free(rules: CLinterRuleArray) {
     }
 
     unsafe {
-        let _ = Box::from_raw(ptr::slice_from_raw_parts_mut(rules.items, rules.len));
+        let rules = Box::from_raw(ptr::slice_from_raw_parts_mut(rules.items, rules.len));
+
+        for rule in &*rules {
+            if !rule.exclude_patterns.is_null() {
+                let exclude_patterns =
+                    ptr::slice_from_raw_parts_mut(rule.exclude_patterns.cast_mut(), rule.exclude_patterns_length);
+                let _ = Box::from_raw(exclude_patterns);
+            }
+
+            if !rule.severity.is_null() {
+                let _ = Box::from_raw(rule.severity.cast_mut());
+            }
+        }
     }
 }

--- a/rust/rubydex/src/config.rs
+++ b/rust/rubydex/src/config.rs
@@ -1,4 +1,5 @@
 use crate::assert_mem_size;
+use crate::diagnostic::Severity;
 use crate::errors::Errors;
 use crate::path_helpers;
 use std::collections::HashSet;
@@ -72,6 +73,8 @@ impl GraphSettings {
 pub struct Rule {
     name: Box<str>,
     enabled: bool,
+    exclude_patterns: Box<[Box<str>]>,
+    severity: Option<Severity>,
 }
 
 impl Rule {
@@ -83,6 +86,16 @@ impl Rule {
     #[must_use]
     pub fn enabled(&self) -> bool {
         self.enabled
+    }
+
+    #[must_use]
+    pub fn exclude_patterns(&self) -> &[Box<str>] {
+        &self.exclude_patterns
+    }
+
+    #[must_use]
+    pub fn severity(&self) -> Option<&Severity> {
+        self.severity.as_ref()
     }
 
     /// Parses a single `[linter.rules.{name}]` table
@@ -98,7 +111,24 @@ impl Rule {
                     "invalid `linter.rules.{name}.enabled` setting: expected a boolean"
                 ));
             }
-            None => return Err(format!("missing `linter.rules.{name}.enabled` setting")),
+            None => true,
+        };
+
+        let exclude_patterns = match table.remove("exclude") {
+            Some(value) => value
+                .try_into::<Vec<Box<str>>>()
+                .map_err(|error| format!("invalid `linter.rules.{name}.exclude` setting: {error}"))?
+                .into_boxed_slice(),
+            None => Box::default(),
+        };
+
+        let severity = match table.remove("severity") {
+            Some(value) => Some(
+                value
+                    .try_into::<Severity>()
+                    .map_err(|error| format!("invalid `linter.rules.{name}.severity` setting: {error}"))?,
+            ),
+            None => None,
         };
 
         if let Some(key) = table.keys().next() {
@@ -108,6 +138,8 @@ impl Rule {
         Ok(Self {
             name: Box::from(name),
             enabled,
+            exclude_patterns,
+            severity,
         })
     }
 }
@@ -385,17 +417,24 @@ mod tests {
 
     #[test]
     fn parse_parses_every_linter_rule() {
-        let config = parse("[linter.rules.Something]\nenabled = true\n\n[linter.rules.Other]\nenabled = false\n")
-            .expect("expected the config to parse");
+        let config = parse(
+            "[linter.rules.Something]\nseverity = \"warning\"\nexclude = [\"components/legacy/**\"]\n\n\
+             [linter.rules.Other]\nenabled = false\n",
+        )
+        .expect("expected the config to parse");
 
         let rules = config.linter().rules();
         assert_eq!(rules.len(), 2);
 
         let something = rules.iter().find(|rule| rule.name() == "Something").unwrap();
         assert!(something.enabled());
+        assert_eq!(something.exclude_patterns(), [Box::from("components/legacy/**")]);
+        assert_eq!(something.severity(), Some(&Severity::Warning));
 
         let other = rules.iter().find(|rule| rule.name() == "Other").unwrap();
         assert!(!other.enabled());
+        assert!(other.exclude_patterns().is_empty());
+        assert_eq!(other.severity(), None);
     }
 
     #[test]
@@ -444,14 +483,9 @@ mod tests {
     }
 
     #[test]
-    fn parse_rejects_a_rule_without_enabled() {
-        let error =
-            parse("[linter.rules.Something]\n").expect_err("a rule setting must state whether the rule is enabled");
-
-        assert!(
-            error.contains("missing `linter.rules.Something.enabled` setting"),
-            "unexpected error: {error}"
-        );
+    fn parse_defaults_a_rule_to_enabled() {
+        let config = parse("[linter.rules.Something]\n").expect("enabled defaults to true");
+        assert!(config.linter().rules()[0].enabled());
     }
 
     #[test]
@@ -466,13 +500,52 @@ mod tests {
 
     #[test]
     fn parse_rejects_an_unknown_rule_setting() {
-        let error = parse("[linter.rules.Something]\nenabled = true\nseverity = \"error\"\n")
-            .expect_err("rules only accept the enabled setting");
+        let error =
+            parse("[linter.rules.Something]\nparallel = true\n").expect_err("unknown rule settings must be rejected");
 
         assert!(
-            error.contains("unknown setting `linter.rules.Something.severity`"),
+            error.contains("unknown setting `linter.rules.Something.parallel`"),
             "unexpected error: {error}"
         );
+    }
+
+    #[test]
+    fn parse_rejects_an_invalid_rule_exclude_setting() {
+        let error = parse("[linter.rules.Something]\nexclude = \"components/legacy/**\"\n")
+            .expect_err("exclude must be an array of strings");
+
+        assert!(
+            error.contains("invalid `linter.rules.Something.exclude` setting"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn parse_rejects_an_invalid_rule_severity_setting() {
+        for severity in ["\"critical\"", "1"] {
+            let error = parse(&format!("[linter.rules.Something]\nseverity = {severity}\n"))
+                .expect_err("severity must be one of the supported strings");
+
+            assert!(
+                error.contains("invalid `linter.rules.Something.severity` setting"),
+                "unexpected error: {error}"
+            );
+        }
+    }
+
+    #[test]
+    fn parse_accepts_every_rule_severity() {
+        for (value, expected) in [
+            ("error", Severity::Error),
+            ("warning", Severity::Warning),
+            ("information", Severity::Information),
+            ("hint", Severity::Hint),
+        ] {
+            let config =
+                parse(&format!("[linter.rules.Something]\nseverity = \"{value}\"\n")).expect("severity should parse");
+
+            assert_eq!(config.linter().rules()[0].severity(), Some(&expected));
+        }
     }
 
     #[test]

--- a/rust/rubydex/src/diagnostic.rs
+++ b/rust/rubydex/src/diagnostic.rs
@@ -61,7 +61,8 @@ impl Diagnostic {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
 pub enum Severity {
     Error,
     Warning,

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -409,11 +409,11 @@ class CLITest < Minitest::Test
 
           add_diagnostic(
             "Foo is not allowed.",
-            primary.name_location || primary.location,
+            diagnostic_location(primary),
             related_information: definitions.map do |definition|
               Rubydex::RelatedInformation.new(
                 "Foo is also defined here.",
-                definition.name_location || definition.location,
+                diagnostic_location(definition),
               )
             end,
           )

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -262,13 +262,23 @@ class CLITest < Minitest::Test
       result = with_bundle_gemfile(nil) { rdx("lint", context.absolute_path) }
 
       refute_success_status(result)
-      assert_stdout_equals(
-        <<~OUTPUT,
-          #{context.absolute_path_to("app.rb")}:1:7: error: CLITestProjectErrorRule: Foo is not allowed.
-            #{context.absolute_path_to("app.rb")}:2:7: Foo is also defined here.
-        OUTPUT
+      assert_stdout_includes(
         result,
+        <<~OUTPUT,
+          Offenses:
+
+          app.rb:1:7: error: CLITestProjectErrorRule: Foo is not allowed.
+            app.rb:2:7: Foo is also defined here.
+
+          class Foo; end
+                ^^^
+        OUTPUT
       )
+      assert_stdout_includes_pattern(
+        result,
+        /\d+ files inspected, 1 offense detected: 1 error, 0 warnings, 0 info, 0 hints/,
+      )
+      refute_stdout_includes(result, context.absolute_path)
       assert_stderr_includes(result, "Indexing workspace...")
       assert_stderr_includes(result, "Resolving graph...")
     end
@@ -282,7 +292,7 @@ class CLITest < Minitest::Test
       result = with_bundle_gemfile(nil) { rdx("lint", context.absolute_path) }
 
       assert_success_status(result)
-      assert_empty_stdout(result)
+      assert_stdout_includes_pattern(result, /\d+ files inspected, no offenses detected/)
     end
   end
 

--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -68,7 +68,8 @@ class ConfigTest < Minitest::Test
     with_context do |context|
       context.write!("rubydex.toml", <<~TOML)
         [linter.rules.Something]
-        enabled = true
+        severity = "warning"
+        exclude = ["components/legacy/**", "test/fixtures/**"]
 
         [linter.rules.Other]
         enabled = false
@@ -80,7 +81,43 @@ class ConfigTest < Minitest::Test
       assert_equal(["Other", "Something"], rules.keys.sort)
       assert_predicate(rules, :frozen?)
       assert_predicate(rules.fetch("Something"), :enabled?)
+      assert_equal(
+        ["components/legacy/**", "test/fixtures/**"],
+        rules.fetch("Something").exclude_patterns,
+      )
+      assert_equal(Rubydex::Severity::Warning, rules.fetch("Something").severity)
       refute_predicate(rules.fetch("Other"), :enabled?)
+      assert_empty(rules.fetch("Other").exclude_patterns)
+      assert_nil(rules.fetch("Other").severity)
+    end
+  end
+
+  def test_linter_maps_every_configured_severity
+    with_context do |context|
+      context.write!("rubydex.toml", <<~TOML)
+        [linter.rules.ErrorRule]
+        severity = "error"
+
+        [linter.rules.WarningRule]
+        severity = "warning"
+
+        [linter.rules.InformationRule]
+        severity = "information"
+
+        [linter.rules.HintRule]
+        severity = "hint"
+      TOML
+
+      rules = Rubydex::Config.load(context.absolute_path).linter.rules
+
+      {
+        "ErrorRule" => Rubydex::Severity::Error,
+        "WarningRule" => Rubydex::Severity::Warning,
+        "InformationRule" => Rubydex::Severity::Information,
+        "HintRule" => Rubydex::Severity::Hint,
+      }.each do |rule_name, severity|
+        assert_equal(severity, rules.fetch(rule_name).severity)
+      end
     end
   end
 end

--- a/test/linter_test.rb
+++ b/test/linter_test.rb
@@ -2,6 +2,7 @@
 
 require "test_helper"
 require "helpers/context"
+require "mocha/minitest"
 require "rubydex/linter"
 
 class LinterTest < Minitest::Test
@@ -64,6 +65,58 @@ class LinterTest < Minitest::Test
     end
   end
 
+  class DependencyPathRule < Rubydex::Linter::Rule
+    def severity = Rubydex::Severity::Information
+
+    def lint
+      path = File.join(graph.workspace_path, "vendor/bundle/gems/example.rb")
+      path.prepend("/") if Gem.win_platform?
+      uri = URI::File.build(path: path).to_s
+
+      add_diagnostic(
+        "Inside a dependency path.",
+        Rubydex::Location.new(uri: uri, start_line: 0, end_line: 0, start_column: 0, end_column: 1),
+      )
+    end
+  end
+
+  class ExcludedPrimaryRule < Rubydex::Linter::Rule
+    def severity = Rubydex::Severity::Information
+
+    def lint
+      add_diagnostic("Excluded primary location.", workspace_location("components/legacy/example.rb"))
+    end
+
+    private
+
+    def workspace_location(relative_path)
+      path = File.join(graph.workspace_path, relative_path)
+      path.prepend("/") if Gem.win_platform?
+      Rubydex::Location.new(
+        uri: URI::File.build(path: path).to_s,
+        start_line: 0,
+        end_line: 0,
+        start_column: 0,
+        end_column: 1,
+      )
+    end
+  end
+
+  class ExcludedRelatedInformationRule < ExcludedPrimaryRule
+    def lint
+      add_diagnostic(
+        "Included primary location.",
+        workspace_location("components/current/example.rb"),
+        related_information: [
+          Rubydex::RelatedInformation.new(
+            "Excluded related location.",
+            workspace_location("components/legacy/example.rb"),
+          ),
+        ],
+      )
+    end
+  end
+
   def test_runner_builds_diagnostics_with_rule_severity_and_related_information
     result = Rubydex::Linter::Runner.new(Rubydex::Graph.new, rules: [WarningRule], config: linter_config).run
     diagnostic = result.diagnostics.fetch(0)
@@ -79,6 +132,13 @@ class LinterTest < Minitest::Test
     rule = WarningRule.new(Rubydex::Graph.new, config:)
 
     assert_same(config, rule.config)
+  end
+
+  def test_configured_severity_overrides_the_rule_severity
+    config = configured_linter_config("WarningRule", severity: Rubydex::Severity::Error)
+    result = Rubydex::Linter::Runner.new(Rubydex::Graph.new, rules: [WarningRule], config:).run
+
+    assert_equal(Rubydex::Severity::Error, result.diagnostics.fetch(0).severity)
   end
 
   def test_runner_drops_disabled_rules
@@ -148,6 +208,46 @@ class LinterTest < Minitest::Test
     end
   end
 
+  def test_runner_filters_diagnostics_under_dependency_paths
+    with_context do |context|
+      context.write!("workspace/inside.rb")
+      graph = Rubydex::Graph.configure_for_workspace(context.absolute_path_to("workspace"))
+      dependency_path = context.absolute_path_to("workspace/vendor/bundle")
+      Gem.stubs(:path).returns([dependency_path])
+
+      result = Rubydex::Linter::Runner.new(graph, rules: [DependencyPathRule], config: linter_config).run
+
+      assert_empty(result.diagnostics)
+    end
+  end
+
+  def test_runner_filters_a_diagnostic_when_its_primary_location_matches_a_rule_exclude
+    with_context do |context|
+      context.write!("workspace/inside.rb")
+      graph = Rubydex::Graph.configure_for_workspace(context.absolute_path_to("workspace"))
+      config = configured_linter_config("ExcludedPrimaryRule", exclude_patterns: ["components/legacy/**"])
+
+      result = Rubydex::Linter::Runner.new(graph, rules: [ExcludedPrimaryRule], config:).run
+
+      assert_empty(result.diagnostics)
+    end
+  end
+
+  def test_runner_keeps_a_diagnostic_when_only_related_information_matches_a_rule_exclude
+    with_context do |context|
+      context.write!("workspace/inside.rb")
+      graph = Rubydex::Graph.configure_for_workspace(context.absolute_path_to("workspace"))
+      config = configured_linter_config(
+        "ExcludedRelatedInformationRule",
+        exclude_patterns: ["components/legacy/**"],
+      )
+
+      result = Rubydex::Linter::Runner.new(graph, rules: [ExcludedRelatedInformationRule], config:).run
+
+      assert_equal(["Included primary location."], result.diagnostics.map(&:message))
+    end
+  end
+
   def test_runner_keeps_diagnostics_indexed_through_a_symlinked_workspace_path
     with_context do |context|
       context.write!("workspace/inside.rb")
@@ -170,6 +270,18 @@ class LinterTest < Minitest::Test
   def linter_config(rules = {})
     Rubydex::LinterConfig.new(
       rules.to_h { |name, enabled| [name, Rubydex::RuleConfig.new(name, enabled)] },
+    )
+  end
+
+  #: (
+  #|   String,
+  #|   ?enabled: bool,
+  #|   ?exclude_patterns: Array[String],
+  #|   ?severity: singleton(Rubydex::Severity::Base)?,
+  #| ) -> Rubydex::LinterConfig
+  def configured_linter_config(rule_name, enabled: true, exclude_patterns: [], severity: nil)
+    Rubydex::LinterConfig.new(
+      rule_name => Rubydex::RuleConfig.new(rule_name, enabled, exclude_patterns, severity),
     )
   end
 

--- a/test/location_test.rb
+++ b/test/location_test.rb
@@ -16,6 +16,28 @@ class LocationTest < Minitest::Test
     )
   end
 
+  def test_to_file_path_decodes_the_uri_path_once
+    uri = Gem.win_platform? ? "file:///D:/my%20app+%2520/file.rb" : "file:///tmp/my%20app+%2520/file.rb"
+    expected = Gem.win_platform? ? "D:/my app+%20/file.rb" : "/tmp/my app+%20/file.rb"
+    location = Rubydex::Location.new(uri: uri, start_line: 0, end_line: 0, start_column: 0, end_column: 0)
+
+    assert_equal(expected, location.to_file_path)
+  end
+
+  def test_to_file_path_rejects_a_file_uri_without_a_path
+    ["file:relative", "file:", "file://host"].each do |uri|
+      location = Rubydex::Location.new(
+        uri: uri,
+        start_line: 0,
+        end_line: 0,
+        start_column: 0,
+        end_column: 0,
+      )
+
+      assert_raises(Rubydex::Location::NotFileUriError) { location.to_file_path }
+    end
+  end
+
   def test_display_location_from_prism_raises_with_conversion_path
     prism_location = PrismLocation.new(start_line: 2, start_column: 12, end_line: 3, end_column: 19)
 

--- a/test/rule_loader_test.rb
+++ b/test/rule_loader_test.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "helpers/context"
+require "rubydex/linter"
+
+class RuleLoaderTest < Minitest::Test
+  include Test::Helpers::WithContext
+
+  def test_load_wraps_rule_file_errors
+    with_context do |context|
+      rule_file = "rubydex_linter/rules/broken_rule.rb"
+      context.write!(rule_file, "class BrokenRule <\n")
+
+      error = with_bundle_gemfile(nil) do
+        assert_raises(Rubydex::Linter::RuleLoadError) do
+          Rubydex::Linter::RuleLoader.load(context.absolute_path)
+        end
+      end
+
+      assert_match(/Unable to load linter rules from .*broken_rule\.rb/, error.message)
+      assert_instance_of(SyntaxError, error.cause)
+    end
+  end
+
+  private
+
+  #: [R] (String?) { -> R } -> R
+  def with_bundle_gemfile(value)
+    previous = ENV["BUNDLE_GEMFILE"]
+    ENV["BUNDLE_GEMFILE"] = value
+    yield
+  ensure
+    ENV["BUNDLE_GEMFILE"] = previous
+  end
+end


### PR DESCRIPTION
Most of this PR ports existing production-rule infrastructure from Core into `Rubydex::Linter`. It preserves the rule and path helpers, diagnostic output, severity overrides, exclusions, and project and in-repo-gem rule discovery that Core uses today. The main Rubydex-specific change adapts this configuration behavior to `rubydex.toml` and the existing Rubydex configuration API.

This PR adds shared infrastructure only. It does not port Core rules or add list and explain commands, rule-test helpers, or Ruby LSP integration.