### PR TITLE
Add graph listing commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,10 @@ jobs:
       - name: Run Ruby tests
         run: bundle exec rake test
 
+      - name: Run Rubydex linter
+        if: matrix.os == 'ubuntu-latest' && matrix.ruby == '4.0'
+        run: bundle exec rdx lint .
+
       - name: Save Rust compile cache
         id: rust-compile-cache-save
         uses: actions/cache/save@v6

--- a/ext/rubydex/config.c
+++ b/ext/rubydex/config.c
@@ -1,4 +1,5 @@
 #include "config.h"
+#include "diagnostic.h"
 #include "rustbindings.h"
 #include "utils.h"
 
@@ -29,9 +30,19 @@ static VALUE config_linter_build(VALUE opaque_rule_array) {
     for (size_t i = 0; i < rule_array->len; i++) {
         CLinterRule rule = rule_array->items[i];
         VALUE rule_name = rb_str_freeze(rb_utf8_str_new(rule.name, (long)rule.name_length));
-        VALUE argv[] = {rule_name, rule.enabled ? Qtrue : Qfalse};
+        VALUE exclude_patterns = rb_ary_new_capa((long)rule.exclude_patterns_length);
+        for (size_t j = 0; j < rule.exclude_patterns_length; j++) {
+            CConfigString pattern = rule.exclude_patterns[j];
+            rb_ary_push(exclude_patterns, rb_str_freeze(rb_utf8_str_new(pattern.data, (long)pattern.length)));
+        }
+        rb_obj_freeze(exclude_patterns);
 
-        rb_hash_aset(rules, rule_name, rb_class_new_instance(2, argv, cRuleConfig));
+        VALUE severity = rule.severity == NULL
+            ? Qnil
+            : rdxi_build_diagnostic_severity_value(mRubydex, *rule.severity);
+        VALUE argv[] = {rule_name, rule.enabled ? Qtrue : Qfalse, exclude_patterns, severity};
+
+        rb_hash_aset(rules, rule_name, rb_class_new_instance(4, argv, cRuleConfig));
     }
 
     return rb_class_new_instance(1, &rules, cLinterConfig);

--- a/lib/rubydex/cli/command/lint.rb
+++ b/lib/rubydex/cli/command/lint.rb
@@ -32,7 +32,12 @@ module Rubydex
 
           graph = build_graph($stderr, workspace_path:, config:, fail_on_index_errors: true)
           result = Rubydex::Linter::Runner.new(graph, rules:, config: config.linter).run
-          result.diagnostics.each { |diagnostic| puts(format_linter_diagnostic(diagnostic)) }
+          if result.diagnostics.empty?
+            print_summary(graph.documents.count, result.diagnostics)
+            return
+          end
+
+          print_offenses(result.diagnostics, graph)
           exit(1) unless result.success?
         end
 
@@ -70,28 +75,94 @@ module Rubydex
           Rubydex::Linter::Rule.subclasses - existing_rules
         end
 
-        #: (Location location) -> String
-        def format_linter_location(location)
-          display_location = location.to_display
-          path = begin
-            display_location.to_file_path
-          rescue Rubydex::Location::NotFileUriError
-            display_location.uri
+        #: (Array[Diagnostic] diagnostics, Graph graph) -> void
+        def print_offenses(diagnostics, graph)
+          puts("Offenses:")
+          puts
+
+          diagnostics.each do |diagnostic|
+            puts(format_linter_diagnostic(diagnostic, workspace_path: graph.workspace_path))
+            print_source_excerpt(diagnostic.location)
+            puts
           end
+
+          print_summary(graph.documents.count, diagnostics)
+        end
+
+        #: (Location location, workspace_path: String) -> String
+        def format_linter_location(location, workspace_path:)
+          display_location = location.to_display
+          path = Rubydex::Linter::Helpers::PathHelpers.display_path(display_location, workspace: workspace_path)
 
           "#{path}:#{display_location.start_line}:#{display_location.start_column}"
         end
 
-        #: (Diagnostic diagnostic) -> String
-        def format_linter_diagnostic(diagnostic)
-          content = +"#{format_linter_location(diagnostic.location)}: " \
+        #: (Diagnostic diagnostic, workspace_path: String) -> String
+        def format_linter_diagnostic(diagnostic, workspace_path:)
+          content = +"#{format_linter_location(diagnostic.location, workspace_path:)}: " \
             "#{diagnostic.severity.value}: #{diagnostic.rule}: #{diagnostic.message}"
 
           diagnostic.related_information.each do |information|
-            content << "\n  #{format_linter_location(information.location)}: #{information.message}"
+            content << "\n  #{format_linter_location(information.location, workspace_path:)}: #{information.message}"
           end
 
           content
+        end
+
+        #: (Location location) -> void
+        def print_source_excerpt(location)
+          line = source_line_for(location)
+          return unless line
+
+          end_column = location.end_line == location.start_line ? location.end_column : line.length
+          carets = "^" * [end_column - location.start_column, 1].max
+
+          puts
+          puts(line)
+          puts("#{" " * location.start_column}#{carets}")
+        end
+
+        #: (Location location) -> String?
+        def source_line_for(location)
+          source_lines_for(location.to_file_path)[location.start_line]
+        rescue Errno::ENOENT, Errno::EACCES, Rubydex::Location::NotFileUriError
+          nil
+        end
+
+        #: (String path) -> Array[String]
+        def source_lines_for(path)
+          @source_lines_cache ||= {} #: Hash[String, Array[String]]?
+          @source_lines_cache[path] ||= File.readlines(path, chomp: true)
+        end
+
+        #: (Integer file_count, Array[Diagnostic] diagnostics) -> void
+        def print_summary(file_count, diagnostics)
+          if diagnostics.empty?
+            puts("#{file_count} #{pluralize("file", file_count)} inspected, no offenses detected")
+            return
+          end
+
+          severity_counts = diagnostics.map(&:severity).tally
+          offense_count = diagnostics.length
+          error_count = severity_counts.fetch(Rubydex::Severity::Error, 0)
+          warning_count = severity_counts.fetch(Rubydex::Severity::Warning, 0)
+          hint_count = severity_counts.fetch(Rubydex::Severity::Hint, 0)
+          severity_summary = [
+            "#{error_count} #{pluralize("error", error_count)}",
+            "#{warning_count} #{pluralize("warning", warning_count)}",
+            "#{severity_counts.fetch(Rubydex::Severity::Information, 0)} info",
+            "#{hint_count} #{pluralize("hint", hint_count)}",
+          ].join(", ")
+
+          puts(
+            "#{file_count} #{pluralize("file", file_count)} inspected, " \
+              "#{offense_count} #{pluralize("offense", offense_count)} detected: #{severity_summary}",
+          )
+        end
+
+        #: (String word, Integer count) -> String
+        def pluralize(word, count)
+          count == 1 ? word : "#{word}s"
         end
       end
     end

--- a/lib/rubydex/cli/command/lint.rb
+++ b/lib/rubydex/cli/command/lint.rb
@@ -7,8 +7,6 @@ module Rubydex
     # `rdx lint [PATH]` — discovers project and dependency rules and runs them against a workspace.
     class Command
       class Lint < Command
-        RULE_GLOB = "rubydex_linter/rules/**/*.rb" #: String
-
         command "lint"
         arguments "[PATH]"
         summary "Run semantic lint rules against a workspace"
@@ -56,23 +54,11 @@ module Rubydex
           )
         end
 
-        #: (String workspace_path) -> Array[singleton(Linter::Rule)]
+        #: (String workspace_path) -> Array[singleton(Rubydex::Linter::Rule)]
         def load_linter_rules(workspace_path)
-          existing_rules = Rubydex::Linter::Rule.subclasses
-          rule_files = Dir.glob(RULE_GLOB, base: workspace_path).map do |rule_file|
-            File.expand_path(rule_file, workspace_path)
-          end
-          if ENV["BUNDLE_GEMFILE"]
-            rule_files.concat(Gem.find_latest_files(RULE_GLOB))
-          end
-
-          rule_files.each do |rule_file|
-            require rule_file
-          rescue LoadError, SyntaxError => error
-            abort("Unable to load linter rules from #{rule_file}: #{error.message}")
-          end
-
-          Rubydex::Linter::Rule.subclasses - existing_rules
+          Rubydex::Linter::RuleLoader.load(workspace_path)
+        rescue Rubydex::Linter::RuleLoadError => error
+          abort(error.message)
         end
 
         #: (Array[Diagnostic] diagnostics, Graph graph) -> void

--- a/lib/rubydex/cli/command/list.rb
+++ b/lib/rubydex/cli/command/list.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require "pathname"
+require "uri"
+require "rubydex/cli/command"
+
+module Rubydex
+  module CLI
+    # `rdx list [docs|roots] [PATH]` — prints the files or roots used to index a workspace.
+    class Command
+      class List < Command
+        command "list"
+        arguments "[docs|roots] [PATH]"
+        summary "Print indexed documents or graph roots"
+
+        #: -> void
+        def run
+          parse_options!
+
+          kind = argv.shift || "docs"
+          workspace_path = File.expand_path(argv.shift || Dir.pwd)
+          abort_with_usage("unexpected argument: #{argv.first}") unless argv.empty?
+          abort_with_usage("workspace is not a directory: #{workspace_path}") unless File.directory?(workspace_path)
+
+          config = Rubydex::Config.load(workspace_path)
+          graph = Rubydex::Graph.new
+          graph.load_config(config)
+
+          case kind
+          when "docs"
+            graph.index_workspace
+
+            graph.documents
+              .map { |document| display_path_for_uri(document.uri, workspace_path:) }
+              .sort
+              .each { |path| puts(path) }
+          when "roots"
+            (graph.workspace_paths - graph.excluded_patterns)
+              .map { |path| display_path_for_path(path, workspace_path:) }
+              .sort
+              .each { |path| puts(path) }
+          else
+            abort_with_usage("Unknown list target: #{kind}. Expected `docs` or `roots`.")
+          end
+        end
+
+        private
+
+        #: (String uri, workspace_path: String) -> String
+        def display_path_for_uri(uri, workspace_path:)
+          parsed_uri = URI(uri)
+          path = parsed_uri.path
+          return uri unless parsed_uri.scheme == "file" && path
+
+          path.delete_prefix!("/") if Gem.win_platform?
+          display_path_for_path(path, workspace_path:)
+        end
+
+        #: (String path, workspace_path: String) -> String
+        def display_path_for_path(path, workspace_path:)
+          relative_path = Pathname.new(path).relative_path_from(Pathname.new(workspace_path)).to_s
+          relative_path.start_with?("../") ? path : relative_path
+        end
+      end
+    end
+  end
+end

--- a/lib/rubydex/config.rb
+++ b/lib/rubydex/config.rb
@@ -43,8 +43,8 @@ module Rubydex
     #: singleton(Severity::Base)?
     attr_reader :severity
 
-    #: (String, bool, Array[String], singleton(Severity::Base)?) -> void
-    def initialize(name, enabled, exclude_patterns, severity)
+    #: (String, bool, ?Array[String], ?singleton(Severity::Base)?) -> void
+    def initialize(name, enabled, exclude_patterns = [], severity = nil)
       @name = name
       @enabled = enabled
       @exclude_patterns = exclude_patterns

--- a/lib/rubydex/config.rb
+++ b/lib/rubydex/config.rb
@@ -20,6 +20,16 @@ module Rubydex
       rule = @rules[rule_class.rule_name]
       !rule || rule.enabled?
     end
+
+    #: (singleton(Linter::Rule) rule_class) -> Array[String]
+    def excludes_for(rule_class)
+      @rules[rule_class.rule_name]&.exclude_patterns || []
+    end
+
+    #: (singleton(Linter::Rule) rule_class, default: singleton(Severity::Base)) -> singleton(Severity::Base)
+    def severity_for(rule_class, default:)
+      @rules[rule_class.rule_name]&.severity || default
+    end
   end
 
   # The settings of a single linter rule, read from a `[linter.rules.RuleName]` table.
@@ -27,10 +37,18 @@ module Rubydex
     #: String
     attr_reader :name
 
-    #: (String, bool) -> void
-    def initialize(name, enabled)
+    #: Array[String]
+    attr_reader :exclude_patterns
+
+    #: singleton(Severity::Base)?
+    attr_reader :severity
+
+    #: (String, bool, Array[String], singleton(Severity::Base)?) -> void
+    def initialize(name, enabled, exclude_patterns, severity)
       @name = name
       @enabled = enabled
+      @exclude_patterns = exclude_patterns
+      @severity = severity
     end
 
     #: () -> bool

--- a/lib/rubydex/linter.rb
+++ b/lib/rubydex/linter.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "rubydex"
+require "rubydex/linter/helpers/path_helpers"
 require "rubydex/linter/result"
 require "rubydex/linter/rule"
 require "rubydex/linter/runner"

--- a/lib/rubydex/linter.rb
+++ b/lib/rubydex/linter.rb
@@ -4,6 +4,7 @@ require "rubydex"
 require "rubydex/linter/helpers/path_helpers"
 require "rubydex/linter/result"
 require "rubydex/linter/rule"
+require "rubydex/linter/rule_loader"
 require "rubydex/linter/runner"
 
 module Rubydex

--- a/lib/rubydex/linter/helpers/path_helpers.rb
+++ b/lib/rubydex/linter/helpers/path_helpers.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require "pathname"
+require "uri"
+
+module Rubydex
+  module Linter
+    module Helpers
+      # @requires_ancestor: Rubydex::Linter::Rule
+      module PathHelpers
+        RUBOCOP_EXCLUDE_FNMATCH_FLAGS =
+          File::FNM_PATHNAME | File::FNM_EXTGLOB | File::FNM_DOTMATCH #: Integer
+        TEST_PATHS = ["test/**", "**/test/**", "**/*_test.rb"].freeze
+
+        class << self
+          #: (String, Array[String], workspace: String, ?flags: Integer) -> bool
+          def path_matches_patterns?(path, patterns, workspace:, flags: 0)
+            return false unless path == workspace || path.start_with?("#{workspace}/")
+
+            relative_path = path.delete_prefix("#{workspace}/")
+            patterns.any? { |pattern| File.fnmatch?(pattern, relative_path, flags) }
+          end
+
+          # Returns the path to show users for a location: relative to the workspace for files inside it, the absolute
+          # path for files outside it (dependencies, for example) and the URI opaque for non file URIs, so that
+          # `untitled:Untitled-1` displays as `Untitled-1`.
+          #
+          #: (Location, workspace: String) -> String
+          def display_path(location, workspace:)
+            path = location.to_file_path
+            relative_path = Pathname.new(path).relative_path_from(workspace).to_s
+            relative_path.start_with?("../") ? path : relative_path
+          rescue Location::NotFileUriError
+            URI(location.uri).opaque #: as !nil
+          end
+        end
+
+        #: (Enumerable[Rubydex::Definition], Array[String]) -> Array[Rubydex::Definition]
+        def reject_definitions_in_paths(definitions, excluded_patterns)
+          workspace = graph.workspace_path
+
+          definitions.reject do |definition|
+            path = path_for_definition(definition)
+            path.nil? || (path != workspace && !path.start_with?("#{workspace}/")) ||
+              path_matches_patterns?(path, excluded_patterns)
+          end
+        end
+
+        #: (Enumerable[Rubydex::Definition], Array[String]) -> Array[Rubydex::Definition]
+        def select_definitions_in_paths(definitions, patterns)
+          definitions.select do |definition|
+            path = path_for_definition(definition)
+            path && path_matches_patterns?(path, patterns)
+          end
+        end
+
+        private
+
+        #: (String, Array[String]) -> bool
+        def path_matches_patterns?(path, patterns)
+          PathHelpers.path_matches_patterns?(path, patterns, workspace: graph.workspace_path)
+        end
+
+        #: (String) -> bool
+        def test_path?(path)
+          path_matches_patterns?(path, TEST_PATHS)
+        end
+
+        #: (Rubydex::Definition) -> String?
+        def path_for_definition(definition)
+          definition.location.to_file_path
+        rescue Location::NotFileUriError
+          nil
+        end
+      end
+    end
+  end
+end

--- a/lib/rubydex/linter/helpers/path_helpers.rb
+++ b/lib/rubydex/linter/helpers/path_helpers.rb
@@ -28,10 +28,11 @@ module Rubydex
           #: (Location, workspace: String) -> String
           def display_path(location, workspace:)
             path = location.to_file_path
-            relative_path = Pathname.new(path).relative_path_from(workspace).to_s
-            relative_path.start_with?("../") ? path : relative_path
+            return path unless path == workspace || path.start_with?("#{workspace}/")
+
+            Pathname.new(path).relative_path_from(workspace).to_s
           rescue Location::NotFileUriError
-            URI(location.uri).opaque #: as !nil
+            URI(location.uri).opaque || location.uri
           end
         end
 

--- a/lib/rubydex/linter/rule.rb
+++ b/lib/rubydex/linter/rule.rb
@@ -27,6 +27,7 @@ module Rubydex
         @graph = graph
         @config = config
         @diagnostics = [] #: Array[Diagnostic]
+        @verified_severity = nil #: singleton(Severity::Base)?
       end
 
       # @abstract
@@ -37,7 +38,7 @@ module Rubydex
 
       #: () -> singleton(Severity::Base)
       def verified_severity
-        config.severity_for(self.class, default: severity)
+        @verified_severity ||= config.severity_for(self.class, default: severity)
       end
 
       # @abstract
@@ -59,13 +60,8 @@ module Rubydex
 
       #: (String) -> String
       def path_for_uri(uri)
-        parsed_uri = URI.parse(uri)
-        if parsed_uri.scheme == "file"
-          path = parsed_uri.path #: as !nil
-          path.delete_prefix!("/") if Gem.win_platform?
-          return path
-        end
-
+        file_location(uri).to_file_path
+      rescue Location::NotFileUriError
         uri
       end
 

--- a/lib/rubydex/linter/rule.rb
+++ b/lib/rubydex/linter/rule.rb
@@ -8,7 +8,8 @@ module Rubydex
       class << self
         #: () -> String
         def rule_name
-          name.split("::").last
+          name #: as !nil
+            .split("::").last #: as !nil
         end
       end
 
@@ -40,6 +41,44 @@ module Rubydex
         raise NotImplementedError, "Subclasses must implement the lint method"
       end
 
+      # Anchors a diagnostic on a definition's name token, falling back to its full range when no name location exists.
+      #: (Definition) -> Location
+      def diagnostic_location(definition)
+        definition.name_location || definition.location
+      end
+
+      # Returns every class inheriting from +base_name+, excluding the base class itself.
+      #: (String) -> Enumerable[Rubydex::Class]
+      def child_classes(base_name)
+        required_namespace(base_name).descendants.lazy.filter_map do |child_declaration|
+          next unless child_declaration.is_a?(Rubydex::Class)
+          next if child_declaration.name == base_name
+
+          child_declaration
+        end
+      end
+
+      #: (String) -> Namespace
+      def required_namespace(name)
+        declaration = graph[name]
+        return declaration if declaration.is_a?(Namespace)
+
+        raise MissingGraphDependencyError.new(rule_name, "`#{name}`")
+      end
+
+      #: (Namespace, String) -> Rubydex::Method
+      def required_method(namespace, method_name)
+        method = namespace.find_member(method_name)
+        return method if method.is_a?(Rubydex::Method)
+
+        raise MissingGraphDependencyError.new(rule_name, "`#{namespace.name}##{method_name}`")
+      end
+
+      #: () -> String
+      def rule_name
+        self.class.rule_name
+      end
+
       protected
 
       #: (
@@ -54,6 +93,26 @@ module Rubydex
           location: location,
           severity: severity,
           related_information: related_information,
+        )
+      end
+
+      private
+
+      #: (Location) -> String?
+      def source_for_location(location)
+        File.read(location.to_file_path)
+      rescue Errno::ENOENT
+        nil
+      end
+    end
+
+    class MissingGraphDependencyError < StandardError
+      #: (String, String) -> void
+      def initialize(rule_name, dependency)
+        super(
+          "Rubydex linter rule `#{rule_name}` requires #{dependency} to exist in the Rubydex graph. " \
+            "This is a rule setup error, not a clean lint result; ensure the source that defines " \
+            "the dependency is indexed and Rubydex can resolve it.",
         )
       end
     end

--- a/lib/rubydex/linter/rule.rb
+++ b/lib/rubydex/linter/rule.rb
@@ -35,6 +35,11 @@ module Rubydex
         raise NotImplementedError, "Subclasses must implement the severity method"
       end
 
+      #: () -> singleton(Severity::Base)
+      def verified_severity
+        config.severity_for(self.class, default: severity)
+      end
+
       # @abstract
       #: () -> void
       def lint
@@ -91,7 +96,7 @@ module Rubydex
           rule: self.class.rule_name,
           message: message,
           location: location,
-          severity: severity,
+          severity: verified_severity,
           related_information: related_information,
         )
       end

--- a/lib/rubydex/linter/rule.rb
+++ b/lib/rubydex/linter/rule.rb
@@ -52,6 +52,23 @@ module Rubydex
         definition.name_location || definition.location
       end
 
+      #: (String) -> Location
+      def file_location(uri)
+        Location.new(uri: uri, start_line: 0, end_line: 0, start_column: 0, end_column: 0)
+      end
+
+      #: (String) -> String
+      def path_for_uri(uri)
+        parsed_uri = URI.parse(uri)
+        if parsed_uri.scheme == "file"
+          path = parsed_uri.path #: as !nil
+          path.delete_prefix!("/") if Gem.win_platform?
+          return path
+        end
+
+        uri
+      end
+
       # Returns every class inheriting from +base_name+, excluding the base class itself.
       #: (String) -> Enumerable[Rubydex::Class]
       def child_classes(base_name)

--- a/lib/rubydex/linter/rule_loader.rb
+++ b/lib/rubydex/linter/rule_loader.rb
@@ -5,17 +5,22 @@ module Rubydex
     # Loads project and bundled-gem rules using the Rubydex linter path convention.
     class RuleLoader
       RULE_GLOB = "rubydex_linter/rules/**/*.rb" #: String
+      BUILT_IN_RULE_GLOB = File.expand_path("../../rubydex_linter/rules/**/*.rb", __dir__) #: String
 
       class << self
         #: (String workspace_path) -> Array[singleton(Rule)]
         def load(workspace_path)
-          rule_files = Dir.glob(RULE_GLOB, base: workspace_path).map do |rule_file|
+          built_in_rule_files = Dir.glob(BUILT_IN_RULE_GLOB)
+          workspace_rule_files = Dir.glob(RULE_GLOB, base: workspace_path).map do |rule_file|
             File.expand_path(rule_file, workspace_path)
           end
-          if ENV["BUNDLE_GEMFILE"]
-            rule_files.concat(Gem.find_latest_files(RULE_GLOB))
+          dependency_rule_files = if ENV["BUNDLE_GEMFILE"]
+            Gem.find_latest_files(RULE_GLOB)
+          else
+            []
           end
 
+          rule_files = built_in_rule_files + workspace_rule_files + dependency_rule_files
           rule_files.each do |rule_file|
             require rule_file
           rescue LoadError, SyntaxError => error
@@ -23,10 +28,20 @@ module Rubydex
           end
 
           expanded_rule_files = rule_files.map { |rule_file| File.expand_path(rule_file) }
-          Rule.subclasses.select do |rule_class|
+          descendants_of(Rule).select do |rule_class|
             rule_name = rule_class.name #: as !nil
             source_location = Object.const_source_location(rule_name)
             source_location && expanded_rule_files.include?(File.expand_path(source_location.fetch(0)))
+          end
+        end
+
+        private
+
+        #: (singleton(Rule)) -> Array[singleton(Rule)]
+        def descendants_of(parent)
+          subclasses = parent.subclasses #: as Array[singleton(Rule)]
+          subclasses.flat_map do |subclass|
+            [subclass, *descendants_of(subclass)]
           end
         end
       end

--- a/lib/rubydex/linter/rule_loader.rb
+++ b/lib/rubydex/linter/rule_loader.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Rubydex
+  module Linter
+    # Loads project and bundled-gem rules using the Rubydex linter path convention.
+    class RuleLoader
+      RULE_GLOB = "rubydex_linter/rules/**/*.rb" #: String
+
+      class << self
+        #: (String workspace_path) -> Array[singleton(Rule)]
+        def load(workspace_path)
+          rule_files = Dir.glob(RULE_GLOB, base: workspace_path).map do |rule_file|
+            File.expand_path(rule_file, workspace_path)
+          end
+          if ENV["BUNDLE_GEMFILE"]
+            rule_files.concat(Gem.find_latest_files(RULE_GLOB))
+          end
+
+          rule_files.each do |rule_file|
+            require rule_file
+          rescue LoadError, SyntaxError => error
+            raise RuleLoadError, "Unable to load linter rules from #{rule_file}: #{error.message}", cause: error
+          end
+
+          expanded_rule_files = rule_files.map { |rule_file| File.expand_path(rule_file) }
+          Rule.subclasses.select do |rule_class|
+            rule_name = rule_class.name #: as !nil
+            source_location = Object.const_source_location(rule_name)
+            source_location && expanded_rule_files.include?(File.expand_path(source_location.fetch(0)))
+          end
+        end
+      end
+    end
+
+    class RuleLoadError < StandardError; end
+  end
+end

--- a/lib/rubydex/linter/runner.rb
+++ b/lib/rubydex/linter/runner.rb
@@ -18,6 +18,7 @@ module Rubydex
         @graph = graph
         @config = config
         @rules = rules.select { |rule| config.rule_enabled?(rule) }.sort_by { |rule| rule.name.to_s }
+        @dependency_paths = Gem.path #: Array[String]
       end
 
       #: () -> Result
@@ -51,21 +52,30 @@ module Rubydex
       #: (Array[Diagnostic], Array[String]) -> Array[Diagnostic]
       def filter_diagnostics(diagnostics, exclude_patterns)
         diagnostics.reject do |diagnostic|
-          path = diagnostic.location.to_file_path
-          Helpers::PathHelpers.path_matches_patterns?(
-            path,
-            exclude_patterns,
-            workspace: @graph.workspace_path,
-            flags: Helpers::PathHelpers::RUBOCOP_EXCLUDE_FNMATCH_FLAGS,
-          )
-        rescue Location::NotFileUriError
-          false
+          location_excluded?(diagnostic.location, exclude_patterns)
         end
+      end
+
+      #: (Location, Array[String]) -> bool
+      def location_excluded?(location, patterns)
+        path = location.to_file_path
+        return true if @dependency_paths.any? do |dependency_path|
+          path == dependency_path || path.start_with?("#{dependency_path}/")
+        end
+
+        Helpers::PathHelpers.path_matches_patterns?(
+          path,
+          patterns,
+          workspace: @graph.workspace_path,
+          flags: Helpers::PathHelpers::RUBOCOP_EXCLUDE_FNMATCH_FLAGS,
+        )
+      rescue Location::NotFileUriError
+        false
       end
 
       #: (Diagnostic) -> bool
       def diagnostic_in_workspace?(diagnostic)
-        path = URI::RFC2396_PARSER.unescape(diagnostic.location.to_file_path)
+        path = diagnostic.location.to_file_path
         workspace_path = Pathname.new(File.expand_path(@graph.workspace_path))
         relative_path = Pathname.new(File.expand_path(path)).relative_path_from(workspace_path)
 

--- a/lib/rubydex/linter/runner.rb
+++ b/lib/rubydex/linter/runner.rb
@@ -25,7 +25,7 @@ module Rubydex
         rule_diagnostics = @rules.flat_map do |rule_class|
           rule = rule_class.new(@graph, config: @config)
           rule.lint
-          rule.diagnostics
+          filter_diagnostics(rule.diagnostics, @config.excludes_for(rule_class))
         end
 
         diagnostics = (@graph.diagnostics + rule_diagnostics).select do |diagnostic|
@@ -47,6 +47,21 @@ module Rubydex
       end
 
       private
+
+      #: (Array[Diagnostic], Array[String]) -> Array[Diagnostic]
+      def filter_diagnostics(diagnostics, exclude_patterns)
+        diagnostics.reject do |diagnostic|
+          path = diagnostic.location.to_file_path
+          Helpers::PathHelpers.path_matches_patterns?(
+            path,
+            exclude_patterns,
+            workspace: @graph.workspace_path,
+            flags: Helpers::PathHelpers::RUBOCOP_EXCLUDE_FNMATCH_FLAGS,
+          )
+        rescue Location::NotFileUriError
+          false
+        end
+      end
 
       #: (Diagnostic) -> bool
       def diagnostic_in_workspace?(diagnostic)

--- a/lib/rubydex/location.rb
+++ b/lib/rubydex/location.rb
@@ -42,6 +42,9 @@ module Rubydex
       raise NotFileUriError, "URI is not a file:// URI: #{@uri}" unless uri.scheme == "file"
 
       path = uri.path
+      raise NotFileUriError, "URI has no file path: #{@uri}" unless path
+
+      path = URI.decode_uri_component(path)
       # TODO: This has to go away once we have a proper URI abstraction
       path.delete_prefix!("/") if Gem.win_platform?
       path

--- a/lib/rubydex_linter/rules/rule_structure.rb
+++ b/lib/rubydex_linter/rules/rule_structure.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+require "rubydex/linter"
+
+module Rubydex
+  module Linter
+    module Rules
+      # Ensures discovered linter rule files contain one correctly placed and named rule class.
+      class RuleStructure < Rule
+        BASE_RULE_NAME = "Rubydex::Linter::Rule" #: String
+        RULE_NAMESPACE = "Rubydex::Linter::Rules" #: String
+        RULE_FILE_PATTERNS = [
+          "rubydex_linter/rules/**/*.rb",
+          "lib/rubydex_linter/rules/**/*.rb",
+        ].freeze #: Array[String]
+        TEST_FILE_PATTERNS = ["test/**/*", "**/test/**/*"].freeze #: Array[String]
+
+        # @override
+        #: -> singleton(Severity::Base)
+        def severity
+          Severity::Error
+        end
+
+        # @override
+        #: -> void
+        def lint
+          rule_class_names = child_classes(BASE_RULE_NAME).to_h { |rule_class| [rule_class.name, true] }
+
+          graph.documents.each do |document|
+            path = path_for_uri(document.uri)
+            next unless workspace_path?(path)
+
+            rule_file = rule_file?(path)
+            next if !rule_file && test_file?(path)
+
+            definitions = rule_definitions(document, rule_class_names)
+            validate_rule_file(document, definitions) if rule_file
+
+            definitions.each do |name, definition|
+              validate_rule_definition(name, definition, path)
+            end
+          end
+        end
+
+        private
+
+        #: (Document, Hash[String, bool]) -> Hash[String, ClassDefinition]
+        def rule_definitions(document, rule_class_names)
+          definitions = {} #: Hash[String, ClassDefinition]
+
+          document.definitions.each do |definition|
+            next unless definition.is_a?(ClassDefinition)
+
+            declaration = definition.declaration
+            next unless declaration
+            next unless rule_class_names.key?(declaration.name)
+
+            definitions[declaration.name] ||= definition
+          end
+
+          definitions
+        end
+
+        #: (Document, Hash[String, ClassDefinition]) -> void
+        def validate_rule_file(document, definitions)
+          return if definitions.one?
+
+          add_diagnostic(
+            "Each rule file must define exactly one class that inherits from `#{BASE_RULE_NAME}`; " \
+              "found #{definitions.length}.",
+            file_location(document.uri),
+            related_information: definitions.map do |name, definition|
+              RelatedInformation.new("`#{name}` is defined here.", diagnostic_location(definition))
+            end,
+          )
+        end
+
+        #: (String, ClassDefinition, String) -> void
+        def validate_rule_definition(name, definition, path)
+          unless rule_file?(path)
+            add_diagnostic(
+              "`#{name}` must be defined under `rubydex_linter/rules/` or `lib/rubydex_linter/rules/`.",
+              diagnostic_location(definition),
+            )
+          end
+
+          return if name.start_with?("#{RULE_NAMESPACE}::")
+
+          add_diagnostic(
+            "`#{name}` must be defined under `#{RULE_NAMESPACE}`.",
+            diagnostic_location(definition),
+          )
+        end
+
+        #: (String) -> bool
+        def workspace_path?(path)
+          workspace = graph.workspace_path
+          path == workspace || path.start_with?("#{workspace}/")
+        end
+
+        #: (String) -> bool
+        def rule_file?(path)
+          path_matches_patterns?(path, RULE_FILE_PATTERNS)
+        end
+
+        #: (String) -> bool
+        def test_file?(path)
+          path_matches_patterns?(path, TEST_FILE_PATTERNS)
+        end
+
+        #: (String, Array[String]) -> bool
+        def path_matches_patterns?(path, patterns)
+          Helpers::PathHelpers.path_matches_patterns?(
+            path,
+            patterns,
+            workspace: graph.workspace_path,
+            flags: Helpers::PathHelpers::RUBOCOP_EXCLUDE_FNMATCH_FLAGS,
+          )
+        end
+      end
+    end
+  end
+end

--- a/rbi/rubydex.rbi
+++ b/rbi/rubydex.rbi
@@ -357,6 +357,57 @@ class Rubydex::Diagnostic
 end
 
 module Rubydex::Linter; end
+module Rubydex::Linter::Helpers; end
+
+module Rubydex::Linter::Helpers::PathHelpers
+  extend T::Helpers
+
+  requires_ancestor { Rubydex::Linter::Rule }
+
+  RUBOCOP_EXCLUDE_FNMATCH_FLAGS = T.let(T.unsafe(nil), Integer)
+  TEST_PATHS = T.let(T.unsafe(nil), T::Array[String])
+
+  sig do
+    params(
+      path: String,
+      patterns: T::Array[String],
+      workspace: String,
+      flags: Integer,
+    ).returns(T::Boolean)
+  end
+  def self.path_matches_patterns?(path, patterns, workspace:, flags: 0); end
+
+  sig { params(location: Rubydex::Location, workspace: String).returns(String) }
+  def self.display_path(location, workspace:); end
+
+  sig do
+    params(
+      definitions: T::Enumerable[Rubydex::Definition],
+      excluded_patterns: T::Array[String],
+    ).returns(T::Array[Rubydex::Definition])
+  end
+  def reject_definitions_in_paths(definitions, excluded_patterns); end
+
+  sig do
+    params(
+      definitions: T::Enumerable[Rubydex::Definition],
+      patterns: T::Array[String],
+    ).returns(T::Array[Rubydex::Definition])
+  end
+  def select_definitions_in_paths(definitions, patterns); end
+
+  private
+
+  sig { params(path: String, patterns: T::Array[String]).returns(T::Boolean) }
+  def path_matches_patterns?(path, patterns); end
+
+  sig { params(path: String).returns(T::Boolean) }
+  def test_path?(path); end
+
+  sig { params(definition: Rubydex::Definition).returns(T.nilable(String)) }
+  def path_for_definition(definition); end
+
+end
 
 class Rubydex::Linter::Rule
   abstract!
@@ -376,6 +427,26 @@ class Rubydex::Linter::Rule
   sig { returns(T::Array[Rubydex::Diagnostic]) }
   def diagnostics; end
 
+  sig { params(definition: Rubydex::Definition).returns(Rubydex::Location) }
+  def diagnostic_location(definition); end
+
+  sig { params(base_name: String).returns(T::Enumerable[Rubydex::Class]) }
+  def child_classes(base_name); end
+
+  sig { params(name: String).returns(Rubydex::Namespace) }
+  def required_namespace(name); end
+
+  sig do
+    params(
+      namespace: Rubydex::Namespace,
+      method_name: String,
+    ).returns(Rubydex::Method)
+  end
+  def required_method(namespace, method_name); end
+
+  sig { returns(String) }
+  def rule_name; end
+
   sig { abstract.returns(T.class_of(Rubydex::Severity::Base)) }
   def severity; end
 
@@ -392,6 +463,16 @@ class Rubydex::Linter::Rule
     ).void
   end
   def add_diagnostic(message, location, related_information: []); end
+
+  private
+
+  sig { params(location: Rubydex::Location).returns(T.nilable(String)) }
+  def source_for_location(location); end
+end
+
+class Rubydex::Linter::MissingGraphDependencyError < StandardError
+  sig { params(rule_name: String, dependency: String).void }
+  def initialize(rule_name, dependency); end
 end
 
 class Rubydex::Linter::Runner

--- a/rbi/rubydex.rbi
+++ b/rbi/rubydex.rbi
@@ -358,6 +358,7 @@ end
 
 module Rubydex::Linter; end
 module Rubydex::Linter::Helpers; end
+module Rubydex::Linter::Rules; end
 
 module Rubydex::Linter::Helpers::PathHelpers
   extend T::Helpers
@@ -488,9 +489,23 @@ class Rubydex::Linter::RuleLoadError < StandardError; end
 
 class Rubydex::Linter::RuleLoader
   RULE_GLOB = T.let(T.unsafe(nil), String)
+  BUILT_IN_RULE_GLOB = T.let(T.unsafe(nil), String)
 
   sig { params(workspace_path: String).returns(T::Array[T.class_of(Rubydex::Linter::Rule)]) }
   def self.load(workspace_path); end
+end
+
+class Rubydex::Linter::Rules::RuleStructure < Rubydex::Linter::Rule
+  BASE_RULE_NAME = T.let(T.unsafe(nil), String)
+  RULE_NAMESPACE = T.let(T.unsafe(nil), String)
+  RULE_FILE_PATTERNS = T.let(T.unsafe(nil), T::Array[String])
+  TEST_FILE_PATTERNS = T.let(T.unsafe(nil), T::Array[String])
+
+  sig { returns(T.class_of(Rubydex::Severity::Base)) }
+  def severity; end
+
+  sig { void }
+  def lint; end
 end
 
 class Rubydex::Linter::Runner

--- a/rbi/rubydex.rbi
+++ b/rbi/rubydex.rbi
@@ -450,6 +450,9 @@ class Rubydex::Linter::Rule
   sig { abstract.returns(T.class_of(Rubydex::Severity::Base)) }
   def severity; end
 
+  sig { returns(T.class_of(Rubydex::Severity::Base)) }
+  def verified_severity; end
+
   sig { abstract.void }
   def lint; end
 
@@ -577,6 +580,17 @@ class Rubydex::LinterConfig
 
   sig { params(rule_class: T.class_of(Rubydex::Linter::Rule)).returns(T::Boolean) }
   def rule_enabled?(rule_class); end
+
+  sig { params(rule_class: T.class_of(Rubydex::Linter::Rule)).returns(T::Array[String]) }
+  def excludes_for(rule_class); end
+
+  sig do
+    params(
+      rule_class: T.class_of(Rubydex::Linter::Rule),
+      default: T.class_of(Rubydex::Severity::Base),
+    ).returns(T.class_of(Rubydex::Severity::Base))
+  end
+  def severity_for(rule_class, default:); end
 end
 
 # The settings of a single linter rule, read from a `[linter.rules.RuleName]` table.
@@ -584,8 +598,21 @@ class Rubydex::RuleConfig
   sig { returns(String) }
   attr_reader :name
 
-  sig { params(name: String, enabled: T::Boolean).void }
-  def initialize(name, enabled); end
+  sig { returns(T::Array[String]) }
+  attr_reader :exclude_patterns
+
+  sig { returns(T.nilable(T.class_of(Rubydex::Severity::Base))) }
+  attr_reader :severity
+
+  sig do
+    params(
+      name: String,
+      enabled: T::Boolean,
+      exclude_patterns: T::Array[String],
+      severity: T.nilable(T.class_of(Rubydex::Severity::Base)),
+    ).void
+  end
+  def initialize(name, enabled, exclude_patterns, severity); end
 
   sig { returns(T::Boolean) }
   def enabled?; end

--- a/rbi/rubydex.rbi
+++ b/rbi/rubydex.rbi
@@ -478,6 +478,15 @@ class Rubydex::Linter::MissingGraphDependencyError < StandardError
   def initialize(rule_name, dependency); end
 end
 
+class Rubydex::Linter::RuleLoadError < StandardError; end
+
+class Rubydex::Linter::RuleLoader
+  RULE_GLOB = T.let(T.unsafe(nil), String)
+
+  sig { params(workspace_path: String).returns(T::Array[T.class_of(Rubydex::Linter::Rule)]) }
+  def self.load(workspace_path); end
+end
+
 class Rubydex::Linter::Runner
   sig do
     params(

--- a/rbi/rubydex.rbi
+++ b/rbi/rubydex.rbi
@@ -627,7 +627,7 @@ class Rubydex::RuleConfig
       severity: T.nilable(T.class_of(Rubydex::Severity::Base)),
     ).void
   end
-  def initialize(name, enabled, exclude_patterns, severity); end
+  def initialize(name, enabled, exclude_patterns = [], severity = nil); end
 
   sig { returns(T::Boolean) }
   def enabled?; end

--- a/rbi/rubydex.rbi
+++ b/rbi/rubydex.rbi
@@ -430,6 +430,12 @@ class Rubydex::Linter::Rule
   sig { params(definition: Rubydex::Definition).returns(Rubydex::Location) }
   def diagnostic_location(definition); end
 
+  sig { params(uri: String).returns(Rubydex::Location) }
+  def file_location(uri); end
+
+  sig { params(uri: String).returns(String) }
+  def path_for_uri(uri); end
+
   sig { params(base_name: String).returns(T::Enumerable[Rubydex::Class]) }
   def child_classes(base_name); end
 

--- a/rust/rubydex-sys/src/config_api.rs
+++ b/rust/rubydex-sys/src/config_api.rs
@@ -1,3 +1,4 @@
+use crate::diagnostic_api::DiagnosticSeverity;
 use crate::utils;
 use libc::{c_char, c_void};
 use rubydex::config::{Config, Rule};
@@ -90,6 +91,14 @@ pub unsafe extern "C" fn rdx_config_free(config: ConfigPointer) {
     }
 }
 
+/// Borrowed string bytes exposed while building Ruby configuration values.
+#[repr(C)]
+#[derive(Debug)]
+pub struct CConfigString {
+    pub data: *const c_char,
+    pub length: usize,
+}
+
 /// C-compatible struct representing a single configured linter rule.
 #[repr(C)]
 #[derive(Debug)]
@@ -97,14 +106,38 @@ pub struct CLinterRule {
     pub name: *const c_char,
     pub name_length: usize,
     pub enabled: bool,
+    pub exclude_patterns: *const CConfigString,
+    pub exclude_patterns_length: usize,
+    pub severity: *const DiagnosticSeverity,
 }
 
 impl From<&Rule> for CLinterRule {
     fn from(rule: &Rule) -> Self {
+        let exclude_patterns = rule
+            .exclude_patterns()
+            .iter()
+            .map(|pattern| CConfigString {
+                data: pattern.as_ptr().cast::<c_char>(),
+                length: pattern.len(),
+            })
+            .collect::<Box<[CConfigString]>>();
+        let exclude_patterns_length = exclude_patterns.len();
+        let exclude_patterns = if exclude_patterns.is_empty() {
+            ptr::null()
+        } else {
+            Box::into_raw(exclude_patterns).cast::<CConfigString>().cast_const()
+        };
+        let severity = rule.severity().map_or(ptr::null(), |severity| {
+            Box::into_raw(Box::new(DiagnosticSeverity::from(severity))).cast_const()
+        });
+
         Self {
             name: rule.name().as_ptr().cast::<c_char>(),
             name_length: rule.name().len(),
             enabled: rule.enabled(),
+            exclude_patterns,
+            exclude_patterns_length,
+            severity,
         }
     }
 }
@@ -155,6 +188,18 @@ pub unsafe extern "C" fn rdx_config_linter_rules_free(rules: CLinterRuleArray) {
     }
 
     unsafe {
-        let _ = Box::from_raw(ptr::slice_from_raw_parts_mut(rules.items, rules.len));
+        let rules = Box::from_raw(ptr::slice_from_raw_parts_mut(rules.items, rules.len));
+
+        for rule in &*rules {
+            if !rule.exclude_patterns.is_null() {
+                let exclude_patterns =
+                    ptr::slice_from_raw_parts_mut(rule.exclude_patterns.cast_mut(), rule.exclude_patterns_length);
+                let _ = Box::from_raw(exclude_patterns);
+            }
+
+            if !rule.severity.is_null() {
+                let _ = Box::from_raw(rule.severity.cast_mut());
+            }
+        }
     }
 }

--- a/rust/rubydex/src/config.rs
+++ b/rust/rubydex/src/config.rs
@@ -1,4 +1,5 @@
 use crate::assert_mem_size;
+use crate::diagnostic::Severity;
 use crate::errors::Errors;
 use crate::path_helpers;
 use std::collections::HashSet;
@@ -72,6 +73,8 @@ impl GraphSettings {
 pub struct Rule {
     name: Box<str>,
     enabled: bool,
+    exclude_patterns: Box<[Box<str>]>,
+    severity: Option<Severity>,
 }
 
 impl Rule {
@@ -83,6 +86,16 @@ impl Rule {
     #[must_use]
     pub fn enabled(&self) -> bool {
         self.enabled
+    }
+
+    #[must_use]
+    pub fn exclude_patterns(&self) -> &[Box<str>] {
+        &self.exclude_patterns
+    }
+
+    #[must_use]
+    pub fn severity(&self) -> Option<&Severity> {
+        self.severity.as_ref()
     }
 
     /// Parses a single `[linter.rules.{name}]` table
@@ -98,7 +111,24 @@ impl Rule {
                     "invalid `linter.rules.{name}.enabled` setting: expected a boolean"
                 ));
             }
-            None => return Err(format!("missing `linter.rules.{name}.enabled` setting")),
+            None => true,
+        };
+
+        let exclude_patterns = match table.remove("exclude") {
+            Some(value) => value
+                .try_into::<Vec<Box<str>>>()
+                .map_err(|error| format!("invalid `linter.rules.{name}.exclude` setting: {error}"))?
+                .into_boxed_slice(),
+            None => Box::default(),
+        };
+
+        let severity = match table.remove("severity") {
+            Some(value) => Some(
+                value
+                    .try_into::<Severity>()
+                    .map_err(|error| format!("invalid `linter.rules.{name}.severity` setting: {error}"))?,
+            ),
+            None => None,
         };
 
         if let Some(key) = table.keys().next() {
@@ -108,6 +138,8 @@ impl Rule {
         Ok(Self {
             name: Box::from(name),
             enabled,
+            exclude_patterns,
+            severity,
         })
     }
 }
@@ -385,17 +417,24 @@ mod tests {
 
     #[test]
     fn parse_parses_every_linter_rule() {
-        let config = parse("[linter.rules.Something]\nenabled = true\n\n[linter.rules.Other]\nenabled = false\n")
-            .expect("expected the config to parse");
+        let config = parse(
+            "[linter.rules.Something]\nseverity = \"warning\"\nexclude = [\"components/legacy/**\"]\n\n\
+             [linter.rules.Other]\nenabled = false\n",
+        )
+        .expect("expected the config to parse");
 
         let rules = config.linter().rules();
         assert_eq!(rules.len(), 2);
 
         let something = rules.iter().find(|rule| rule.name() == "Something").unwrap();
         assert!(something.enabled());
+        assert_eq!(something.exclude_patterns(), [Box::from("components/legacy/**")]);
+        assert_eq!(something.severity(), Some(&Severity::Warning));
 
         let other = rules.iter().find(|rule| rule.name() == "Other").unwrap();
         assert!(!other.enabled());
+        assert!(other.exclude_patterns().is_empty());
+        assert_eq!(other.severity(), None);
     }
 
     #[test]
@@ -444,14 +483,9 @@ mod tests {
     }
 
     #[test]
-    fn parse_rejects_a_rule_without_enabled() {
-        let error =
-            parse("[linter.rules.Something]\n").expect_err("a rule setting must state whether the rule is enabled");
-
-        assert!(
-            error.contains("missing `linter.rules.Something.enabled` setting"),
-            "unexpected error: {error}"
-        );
+    fn parse_defaults_a_rule_to_enabled() {
+        let config = parse("[linter.rules.Something]\n").expect("enabled defaults to true");
+        assert!(config.linter().rules()[0].enabled());
     }
 
     #[test]
@@ -466,13 +500,52 @@ mod tests {
 
     #[test]
     fn parse_rejects_an_unknown_rule_setting() {
-        let error = parse("[linter.rules.Something]\nenabled = true\nseverity = \"error\"\n")
-            .expect_err("rules only accept the enabled setting");
+        let error =
+            parse("[linter.rules.Something]\nparallel = true\n").expect_err("unknown rule settings must be rejected");
 
         assert!(
-            error.contains("unknown setting `linter.rules.Something.severity`"),
+            error.contains("unknown setting `linter.rules.Something.parallel`"),
             "unexpected error: {error}"
         );
+    }
+
+    #[test]
+    fn parse_rejects_an_invalid_rule_exclude_setting() {
+        let error = parse("[linter.rules.Something]\nexclude = \"components/legacy/**\"\n")
+            .expect_err("exclude must be an array of strings");
+
+        assert!(
+            error.contains("invalid `linter.rules.Something.exclude` setting"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn parse_rejects_an_invalid_rule_severity_setting() {
+        for severity in ["\"critical\"", "1"] {
+            let error = parse(&format!("[linter.rules.Something]\nseverity = {severity}\n"))
+                .expect_err("severity must be one of the supported strings");
+
+            assert!(
+                error.contains("invalid `linter.rules.Something.severity` setting"),
+                "unexpected error: {error}"
+            );
+        }
+    }
+
+    #[test]
+    fn parse_accepts_every_rule_severity() {
+        for (value, expected) in [
+            ("error", Severity::Error),
+            ("warning", Severity::Warning),
+            ("information", Severity::Information),
+            ("hint", Severity::Hint),
+        ] {
+            let config =
+                parse(&format!("[linter.rules.Something]\nseverity = \"{value}\"\n")).expect("severity should parse");
+
+            assert_eq!(config.linter().rules()[0].severity(), Some(&expected));
+        }
     }
 
     #[test]

--- a/rust/rubydex/src/diagnostic.rs
+++ b/rust/rubydex/src/diagnostic.rs
@@ -60,7 +60,8 @@ impl Diagnostic {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
 pub enum Severity {
     Error,
     Warning,

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -358,11 +358,11 @@ class CLITest < Minitest::Test
 
           add_diagnostic(
             "Foo is not allowed.",
-            primary.name_location || primary.location,
+            diagnostic_location(primary),
             related_information: definitions.map do |definition|
               Rubydex::RelatedInformation.new(
                 "Foo is also defined here.",
-                definition.name_location || definition.location,
+                diagnostic_location(definition),
               )
             end,
           )

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -298,13 +298,13 @@ class CLITest < Minitest::Test
     with_context do |context|
       rule_path = "fake_gem/lib/rubydex_linter/rules/no_foo.rb"
       write_linter_rule(context, "CLITestDependencyErrorRule", path: rule_path)
-      context.write!("app.rb", "class Foo; end\n")
+      context.write!("workspace/app.rb", "class Foo; end\n")
       Gem.expects(:find_latest_files)
         .with("rubydex_linter/rules/**/*.rb")
         .returns([context.absolute_path_to(rule_path)])
 
       result = with_bundle_gemfile(context.absolute_path_to("Gemfile")) do
-        rdx("lint", context.absolute_path)
+        rdx("lint", context.absolute_path_to("workspace"))
       end
 
       refute_success_status(result)
@@ -312,16 +312,16 @@ class CLITest < Minitest::Test
     end
   end
 
-  def test_lint_requires_a_discovered_rule_before_indexing
+  def test_lint_runs_built_in_rules_without_project_rules
     with_context do |context|
-      context.write!("app.rb", "class Foo; end\n")
+      context.write!("app.rb", "class Bar; end\n")
 
       result = with_bundle_gemfile(nil) { rdx("lint", context.absolute_path) }
 
-      refute_success_status(result)
-      assert_empty_stdout(result)
-      assert_stderr_includes(result, "No Rubydex::Linter::Rule subclasses were loaded")
-      refute_stderr_includes(result, "Indexing workspace...")
+      assert_success_status(result)
+      assert_stdout_includes_pattern(result, /\d+ files inspected, no offenses detected/)
+      assert_stderr_includes(result, "Indexing workspace...")
+      refute_stderr_includes(result, "No Rubydex::Linter::Rule subclasses were loaded")
     end
   end
 
@@ -355,7 +355,7 @@ class CLITest < Minitest::Test
     context.write!(path, <<~RUBY)
       # frozen_string_literal: true
 
-      class #{class_name} < Rubydex::Linter::Rule
+      class Rubydex::Linter::Rules::#{class_name} < Rubydex::Linter::Rule
         def severity = Rubydex::Severity::Error
 
         def lint

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -260,13 +260,23 @@ class CLITest < Minitest::Test
       result = with_bundle_gemfile(nil) { rdx("lint", context.absolute_path) }
 
       refute_success_status(result)
-      assert_stdout_equals(
-        <<~OUTPUT,
-          #{context.absolute_path_to("app.rb")}:1:7: error: CLITestProjectErrorRule: Foo is not allowed.
-            #{context.absolute_path_to("app.rb")}:2:7: Foo is also defined here.
-        OUTPUT
+      assert_stdout_includes(
         result,
+        <<~OUTPUT,
+          Offenses:
+
+          app.rb:1:7: error: CLITestProjectErrorRule: Foo is not allowed.
+            app.rb:2:7: Foo is also defined here.
+
+          class Foo; end
+                ^^^
+        OUTPUT
       )
+      assert_stdout_includes_pattern(
+        result,
+        /\d+ files inspected, 1 offense detected: 1 error, 0 warnings, 0 info, 0 hints/,
+      )
+      refute_stdout_includes(result, context.absolute_path)
       assert_stderr_includes(result, "Indexing workspace...")
       assert_stderr_includes(result, "Resolving graph...")
     end
@@ -280,7 +290,7 @@ class CLITest < Minitest::Test
       result = with_bundle_gemfile(nil) { rdx("lint", context.absolute_path) }
 
       assert_success_status(result)
-      assert_empty_stdout(result)
+      assert_stdout_includes_pattern(result, /\d+ files inspected, no offenses detected/)
     end
   end
 

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -25,6 +25,7 @@ class CLITest < Minitest::Test
 
     assert_includes(commands, Rubydex::CLI::Command::Query)
     assert_includes(commands, Rubydex::CLI::Command::Console)
+    assert_includes(commands, Rubydex::CLI::Command::List)
     assert_includes(commands, Rubydex::CLI::Command::Lint)
     assert_includes(commands, Rubydex::CLI::Command::Mcp)
 
@@ -32,6 +33,7 @@ class CLITest < Minitest::Test
     assert_equal("query", Rubydex::CLI::Command::Query.command_name)
     assert_equal("query <CYPHER>", Rubydex::CLI::Command::Query.usage_form)
     assert_equal("console", Rubydex::CLI::Command::Console.usage_form)
+    assert_equal("list [docs|roots] [PATH]", Rubydex::CLI::Command::List.usage_form)
     assert_equal("lint [PATH]", Rubydex::CLI::Command::Lint.usage_form)
   end
 
@@ -47,12 +49,13 @@ class CLITest < Minitest::Test
     # before the offsets are compared: a missing one fails on its own assertion rather than on a
     # comparison against nil. We collect the beginning offset of the first match (index 0) for each
     # command so that we can compare their order below.
-    console, lint, mcp, query, help = ["console", "lint", "mcp", "query", "help"].map do |name|
+    console, lint, list, mcp, query, help = ["console", "lint", "list", "mcp", "query", "help"].map do |name|
       assert_stdout_includes_pattern(result, /^  #{name}\b/).begin(0)
     end
 
     assert_operator(console, :<, lint)
-    assert_operator(lint, :<, mcp)
+    assert_operator(lint, :<, list)
+    assert_operator(list, :<, mcp)
     assert_operator(mcp, :<, query)
     # `help` is listed last rather than in alphabetical position.
     assert_operator(query, :<, help)
@@ -96,6 +99,7 @@ class CLITest < Minitest::Test
     [
       Rubydex::CLI::Command::Query,
       Rubydex::CLI::Command::Console,
+      Rubydex::CLI::Command::List,
       Rubydex::CLI::Command::Lint,
       Rubydex::CLI::Command::Mcp,
     ].each do |command|
@@ -206,7 +210,7 @@ class CLITest < Minitest::Test
   end
 
   def test_command_help_is_available_per_subcommand
-    ["query", "console", "lint", "mcp"].each do |command|
+    ["query", "console", "list", "lint", "mcp"].each do |command|
       result = rdx(command, "--help")
 
       assert_success_status(result)
@@ -215,7 +219,7 @@ class CLITest < Minitest::Test
   end
 
   def test_every_command_reports_an_invalid_option_with_the_usage
-    ["query", "console", "lint", "mcp"].each do |command|
+    ["query", "console", "list", "lint", "mcp"].each do |command|
       result = rdx(command, "--bogus-flag")
 
       refute_success_status(result)
@@ -245,6 +249,48 @@ class CLITest < Minitest::Test
     assert_stderr_includes(result, "unexpected argument: two")
     assert_stderr_includes(result, "Usage: rdx mcp [PATH]")
     refute_stderr_includes(result, "Usage: rdx <command> [options]")
+  end
+
+  def test_list_docs_prints_sorted_workspace_relative_paths
+    with_context do |context|
+      context.write!("z.rb", "class Z; end\n")
+      context.write!("lib/a.rb", "class A; end\n")
+
+      result = rdx("list", chdir: context.absolute_path)
+
+      assert_success_status(result)
+      paths = result.out.lines(chomp: true)
+      assert_equal(paths.sort, paths)
+      assert_includes(paths, "lib/a.rb")
+      assert_includes(paths, "z.rb")
+    end
+  end
+
+  def test_list_roots_omits_excluded_roots
+    with_context do |context|
+      context.write!("app/main.rb", "class Main; end\n")
+      context.write!("ignored/skip.rb", "class Skip; end\n")
+      context.write!("rubydex.toml", "[graph]\nexclude = [\"ignored\"]\n")
+
+      result = rdx("list", "roots", context.absolute_path)
+
+      assert_success_status(result)
+      paths = result.out.lines(chomp: true)
+      assert_equal(paths.sort, paths)
+      assert_includes(paths, "app")
+      refute_includes(paths, "ignored")
+    end
+  end
+
+  def test_list_rejects_an_unknown_target
+    with_context do |context|
+      result = rdx("list", "things", context.absolute_path)
+
+      refute_success_status(result)
+      assert_empty_stdout(result)
+      assert_stderr_includes(result, "Unknown list target: things. Expected `docs` or `roots`.")
+      assert_stderr_includes(result, "Usage: rdx list [docs|roots] [PATH]")
+    end
   end
 
   def test_lint_reports_a_project_rule_diagnostic_with_related_information

--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -68,7 +68,8 @@ class ConfigTest < Minitest::Test
     with_context do |context|
       context.write!("rubydex.toml", <<~TOML)
         [linter.rules.Something]
-        enabled = true
+        severity = "warning"
+        exclude = ["components/legacy/**", "test/fixtures/**"]
 
         [linter.rules.Other]
         enabled = false
@@ -80,7 +81,43 @@ class ConfigTest < Minitest::Test
       assert_equal(["Other", "Something"], rules.keys.sort)
       assert_predicate(rules, :frozen?)
       assert_predicate(rules.fetch("Something"), :enabled?)
+      assert_equal(
+        ["components/legacy/**", "test/fixtures/**"],
+        rules.fetch("Something").exclude_patterns,
+      )
+      assert_equal(Rubydex::Severity::Warning, rules.fetch("Something").severity)
       refute_predicate(rules.fetch("Other"), :enabled?)
+      assert_empty(rules.fetch("Other").exclude_patterns)
+      assert_nil(rules.fetch("Other").severity)
+    end
+  end
+
+  def test_linter_maps_every_configured_severity
+    with_context do |context|
+      context.write!("rubydex.toml", <<~TOML)
+        [linter.rules.ErrorRule]
+        severity = "error"
+
+        [linter.rules.WarningRule]
+        severity = "warning"
+
+        [linter.rules.InformationRule]
+        severity = "information"
+
+        [linter.rules.HintRule]
+        severity = "hint"
+      TOML
+
+      rules = Rubydex::Config.load(context.absolute_path).linter.rules
+
+      {
+        "ErrorRule" => Rubydex::Severity::Error,
+        "WarningRule" => Rubydex::Severity::Warning,
+        "InformationRule" => Rubydex::Severity::Information,
+        "HintRule" => Rubydex::Severity::Hint,
+      }.each do |rule_name, severity|
+        assert_equal(severity, rules.fetch(rule_name).severity)
+      end
     end
   end
 end

--- a/test/linter_test.rb
+++ b/test/linter_test.rb
@@ -64,6 +64,43 @@ class LinterTest < Minitest::Test
     end
   end
 
+  class ExcludedPrimaryRule < Rubydex::Linter::Rule
+    def severity = Rubydex::Severity::Information
+
+    def lint
+      add_diagnostic("Excluded primary location.", workspace_location("components/legacy/example.rb"))
+    end
+
+    private
+
+    def workspace_location(relative_path)
+      path = File.join(graph.workspace_path, relative_path)
+      path.prepend("/") if Gem.win_platform?
+      Rubydex::Location.new(
+        uri: URI::File.build(path: path).to_s,
+        start_line: 0,
+        end_line: 0,
+        start_column: 0,
+        end_column: 1,
+      )
+    end
+  end
+
+  class ExcludedRelatedInformationRule < ExcludedPrimaryRule
+    def lint
+      add_diagnostic(
+        "Included primary location.",
+        workspace_location("components/current/example.rb"),
+        related_information: [
+          Rubydex::RelatedInformation.new(
+            "Excluded related location.",
+            workspace_location("components/legacy/example.rb"),
+          ),
+        ],
+      )
+    end
+  end
+
   def test_runner_builds_diagnostics_with_rule_severity_and_related_information
     result = Rubydex::Linter::Runner.new(Rubydex::Graph.new, rules: [WarningRule], config: linter_config).run
     diagnostic = result.diagnostics.fetch(0)
@@ -79,6 +116,13 @@ class LinterTest < Minitest::Test
     rule = WarningRule.new(Rubydex::Graph.new, config:)
 
     assert_same(config, rule.config)
+  end
+
+  def test_configured_severity_overrides_the_rule_severity
+    config = configured_linter_config("WarningRule", severity: Rubydex::Severity::Error)
+    result = Rubydex::Linter::Runner.new(Rubydex::Graph.new, rules: [WarningRule], config:).run
+
+    assert_equal(Rubydex::Severity::Error, result.diagnostics.fetch(0).severity)
   end
 
   def test_runner_drops_disabled_rules
@@ -148,6 +192,33 @@ class LinterTest < Minitest::Test
     end
   end
 
+  def test_runner_filters_a_diagnostic_when_its_primary_location_matches_a_rule_exclude
+    with_context do |context|
+      context.write!("workspace/inside.rb")
+      graph = Rubydex::Graph.configure_for_workspace(context.absolute_path_to("workspace"))
+      config = configured_linter_config("ExcludedPrimaryRule", exclude_patterns: ["components/legacy/**"])
+
+      result = Rubydex::Linter::Runner.new(graph, rules: [ExcludedPrimaryRule], config:).run
+
+      assert_empty(result.diagnostics)
+    end
+  end
+
+  def test_runner_keeps_a_diagnostic_when_only_related_information_matches_a_rule_exclude
+    with_context do |context|
+      context.write!("workspace/inside.rb")
+      graph = Rubydex::Graph.configure_for_workspace(context.absolute_path_to("workspace"))
+      config = configured_linter_config(
+        "ExcludedRelatedInformationRule",
+        exclude_patterns: ["components/legacy/**"],
+      )
+
+      result = Rubydex::Linter::Runner.new(graph, rules: [ExcludedRelatedInformationRule], config:).run
+
+      assert_equal(["Included primary location."], result.diagnostics.map(&:message))
+    end
+  end
+
   def test_runner_keeps_diagnostics_indexed_through_a_symlinked_workspace_path
     with_context do |context|
       context.write!("workspace/inside.rb")
@@ -169,7 +240,19 @@ class LinterTest < Minitest::Test
   #: (?Hash[String, bool] rules) -> Rubydex::LinterConfig
   def linter_config(rules = {})
     Rubydex::LinterConfig.new(
-      rules.to_h { |name, enabled| [name, Rubydex::RuleConfig.new(name, enabled)] },
+      rules.to_h { |name, enabled| [name, Rubydex::RuleConfig.new(name, enabled, [], nil)] },
+    )
+  end
+
+  #: (
+  #|   String,
+  #|   ?enabled: bool,
+  #|   ?exclude_patterns: Array[String],
+  #|   ?severity: singleton(Rubydex::Severity::Base)?,
+  #| ) -> Rubydex::LinterConfig
+  def configured_linter_config(rule_name, enabled: true, exclude_patterns: [], severity: nil)
+    Rubydex::LinterConfig.new(
+      rule_name => Rubydex::RuleConfig.new(rule_name, enabled, exclude_patterns, severity),
     )
   end
 

--- a/test/linter_test.rb
+++ b/test/linter_test.rb
@@ -118,6 +118,27 @@ class LinterTest < Minitest::Test
     assert_same(config, rule.config)
   end
 
+  def test_rule_builds_a_zero_width_file_location
+    location = WarningRule.new(Rubydex::Graph.new, config: linter_config).file_location("file:///tmp/example.rb")
+
+    assert_equal("file:///tmp/example.rb", location.uri)
+    assert_equal([0, 0, 0, 0], [
+      location.start_line,
+      location.start_column,
+      location.end_line,
+      location.end_column,
+    ])
+  end
+
+  def test_rule_extracts_file_paths_and_preserves_other_uris
+    with_context do |context|
+      rule = WarningRule.new(Rubydex::Graph.new, config: linter_config)
+
+      assert_equal(context.absolute_path_to("example.rb"), rule.path_for_uri(context.uri_to("example.rb")))
+      assert_equal("untitled:example.rb", rule.path_for_uri("untitled:example.rb"))
+    end
+  end
+
   def test_configured_severity_overrides_the_rule_severity
     config = configured_linter_config("WarningRule", severity: Rubydex::Severity::Error)
     result = Rubydex::Linter::Runner.new(Rubydex::Graph.new, rules: [WarningRule], config:).run

--- a/test/linter_test.rb
+++ b/test/linter_test.rb
@@ -2,6 +2,7 @@
 
 require "test_helper"
 require "helpers/context"
+require "mocha/minitest"
 require "rubydex/linter"
 
 class LinterTest < Minitest::Test
@@ -64,6 +65,21 @@ class LinterTest < Minitest::Test
     end
   end
 
+  class DependencyPathRule < Rubydex::Linter::Rule
+    def severity = Rubydex::Severity::Information
+
+    def lint
+      path = File.join(graph.workspace_path, "vendor/bundle/gems/example.rb")
+      path.prepend("/") if Gem.win_platform?
+      uri = URI::File.build(path: path).to_s
+
+      add_diagnostic(
+        "Inside a dependency path.",
+        Rubydex::Location.new(uri: uri, start_line: 0, end_line: 0, start_column: 0, end_column: 1),
+      )
+    end
+  end
+
   class ExcludedPrimaryRule < Rubydex::Linter::Rule
     def severity = Rubydex::Severity::Information
 
@@ -116,27 +132,6 @@ class LinterTest < Minitest::Test
     rule = WarningRule.new(Rubydex::Graph.new, config:)
 
     assert_same(config, rule.config)
-  end
-
-  def test_rule_builds_a_zero_width_file_location
-    location = WarningRule.new(Rubydex::Graph.new, config: linter_config).file_location("file:///tmp/example.rb")
-
-    assert_equal("file:///tmp/example.rb", location.uri)
-    assert_equal([0, 0, 0, 0], [
-      location.start_line,
-      location.start_column,
-      location.end_line,
-      location.end_column,
-    ])
-  end
-
-  def test_rule_extracts_file_paths_and_preserves_other_uris
-    with_context do |context|
-      rule = WarningRule.new(Rubydex::Graph.new, config: linter_config)
-
-      assert_equal(context.absolute_path_to("example.rb"), rule.path_for_uri(context.uri_to("example.rb")))
-      assert_equal("untitled:example.rb", rule.path_for_uri("untitled:example.rb"))
-    end
   end
 
   def test_configured_severity_overrides_the_rule_severity
@@ -213,6 +208,19 @@ class LinterTest < Minitest::Test
     end
   end
 
+  def test_runner_filters_diagnostics_under_dependency_paths
+    with_context do |context|
+      context.write!("workspace/inside.rb")
+      graph = Rubydex::Graph.configure_for_workspace(context.absolute_path_to("workspace"))
+      dependency_path = context.absolute_path_to("workspace/vendor/bundle")
+      Gem.stubs(:path).returns([dependency_path])
+
+      result = Rubydex::Linter::Runner.new(graph, rules: [DependencyPathRule], config: linter_config).run
+
+      assert_empty(result.diagnostics)
+    end
+  end
+
   def test_runner_filters_a_diagnostic_when_its_primary_location_matches_a_rule_exclude
     with_context do |context|
       context.write!("workspace/inside.rb")
@@ -261,7 +269,7 @@ class LinterTest < Minitest::Test
   #: (?Hash[String, bool] rules) -> Rubydex::LinterConfig
   def linter_config(rules = {})
     Rubydex::LinterConfig.new(
-      rules.to_h { |name, enabled| [name, Rubydex::RuleConfig.new(name, enabled, [], nil)] },
+      rules.to_h { |name, enabled| [name, Rubydex::RuleConfig.new(name, enabled)] },
     )
   end
 

--- a/test/location_test.rb
+++ b/test/location_test.rb
@@ -16,6 +16,26 @@ class LocationTest < Minitest::Test
     )
   end
 
+  def test_to_file_path_decodes_the_uri_path_once
+    uri = Gem.win_platform? ? "file:///D:/my%20app+%2520/file.rb" : "file:///tmp/my%20app+%2520/file.rb"
+    expected = Gem.win_platform? ? "D:/my app+%20/file.rb" : "/tmp/my app+%20/file.rb"
+    location = Rubydex::Location.new(uri: uri, start_line: 0, end_line: 0, start_column: 0, end_column: 0)
+
+    assert_equal(expected, location.to_file_path)
+  end
+
+  def test_to_file_path_rejects_a_file_uri_without_a_path
+    location = Rubydex::Location.new(
+      uri: "file:relative",
+      start_line: 0,
+      end_line: 0,
+      start_column: 0,
+      end_column: 0,
+    )
+
+    assert_raises(Rubydex::Location::NotFileUriError) { location.to_file_path }
+  end
+
   def test_display_location_from_prism_raises_with_conversion_path
     prism_location = PrismLocation.new(start_line: 2, start_column: 12, end_line: 3, end_column: 19)
 

--- a/test/rubydex_linter/rule_test_case.rb
+++ b/test/rubydex_linter/rule_test_case.rb
@@ -1,0 +1,383 @@
+# frozen_string_literal: true
+
+require "fileutils"
+require "minitest/test"
+require "pathname"
+require "tmpdir"
+require "uri"
+require "rubydex/linter"
+
+module Rubydex
+  module Linter
+    # Base test case for `Rubydex::Linter::Rule` subclasses, modeled on RuboCop's
+    # `assert_offense` / `assert_no_offenses`.
+    #
+    # Write the source the rule should run against and inline expected
+    # diagnostics directly under the offending range with `^^^^^ Message`
+    # carets:
+    #
+    #     module Rubydex
+    #       module Linter
+    #         module Rules
+    #           class NoConstantsDefinedUnderObjectTest < RuleTestCase
+    #             def test_flags_uppercase_constants_under_object
+    #               assert_diagnostics(<<~RUBY)
+    #                 FOO = 123
+    #                 ^^^ Failure: FOO
+    #               RUBY
+    #             end
+    #
+    #             def test_allows_classish_names
+    #               assert_no_diagnostics("Foo = Object\n")
+    #             end
+    #           end
+    #         end
+    #       end
+    #     end
+    #
+    # The number of carets matches the diagnostic's location range
+    # (`start_column`..`end_column`); leading whitespace before the carets
+    # determines the start column. Use `^{}` to mark a zero-width diagnostic.
+    #
+    # For multi-line diagnostic messages, repeat the same caret line and put
+    # each line of the message on its own annotation row. Consecutive
+    # annotation lines that target the same source line and the same caret
+    # range are merged into one diagnostic with a newline-joined message.
+    #
+    # For rules that need fixtures across multiple files, pass a hash of
+    # `filename => annotated_source`:
+    #
+    #     assert_diagnostics(
+    #       "lib/base.rb" => "class ApplicationController; end\n",
+    #       "lib/foo.rb" => <<~RUBY,
+    #         class FooController < ApplicationController; end
+    #         ^^^^^^^^^^^^^ Failure: FooController
+    #       RUBY
+    #     )
+    #
+    # Files without annotations are still indexed but contribute no expected
+    # diagnostics. A diagnostic reported in a file you didn't pass in is
+    # treated as a failure.
+    #
+    # The rule under test is inferred from the test class name by stripping
+    # the trailing `Test`. Override `#rule_class` for non-conventional names.
+    class RuleTestCase < Minitest::Test
+      DEFAULT_FILE = "test.rb" #: String
+
+      ANNOTATION_PATTERN = /\A(?<indent>\s*)(?<carets>(?<!\\)\^+|\^\{\})(?:\s(?<message>.*))?\z/ #: Regexp
+
+      #: type annotation = [Integer, Integer, Integer, String]
+
+      #: String
+      attr_reader :workspace_path
+
+      #: (String) -> void
+      def initialize(name)
+        super
+        @workspace_path = File.realpath(Dir.mktmpdir("rubydex-rule-test-")) #: String
+      end
+
+      #: -> void
+      def teardown
+        super
+      ensure
+        FileUtils.remove_entry(workspace_path)
+      end
+
+      #: -> singleton(Rule)
+      def rule_class
+        @rule_class ||= begin
+          name = self.class.to_s.delete_suffix("Test")
+          if name == self.class.to_s
+            raise "Could not infer rule class from #{self.class}; override `#rule_class`"
+          end
+
+          Object.const_get(name) #: as singleton(Rule)
+        end #: singleton(Rule)?
+      end
+
+      # Registers sources that are loaded into the graph for every assertion.
+      # Shared sources must not contain caret annotations. Test-specific
+      # sources win on filename collision.
+      #: (Hash[String, String]) -> void
+      def add_shared_source(sources)
+        shared_sources.merge!(sources)
+      end
+
+      # Returns absolute file paths whose diagnostics should be ignored.
+      #: -> Array[String]
+      def ignored_diagnostic_files
+        @ignored_diagnostic_files ||= [] #: Array[String]?
+      end
+
+      #: -> LinterConfig
+      def rule_config
+        @rule_config ||= LinterConfig.new({}) #: LinterConfig?
+      end
+
+      # Runs the rule and compares every diagnostic location with the inline
+      # annotations in the corresponding source.
+      #: (*(String | Hash[String | Symbol, String])) ?{ (Graph) -> Rule } -> Array[Diagnostic]
+      def assert_diagnostics(*args, &rule_builder)
+        sources = validated_shared_source.merge(normalize_sources(args))
+        clean_per_file, expected_per_file = write_sources(sources)
+
+        diagnostics = run_rule(&rule_builder)
+        actual_per_file = annotations_for_diagnostics(diagnostics, clean_per_file)
+
+        surprise_files = actual_per_file.keys - clean_per_file.keys - ignored_diagnostic_files
+        refute_predicate(
+          surprise_files,
+          :any?,
+          "Diagnostics in unexpected files: #{surprise_files.inspect}",
+        )
+
+        clean_per_file.each do |filename, clean|
+          expected = render_annotated(clean, expected_per_file[filename] || [])
+          actual = render_annotated(clean, actual_per_file[filename] || [])
+          assert_equal(expected, actual, "Mismatch in #{filename}")
+        end
+
+        diagnostics
+      end
+
+      # Runs the rule and asserts no diagnostics are reported in the provided
+      # sources. Sources must not contain caret annotations.
+      #: (*(String | Hash[String | Symbol, String])) ?{ (Graph) -> Rule } -> Array[Diagnostic]
+      def assert_no_diagnostics(*args, &rule_builder)
+        sources = validated_shared_source.merge(normalize_sources(args))
+        write_sources(sources)
+
+        diagnostics = run_rule(&rule_builder)
+        ignored = ignored_diagnostic_files
+        reported = diagnostics.reject { |diagnostic| ignored.include?(diagnostic.location.to_file_path) }
+        assert_empty(reported, "Expected no diagnostics, got #{reported.map(&:message).inspect}")
+        diagnostics
+      end
+
+      #: (
+      #|   String,
+      #|   *(String | Hash[String | Symbol, String]),
+      #|   ?after_excluding: Array[String],
+      #| ) ?{ (Graph) -> Rule } -> void
+      def assert_handles_missing_required_dependency(dependency, *args, after_excluding: [], &rule_builder)
+        sources = validated_shared_source.dup #: Hash[String, String]
+        after_excluding.each { |filename| sources.delete(filename) }
+        sources.merge!(normalize_sources(args))
+        write_sources(sources)
+
+        error = assert_raises(MissingGraphDependencyError) do
+          run_rule(&rule_builder)
+        end
+
+        expected_message = MissingGraphDependencyError.new(rule_class.rule_name, dependency).message
+        assert_equal(expected_message, error.message)
+      end
+
+      private
+
+      #: (Hash[String, String]) -> [Hash[String, String], Hash[String, Array[annotation]]]
+      def write_sources(sources)
+        clean_per_file = {} #: Hash[String, String]
+        expected_per_file = {} #: Hash[String, Array[annotation]]
+
+        virtual_sources.clear
+
+        sources.each do |filename, annotated|
+          clean, annotations = parse_annotations(annotated)
+          if Pathname(filename).absolute?
+            absolute_path = filename
+            virtual_sources[absolute_path] = clean
+          else
+            absolute_path = File.join(workspace_path, filename)
+            FileUtils.mkdir_p(File.dirname(absolute_path))
+            File.write(absolute_path, clean)
+            absolute_path = File.realpath(absolute_path)
+          end
+          clean_per_file[absolute_path] = clean
+          expected_per_file[absolute_path] = annotations
+        end
+
+        [clean_per_file, expected_per_file]
+      end
+
+      #: -> Hash[String, String]
+      def shared_sources
+        @shared_sources ||= {} #: Hash[String, String]?
+      end
+
+      #: -> Hash[String, String]
+      def virtual_sources
+        @virtual_sources ||= {} #: Hash[String, String]?
+      end
+
+      #: -> Hash[String, String]
+      def validated_shared_source
+        shared_sources.each do |filename, source|
+          _, annotations = parse_annotations(source)
+          raise "Shared source #{filename} must not contain caret annotations" unless annotations.empty?
+        end
+        shared_sources
+      end
+
+      #: (Array[String | Hash[String | Symbol, String]]) -> Hash[String, String]
+      def normalize_sources(args)
+        case args
+        in []
+          {}
+        in [String => source]
+          { DEFAULT_FILE => source }
+        in [Hash => hash]
+          hash.transform_keys(&:to_s)
+        else
+          raise ArgumentError, "expected a String or a { filename => source } Hash, got: #{args.inspect}"
+        end
+      end
+
+      #: (String) -> [String, Array[annotation]]
+      def parse_annotations(annotated_source)
+        clean = [] #: Array[String]
+        annotations = [] #: Array[annotation]
+
+        annotated_source.each_line do |line|
+          if (match = ANNOTATION_PATTERN.match(line.chomp))
+            indent = match[:indent]&.length #: as !nil
+            carets = match[:carets] #: as !nil
+            start_column = indent
+            end_column = if carets == "^{}"
+              indent
+            else
+              indent + carets.length
+            end
+
+            target_line = clean.empty? ? 0 : clean.size - 1
+            message = match[:message].to_s
+            last = annotations.last
+            if last && last[0] == target_line && last[1] == start_column && last[2] == end_column
+              last[3] = "#{last[3]}\n#{message}"
+            else
+              annotations << [target_line, start_column, end_column, message]
+            end
+          else
+            clean << line
+          end
+        end
+
+        [clean.join, annotations]
+      end
+
+      #: ?{ (Graph) -> Rule } -> Array[Diagnostic]
+      def run_rule(&rule_builder)
+        graph = Graph.configure_for_workspace(workspace_path)
+        file_paths = workspace_file_paths
+        graph.index_all(file_paths.reject { |path| File.extname(path) == ".rake" })
+        index_rake_files(graph, file_paths)
+
+        virtual_sources.each do |path, source|
+          graph.index_source(uri_for_path(path), source, source_id_for(path))
+        end
+        graph.resolve
+
+        rule = rule_builder ? rule_builder.call(graph) : rule_class.new(graph, config: rule_config)
+        rule.lint
+        rule.diagnostics
+      end
+
+      #: (Graph, Array[String]) -> void
+      def index_rake_files(graph, file_paths)
+        file_paths.each do |path|
+          next unless File.extname(path) == ".rake"
+
+          graph.index_source(uri_for_path(path), File.read(path), "ruby")
+        end
+      end
+
+      #: -> Array[String]
+      def workspace_file_paths
+        Dir.glob("**/*", base: workspace_path).sort.filter_map do |relative_path|
+          absolute_path = File.join(workspace_path, relative_path)
+          next unless File.file?(absolute_path)
+
+          case File.extname(relative_path)
+          when ".rb", ".rbi", ".rake", ".rbs"
+            File.realpath(absolute_path)
+          else
+            raise "Unsupported file type: #{relative_path}"
+          end
+        end
+      end
+
+      #: (String) -> String
+      def source_id_for(path)
+        case File.extname(path)
+        when ".rb", ".rbi", ".rake", ".ru"
+          "ruby"
+        when ".rbs"
+          "rbs"
+        else
+          raise "Unsupported file type: #{path}"
+        end
+      end
+
+      #: (Array[Diagnostic], Hash[String, String]) -> Hash[String, Array[annotation]]
+      def annotations_for_diagnostics(diagnostics, sources)
+        result = Hash.new { |hash, key| hash[key] = [] } #: Hash[String, Array[annotation]]
+
+        diagnostics.each do |diagnostic|
+          located_messages = [[diagnostic.location, diagnostic.message]] #: Array[[Location, String]]
+          diagnostic.related_information.each do |related|
+            located_messages << [related.location, related.message]
+          end
+
+          located_messages.each do |location, message|
+            path = location.to_file_path
+            line_index = location.start_line
+            start_column = location.start_column
+            end_column =
+              if location.end_line == location.start_line
+                location.end_column
+              else
+                clean = sources[path]
+                line_text = clean ? (clean.each_line.to_a[line_index] || "").chomp : ""
+                line_text.length
+              end
+
+            annotations = result[path] #: as !nil
+            annotations << [line_index, start_column, end_column, message.chomp]
+          end
+        end
+
+        result
+      end
+
+      #: (String, Array[annotation]) -> String
+      def render_annotated(clean_source, annotations)
+        lines = clean_source.each_line.to_a
+        sorted = annotations.sort_by do |line_index, start_column, end_column, message|
+          [line_index, start_column, end_column, message]
+        end
+        output = lines.dup
+
+        sorted.reverse_each do |line_index, start_column, end_column, message|
+          caret_count = end_column - start_column
+          indentation = " " * start_column
+          carets = caret_count.zero? ? "^{}" : "^" * caret_count
+          markers = if message.empty?
+            ["#{indentation}#{carets}\n"]
+          else
+            message.split("\n", -1).map { |line| "#{indentation}#{carets} #{line}\n" }
+          end
+          output[line_index + 1, 0] = markers
+        end
+
+        output.join
+      end
+
+      #: (String) -> String
+      def uri_for_path(path)
+        uri_path = Gem.win_platform? ? "/#{path}" : path
+        URI::File.build(path: uri_path).to_s
+      end
+    end
+  end
+end

--- a/test/rubydex_linter/rules/rule_structure_test.rb
+++ b/test/rubydex_linter/rules/rule_structure_test.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "rubydex_linter/rule_test_case"
+require "rubydex_linter/rules/rule_structure"
+
+module Rubydex
+  module Linter
+    module Rules
+      class RuleStructureTest < RuleTestCase
+        BASE_RULE_SOURCE = <<~RUBY
+          module Rubydex
+            module Linter
+              class Rule; end
+              module Rules; end
+            end
+          end
+        RUBY
+
+        def setup
+          super
+          add_shared_source("lib/rubydex/linter/rule.rb" => BASE_RULE_SOURCE)
+        end
+
+        def test_allows_one_rule_class_in_each_supported_rule_directory
+          assert_no_diagnostics(
+            "rubydex_linter/rules/project_rule.rb" => rule_source("ProjectRule"),
+            "lib/rubydex_linter/rules/gem_rule.rb" => rule_source("GemRule"),
+          )
+        end
+
+        def test_allows_indirect_rule_subclasses_and_helper_classes
+          assert_no_diagnostics(
+            "rubydex_linter/rules/base_rule.rb" => rule_source("BaseRule"),
+            "rubydex_linter/rules/indirect_rule.rb" => <<~RUBY,
+              class Rubydex::Linter::Rules::Helper; end
+              class Rubydex::Linter::Rules::IndirectRule < Rubydex::Linter::Rules::BaseRule; end
+            RUBY
+          )
+        end
+
+        def test_reports_a_rule_file_without_a_rule_class
+          diagnostics = assert_diagnostics(
+            "rubydex_linter/rules/not_a_rule.rb" => <<~RUBY,
+              class Rubydex::Linter::Rules::NotARule; end
+              ^{} Each rule file must define exactly one class that inherits from `Rubydex::Linter::Rule`; found 0.
+            RUBY
+          )
+
+          diagnostic = diagnostics.fetch(0)
+          assert_same(Severity::Error, diagnostic.severity)
+          assert_equal("RuleStructure", diagnostic.rule)
+        end
+
+        def test_reports_multiple_rule_classes_in_one_file
+          diagnostics = assert_diagnostics(
+            "rubydex_linter/rules/two_rules.rb" => <<~RUBY,
+              class Rubydex::Linter::Rules::FirstRule < Rubydex::Linter::Rule; end
+              ^{} Each rule file must define exactly one class that inherits from `Rubydex::Linter::Rule`; found 2.
+                                            ^^^^^^^^^ `Rubydex::Linter::Rules::FirstRule` is defined here.
+              class Rubydex::Linter::Rules::SecondRule < Rubydex::Linter::Rule; end
+                                            ^^^^^^^^^^ `Rubydex::Linter::Rules::SecondRule` is defined here.
+            RUBY
+          )
+
+          assert_equal(1, diagnostics.length)
+          assert_equal(
+            [
+              "`Rubydex::Linter::Rules::FirstRule` is defined here.",
+              "`Rubydex::Linter::Rules::SecondRule` is defined here.",
+            ],
+            diagnostics.fetch(0).related_information.map(&:message),
+          )
+        end
+
+        def test_reports_a_rule_class_outside_the_rules_namespace
+          assert_diagnostics(
+            "rubydex_linter/rules/wrong_namespace.rb" => <<~RUBY,
+              module ConsumerRules
+                class WrongNamespace < Rubydex::Linter::Rule; end
+                      ^^^^^^^^^^^^^^ `ConsumerRules::WrongNamespace` must be defined under `Rubydex::Linter::Rules`.
+              end
+            RUBY
+          )
+        end
+
+        def test_reports_a_rule_class_outside_a_rule_directory
+          assert_diagnostics(
+            "app/rules/wrong_place.rb" => <<~RUBY,
+              class Rubydex::Linter::Rules::WrongPlace < Rubydex::Linter::Rule; end
+                                            ^^^^^^^^^^ `Rubydex::Linter::Rules::WrongPlace` must be defined under `rubydex_linter/rules/` or `lib/rubydex_linter/rules/`.
+            RUBY
+          )
+        end
+
+        def test_ignores_rule_fixture_classes_under_test_directories
+          assert_no_diagnostics(
+            "test/fixtures/fixture_rule.rb" => <<~RUBY,
+              module RuleStructureTestFixtures
+                class FixtureRule < Rubydex::Linter::Rule; end
+              end
+            RUBY
+          )
+        end
+
+        def test_checks_rule_files_nested_under_a_test_directory
+          assert_diagnostics(
+            "rubydex_linter/rules/test/not_a_rule.rb" => <<~RUBY,
+              class NotARule; end
+              ^{} Each rule file must define exactly one class that inherits from `Rubydex::Linter::Rule`; found 0.
+            RUBY
+          )
+        end
+
+        private
+
+        #: (String) -> String
+        def rule_source(class_name)
+          "class Rubydex::Linter::Rules::#{class_name} < Rubydex::Linter::Rule; end\n"
+        end
+      end
+    end
+  end
+end

--- a/test/rule_loader_test.rb
+++ b/test/rule_loader_test.rb
@@ -5,7 +5,12 @@ require "helpers/context"
 require "mocha/minitest"
 require "rubydex/linter"
 
-module RuleLoaderTestFixtures; end
+module RuleLoaderTestFixtures
+  class IntermediateRule < Rubydex::Linter::Rule
+    def severity = Rubydex::Severity::Error
+    def lint; end
+  end
+end
 
 class RuleLoaderTest < Minitest::Test
   include Test::Helpers::WithContext
@@ -24,9 +29,42 @@ class RuleLoaderTest < Minitest::Test
         first_load = Rubydex::Linter::RuleLoader.load(context.absolute_path)
         second_load = Rubydex::Linter::RuleLoader.load(context.absolute_path)
 
-        assert_equal(["DependencyRule", "ProjectRule"], first_load.map(&:rule_name).sort)
+        rule_names = first_load.map(&:rule_name)
+        assert_includes(rule_names, "DependencyRule")
+        assert_includes(rule_names, "ProjectRule")
+        assert_includes(rule_names, "RuleStructure")
         assert_equal(first_load, second_load)
       end
+    end
+  end
+
+  def test_load_returns_built_in_rules_without_bundler
+    with_context do |context|
+      Gem.expects(:find_latest_files).never
+
+      rules = with_bundle_gemfile(nil) do
+        Rubydex::Linter::RuleLoader.load(context.absolute_path)
+      end
+
+      assert_includes(rules, Rubydex::Linter::Rules::RuleStructure)
+    end
+  end
+
+  def test_load_returns_indirect_rule_subclasses
+    with_context do |context|
+      write_rule(
+        context,
+        "rubydex_linter/rules/indirect_rule.rb",
+        "IndirectRule",
+        superclass: "RuleLoaderTestFixtures::IntermediateRule",
+      )
+
+      rules = with_bundle_gemfile(nil) do
+        Rubydex::Linter::RuleLoader.load(context.absolute_path)
+      end
+
+      assert_includes(rules, RuleLoaderTestFixtures::IndirectRule)
+      refute_includes(rules, RuleLoaderTestFixtures::IntermediateRule)
     end
   end
 
@@ -48,13 +86,13 @@ class RuleLoaderTest < Minitest::Test
 
   private
 
-  #: (Test::Helpers::Context, String, String) -> void
-  def write_rule(context, path, class_name)
+  #: (Test::Helpers::Context, String, String, ?superclass: String) -> void
+  def write_rule(context, path, class_name, superclass: "Rubydex::Linter::Rule")
     context.write!(path, <<~RUBY)
       # frozen_string_literal: true
 
       module RuleLoaderTestFixtures
-        class #{class_name} < Rubydex::Linter::Rule
+        class #{class_name} < #{superclass}
           def severity = Rubydex::Severity::Error
           def lint; end
         end

--- a/test/rule_loader_test.rb
+++ b/test/rule_loader_test.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "helpers/context"
+require "mocha/minitest"
+require "rubydex/linter"
+
+module RuleLoaderTestFixtures; end
+
+class RuleLoaderTest < Minitest::Test
+  include Test::Helpers::WithContext
+
+  def test_load_returns_project_and_bundled_rules_on_repeated_calls
+    with_context do |context|
+      project_rule = "rubydex_linter/rules/project_rule.rb"
+      dependency_rule = "fake_gem/lib/rubydex_linter/rules/dependency_rule.rb"
+      write_rule(context, project_rule, "ProjectRule")
+      write_rule(context, dependency_rule, "DependencyRule")
+      Gem.stubs(:find_latest_files).with(Rubydex::Linter::RuleLoader::RULE_GLOB).returns(
+        [context.absolute_path_to(dependency_rule)],
+      )
+
+      with_bundle_gemfile(context.absolute_path_to("Gemfile")) do
+        first_load = Rubydex::Linter::RuleLoader.load(context.absolute_path)
+        second_load = Rubydex::Linter::RuleLoader.load(context.absolute_path)
+
+        assert_equal(["DependencyRule", "ProjectRule"], first_load.map(&:rule_name).sort)
+        assert_equal(first_load, second_load)
+      end
+    end
+  end
+
+  def test_load_wraps_rule_file_errors
+    with_context do |context|
+      rule_file = "rubydex_linter/rules/broken_rule.rb"
+      context.write!(rule_file, "class BrokenRule <\n")
+
+      error = with_bundle_gemfile(nil) do
+        assert_raises(Rubydex::Linter::RuleLoadError) do
+          Rubydex::Linter::RuleLoader.load(context.absolute_path)
+        end
+      end
+
+      assert_match(/Unable to load linter rules from .*broken_rule\.rb/, error.message)
+      assert_instance_of(SyntaxError, error.cause)
+    end
+  end
+
+  private
+
+  #: (Test::Helpers::Context, String, String) -> void
+  def write_rule(context, path, class_name)
+    context.write!(path, <<~RUBY)
+      # frozen_string_literal: true
+
+      module RuleLoaderTestFixtures
+        class #{class_name} < Rubydex::Linter::Rule
+          def severity = Rubydex::Severity::Error
+          def lint; end
+        end
+      end
+    RUBY
+  end
+
+  #: [R] (String?) { -> R } -> R
+  def with_bundle_gemfile(value)
+    previous = ENV["BUNDLE_GEMFILE"]
+    ENV["BUNDLE_GEMFILE"] = value
+    yield
+  ensure
+    ENV["BUNDLE_GEMFILE"] = previous
+  end
+end


### PR DESCRIPTION
Add `rdx list docs` and `rdx list roots` for inspecting the files and roots Rubydex uses to build a workspace graph. The command follows the existing CLI graph and configuration flow and keeps workspace paths relative in its output.