### PR TITLE
Add an in-project linter rule and rule test support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,12 @@ jobs:
       - name: Lint
         run: bundle exec rake lint
 
+      - name: Compile
+        run: bundle exec rake compile
+
+      - name: Run Rubydex linter
+        run: bundle exec rdx lint .
+
       # Verify that licenses conform to the policy in rust/about.toml
       - name: Check licenses
         run: |

--- a/lib/ruby_lsp/rubydex/addon.rb
+++ b/lib/ruby_lsp/rubydex/addon.rb
@@ -122,6 +122,8 @@ module Rubydex
         def initialize(global_state)
           @graph = global_state.graph #: ::Rubydex::Graph
           @workspace_path = global_state.workspace_path #: String
+          ::Rubydex::Linter::RuleLoader.load(@workspace_path)
+          @rules = ::Rubydex::Linter::Rule.subclasses #: Array[singleton(::Rubydex::Linter::Rule)]
           @runner = build_runner #: ::Rubydex::Linter::Runner
 
           @current_diagnostics = {} #: Hash[String, Array[::RubyLsp::Interface::Diagnostic]]
@@ -165,8 +167,7 @@ module Rubydex
         #: () -> ::Rubydex::Linter::Runner
         def build_runner
           config = ::Rubydex::Config.load(@workspace_path)
-          rules = ::Rubydex::Linter::RuleLoader.load(@workspace_path)
-          ::Rubydex::Linter::Runner.new(@graph, rules:, config: config.linter)
+          ::Rubydex::Linter::Runner.new(@graph, rules: @rules, config: config.linter)
         end
 
         #: (::Rubydex::Diagnostic) -> ::RubyLsp::Interface::Diagnostic

--- a/lib/rubydex/cli/command.rb
+++ b/lib/rubydex/cli/command.rb
@@ -138,18 +138,11 @@ module Rubydex
       end
 
       # Builds the workspace graph, sending progress messages to `progress_io`.
-      #: (IO progress_io, ?workspace_path: String, ?config: Rubydex::Config, ?fail_on_index_errors: bool) -> Rubydex::Graph
-      def build_graph(
-        progress_io,
-        workspace_path: Dir.pwd,
-        config: Rubydex::Config.load(workspace_path),
-        fail_on_index_errors: false
-      )
+      #: (IO progress_io, ?workspace_path: String, ?config: Rubydex::Config) -> Rubydex::Graph
+      def build_graph(progress_io, workspace_path: Dir.pwd, config: Rubydex::Config.load(workspace_path))
         graph = Rubydex::Graph.new
         graph.load_config(config)
-        errors = with_timer(progress_io, "Indexing workspace...") { graph.index_workspace }
-        abort(errors.join("\n")) if fail_on_index_errors && !errors.empty?
-
+        with_timer(progress_io, "Indexing workspace...") { graph.index_workspace }
         with_timer(progress_io, "Resolving graph...") { graph.resolve }
         graph
       end

--- a/lib/rubydex/cli/command/lint.rb
+++ b/lib/rubydex/cli/command/lint.rb
@@ -28,8 +28,11 @@ module Rubydex
           config = Rubydex::Config.load(workspace_path)
           warn_unknown_rules(config.linter, rules)
 
-          graph = build_graph($stderr, workspace_path:, config:, fail_on_index_errors: true)
-          result = Rubydex::Linter::Runner.new(graph, rules:, config: config.linter).run
+          graph = build_graph($stderr, workspace_path:, config:)
+          runner = Rubydex::Linter::Runner.new(graph, rules:, config: config.linter)
+          rule_count = runner.rules.size
+          $stderr.puts("Running #{rule_count} #{pluralize("rule", rule_count)}...")
+          result = runner.run
           if result.diagnostics.empty?
             print_summary(graph.documents.count, result.diagnostics)
             return
@@ -57,6 +60,7 @@ module Rubydex
         #: (String workspace_path) -> Array[singleton(Rubydex::Linter::Rule)]
         def load_linter_rules(workspace_path)
           Rubydex::Linter::RuleLoader.load(workspace_path)
+          Rubydex::Linter::Rule.subclasses
         rescue Rubydex::Linter::RuleLoadError => error
           abort(error.message)
         end

--- a/lib/rubydex/linter.rb
+++ b/lib/rubydex/linter.rb
@@ -5,6 +5,11 @@ require "rubydex/linter/helpers/path_helpers"
 require "rubydex/linter/helpers/source_access_helpers"
 require "rubydex/linter/result"
 require "rubydex/linter/rule"
+
+Dir.glob(File.expand_path("../rubydex_linter/rules/**/*.rb", __dir__)).each do |rule_file|
+  require rule_file
+end
+
 require "rubydex/linter/rule_loader"
 require "rubydex/linter/runner"
 

--- a/lib/rubydex/linter/rule_loader.rb
+++ b/lib/rubydex/linter/rule_loader.rb
@@ -7,23 +7,18 @@ module Rubydex
       RULE_GLOB = "rubydex_linter/rules/**/*.rb" #: String
 
       class << self
-        #: (String workspace_path) -> Array[singleton(Rule)]
+        #: (String workspace_path) -> void
         def load(workspace_path)
-          existing_rules = Rule.subclasses
           rule_files = Dir.glob(RULE_GLOB, base: workspace_path).map do |rule_file|
             File.expand_path(rule_file, workspace_path)
           end
-          if ENV["BUNDLE_GEMFILE"]
-            rule_files.concat(Gem.find_latest_files(RULE_GLOB))
-          end
+          rule_files.concat(Gem.find_latest_files(RULE_GLOB)) if ENV["BUNDLE_GEMFILE"]
 
           rule_files.each do |rule_file|
             require rule_file
           rescue LoadError, SyntaxError => error
             raise RuleLoadError, "Unable to load linter rules from #{rule_file}: #{error.message}", cause: error
           end
-
-          Rule.subclasses - existing_rules
         end
       end
     end

--- a/lib/rubydex/linter/rule_test_case.rb
+++ b/lib/rubydex/linter/rule_test_case.rb
@@ -1,0 +1,343 @@
+# frozen_string_literal: true
+
+require "fileutils"
+require "minitest/test"
+require "pathname"
+require "tmpdir"
+require "uri"
+require "rubydex/linter"
+
+module Rubydex
+  module Linter
+    # Base test case for Rubydex linter rules.
+    #
+    # Add expected diagnostics below the source:
+    #
+    #     assert_diagnostics(<<~RUBY)
+    #       FOO = 123
+    #       ^^^ Failure: FOO
+    #     RUBY
+    #
+    # The carets mark the diagnostic range. Use `^{}` for a zero-width range.
+    # Pass a hash to test multiple files. Repeat an annotation line for each message line.
+    # By default, `FooTest` tests the `Foo` rule.
+    class RuleTestCase < Minitest::Test
+      DEFAULT_FILE = "test.rb" #: String
+
+      ANNOTATION_PATTERN = /\A(?<indent>\s*)(?<carets>(?<!\\)\^+|\^\{\})(?:\s(?<message>.*))?\z/ #: Regexp
+
+      #: type annotation = [Integer, Integer, Integer, String]
+
+      #: String
+      attr_reader :workspace_path
+
+      #: (String) -> void
+      def initialize(name)
+        super
+        @workspace_path = File.realpath(Dir.mktmpdir("rubydex-rule-test-")) #: String
+      end
+
+      #: -> void
+      def teardown
+        super
+      ensure
+        FileUtils.remove_entry(workspace_path)
+      end
+
+      #: -> singleton(Rule)
+      def rule_class
+        @rule_class ||= begin
+          name = self.class.to_s.delete_suffix("Test")
+          if name == self.class.to_s
+            raise "Could not infer rule class from #{self.class}; override `#rule_class`"
+          end
+
+          Object.const_get(name) #: as singleton(Rule)
+        end #: singleton(Rule)?
+      end
+
+      # Registers sources that are loaded into the graph for every assertion.
+      # Shared sources must not contain caret annotations. Test-specific
+      # sources win on filename collision.
+      #: (Hash[String, String]) -> void
+      def add_shared_source(sources)
+        shared_sources.merge!(sources)
+      end
+
+      # Returns absolute file paths whose diagnostics should be ignored.
+      #: -> Array[String]
+      def ignored_diagnostic_files
+        @ignored_diagnostic_files ||= [] #: Array[String]?
+      end
+
+      #: -> LinterConfig
+      def rule_config
+        @rule_config ||= LinterConfig.new({}) #: LinterConfig?
+      end
+
+      # Runs the rule and compares every diagnostic location with the inline
+      # annotations in the corresponding source.
+      #: (*(String | Hash[String | Symbol, String])) ?{ (Graph) -> Rule } -> Array[Diagnostic]
+      def assert_diagnostics(*args, &rule_builder)
+        sources = validated_shared_source.merge(normalize_sources(args))
+        clean_per_file, expected_per_file = write_sources(sources)
+
+        diagnostics = run_rule(&rule_builder)
+        actual_per_file = annotations_for_diagnostics(diagnostics, clean_per_file)
+
+        surprise_files = actual_per_file.keys - clean_per_file.keys - ignored_diagnostic_files
+        refute_predicate(
+          surprise_files,
+          :any?,
+          "Diagnostics in unexpected files: #{surprise_files.inspect}",
+        )
+
+        clean_per_file.each do |filename, clean|
+          expected = render_annotated(clean, expected_per_file[filename] || [])
+          actual = render_annotated(clean, actual_per_file[filename] || [])
+          assert_equal(expected, actual, "Mismatch in #{filename}")
+        end
+
+        diagnostics
+      end
+
+      # Runs the rule and asserts no diagnostics are reported in the provided
+      # sources. Sources must not contain caret annotations.
+      #: (*(String | Hash[String | Symbol, String])) ?{ (Graph) -> Rule } -> Array[Diagnostic]
+      def assert_no_diagnostics(*args, &rule_builder)
+        sources = validated_shared_source.merge(normalize_sources(args))
+        write_sources(sources)
+
+        diagnostics = run_rule(&rule_builder)
+        ignored = ignored_diagnostic_files
+        reported = diagnostics.reject { |diagnostic| ignored.include?(diagnostic.location.to_file_path) }
+        assert_empty(reported, "Expected no diagnostics, got #{reported.map(&:message).inspect}")
+        diagnostics
+      end
+
+      #: (
+      #|   String,
+      #|   *(String | Hash[String | Symbol, String]),
+      #|   ?after_excluding: Array[String],
+      #| ) ?{ (Graph) -> Rule } -> void
+      def assert_handles_missing_required_dependency(dependency, *args, after_excluding: [], &rule_builder)
+        sources = validated_shared_source.dup #: Hash[String, String]
+        after_excluding.each { |filename| sources.delete(filename) }
+        sources.merge!(normalize_sources(args))
+        write_sources(sources)
+
+        error = assert_raises(MissingGraphDependencyError) do
+          run_rule(&rule_builder)
+        end
+
+        expected_message = MissingGraphDependencyError.new(rule_class.rule_name, dependency).message
+        assert_equal(expected_message, error.message)
+      end
+
+      private
+
+      #: (Hash[String, String]) -> [Hash[String, String], Hash[String, Array[annotation]]]
+      def write_sources(sources)
+        clean_per_file = {} #: Hash[String, String]
+        expected_per_file = {} #: Hash[String, Array[annotation]]
+
+        virtual_sources.clear
+
+        sources.each do |filename, annotated|
+          clean, annotations = parse_annotations(annotated)
+          if Pathname(filename).absolute?
+            absolute_path = filename
+            virtual_sources[absolute_path] = clean
+          else
+            absolute_path = File.join(workspace_path, filename)
+            FileUtils.mkdir_p(File.dirname(absolute_path))
+            File.write(absolute_path, clean)
+            absolute_path = File.realpath(absolute_path)
+          end
+          clean_per_file[absolute_path] = clean
+          expected_per_file[absolute_path] = annotations
+        end
+
+        [clean_per_file, expected_per_file]
+      end
+
+      #: -> Hash[String, String]
+      def shared_sources
+        @shared_sources ||= {} #: Hash[String, String]?
+      end
+
+      #: -> Hash[String, String]
+      def virtual_sources
+        @virtual_sources ||= {} #: Hash[String, String]?
+      end
+
+      #: -> Hash[String, String]
+      def validated_shared_source
+        shared_sources.each do |filename, source|
+          _, annotations = parse_annotations(source)
+          raise "Shared source #{filename} must not contain caret annotations" unless annotations.empty?
+        end
+        shared_sources
+      end
+
+      #: (Array[String | Hash[String | Symbol, String]]) -> Hash[String, String]
+      def normalize_sources(args)
+        case args
+        in []
+          {}
+        in [String => source]
+          { DEFAULT_FILE => source }
+        in [Hash => hash]
+          hash.transform_keys(&:to_s)
+        else
+          raise ArgumentError, "expected a String or a { filename => source } Hash, got: #{args.inspect}"
+        end
+      end
+
+      #: (String) -> [String, Array[annotation]]
+      def parse_annotations(annotated_source)
+        clean = [] #: Array[String]
+        annotations = [] #: Array[annotation]
+
+        annotated_source.each_line do |line|
+          if (match = ANNOTATION_PATTERN.match(line.chomp))
+            indent = match[:indent]&.length #: as !nil
+            carets = match[:carets] #: as !nil
+            start_column = indent
+            end_column = if carets == "^{}"
+              indent
+            else
+              indent + carets.length
+            end
+
+            target_line = clean.empty? ? 0 : clean.size - 1
+            message = match[:message].to_s
+            last = annotations.last
+            if last && last[0] == target_line && last[1] == start_column && last[2] == end_column
+              last[3] = "#{last[3]}\n#{message}"
+            else
+              annotations << [target_line, start_column, end_column, message]
+            end
+          else
+            clean << line
+          end
+        end
+
+        [clean.join, annotations]
+      end
+
+      #: ?{ (Graph) -> Rule } -> Array[Diagnostic]
+      def run_rule(&rule_builder)
+        graph = Graph.configure_for_workspace(workspace_path)
+        file_paths = workspace_file_paths
+        graph.index_all(file_paths.reject { |path| File.extname(path) == ".rake" })
+        index_rake_files(graph, file_paths)
+
+        virtual_sources.each do |path, source|
+          graph.index_source(uri_for_path(path), source, source_id_for(path))
+        end
+        graph.resolve
+
+        rule = rule_builder ? rule_builder.call(graph) : rule_class.new(graph, config: rule_config)
+        rule.lint
+        rule.diagnostics
+      end
+
+      #: (Graph, Array[String]) -> void
+      def index_rake_files(graph, file_paths)
+        file_paths.each do |path|
+          next unless File.extname(path) == ".rake"
+
+          graph.index_source(uri_for_path(path), File.read(path), "ruby")
+        end
+      end
+
+      #: -> Array[String]
+      def workspace_file_paths
+        Dir.glob("**/*", base: workspace_path).sort.filter_map do |relative_path|
+          absolute_path = File.join(workspace_path, relative_path)
+          next unless File.file?(absolute_path)
+
+          case File.extname(relative_path)
+          when ".rb", ".rbi", ".rake", ".rbs"
+            File.realpath(absolute_path)
+          else
+            raise "Unsupported file type: #{relative_path}"
+          end
+        end
+      end
+
+      #: (String) -> String
+      def source_id_for(path)
+        case File.extname(path)
+        when ".rb", ".rbi", ".rake", ".ru"
+          "ruby"
+        when ".rbs"
+          "rbs"
+        else
+          raise "Unsupported file type: #{path}"
+        end
+      end
+
+      #: (Array[Diagnostic], Hash[String, String]) -> Hash[String, Array[annotation]]
+      def annotations_for_diagnostics(diagnostics, sources)
+        result = Hash.new { |hash, key| hash[key] = [] } #: Hash[String, Array[annotation]]
+
+        diagnostics.each do |diagnostic|
+          located_messages = [[diagnostic.location, diagnostic.message]] #: Array[[Location, String]]
+          diagnostic.related_information.each do |related|
+            located_messages << [related.location, related.message]
+          end
+
+          located_messages.each do |location, message|
+            path = location.to_file_path
+            line_index = location.start_line
+            start_column = location.start_column
+            end_column =
+              if location.end_line == location.start_line
+                location.end_column
+              else
+                clean = sources[path]
+                line_text = clean ? (clean.each_line.to_a[line_index] || "").chomp : ""
+                line_text.length
+              end
+
+            annotations = result[path] #: as !nil
+            annotations << [line_index, start_column, end_column, message.chomp]
+          end
+        end
+
+        result
+      end
+
+      #: (String, Array[annotation]) -> String
+      def render_annotated(clean_source, annotations)
+        lines = clean_source.each_line.to_a
+        sorted = annotations.sort_by do |line_index, start_column, end_column, message|
+          [line_index, start_column, end_column, message]
+        end
+        output = lines.dup
+
+        sorted.reverse_each do |line_index, start_column, end_column, message|
+          caret_count = end_column - start_column
+          indentation = " " * start_column
+          carets = caret_count.zero? ? "^{}" : "^" * caret_count
+          markers = if message.empty?
+            ["#{indentation}#{carets}\n"]
+          else
+            message.split("\n", -1).map { |line| "#{indentation}#{carets} #{line}\n" }
+          end
+          output[line_index + 1, 0] = markers
+        end
+
+        output.join
+      end
+
+      #: (String) -> String
+      def uri_for_path(path)
+        uri_path = Gem.win_platform? ? "/#{path}" : path
+        URI::File.build(path: uri_path).to_s
+      end
+    end
+  end
+end

--- a/lib/rubydex/linter/runner.rb
+++ b/lib/rubydex/linter/runner.rb
@@ -27,7 +27,8 @@ module Rubydex
           filter_diagnostics(rule.diagnostics, @config.excludes_for(rule_class))
         end
 
-        diagnostics = (@graph.diagnostics + rule_diagnostics).select do |diagnostic|
+        graph_diagnostics = filter_diagnostics(@graph.diagnostics, [])
+        diagnostics = (graph_diagnostics + rule_diagnostics).select do |diagnostic|
           diagnostic_in_workspace?(diagnostic)
         end.sort_by do |diagnostic|
           location = diagnostic.location

--- a/lib/rubydex_linter/rules/rule_structure.rb
+++ b/lib/rubydex_linter/rules/rule_structure.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+module Rubydex
+  module Linter
+    module Rules
+      # Ensures discovered workspace linter rules follow these conventions:
+      #
+      # - A rule file does not define more than one linter rule.
+      # - Each rule subclass outside a test directory is in a rule directory.
+      # - Each checked rule subclass is in the `Rubydex::Linter::Rules` namespace.
+      #
+      # The rule directories are `rubydex_linter/rules/` and `lib/rubydex_linter/rules/`.
+      # This rule does not report files in those directories that define no rule subclass.
+      class RuleStructure < Rule
+        include Helpers::SourceAccessHelpers
+
+        BASE_RULE_NAME = "Rubydex::Linter::Rule" #: String
+        RULE_NAMESPACE = "Rubydex::Linter::Rules" #: String
+        RULE_FILE_PATTERNS = [
+          "rubydex_linter/rules/**/*.rb",
+          "lib/rubydex_linter/rules/**/*.rb",
+        ].freeze #: Array[String]
+        TEST_FILE_PATTERNS = ["test/**/*", "**/test/**/*"].freeze #: Array[String]
+
+        # @override
+        #: -> singleton(Severity::Base)
+        def severity
+          Severity::Error
+        end
+
+        # @override
+        #: -> void
+        def lint
+          rules = child_classes(BASE_RULE_NAME)
+          rule_definitions_by_file = {} #: Hash[String, Hash[Rubydex::Class, Definition]]
+
+          rules.each do |rule|
+            rule.definitions.each do |rule_definition|
+              uri = rule_definition.document.uri
+              path = path_for_uri(uri)
+              next unless path_in_workspace?(path)
+
+              if rule_file?(path)
+                rule_definitions = (rule_definitions_by_file[uri] ||= {}) #: Hash[Rubydex::Class, Definition]
+                rule_definitions[rule] ||= rule_definition
+              elsif !test_file?(path)
+                report_wrong_rule_directory(rule.name, rule_definition)
+              end
+            end
+
+            rule_definition = rule.definitions.find do |definition|
+              path = path_for_uri(definition.document.uri)
+              path_in_workspace?(path) && (rule_file?(path) || !test_file?(path))
+            end
+            next unless rule_definition
+            next if rule.name.start_with?("#{RULE_NAMESPACE}::")
+
+            report_wrong_rule_namespace(rule.name, rule_definition)
+          end
+
+          rule_definitions_by_file.each do |uri, rule_definitions|
+            next if rule_definitions.length <= 1
+
+            add_diagnostic(
+              "Each rule file must define only one linter rule; found #{rule_definitions.length}.",
+              file_location(uri),
+              related_information: rule_definitions.map do |rule, rule_definition|
+                RelatedInformation.new(
+                  "`#{rule.name}` is defined here.",
+                  diagnostic_location(rule_definition),
+                )
+              end,
+            )
+          end
+        end
+
+        private
+
+        #: (String, Definition) -> void
+        def report_wrong_rule_directory(rule_name, rule_definition)
+          add_diagnostic(
+            "`#{rule_name}` must be defined under `rubydex_linter/rules/` or `lib/rubydex_linter/rules/`.",
+            diagnostic_location(rule_definition),
+          )
+        end
+
+        #: (String, Definition) -> void
+        def report_wrong_rule_namespace(rule_name, rule_definition)
+          add_diagnostic(
+            "`#{rule_name}` must be defined under `#{RULE_NAMESPACE}`.",
+            diagnostic_location(rule_definition),
+          )
+        end
+
+        #: (String) -> bool
+        def path_in_workspace?(path)
+          workspace = graph.workspace_path
+          path == workspace || path.start_with?("#{workspace}/")
+        end
+
+        #: (String) -> bool
+        def rule_file?(path)
+          path_matches_patterns?(path, RULE_FILE_PATTERNS)
+        end
+
+        #: (String) -> bool
+        def test_file?(path)
+          path_matches_patterns?(path, TEST_FILE_PATTERNS)
+        end
+
+        #: (String, Array[String]) -> bool
+        def path_matches_patterns?(path, patterns)
+          Helpers::PathHelpers.path_matches_patterns?(
+            path,
+            patterns,
+            workspace: graph.workspace_path,
+            flags: Helpers::PathHelpers::RUBOCOP_EXCLUDE_FNMATCH_FLAGS,
+          )
+        end
+      end
+    end
+  end
+end

--- a/rbi/rubydex.rbi
+++ b/rbi/rubydex.rbi
@@ -358,6 +358,7 @@ end
 
 module Rubydex::Linter; end
 module Rubydex::Linter::Helpers; end
+module Rubydex::Linter::Rules; end
 
 module Rubydex::Linter::Helpers::PathHelpers
   extend T::Helpers
@@ -492,8 +493,75 @@ class Rubydex::Linter::RuleLoadError < StandardError; end
 class Rubydex::Linter::RuleLoader
   RULE_GLOB = T.let(T.unsafe(nil), String)
 
-  sig { params(workspace_path: String).returns(T::Array[T.class_of(Rubydex::Linter::Rule)]) }
+  sig { params(workspace_path: String).void }
   def self.load(workspace_path); end
+end
+
+class Rubydex::Linter::Rules::RuleStructure < Rubydex::Linter::Rule
+  include Rubydex::Linter::Helpers::SourceAccessHelpers
+
+  BASE_RULE_NAME = T.let(T.unsafe(nil), String)
+  RULE_NAMESPACE = T.let(T.unsafe(nil), String)
+  RULE_FILE_PATTERNS = T.let(T.unsafe(nil), T::Array[String])
+  TEST_FILE_PATTERNS = T.let(T.unsafe(nil), T::Array[String])
+
+  sig { returns(T.class_of(Rubydex::Severity::Base)) }
+  def severity; end
+
+  sig { void }
+  def lint; end
+end
+
+class Rubydex::Linter::RuleTestCase < ::Minitest::Test
+  DEFAULT_FILE = T.let(T.unsafe(nil), String)
+  ANNOTATION_PATTERN = T.let(T.unsafe(nil), Regexp)
+
+  sig { returns(String) }
+  def workspace_path; end
+
+  sig { params(name: String).void }
+  def initialize(name); end
+
+  sig { void }
+  def teardown; end
+
+  sig { returns(T.class_of(Rubydex::Linter::Rule)) }
+  def rule_class; end
+
+  sig { params(sources: T::Hash[String, String]).void }
+  def add_shared_source(sources); end
+
+  sig { returns(T::Array[String]) }
+  def ignored_diagnostic_files; end
+
+  sig { returns(Rubydex::LinterConfig) }
+  def rule_config; end
+
+  sig do
+    params(
+      args: T.any(String, T::Hash[T.any(String, Symbol), String]),
+      rule_builder: T.nilable(T.proc.params(graph: Rubydex::Graph).returns(Rubydex::Linter::Rule)),
+    ).returns(T::Array[Rubydex::Diagnostic])
+  end
+  def assert_diagnostics(*args, &rule_builder); end
+
+  sig do
+    params(
+      args: T.any(String, T::Hash[T.any(String, Symbol), String]),
+      rule_builder: T.nilable(T.proc.params(graph: Rubydex::Graph).returns(Rubydex::Linter::Rule)),
+    ).returns(T::Array[Rubydex::Diagnostic])
+  end
+  def assert_no_diagnostics(*args, &rule_builder); end
+
+  sig do
+    params(
+      dependency: String,
+      args: T.any(String, T::Hash[T.any(String, Symbol), String]),
+      after_excluding: T::Array[String],
+      rule_builder: T.nilable(T.proc.params(graph: Rubydex::Graph).returns(Rubydex::Linter::Rule)),
+    ).void
+  end
+  def assert_handles_missing_required_dependency(dependency, *args, after_excluding: [], &rule_builder); end
 end
 
 class Rubydex::Linter::Runner

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -6,6 +6,7 @@ require "helpers/context"
 require "json"
 require "mocha/minitest"
 require "rubydex/cli"
+require "rubydex/linter"
 
 # `cli.rb` loads the command files lazily, so that `rdx --version` pulls in nothing it does not
 # need. Load them here so the tests can refer to the command classes by constant regardless of the
@@ -19,6 +20,30 @@ Rubydex::CLI::Command.all
 class CLITest < Minitest::Test
   include Test::Helpers::WithCLI
   include Test::Helpers::WithContext
+
+  class CLITestProjectErrorRule < Rubydex::Linter::Rule
+    def severity = Rubydex::Severity::Error
+
+    def lint
+      declaration = graph["Foo"]
+      return unless declaration
+
+      definitions = declaration.definitions.sort_by(&:location).to_a
+      primary = definitions.shift
+      return unless primary
+
+      add_diagnostic(
+        "Foo is not allowed.",
+        diagnostic_location(primary),
+        related_information: definitions.map do |definition|
+          Rubydex::RelatedInformation.new(
+            "Foo is also defined here.",
+            diagnostic_location(definition),
+          )
+        end,
+      )
+    end
+  end
 
   def test_commands_are_discovered_from_subclasses
     commands = Rubydex::CLI::Command.all
@@ -249,17 +274,14 @@ class CLITest < Minitest::Test
     refute_stderr_includes(result, "Usage: rdx <command> [options]")
   end
 
-  def test_lint_reports_a_project_rule_diagnostic_with_related_information
+  def test_lint_reports_a_rule_diagnostic_with_related_information
     with_context do |context|
-      write_linter_rule(
-        context,
-        "CLITestProjectErrorRule",
-        path: "rubydex_linter/rules/nested/no_foo.rb",
-      )
       context.write!("app.rb", "class Foo; end\nclass Foo; end\n")
-      Gem.expects(:find_latest_files).never
+      Rubydex::Linter::RuleLoader.expects(:load)
+        .with(context.absolute_path)
+      Rubydex::Linter::Rule.stubs(:subclasses).returns([CLITestProjectErrorRule])
 
-      result = with_bundle_gemfile(nil) { rdx("lint", context.absolute_path) }
+      result = rdx("lint", context.absolute_path)
 
       refute_success_status(result)
       assert_stdout_includes(
@@ -281,49 +303,33 @@ class CLITest < Minitest::Test
       refute_stdout_includes(result, context.absolute_path)
       assert_stderr_includes(result, "Indexing workspace...")
       assert_stderr_includes(result, "Resolving graph...")
+      assert_stderr_includes(result, "Running 1 rule...")
     end
   end
 
   def test_lint_allows_a_clean_workspace
     with_context do |context|
-      write_linter_rule(context, "CLITestProjectCleanRule")
       context.write!("app.rb", "class Bar; end\n")
+      Rubydex::Linter::RuleLoader.expects(:load)
+        .with(context.absolute_path)
+      Rubydex::Linter::Rule.stubs(:subclasses).returns([CLITestProjectErrorRule])
 
-      result = with_bundle_gemfile(nil) { rdx("lint", context.absolute_path) }
+      result = rdx("lint", context.absolute_path)
 
       assert_success_status(result)
       assert_stdout_includes_pattern(result, /\d+ files inspected, no offenses detected/)
     end
   end
 
-  def test_lint_loads_rules_from_bundled_dependencies
+  def test_lint_allows_a_plain_workspace_without_project_rules
     with_context do |context|
-      rule_path = "fake_gem/lib/rubydex_linter/rules/no_foo.rb"
-      write_linter_rule(context, "CLITestDependencyErrorRule", path: rule_path)
-      context.write!("app.rb", "class Foo; end\n")
-      Gem.expects(:find_latest_files)
-        .with("rubydex_linter/rules/**/*.rb")
-        .returns([context.absolute_path_to(rule_path)])
+      context.write!("app.rb", "class App; end\n")
+      Rubydex::Linter::Rule.stubs(:subclasses).returns([Rubydex::Linter::Rules::RuleStructure])
 
-      result = with_bundle_gemfile(context.absolute_path_to("Gemfile")) do
-        rdx("lint", context.absolute_path)
-      end
+      result = rdx("lint", context.absolute_path)
 
-      refute_success_status(result)
-      assert_stdout_includes(result, "error: CLITestDependencyErrorRule: Foo is not allowed.")
-    end
-  end
-
-  def test_lint_requires_a_discovered_rule_before_indexing
-    with_context do |context|
-      context.write!("app.rb", "class Foo; end\n")
-
-      result = with_bundle_gemfile(nil) { rdx("lint", context.absolute_path) }
-
-      refute_success_status(result)
-      assert_empty_stdout(result)
-      assert_stderr_includes(result, "No Rubydex::Linter::Rule subclasses were loaded")
-      refute_stderr_includes(result, "Indexing workspace...")
+      assert_success_status(result)
+      assert_stdout_includes_pattern(result, /\d+ files inspected, no offenses detected/)
     end
   end
 
@@ -398,48 +404,6 @@ class CLITest < Minitest::Test
   end
 
   private
-
-  # Each in-process invocation loads a distinct named rule. Reopening the same class would not add
-  # a subclass, so the linter could not identify which rule came from that invocation.
-  #: (Test::Helpers::Context context, String class_name, ?path: String) -> void
-  def write_linter_rule(context, class_name, path: "rubydex_linter/rules/no_foo.rb")
-    context.write!(path, <<~RUBY)
-      # frozen_string_literal: true
-
-      class #{class_name} < Rubydex::Linter::Rule
-        def severity = Rubydex::Severity::Error
-
-        def lint
-          declaration = graph["Foo"]
-          return unless declaration
-
-          definitions = declaration.definitions.sort_by { |definition| definition.location }.to_a
-          primary = definitions.shift
-          return unless primary
-
-          add_diagnostic(
-            "Foo is not allowed.",
-            diagnostic_location(primary),
-            related_information: definitions.map do |definition|
-              Rubydex::RelatedInformation.new(
-                "Foo is also defined here.",
-                diagnostic_location(definition),
-              )
-            end,
-          )
-        end
-      end
-    RUBY
-  end
-
-  #: [R] (String?) { -> R } -> R
-  def with_bundle_gemfile(value)
-    previous = ENV["BUNDLE_GEMFILE"]
-    ENV["BUNDLE_GEMFILE"] = value
-    yield
-  ensure
-    ENV["BUNDLE_GEMFILE"] = previous
-  end
 
   #: (LoadError error) -> void
   def console_raising_on_require(error)

--- a/test/linter_test.rb
+++ b/test/linter_test.rb
@@ -220,6 +220,20 @@ class LinterTest < Minitest::Test
     end
   end
 
+  def test_runner_filters_native_diagnostics_under_dependency_paths
+    with_context do |context|
+      context.write!("workspace/inside.rb")
+      graph = Rubydex::Graph.configure_for_workspace(context.absolute_path_to("workspace"))
+      dependency_path = context.absolute_path_to("workspace/.dev/gem")
+      graph.index_source(context.uri_to("workspace/.dev/gem/broken.rb"), "class Broken", "ruby")
+      Gem.stubs(:path).returns([dependency_path])
+
+      result = Rubydex::Linter::Runner.new(graph, rules: [SilentRule], config: linter_config).run
+
+      assert_empty(result.diagnostics)
+    end
+  end
+
   def test_runner_filters_a_diagnostic_when_its_primary_location_matches_a_rule_exclude
     with_context do |context|
       context.write!("workspace/inside.rb")

--- a/test/rubydex_linter/rules/rule_structure_test.rb
+++ b/test/rubydex_linter/rules/rule_structure_test.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "rubydex/linter/rule_test_case"
+require "rubydex_linter/rules/rule_structure"
+
+module Rubydex
+  module Linter
+    module Rules
+      class RuleStructureTest < RuleTestCase
+        BASE_RULE_SOURCE = <<~RUBY
+          module Rubydex
+            module Linter
+              class Rule; end
+              module Rules; end
+            end
+          end
+        RUBY
+
+        def setup
+          super
+          add_shared_source("lib/rubydex/linter/rule.rb" => BASE_RULE_SOURCE)
+        end
+
+        def test_allows_one_rule_class_in_each_supported_rule_directory
+          assert_no_diagnostics(
+            "rubydex_linter/rules/project_rule.rb" => rule_source("ProjectRule"),
+            "lib/rubydex_linter/rules/gem_rule.rb" => rule_source("GemRule"),
+          )
+        end
+
+        def test_allows_indirect_rule_subclasses_and_helper_classes
+          assert_no_diagnostics(
+            "rubydex_linter/rules/base_rule.rb" => rule_source("BaseRule"),
+            "rubydex_linter/rules/indirect_rule.rb" => <<~RUBY,
+              class Rubydex::Linter::Rules::Helper; end
+              class Rubydex::Linter::Rules::IndirectRule < Rubydex::Linter::Rules::BaseRule; end
+            RUBY
+          )
+        end
+
+        def test_reports_multiple_rule_classes_in_one_file_when_one_is_reopened
+          diagnostics = assert_diagnostics(
+            "rubydex_linter/rules/first_rule.rb" => rule_source("FirstRule"),
+            "rubydex_linter/rules/two_rules.rb" => <<~RUBY,
+              class Rubydex::Linter::Rules::FirstRule; end
+              ^{} Each rule file must define only one linter rule; found 2.
+                                            ^^^^^^^^^ `Rubydex::Linter::Rules::FirstRule` is defined here.
+              class Rubydex::Linter::Rules::SecondRule < Rubydex::Linter::Rule; end
+                                            ^^^^^^^^^^ `Rubydex::Linter::Rules::SecondRule` is defined here.
+            RUBY
+          )
+
+          assert_equal(1, diagnostics.length)
+          assert_equal(
+            [
+              "`Rubydex::Linter::Rules::FirstRule` is defined here.",
+              "`Rubydex::Linter::Rules::SecondRule` is defined here.",
+            ],
+            diagnostics.fetch(0).related_information.map(&:message),
+          )
+        end
+
+        def test_reports_a_rule_class_outside_the_rules_namespace
+          assert_diagnostics(
+            "rubydex_linter/rules/wrong_namespace.rb" => <<~RUBY,
+              module ConsumerRules
+                class WrongNamespace < Rubydex::Linter::Rule; end
+                      ^^^^^^^^^^^^^^ `ConsumerRules::WrongNamespace` must be defined under `Rubydex::Linter::Rules`.
+              end
+            RUBY
+          )
+        end
+
+        def test_reports_a_rule_class_outside_a_rule_directory
+          assert_diagnostics(
+            "app/rules/wrong_place.rb" => <<~RUBY,
+              class Rubydex::Linter::Rules::WrongPlace < Rubydex::Linter::Rule; end
+                                            ^^^^^^^^^^ `Rubydex::Linter::Rules::WrongPlace` must be defined under `rubydex_linter/rules/` or `lib/rubydex_linter/rules/`.
+            RUBY
+          )
+        end
+
+        def test_ignores_rule_fixture_classes_under_test_directories
+          assert_no_diagnostics(
+            "test/fixtures/fixture_rule.rb" => <<~RUBY,
+              module RuleStructureTestFixtures
+                class FixtureRule < Rubydex::Linter::Rule; end
+              end
+            RUBY
+          )
+        end
+
+        private
+
+        #: (String) -> String
+        def rule_source(class_name)
+          "class Rubydex::Linter::Rules::#{class_name} < Rubydex::Linter::Rule; end\n"
+        end
+      end
+    end
+  end
+end

--- a/test/rule_loader_test.rb
+++ b/test/rule_loader_test.rb
@@ -2,10 +2,49 @@
 
 require "test_helper"
 require "helpers/context"
+require "mocha/minitest"
 require "rubydex/linter"
 
 class RuleLoaderTest < Minitest::Test
   include Test::Helpers::WithContext
+
+  def test_built_in_rules_are_available_without_bundler
+    with_context do |context|
+      with_bundle_gemfile(nil) do
+        Rubydex::Linter::RuleLoader.load(context.absolute_path)
+      end
+
+      assert_includes(Rubydex::Linter::Rule.subclasses, Rubydex::Linter::Rules::RuleStructure)
+    end
+  end
+
+  def test_loads_project_rules
+    with_context do |context|
+      write_linter_rule(context, "RuleLoaderTestProjectRule")
+
+      with_bundle_gemfile(nil) do
+        Rubydex::Linter::RuleLoader.load(context.absolute_path)
+      end
+
+      assert_includes(Rubydex::Linter::Rule.subclasses.map(&:rule_name), "RuleLoaderTestProjectRule")
+    end
+  end
+
+  def test_loads_rules_from_bundled_dependencies
+    with_context do |context|
+      rule_path = "fake_gem/lib/rubydex_linter/rules/dependency_rule.rb"
+      write_linter_rule(context, "RuleLoaderTestDependencyRule", path: rule_path)
+      Gem.expects(:find_latest_files)
+        .with("rubydex_linter/rules/**/*.rb")
+        .returns([context.absolute_path_to(rule_path)])
+
+      with_bundle_gemfile(context.absolute_path_to("Gemfile")) do
+        Rubydex::Linter::RuleLoader.load(context.absolute_path_to("workspace"))
+      end
+
+      assert_includes(Rubydex::Linter::Rule.subclasses.map(&:rule_name), "RuleLoaderTestDependencyRule")
+    end
+  end
 
   def test_load_wraps_rule_file_errors
     with_context do |context|
@@ -24,6 +63,13 @@ class RuleLoaderTest < Minitest::Test
   end
 
   private
+
+  #: (Test::Helpers::Context, String, ?path: String) -> void
+  def write_linter_rule(context, class_name, path: "rubydex_linter/rules/rule.rb")
+    context.write!(path, <<~RUBY)
+      class Rubydex::Linter::Rules::#{class_name} < Rubydex::Linter::Rule; end
+    RUBY
+  end
 
   #: [R] (String?) { -> R } -> R
   def with_bundle_gemfile(value)


### PR DESCRIPTION
Add a built-in rule that checks the structure of discovered linter rules. The rule also provides an end-to-end smoke test for the linter infrastructure.

This PR also adds test support for project rules. Missing gem load paths and diagnostics from installed gems no longer block `rdx lint`.
