### PR TITLE
Add `rdx lint explain` command to show rule documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         run: bundle exec rake compile
 
       - name: Run Rubydex linter
-        run: bundle exec rdx lint .
+        run: bundle exec rdx lint
 
       # Verify that licenses conform to the policy in rust/about.toml
       - name: Check licenses

--- a/README.md
+++ b/README.md
@@ -156,10 +156,10 @@ Put rule files under `rubydex_linter/rules`. Each rule must inherit from `Rubyde
 Run the linter:
 
 ```bash
-bundle exec rdx lint [PATH]
+bundle exec rdx lint
 ```
 
-If you omit `PATH`, Rubydex uses the current directory.
+Rubydex uses the bundle root, or the current directory when no bundle is available.
 
 Configure a rule in `rubydex.toml`:
 

--- a/lib/rubydex/cli/command.rb
+++ b/lib/rubydex/cli/command.rb
@@ -137,6 +137,13 @@ module Rubydex
         abort_with_usage(e.message)
       end
 
+      #: -> String
+      def current_workspace_path
+        Bundler.root.to_s
+      rescue Bundler::GemfileNotFound
+        Dir.pwd
+      end
+
       # Builds the workspace graph, sending progress messages to `progress_io`.
       #: (IO progress_io, ?workspace_path: String, ?config: Rubydex::Config) -> Rubydex::Graph
       def build_graph(progress_io, workspace_path: Dir.pwd, config: Rubydex::Config.load(workspace_path))

--- a/lib/rubydex/cli/command/lint.rb
+++ b/lib/rubydex/cli/command/lint.rb
@@ -4,20 +4,31 @@ require "rubydex/cli/command"
 
 module Rubydex
   module CLI
-    # `rdx lint [PATH]` — discovers project and dependency rules and runs them against a workspace.
+    # `rdx lint` — discovers project and dependency rules and runs them against the current workspace.
     class Command
       class Lint < Command
         command "lint"
-        arguments "[PATH]"
-        summary "Run semantic lint rules against a workspace"
+        summary "Run semantic lint rules in the current workspace"
 
         #: -> void
         def run
-          parse_options!
+          if argv.first == "explain"
+            argv.shift
+            require "rubydex/cli/command/lint/explain"
+            Explain.new(argv).run
+            return
+          end
 
-          workspace_path = File.expand_path(argv.shift || Dir.pwd)
+          parse_options! do |parser|
+            parser.separator("")
+            parser.separator("Commands:")
+            parser.separator("  explain <RULE>  Print documentation for matching linter rules")
+            parser.separator("")
+            parser.separator("Options:")
+          end
+
           abort_with_usage("unexpected argument: #{argv.first}") unless argv.empty?
-          abort_with_usage("workspace is not a directory: #{workspace_path}") unless File.directory?(workspace_path)
+          workspace_path = current_workspace_path
 
           # Keep top-level help lightweight: command discovery loads this file before the native
           # extension, while linter support is only needed when this command runs.
@@ -77,6 +88,7 @@ module Rubydex
           end
 
           print_summary(graph.documents.count, diagnostics)
+          puts("For more information about a rule, run `rdx lint explain RuleName`.")
         end
 
         #: (Location location, workspace_path: String) -> String

--- a/lib/rubydex/cli/command/lint/explain.rb
+++ b/lib/rubydex/cli/command/lint/explain.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require "rubydex"
+require "rubydex/linter/rule_loader"
+
+module Rubydex
+  module CLI
+    class Command
+      class Lint
+        # `rdx lint explain <RULE>` — prints documentation for rules with a matching name.
+        class Explain < Command
+          BASE_RULE_NAME = "Rubydex::Linter::Rule" #: String
+          BASE_RULE_PATH = File.expand_path("../../../linter/rule.rb", __dir__) #: String
+
+          class << self
+            #: -> String
+            def usage_form
+              "lint explain <RULE>"
+            end
+          end
+
+          #: -> void
+          def run
+            parse_options!
+
+            rule_name = argv.shift
+            abort_with_usage("`lint explain` requires a rule name argument") unless rule_name
+            abort_with_usage("unexpected argument: #{argv.first}") unless argv.empty?
+
+            workspace_path = current_workspace_path
+
+            graph = Rubydex::Graph.configure_for_workspace(workspace_path)
+            graph.index_all([BASE_RULE_PATH, *Rubydex::Linter::RuleLoader.paths(workspace_path)])
+            graph.resolve
+
+            base_rule = graph[BASE_RULE_NAME]
+            abort("Base rule class #{BASE_RULE_NAME} is not found. This is likely an issue in Rubydex itself") unless base_rule.is_a?(Rubydex::Class)
+
+            rule_declarations = base_rule.descendants.grep(Rubydex::Class) #: as Array[Rubydex::Class]
+            matched_rule_names = rule_declarations.filter_map do |declaration|
+              declaration_name = declaration.name
+              next unless declaration_name
+              next if declaration_name == BASE_RULE_NAME
+              next unless declaration_name.end_with?(rule_name)
+
+              declaration
+            end
+            abort("Rule does not exist: #{rule_name}") if matched_rule_names.empty?
+
+            puts(matched_rule_names.sort_by(&:name).map { |rule| documentation_for(rule) }.join("\n"))
+          end
+
+          private
+
+          #: (Rubydex::Class rule) -> String
+          def documentation_for(rule)
+            rule_name = rule.name #: as !nil
+            documentation = rule.definitions.flat_map do |definition|
+              definition.comments.map { |comment| comment.string.gsub(/^#\s*/, "") }
+            end.join("\n")
+
+            return "#{rule_name}: no documentation available." if documentation.empty?
+
+            <<~DOCUMENTATION
+              #{rule_name}
+
+              #{documentation}
+            DOCUMENTATION
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rubydex/linter/rule_loader.rb
+++ b/lib/rubydex/linter/rule_loader.rb
@@ -4,17 +4,25 @@ module Rubydex
   module Linter
     # Loads project and bundled-gem rules using the Rubydex linter path convention.
     class RuleLoader
+      BUILT_IN_RULE_GLOB = File.expand_path("../../rubydex_linter/rules/**/*.rb", __dir__) #: String
       RULE_GLOB = "rubydex_linter/rules/**/*.rb" #: String
 
       class << self
-        #: (String workspace_path) -> void
-        def load(workspace_path)
-          rule_files = Dir.glob(RULE_GLOB, base: workspace_path).map do |rule_file|
+        #: (String workspace_path) -> Array[String]
+        def paths(workspace_path)
+          rule_files = Dir.glob(BUILT_IN_RULE_GLOB)
+          rule_files.concat(Dir.glob(RULE_GLOB, base: workspace_path).map do |rule_file|
             File.expand_path(rule_file, workspace_path)
-          end
+          end)
           rule_files.concat(Gem.find_latest_files(RULE_GLOB)) if ENV["BUNDLE_GEMFILE"]
 
-          rule_files.each do |rule_file|
+          # Bundler can return Rubydex's built-in rules through the gem search as well.
+          rule_files.uniq
+        end
+
+        #: (String workspace_path) -> void
+        def load(workspace_path)
+          paths(workspace_path).each do |rule_file|
             require rule_file
           rescue LoadError, SyntaxError => error
             raise RuleLoadError, "Unable to load linter rules from #{rule_file}: #{error.message}", cause: error

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -58,7 +58,7 @@ class CLITest < Minitest::Test
     assert_equal("query", Rubydex::CLI::Command::Query.command_name)
     assert_equal("query <CYPHER>", Rubydex::CLI::Command::Query.usage_form)
     assert_equal("console", Rubydex::CLI::Command::Console.usage_form)
-    assert_equal("lint [PATH]", Rubydex::CLI::Command::Lint.usage_form)
+    assert_equal("lint", Rubydex::CLI::Command::Lint.usage_form)
   end
 
   def test_commands_are_listed_alphabetically
@@ -241,6 +241,16 @@ class CLITest < Minitest::Test
     end
   end
 
+  def test_lint_help_lists_explain
+    result = rdx("lint", "--help")
+
+    assert_success_status(result)
+    assert_stdout_includes_pattern(
+      result,
+      /^Commands:\n  explain <RULE>\s{2,}Print documentation for matching linter rules\n\nOptions:\n    -h, --help\s+Show this help$/,
+    )
+  end
+
   def test_every_command_reports_an_invalid_option_with_the_usage
     ["query", "console", "lint", "mcp"].each do |command|
       result = rdx(command, "--bogus-flag")
@@ -274,6 +284,149 @@ class CLITest < Minitest::Test
     refute_stderr_includes(result, "Usage: rdx <command> [options]")
   end
 
+  def test_explain_reports_all_rules_with_a_matching_name
+    with_context do |context|
+      context.write!("rubydex_linter/rules/first_shared_rule.rb", <<~RUBY)
+        module ExplainDuplicateFixtures
+          module First
+            # Flags raw SQL built through application query helpers.
+            #
+            # Prefer parameter binding instead.
+            class SharedRule < Rubydex::Linter::Rule
+              def severity = Rubydex::Severity::Error
+              def lint; end
+            end
+          end
+        end
+      RUBY
+
+      context.write!("rubydex_linter/rules/second_shared_rule.rb", <<~RUBY)
+        module ExplainDuplicateFixtures
+          class SharedBaseRule < Rubydex::Linter::Rule
+            def severity = Rubydex::Severity::Error
+            def lint; end
+          end
+
+          module Second
+            class SharedRule < ExplainDuplicateFixtures::SharedBaseRule
+              def severity = Rubydex::Severity::Error
+              def lint; end
+            end
+          end
+        end
+      RUBY
+
+      Bundler.stubs(:root).returns(Pathname.new(context.absolute_path))
+      result = rdx("lint", "explain", "SharedRule")
+
+      assert_success_status(result)
+      assert_stdout_equals(<<~DOCS, result)
+        ExplainDuplicateFixtures::First::SharedRule
+
+        Flags raw SQL built through application query helpers.
+
+        Prefer parameter binding instead.
+
+        ExplainDuplicateFixtures::Second::SharedRule: no documentation available.
+      DOCS
+    end
+  end
+
+  def test_explain_accepts_a_partially_qualified_rule_name
+    with_context do |context|
+      context.write!("rubydex_linter/rules/exact_rule.rb", <<~RUBY)
+        module ExplainExactFixtures
+          # Flags exact matches.
+          class ExactRule < Rubydex::Linter::Rule
+            def severity = Rubydex::Severity::Error
+            def lint; end
+          end
+        end
+      RUBY
+
+      Bundler.stubs(:root).returns(Pathname.new(context.absolute_path))
+
+      result = rdx("lint", "explain", "ExactFixtures::ExactRule")
+
+      assert_success_status(result)
+      assert_stdout_equals(<<~DOCS, result)
+        ExplainExactFixtures::ExactRule
+
+        Flags exact matches.
+      DOCS
+    end
+  end
+
+  def test_explain_rejects_an_unknown_rule
+    with_context do |context|
+      context.write!("rubydex_linter/rules/known_rule.rb", <<~RUBY)
+        class ExplainKnownRule < Rubydex::Linter::Rule
+          def severity = Rubydex::Severity::Error
+          def lint; end
+        end
+      RUBY
+
+      Bundler.stubs(:root).returns(Pathname.new(context.absolute_path))
+      result = rdx("lint", "explain", "ExplainKnownFixtures::MissingRule")
+
+      refute_success_status(result)
+      assert_empty_stdout(result)
+      assert_stderr_includes(result, "Rule does not exist: ExplainKnownFixtures::MissingRule")
+    end
+  end
+
+  def test_explain_uses_the_current_directory_without_a_bundle
+    with_context do |context|
+      context.write!("rubydex_linter/rules/fallback_rule.rb", <<~RUBY)
+        module ExplainFallbackFixtures
+          # Flags fallback behavior.
+          class Rule < Rubydex::Linter::Rule
+            def severity = Rubydex::Severity::Error
+            def lint; end
+          end
+        end
+      RUBY
+
+      ENV.stubs(:[]).with("BUNDLE_GEMFILE").returns(nil)
+      Bundler.stubs(:root).raises(Bundler::GemfileNotFound)
+      result = rdx("lint", "explain", "ExplainFallbackFixtures::Rule", chdir: context.absolute_path)
+
+      assert_success_status(result)
+      assert_stdout_equals(<<~DOCS, result)
+        ExplainFallbackFixtures::Rule
+
+        Flags fallback behavior.
+      DOCS
+    end
+  end
+
+  def test_explain_requires_a_rule_name
+    result = rdx("lint", "explain")
+
+    refute_success_status(result)
+    assert_empty_stdout(result)
+    assert_stderr_includes(result, "`lint explain` requires a rule name argument")
+    assert_stderr_includes(result, "Usage: rdx lint explain <RULE>")
+  end
+
+  def test_explain_rejects_extra_arguments
+    result = rdx("lint", "explain", "Rubydex::Linter::Rules::RuleStructure", "workspace")
+
+    refute_success_status(result)
+    assert_empty_stdout(result)
+    assert_stderr_includes(result, "unexpected argument: workspace")
+    assert_stderr_includes(result, "Usage: rdx lint explain <RULE>")
+  end
+
+  def test_lint_rejects_a_workspace_argument
+    result = rdx("lint", "workspace")
+
+    refute_success_status(result)
+    assert_empty_stdout(result)
+    assert_stderr_includes(result, "unexpected argument: workspace")
+    assert_stderr_includes(result, "Usage: rdx lint")
+  end
+
   def test_lint_reports_a_rule_diagnostic_with_related_information
     with_context do |context|
       context.write!("app.rb", "class Foo; end\nclass Foo; end\n")
@@ -281,7 +434,8 @@ class CLITest < Minitest::Test
         .with(context.absolute_path)
       Rubydex::Linter::Rule.stubs(:subclasses).returns([CLITestProjectErrorRule])
 
-      result = rdx("lint", context.absolute_path)
+      Bundler.stubs(:root).returns(Pathname.new(context.absolute_path))
+      result = rdx("lint")
 
       refute_success_status(result)
       assert_stdout_includes(
@@ -300,6 +454,7 @@ class CLITest < Minitest::Test
         result,
         /\d+ files inspected, 1 offense detected: 1 error, 0 warnings, 0 info, 0 hints/,
       )
+      assert_stdout_includes(result, "For more information about a rule, run `rdx lint explain RuleName`.")
       refute_stdout_includes(result, context.absolute_path)
       assert_stderr_includes(result, "Indexing workspace...")
       assert_stderr_includes(result, "Resolving graph...")
@@ -314,7 +469,8 @@ class CLITest < Minitest::Test
         .with(context.absolute_path)
       Rubydex::Linter::Rule.stubs(:subclasses).returns([CLITestProjectErrorRule])
 
-      result = rdx("lint", context.absolute_path)
+      Bundler.stubs(:root).returns(Pathname.new(context.absolute_path))
+      result = rdx("lint")
 
       assert_success_status(result)
       assert_stdout_includes_pattern(result, /\d+ files inspected, no offenses detected/)
@@ -326,7 +482,8 @@ class CLITest < Minitest::Test
       context.write!("app.rb", "class App; end\n")
       Rubydex::Linter::Rule.stubs(:subclasses).returns([Rubydex::Linter::Rules::RuleStructure])
 
-      result = rdx("lint", context.absolute_path)
+      Bundler.stubs(:root).returns(Pathname.new(context.absolute_path))
+      result = rdx("lint")
 
       assert_success_status(result)
       assert_stdout_includes_pattern(result, /\d+ files inspected, no offenses detected/)

--- a/test/rule_loader_test.rb
+++ b/test/rule_loader_test.rb
@@ -8,6 +8,51 @@ require "rubydex/linter"
 class RuleLoaderTest < Minitest::Test
   include Test::Helpers::WithContext
 
+  def test_paths_include_built_in_and_project_rules_without_bundler
+    with_context do |context|
+      project_rule_path = "workspace/rubydex_linter/rules/project_rule.rb"
+      write_linter_rule(context, "RuleLoaderTestProjectPathRule", path: project_rule_path)
+
+      paths = with_bundle_gemfile(nil) do
+        Rubydex::Linter::RuleLoader.paths(context.absolute_path_to("workspace"))
+      end
+
+      assert_includes(paths, File.expand_path("../lib/rubydex_linter/rules/rule_structure.rb", __dir__))
+      assert_includes(paths, context.absolute_path_to(project_rule_path))
+    end
+  end
+
+  def test_paths_include_rules_from_bundled_dependencies
+    with_context do |context|
+      dependency_rule_path = "fake_gem/lib/rubydex_linter/rules/dependency_rule.rb"
+      write_linter_rule(context, "RuleLoaderTestDependencyPathRule", path: dependency_rule_path)
+      Gem.expects(:find_latest_files)
+        .with("rubydex_linter/rules/**/*.rb")
+        .returns([context.absolute_path_to(dependency_rule_path)])
+
+      paths = with_bundle_gemfile(context.absolute_path_to("Gemfile")) do
+        Rubydex::Linter::RuleLoader.paths(context.absolute_path_to("workspace"))
+      end
+
+      assert_includes(paths, context.absolute_path_to(dependency_rule_path))
+    end
+  end
+
+  def test_paths_remove_built_in_rules_rediscovered_through_bundler
+    with_context do |context|
+      built_in_rule_path = File.expand_path("../lib/rubydex_linter/rules/rule_structure.rb", __dir__)
+      Gem.expects(:find_latest_files)
+        .with("rubydex_linter/rules/**/*.rb")
+        .returns([built_in_rule_path])
+
+      paths = with_bundle_gemfile(context.absolute_path_to("Gemfile")) do
+        Rubydex::Linter::RuleLoader.paths(context.absolute_path)
+      end
+
+      assert_equal(1, paths.count(built_in_rule_path))
+    end
+  end
+
   def test_built_in_rules_are_available_without_bundler
     with_context do |context|
       with_bundle_gemfile(nil) do


### PR DESCRIPTION
Add `rdx lint explain <Unqualified Rule Name>` for showing each Rule class's comments:

```
$ be rdx lint explain RuleStructure
Rubydex::Linter::Rules::RuleStructure

Ensures discovered workspace linter rules follow these conventions:

- A rule file does not define more than one linter rule.
- Each rule subclass outside a test directory is in a rule directory.
- Each checked rule subclass is in the `Rubydex::Linter::Rules` namespace.

The rule directories are `rubydex_linter/rules/` and `lib/rubydex_linter/rules/`.
This rule does not report files in those directories that define no rule subclass.
```