### PR TITLE
Print command-specific usage for CLI errors

### DIFF
--- a/lib/rubydex/cli.rb
+++ b/lib/rubydex/cli.rb
@@ -28,8 +28,9 @@ module Rubydex
         dispatch(argv.shift, argv)
       end
 
-      # Reports `message`, then the usage text, and exits non-zero. Public because the subcommands
-      # report their own argument errors through it.
+      private
+
+      # Reports `message`, then the top-level usage text, and exits non-zero.
       #: (String message) -> void
       def abort_with_usage(message)
         warn(message)
@@ -37,8 +38,6 @@ module Rubydex
         warn(usage)
         exit(1)
       end
-
-      private
 
       # The top-level usage text, built from the declared commands.
       #: -> String

--- a/lib/rubydex/cli/command.rb
+++ b/lib/rubydex/cli/command.rb
@@ -106,7 +106,10 @@ module Rubydex
 
       #: (String message) -> void
       def abort_with_usage(message)
-        CLI.abort_with_usage(message)
+        warn(message)
+        warn("")
+        warn(@parser)
+        exit(1)
       end
 
       # Parses this command's options out of `argv`, with a banner derived from the command's own
@@ -120,7 +123,7 @@ module Rubydex
         banner = +"Usage: rdx #{self.class.usage_form}"
         banner << " [options]" if options
 
-        parser = OptionParser.new do |p|
+        @parser = OptionParser.new do |p|
           p.banner = banner
           yield(p) if block_given?
           p.on("-h", "--help", "Show this help") do
@@ -129,7 +132,7 @@ module Rubydex
           end
         end
 
-        parser.parse!(argv)
+        @parser.parse!(argv)
       rescue OptionParser::ParseError => e
         abort_with_usage(e.message)
       end

--- a/lib/rubydex/cli/command/query.rb
+++ b/lib/rubydex/cli/command/query.rb
@@ -37,7 +37,9 @@ module Rubydex
             return
           end
 
-          abort_with_usage("`query` requires a Cypher query argument (or pass `--schema`)") if query.nil? || query.empty?
+          if query.nil? || query.empty?
+            abort_with_usage("`query` requires a Cypher query argument (or pass `--schema`)")
+          end
 
           # Parse the query up front so a malformed query fails fast, before the expensive indexing.
           parsed = parse_query(query)

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -159,6 +159,9 @@ class CLITest < Minitest::Test
 
     refute_success_status(result)
     assert_stderr_includes(result, "`query` requires a Cypher query argument")
+    assert_stderr_includes(result, "Usage: rdx query <CYPHER> [options]")
+    assert_stderr_includes(result, "--format FORMAT")
+    refute_stderr_includes(result, "Usage: rdx <command> [options]")
   end
 
   def test_malformed_query_fails_before_indexing
@@ -213,7 +216,8 @@ class CLITest < Minitest::Test
 
       refute_success_status(result)
       assert_stderr_includes(result, "invalid option: --bogus-flag")
-      assert_stderr_includes(result, "Usage: rdx <command> [options]")
+      assert_stderr_includes(result, "Usage: rdx #{command}")
+      refute_stderr_includes(result, "Usage: rdx <command> [options]")
       # A bad option must not produce a Ruby backtrace.
       refute_stderr_includes(result, "OptionParser::InvalidOption")
       assert_empty_stdout(result)
@@ -225,6 +229,8 @@ class CLITest < Minitest::Test
 
     refute_success_status(result)
     assert_stderr_includes(result, "invalid argument: --format yaml")
+    assert_stderr_includes(result, "--format FORMAT")
+    assert_stderr_includes(result, "Output format (table or json)")
     refute_stderr_includes(result, "OptionParser::InvalidArgument")
   end
 
@@ -233,6 +239,8 @@ class CLITest < Minitest::Test
 
     refute_success_status(result)
     assert_stderr_includes(result, "unexpected argument: two")
+    assert_stderr_includes(result, "Usage: rdx mcp [PATH]")
+    refute_stderr_includes(result, "Usage: rdx <command> [options]")
   end
 
   # `irb` is not a runtime dependency, so its absence is reported rather than raised. The graph is


### PR DESCRIPTION
## Why

Follow-up to https://github.com/Shopify/rubydex/pull/971#discussion_r3693074796.

Once a subcommand has been resolved, option and argument errors should show that command's parser rather than rebuilding the top-level usage. This gives users the valid command-specific flags and avoids loading every command file while reporting a parse error.

## What changed

- Print each command's `OptionParser` for invalid options and arguments.
- Keep unknown-command errors on the top-level CLI usage path.
- Reuse the parsed command parser for validation after option parsing.

cc @paracycle 