### PR TITLE
Add Rubydex skill library with CLI command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,9 @@ the Ruby VM to the Rust crate logic.
 - `ext/rubydex`: The C native extension that connects the Ruby VM with the Rust crate logic through FFI
 - `lib`: The rest of the Ruby code
 - `test`: Ruby test files
+- `skills`: the skill library for deterministic skill loading. These are NOT for developing on Rubydex and should not be loaded unless explicitly requested. Each `skills/<id>/SKILL.md` is a Markdown playbook with YAML frontmatter (`name`,
+`description`) that `rdx skill <id>` prints for an AI agent. The directory name is the id and the frontmatter `name`
+must repeat it. Add a skill by adding the directory and the file; nothing else registers it
 
 ### Naming Conventions
 

--- a/README.md
+++ b/README.md
@@ -189,6 +189,14 @@ like Claude to semantically query your Ruby codebase.
 | `get_file_declarations` | List declarations defined in a specific file |
 | `codebase_stats` | High-level statistics about the indexed codebase |
 
+## Skill Library (Experimental)
+
+Rubydex ships with a built in skill library. These skills are referenced by id by Rubydex tools (for example: `send-private-method` maps to `skills/send-private-method/SKILL.md`).
+
+The intention is for Rubydex to provide deterministic skill loading for agents. If a rule returns a skill id, the agent can then fetch the skill with `rdx skill <id>`.
+
+This removes the need for agents to load a large number of possibly unrelated skill descriptions when they may or may not be necessary. The information only surfaces if there is a verified violation to fix, and it only needs to be loaded once, rather than inlining it on every violation in every run of the tool (the common pattern for linters and analyzers).
+
 ## Contributing
 
 See [the contributing documentation](CONTRIBUTING.md).

--- a/lib/rubydex/cli/command/skill.rb
+++ b/lib/rubydex/cli/command/skill.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require "rubydex/cli/command"
+
+module Rubydex
+  module CLI
+    class Command
+      # `rdx skill [ID]` — lists available skill ids, or loads and prints a skill's body by id.
+      class Skill < Command
+        command "skill"
+        arguments "[ID]"
+        summary <<~TEXT
+          Load a Rubydex skill from the library by id. With no id, list the available skills.
+        TEXT
+
+        #: -> void
+        def run
+          parse_options!
+
+          id = argv.shift
+          abort_with_usage("unexpected argument: #{argv.first}") unless argv.empty?
+
+          id ? print_skill(id) : list_skills
+        rescue Rubydex::SkillError => e
+          abort(e.message)
+        end
+
+        private
+
+        #: -> void
+        def list_skills
+          ids = registry.ids
+
+          if ids.empty?
+            puts(available_skills)
+            return
+          end
+
+          ids.each { |id| puts(id) }
+        end
+
+        #: (String id) -> void
+        def print_skill(id)
+          puts(registry.fetch(id).body)
+        rescue Rubydex::UnknownSkillError => e
+          abort("#{e.message}. #{available_skills}")
+        end
+
+        #: -> String
+        def available_skills
+          ids = registry.ids
+
+          ids.empty? ? "No skills are available." : "Available skills: #{ids.join(", ")}"
+        end
+
+        #: -> Rubydex::SkillRegistry
+        def registry
+          require "rubydex/skill_registry"
+          @registry ||= Rubydex::SkillRegistry.load(skills_directory)
+        end
+
+        #: -> String
+        def skills_directory
+          File.expand_path("../../../../skills", __dir__)
+        end
+      end
+    end
+  end
+end

--- a/lib/rubydex/errors.rb
+++ b/lib/rubydex/errors.rb
@@ -9,4 +9,16 @@ module Rubydex
   # Raised by `Config.load` when the workspace does not exist, or when its config file cannot be read or is malformed.
   # A workspace with no config file at all is not an error.
   class ConfigError < Error; end
+
+  # Raised by `Skill.load` when the file cannot be read, is missing frontmatter, has malformed YAML, or lacks the
+  # required `name` or `description` fields.
+  # Every failure to produce a Skill is a `SkillError`, so a caller rescues one class instead
+  # of the union of what `File.read` and Psych happen to raise.
+  class SkillError < Error; end
+
+  # Raised by `SkillRegistry#fetch` when the library has no skill under the requested id.
+  class UnknownSkillError < SkillError; end
+
+  # Raised by `SkillRegistry.load` when the skill directory doesn't exist.
+  class UnknownSkillDirectoryError < SkillError; end
 end

--- a/lib/rubydex/skill.rb
+++ b/lib/rubydex/skill.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require "rubydex/errors"
+
+module Rubydex
+  # A skill file loaded from disk. Skill files are Markdown documents with YAML frontmatter
+  # that declare a `name` and `description`. The body is the Markdown content after the frontmatter.
+  class Skill
+    #: String
+    attr_reader :name
+
+    #: String
+    attr_reader :description
+
+    #: String
+    attr_reader :body
+
+    class << self
+      #: (String path) -> Rubydex::Skill
+      def load(path)
+        from_content(File.read(path), path:)
+      rescue SystemCallError, IOError => e
+        raise SkillError, "Cannot read skill file #{path}: #{e.message}"
+      end
+
+      #: (String content, ?path: String?) -> Rubydex::Skill
+      def from_content(content, path: nil)
+        new(**parse(content, path:))
+      end
+
+      private
+
+      #: (String content, path: String?) -> { name: String, description: String, body: String }
+      def parse(content, path:)
+        lines = content.lines
+
+        unless lines.first&.strip == "---"
+          raise SkillError, "Missing YAML frontmatter delimiter#{location(path)}"
+        end
+
+        closing_index = (1...lines.length).find { |i| lines[i].strip == "---" }
+        unless closing_index
+          raise SkillError, "Unterminated YAML frontmatter#{location(path)}"
+        end
+
+        frontmatter = lines[1...closing_index].join
+        body = lines[(closing_index + 1)..].join.strip
+
+        yaml = parse_frontmatter(frontmatter, path)
+        unless yaml.is_a?(Hash)
+          raise SkillError, "Empty or malformed YAML frontmatter#{location(path)}"
+        end
+
+        name = yaml["name"]
+        unless name.is_a?(String)
+          raise SkillError, "Missing or non-string `name` in frontmatter#{location(path)}"
+        end
+
+        description = yaml["description"]
+        unless description.is_a?(String)
+          raise SkillError, "Missing or non-string `description` in frontmatter#{location(path)}"
+        end
+
+        { name:, description:, body: }
+      end
+
+      #: (String frontmatter, String? path) -> untyped
+      def parse_frontmatter(frontmatter, path)
+        YAML.safe_load(frontmatter)
+      rescue Psych::Exception => e
+        raise SkillError, "Malformed YAML frontmatter#{location(path)}: #{e.message}"
+      end
+
+      #: (String?) -> String
+      def location(path)
+        path ? " in #{path}" : ""
+      end
+    end
+
+    #: (name: String, description: String, body: String) -> void
+    def initialize(name:, description:, body:)
+      @name = name.freeze
+      @description = description.freeze
+      @body = body.freeze
+      freeze
+    end
+  end
+end

--- a/lib/rubydex/skill_registry.rb
+++ b/lib/rubydex/skill_registry.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "rubydex/skill"
+
+module Rubydex
+  # The skills available on disk, keyed by id. `load` scans a directory for `<id>/SKILL.md` entries
+  # and records their paths.
+  # A skill file is only read when {#fetch} asks for it. Listing every description reads all skill files.
+  #
+  # The directory name is the id: it is what `rdx skill <id>` takes as a parameter.
+  class SkillRegistry
+    class << self
+      #: (String directory) -> Rubydex::SkillRegistry
+      def load(directory)
+        unless File.directory?(directory)
+          raise UnknownSkillDirectoryError, "Skill directory does not exist: #{directory}"
+        end
+
+        paths = {}
+        Dir.foreach(directory) do |entry|
+          next if entry == "." || entry == ".."
+
+          skill_path = File.join(directory, entry, "SKILL.md")
+          next unless File.file?(skill_path)
+
+          paths[entry] = skill_path
+        end
+
+        new(paths)
+      end
+    end
+
+    #: (Hash[String, String] paths) -> void
+    def initialize(paths)
+      @paths = paths.freeze
+      # Deliberately mutable inside a frozen registry: `freeze` protects the set of skills, while
+      # the cache only remembers what was already read from those files.
+      @cache = {} #: Hash[String, Skill]
+      freeze
+    end
+
+    #: -> Array[String]
+    def ids
+      @paths.keys.sort
+    end
+
+    #: (String id) -> Rubydex::Skill
+    def fetch(id)
+      @cache[id] ||= begin
+        path = @paths[id]
+        raise UnknownSkillError, "Unknown skill: #{id}" unless path
+
+        skill = Skill.load(path)
+        unless skill.name == id
+          raise SkillError, "Skill in #{path} declares `name: #{skill.name}` but lives in `#{id}`"
+        end
+
+        skill
+      end
+    end
+  end
+end

--- a/rubydex.gemspec
+++ b/rubydex.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
     Dir.glob("lib/**/*.rb") +
     Dir.glob("rbi/**/*.rbi") +
     Dir.glob("ext/rubydex/**/*.{c,h}") +
+    Dir.glob("skills/**/SKILL.md") +
     Dir.glob("rust/**/*.{rs,toml,lock,hbs}").reject { |f| f.start_with?("rust/target") }
 
   if ENV["RELEASE"]

--- a/skills/send-private-method/SKILL.md
+++ b/skills/send-private-method/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: send-private-method
+description: Remediate a `send`/`__send__` call that reaches a private method, restoring a real public seam instead of bypassing visibility. Use when send is being used to invoke private functionality in a class.
+---
+
+# Send Private Method
+
+A test calls `obj.send(:some_private_method)` (or `__send__`) to invoke a method Ruby's visibility system would otherwise forbid. `send` deliberately bypasses encapsulation. `__send__` behaves identically and is the conventional spelling when a class defines its own `send`; Ruby warns when you redefine `__send__`, but it is not un-overridable. Remediation is the same for both. The smell is not "you used `send`" — it is "the test reaches past the public API into an implementation detail," which breaks the moment the private method is renamed, reorganized, or removed even though the public contract is unchanged.
+
+## Confirm the receiver and the method
+
+You have a call site: a file path and a line number. Before changing anything, answer two questions:
+
+1. **What is the receiver's real type?** Trace the receiver expression at the flagged line back to its class. If it is a local/ivar, find where it is assigned (a `let`, `setup`, factory, or constructor).
+2. **Where is the private method defined?** Search the workspace for `def <method_name>` (and `define_method :<method_name>`). Confirm the definition is under `private` (or `private :<method_name>`). Note its enclosing class/module and read the method body — you cannot decide the fix without knowing what the method does.
+
+A name-based search matches by method *name* across the whole workspace, so a public method and a private method sharing the same unqualified name on different classes can produce a false positive. If the receiver's type has a *public* method of that name, this is not the smell — stop here.
+
+## Decide which situation you are in
+
+Read the method body and the test. Exactly one of these applies:
+
+- **The caller needs behavior that should be public.** The private method does something the application legitimately depends on, and there is no public entry point that exposes it. The encapsulation boundary was drawn too tightly.
+- **The caller is a test reaching past an existing public API.** A public method already wraps or drives this private one; the test bypassed it to assert on an intermediate result instead of the observable outcome. If the public outcome is already tested elsewhere, the private-method test is redundant — delete it rather than rewriting it.
+- **The private method is the wrong home for the logic.** The behavior is genuinely useful to more than one caller, but it lives tucked away inside one class's private section. Both production and tests want it.
+
+## Fix per situation
+
+### 1. Promote to public (or `protected`)
+
+If the behavior is part of the object's real contract, make it public and document it as API. Use `protected` only when every legitimate caller is an instance inside the same class hierarchy as the class that defines the method — never to paper over a single test's reach-in.
+
+Before:
+```ruby
+class Foo
+  def bar = qux.sum
+
+  private
+
+  def qux
+    @items.reject(&:voided?).map { |i| i.baz - i.discount }
+  end
+end
+# test
+foo.send(:qux)
+```
+
+After:
+```ruby
+class Foo
+  def bar = qux.sum
+
+  # Public: items with discounts applied, voided items excluded.
+  # Used by reporting and by #bar's total.
+  def qux
+    @items.reject(&:voided?).map { |i| i.baz - i.discount }
+  end
+end
+# test
+foo.qux
+```
+
+### 2. Drive the public entry point, assert on the observable outcome
+
+If a public method already exercises the private one, call the public method and assert on what it produces — not on the private intermediate.
+
+Before:
+```ruby
+class Foo
+  def bar(baz) = Receipt.new(tax: baz.amount * qux(baz.quux))
+
+  private
+
+  def qux(quux) = RATES.fetch(quux)
+end
+# test
+foo.send(:qux, "CA") # => 0.05
+```
+
+After:
+```ruby
+# test — assert on the observable result of the public API
+result = foo.bar(baz_with(quux: "CA", amount: 100))
+assert_equal 5.0, result.tax
+```
+
+### 3. Extract to its own object/module
+
+When the logic serves multiple callers but is trapped in one class's private section, move it to a dedicated object or module with a public interface both callers can use.
+
+Before:
+```ruby
+class Foo
+  private
+
+  def bar(raw) = raw.transform_keys(&:to_s).compact
+end
+# test
+foo.send(:bar, { baz: "Q" })
+```
+
+After:
+```ruby
+class Bar
+  def call(raw) = raw.transform_keys(&:to_s).compact
+end
+
+class Foo
+  def initialize(bar: Bar.new) = @bar = bar
+  def baz(raw) = @bar.call(raw)
+end
+# test
+assert_equal({ "baz" => "Q" }, Bar.new.call({ baz: "Q" }))
+```
+
+## Private class methods and `module_function`
+
+The three situations above cover instance methods. Two related visibility forms need special handling:
+
+- **Private class methods** (`private_class_method :bar`, or a `def bar` under `private` inside `class << self`). A bare `private` does **not** apply to `def self.bar`: that singleton method stays public wherever it sits relative to the `private` line, so a public `def self.bar` under `private` is not this smell. A `send` like `Foo.send(:bar)` reaches a genuinely private singleton method. The remediation mirrors instance methods — promote with `public_class_method :bar` (or drop the `private_class_method :bar` call), drive an existing public class method, or extract. Do not use the instance-method patterns verbatim; the fix targets the singleton class.
+- **`module_function`**. `module_function :foo` creates a public singleton method and a private instance method. If the test calls `instance.send(:foo)` on the private instance side, the public entry point already exists: call `MyModule.foo` directly. This is situation 2 — drive the public singleton method, do not promote the instance method.
+
+## Legitimate exceptions — and what to do about them
+
+Not every `send` to a private name is a smell to remove. Handle these deliberately:
+
+- **Dynamic dispatch over a validated allowlist.** The method name is genuinely computed (`send(action)`), and the action set is bounded and checked. Constrain it: define an `ALLOWED_ACTIONS = %i[...].freeze` constant, guard with `raise unless ALLOWED_ACTIONS.include?(action)`, and call `public_send(action)` so the visibility system still applies. If every allowed action is public, the smell is gone.
+- **Framework or DSL callbacks.** Some libraries require `send` to reach hooks they themselves marked private. If the method name is dictated by the framework contract, leave the call but add a one-line comment naming the framework and the callback it satisfies.
+- **Third-party code you cannot change.** The private method belongs to a gem or an owned-elsewhere class you must not edit. Wrap the reach-in behind a single named adapter method in your own code with a comment stating why (e.g. `# Sends :bar to avoid the gem's private API; remove when upstream exposes a public hook.`). The adapter localizes the violation so it is auditable and removable in one place.
+
+## What does NOT fix it
+
+Switching `send` to `public_send` on a method that is *still private* does not fix anything — it just moves the failure from "silently bypassed encapsulation" to a `NoMethodError` at runtime. Answer the encapsulation question first; only then choose `public_send` (for dynamic dispatch over public methods) or a direct call (once promoted).

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -27,6 +27,7 @@ class CLITest < Minitest::Test
     assert_includes(commands, Rubydex::CLI::Command::Console)
     assert_includes(commands, Rubydex::CLI::Command::Lint)
     assert_includes(commands, Rubydex::CLI::Command::Mcp)
+    assert_includes(commands, Rubydex::CLI::Command::Skill)
 
     # The declared name is what the class reports, and drives its usage line.
     assert_equal("query", Rubydex::CLI::Command::Query.command_name)
@@ -98,6 +99,7 @@ class CLITest < Minitest::Test
       Rubydex::CLI::Command::Console,
       Rubydex::CLI::Command::Lint,
       Rubydex::CLI::Command::Mcp,
+      Rubydex::CLI::Command::Skill,
     ].each do |command|
       assert_stdout_includes_pattern(result, /^  #{Regexp.escape(command.usage_form)}\s{2,}\S/)
     end
@@ -336,6 +338,55 @@ class CLITest < Minitest::Test
     assert_equal("fiddle/import", error.path)
   end
 
+  def test_skill_lists_available_skill_ids
+    result = rdx("skill")
+
+    assert_success_status(result)
+    assert_stdout_includes(result, "send-private-method")
+  end
+
+  def test_skill_loads_a_skill_by_id
+    result = rdx("skill", "send-private-method")
+
+    assert_success_status(result)
+    assert_stdout_includes(result, "# Send Private Method")
+  end
+
+  def test_skill_rejects_an_unknown_id
+    result = rdx("skill", "nonexistent")
+
+    refute_success_status(result)
+    # The CLI, not the registry, decides to answer an unknown id with the ids it does have.
+    assert_stderr_includes(result, "Unknown skill: nonexistent. Available skills: send-private-method")
+    refute_match(/Usage: rdx <command>/, result.err)
+  end
+
+  def test_skill_rejects_an_extra_argument
+    result = rdx("skill", "send-private-method", "extra")
+
+    refute_success_status(result)
+    assert_stderr_includes(result, "unexpected argument: extra")
+    assert_empty_stdout(result)
+  end
+
+  def test_skill_reports_a_library_with_no_skills
+    with_empty_skill_library do
+      result = rdx("skill")
+
+      assert_success_status(result)
+      assert_stdout_includes(result, "No skills are available.")
+    end
+  end
+
+  def test_skill_reports_a_library_with_no_skills_for_an_unknown_id
+    with_empty_skill_library do
+      result = rdx("skill", "alpha")
+
+      refute_success_status(result)
+      assert_stderr_includes(result, "Unknown skill: alpha. No skills are available.")
+    end
+  end
+
   private
 
   # Each in-process invocation loads a distinct named rule. Reopening the same class would not add
@@ -385,6 +436,19 @@ class CLITest < Minitest::Test
     console = Rubydex::CLI::Command::Console.any_instance
     console.stubs(:build_graph).returns(:unused)
     console.stubs(:require).with("irb").raises(error)
+  end
+
+  # Points the `skill` command at a library of its own, so the tests that need one without skills do
+  # not depend on what `skills/` happens to hold.
+  #: { -> void } -> void
+  def with_empty_skill_library(&block)
+    with_context do |context|
+      context.write!("skills/.keep", "")
+      Rubydex::CLI::Command::Skill.any_instance.stubs(:skills_directory)
+        .returns(context.absolute_path_to("skills"))
+
+      block.call
+    end
   end
 
   # `LoadError#path` names the feature that could not be loaded, and has no public writer.

--- a/test/skill_registry_test.rb
+++ b/test/skill_registry_test.rb
@@ -1,0 +1,172 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "helpers/context"
+require "mocha/minitest"
+require "rubydex/skill"
+require "rubydex/skill_registry"
+
+class SkillRegistryTest < Minitest::Test
+  include Test::Helpers::WithContext
+
+  def test_load_scans_directory_and_returns_ids
+    with_context do |context|
+      write_skill(context, "alpha", "Alpha skill.", "# Alpha")
+      write_skill(context, "beta", "Beta skill.", "# Beta")
+
+      registry = Rubydex::SkillRegistry.load(context.absolute_path_to("skills"))
+
+      assert_equal(["alpha", "beta"], registry.ids)
+    end
+  end
+
+  def test_load_records_paths_without_reading_the_files
+    with_context do |context|
+      write_skill(context, "alpha", "Alpha skill.", "# Alpha")
+
+      # A skill file is only opened when it is fetched, so scanning records paths and nothing else.
+      File.expects(:read).never
+
+      registry = Rubydex::SkillRegistry.load(context.absolute_path_to("skills"))
+
+      assert_equal(["alpha"], registry.ids)
+    end
+  end
+
+  def test_fetch_returns_a_loaded_skill
+    with_context do |context|
+      write_skill(context, "alpha", "Alpha skill.", "# Alpha\n\nBody.")
+
+      registry = Rubydex::SkillRegistry.load(context.absolute_path_to("skills"))
+      skill = registry.fetch("alpha")
+
+      assert_equal("alpha", skill.name)
+      assert_equal("Alpha skill.", skill.description)
+      assert_equal("# Alpha\n\nBody.", skill.body)
+    end
+  end
+
+  def test_fetch_caches_the_loaded_skill
+    with_context do |context|
+      write_skill(context, "alpha", "Alpha skill.", "# Alpha")
+
+      registry = Rubydex::SkillRegistry.load(context.absolute_path_to("skills"))
+
+      first = registry.fetch("alpha")
+      second = registry.fetch("alpha")
+
+      assert_same(first, second)
+    end
+  end
+
+  def test_fetch_names_only_the_id_for_an_unknown_skill
+    with_context do |context|
+      write_skill(context, "alpha", "Alpha skill.", "# Alpha")
+      write_skill(context, "beta", "Beta skill.", "# Beta")
+
+      registry = Rubydex::SkillRegistry.load(context.absolute_path_to("skills"))
+
+      error = assert_raises(Rubydex::UnknownSkillError) { registry.fetch("nonexistent") }
+
+      # Which ids to offer instead is the interface's decision, so the registry does not spell them
+      # into the message.
+      assert_equal("Unknown skill: nonexistent", error.message)
+      assert_kind_of(Rubydex::SkillError, error)
+    end
+  end
+
+  def test_fetch_rejects_a_name_that_disagrees_with_the_directory
+    with_context do |context|
+      # The directory is the id callers use, so a frontmatter `name` that spells something else is a
+      # second, unreachable id rather than a harmless mismatch.
+      context.write!("skills/alpha/SKILL.md", <<~SKILL)
+        ---
+        name: not-alpha
+        description: Alpha skill.
+        ---
+
+        # Alpha
+      SKILL
+
+      registry = Rubydex::SkillRegistry.load(context.absolute_path_to("skills"))
+
+      error = assert_raises(Rubydex::SkillError) { registry.fetch("alpha") }
+
+      assert_match(/declares `name: not-alpha` but lives in `alpha`/, error.message)
+    end
+  end
+
+  def test_fetch_reports_a_malformed_skill_file_as_a_skill_error
+    with_context do |context|
+      context.write!("skills/alpha/SKILL.md", <<~SKILL)
+        ---
+        name: alpha
+        description: "unterminated
+        ---
+
+        # Alpha
+      SKILL
+
+      registry = Rubydex::SkillRegistry.load(context.absolute_path_to("skills"))
+
+      error = assert_raises(Rubydex::SkillError) { registry.fetch("alpha") }
+
+      assert_match(/Malformed YAML frontmatter/, error.message)
+    end
+  end
+
+  def test_load_skips_subdirectories_without_skill_file
+    with_context do |context|
+      write_skill(context, "alpha", "Alpha skill.", "# Alpha")
+      context.write!("skills/not-a-skill/other.md", "# Other")
+
+      registry = Rubydex::SkillRegistry.load(context.absolute_path_to("skills"))
+
+      assert_equal(["alpha"], registry.ids)
+    end
+  end
+
+  def test_load_returns_empty_registry_for_empty_directory
+    with_context do |context|
+      context.write!("skills/.keep", "")
+
+      registry = Rubydex::SkillRegistry.load(context.absolute_path_to("skills"))
+
+      assert_empty(registry.ids)
+    end
+  end
+
+  def test_load_raises_when_directory_does_not_exist
+    with_context do |context|
+      assert_raises(Rubydex::UnknownSkillDirectoryError) do
+        Rubydex::SkillRegistry.load(context.absolute_path_to("nonexistent"))
+      end
+    end
+  end
+
+  def test_registry_is_frozen
+    with_context do |context|
+      write_skill(context, "alpha", "Alpha skill.", "# Alpha")
+
+      registry = Rubydex::SkillRegistry.load(context.absolute_path_to("skills"))
+
+      assert_predicate(registry, :frozen?)
+      # The cache lives inside the frozen registry, so fetching must still work.
+      assert_equal("alpha", registry.fetch("alpha").name)
+    end
+  end
+
+  private
+
+  #: (Test::Helpers::Context, String, String, String) -> void
+  def write_skill(context, id, description, body)
+    context.write!("skills/#{id}/SKILL.md", <<~SKILL)
+      ---
+      name: #{id}
+      description: #{description}
+      ---
+
+      #{body}
+    SKILL
+  end
+end

--- a/test/skill_test.rb
+++ b/test/skill_test.rb
@@ -1,0 +1,189 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "helpers/context"
+require "rubydex/skill"
+
+class SkillTest < Minitest::Test
+  include Test::Helpers::WithContext
+
+  def test_load_parses_name_description_and_body
+    with_context do |context|
+      context.write!("SKILL.md", <<~SKILL)
+        ---
+        name: my-skill
+        description: Does a thing.
+        ---
+
+        # My Skill
+
+        Some body text.
+      SKILL
+
+      skill = Rubydex::Skill.load(context.absolute_path_to("SKILL.md"))
+
+      assert_equal("my-skill", skill.name)
+      assert_equal("Does a thing.", skill.description)
+      assert_equal("# My Skill\n\nSome body text.", skill.body)
+    end
+  end
+
+  def test_load_freezes_the_instance
+    with_context do |context|
+      context.write!("SKILL.md", <<~SKILL)
+        ---
+        name: my-skill
+        description: Does a thing.
+        ---
+
+        Body.
+      SKILL
+
+      skill = Rubydex::Skill.load(context.absolute_path_to("SKILL.md"))
+
+      assert_predicate(skill, :frozen?)
+      assert_predicate(skill.name, :frozen?)
+      assert_predicate(skill.description, :frozen?)
+      assert_predicate(skill.body, :frozen?)
+    end
+  end
+
+  def test_from_content_parses_without_a_file
+    skill = Rubydex::Skill.from_content(<<~SKILL)
+      ---
+      name: inline-skill
+      description: Inline description.
+      ---
+
+      # Inline
+    SKILL
+
+    assert_equal("inline-skill", skill.name)
+    assert_equal("Inline description.", skill.description)
+    assert_equal("# Inline", skill.body)
+  end
+
+  def test_load_raises_when_frontmatter_is_missing
+    with_context do |context|
+      context.write!("SKILL.md", "# No frontmatter here")
+
+      error = assert_raises(Rubydex::SkillError) do
+        Rubydex::Skill.load(context.absolute_path_to("SKILL.md"))
+      end
+
+      assert_match(/Missing YAML frontmatter/, error.message)
+    end
+  end
+
+  def test_load_raises_when_frontmatter_is_unterminated
+    with_context do |context|
+      context.write!("SKILL.md", <<~SKILL)
+        ---
+        name: my-skill
+        description: Does a thing.
+
+        # No closing delimiter
+      SKILL
+
+      error = assert_raises(Rubydex::SkillError) do
+        Rubydex::Skill.load(context.absolute_path_to("SKILL.md"))
+      end
+
+      assert_match(/Unterminated/, error.message)
+    end
+  end
+
+  def test_load_raises_when_name_is_missing
+    with_context do |context|
+      context.write!("SKILL.md", <<~SKILL)
+        ---
+        description: Does a thing.
+        ---
+
+        Body.
+      SKILL
+
+      error = assert_raises(Rubydex::SkillError) do
+        Rubydex::Skill.load(context.absolute_path_to("SKILL.md"))
+      end
+
+      assert_match(/`name`/, error.message)
+    end
+  end
+
+  def test_load_raises_when_description_is_missing
+    with_context do |context|
+      context.write!("SKILL.md", <<~SKILL)
+        ---
+        name: my-skill
+        ---
+
+        Body.
+      SKILL
+
+      error = assert_raises(Rubydex::SkillError) do
+        Rubydex::Skill.load(context.absolute_path_to("SKILL.md"))
+      end
+
+      assert_match(/`description`/, error.message)
+    end
+  end
+
+  def test_load_includes_path_in_error_message
+    with_context do |context|
+      context.write!("SKILL.md", "# No frontmatter")
+      path = context.absolute_path_to("SKILL.md")
+
+      error = assert_raises(Rubydex::SkillError) do
+        Rubydex::Skill.load(path)
+      end
+
+      assert_match(/SKILL\.md/, error.message)
+    end
+  end
+
+  def test_from_content_omits_path_in_error_message
+    error = assert_raises(Rubydex::SkillError) do
+      Rubydex::Skill.from_content("# No frontmatter")
+    end
+
+    refute_match(/ in /, error.message)
+  end
+
+  def test_load_reports_a_missing_file_as_a_skill_error
+    with_context do |context|
+      path = context.absolute_path_to("nonexistent/SKILL.md")
+
+      error = assert_raises(Rubydex::SkillError) { Rubydex::Skill.load(path) }
+
+      assert_match(/Cannot read skill file #{Regexp.escape(path)}/, error.message)
+    end
+  end
+
+  def test_load_reports_malformed_yaml_as_a_skill_error
+    with_context do |context|
+      # An unterminated quoted scalar makes Psych raise; the caller must still see a `SkillError`.
+      context.write!("SKILL.md", <<~SKILL)
+        ---
+        name: my-skill
+        description: "unterminated
+        ---
+
+        Body.
+      SKILL
+      path = context.absolute_path_to("SKILL.md")
+
+      error = assert_raises(Rubydex::SkillError) { Rubydex::Skill.load(path) }
+
+      assert_match(/Malformed YAML frontmatter in #{Regexp.escape(path)}/, error.message)
+    end
+  end
+
+  def test_from_content_reports_a_disallowed_yaml_tag_as_a_skill_error
+    error = assert_raises(Rubydex::SkillError) do
+      Rubydex::Skill.from_content("---\nname: my-skill\ndescription: !ruby/object {}\n---\n\nBody.\n")
+    end
+
+    assert_match(/Malformed YAML frontmatter/, error.message)
+  end
+end

--- a/test/skills_directory_test.rb
+++ b/test/skills_directory_test.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "rubydex/skill"
+require "rubydex/skill_registry"
+
+# Validates that every skill shipped in the repository's `skills/` directory can be parsed and
+# satisfies the contracts the registry enforces: a `SKILL.md` with YAML frontmatter declaring a
+# `name` (matching its directory) and `description`, plus a non-empty Markdown body.
+# This guards against a malformed skill file landing in a release unnoticed.
+class SkillsDirectoryTest < Minitest::Test
+  SKILLS_DIRECTORY = File.expand_path("../skills", __dir__) #: String
+
+  def test_every_skill_in_the_repository_parses
+    registry = Rubydex::SkillRegistry.load(SKILLS_DIRECTORY)
+
+    refute_empty(registry.ids, "expected at least one skill in #{SKILLS_DIRECTORY}")
+
+    registry.ids.each do |id|
+      skill = registry.fetch(id)
+
+      assert_equal(id, skill.name, "frontmatter `name` for #{id} must match its directory")
+      refute_empty(skill.description, "description for #{id} must not be empty")
+      refute_empty(skill.body, "body for #{id} must not be empty")
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds a skill system that lets the `rdx` CLI load and display skill files — Markdown documents with YAML frontmatter that encode remediation guidance for linter rules.

This is the first part of a system that will allow Rubydex tools to provide references to detailed skills for fixing issues, without having to load every skill. The linter finding is the trigger point for skill loading, rather than relying on the agent pulling from context.

<img width="1063" height="242" alt="Screenshot 2026-08-05 at 3 58 27 PM" src="https://github.com/user-attachments/assets/0dc7cd17-9fa3-4469-8fe3-f4b5becc0c84" />

Skill files live at `skills/<id>/SKILL.md` and use YAML frontmatter to declare a `name` and `description`. This is the standard agent skill format.

- `rdx skill` — lists available skills with id and description, aligned in columns
- `rdx skill <id>` — loads and prints the skill body
- `rdx skill <unknown id>` — reports `unknown skill: <id>` on stderr, exits non-zero

The skills directory is resolved relative to the source file (`__dir__`), so it works both in development and when installed as a gem. Skills are also added to the gemspec file list.

The diagram below illustrates the intended use of skill ids in a Rubydex tooling loop.

<img width="1076" height="612" alt="Screenshot 2026-08-05 at 3 58 52 PM" src="https://github.com/user-attachments/assets/a5297709-b487-41fa-a41f-9fed95ee9f12" />
