### PR TITLE
Make Cypher query execution return a `Result` instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,10 +136,14 @@ graph = Rubydex::Graph.new
 graph.index_workspace
 graph.resolve
 
-# Parse once, render against a graph as a table or JSON string
+# Parse once, then run against a graph. `run` executes the query and returns the result set.
 query = Rubydex::Query.parse("MATCH (c:Class) RETURN c.name")
-puts query.render(graph, "table")
-puts query.render(graph, "json")
+result = query.run(graph)
+
+# Read the rows as Ruby objects, or render the same result set as a table or JSON string
+result.rows.each { |row| puts row["c.name"] }
+puts result.render("table")
+puts result.render("json")
 
 # Describe the schema
 puts Rubydex::Query.schema("table")

--- a/ext/rubydex/query.c
+++ b/ext/rubydex/query.c
@@ -7,6 +7,38 @@
 #include "utils.h"
 
 /*
+ * RDoc parser workaround for https://github.com/ruby/rdoc/issues/1744:
+ * mRubydex = rb_define_module("Rubydex")
+ */
+
+static VALUE mRubydex;
+static VALUE cQueryResult;
+
+// Raises the Ruby error that matches a Cypher failure reported by Rust and releases `message`.
+// Syntax and execution failures get a Rubydex error; everything else is a Ruby argument error.
+NORETURN(static void raise_query_error(const char *message, CQueryErrorKind kind));
+
+static void raise_query_error(const char *message, CQueryErrorKind kind) {
+    VALUE error_message = rb_utf8_str_new_cstr(message);
+    free_c_string(message);
+
+    VALUE error_class;
+    switch (kind) {
+    case CQueryErrorKind_Syntax:
+        error_class = rb_const_get(mRubydex, rb_intern("QuerySyntaxError"));
+        break;
+    case CQueryErrorKind_Execution:
+        error_class = rb_const_get(mRubydex, rb_intern("QueryExecutionError"));
+        break;
+    default:
+        error_class = rb_eArgError;
+        break;
+    }
+
+    rb_exc_raise(rb_exc_new_str(error_class, error_message));
+}
+
+/*
  * call-seq:
  *   Rubydex::Query.schema(format = :table) -> String
  *
@@ -51,51 +83,98 @@ static const rb_data_type_t query_type = {
  *   Rubydex::Query.parse(query) -> Rubydex::Query
  *
  * Parses a Cypher query into an opaque, reusable object without needing a graph. Raises
- * ArgumentError on a syntax error, so a query can be validated before building a graph.
+ * Rubydex::QuerySyntaxError on a syntax error, so a query can be validated before building a graph.
  */
 static VALUE rdxr_query_parse(VALUE klass, VALUE query) {
     Check_Type(query, T_STRING);
 
     struct CParseResult result = rdx_cypher_parse(StringValueCStr(query));
     if (result.error != NULL) {
-        VALUE message = rb_utf8_str_new_cstr(result.error);
-        free_c_string(result.error);
-        rb_raise(rb_eArgError, "%s", StringValueCStr(message));
+        raise_query_error(result.error, result.error_kind);
     }
 
     return TypedData_Wrap_Struct(klass, &query_type, result.query);
 }
 
+// Backing data for Rubydex::Query::Result: the executed result set plus the graph it came from.
+typedef struct {
+    void *result_set; // Result set owned by Rust, released with rdx_result_set_free
+    VALUE graph_obj;  // Ruby Graph object to keep it alive, since node cells build handles from it
+    VALUE rows;       // Memoized array of row hashes, nil until `rows` builds it
+} QueryResultData;
+
+// Marks the references movable, so that a compaction can relocate them. `query_result_compact`
+// then writes their new locations back into the struct.
+static void query_result_mark(void *ptr) {
+    if (ptr) {
+        QueryResultData *data = (QueryResultData *)ptr;
+        rb_gc_mark_movable(data->graph_obj);
+        rb_gc_mark_movable(data->rows);
+    }
+}
+
+static void query_result_compact(void *ptr) {
+    if (ptr) {
+        QueryResultData *data = (QueryResultData *)ptr;
+        data->graph_obj = rb_gc_location(data->graph_obj);
+        data->rows = rb_gc_location(data->rows);
+    }
+}
+
+static void query_result_free(void *ptr) {
+    if (ptr) {
+        QueryResultData *data = (QueryResultData *)ptr;
+        rdx_result_set_free(data->result_set);
+        xfree(data);
+    }
+}
+
+static const rb_data_type_t query_result_type = {
+    .wrap_struct_name = "Rubydex::Query::Result",
+    .function = {
+        .dmark = query_result_mark,
+        .dfree = query_result_free,
+        .dsize = NULL,
+        .dcompact = query_result_compact,
+    },
+    .parent = NULL,
+    .data = NULL,
+    .flags = RUBY_TYPED_FREE_IMMEDIATELY,
+};
+
+static inline QueryResultData *query_result_data(VALUE self) {
+    QueryResultData *data;
+    TypedData_Get_Struct(self, QueryResultData, &query_result_type, data);
+    return data;
+}
+
 /*
  * call-seq:
- *   render(graph, format = :table) -> String
+ *   run(graph) -> Rubydex::Query::Result
  *
- * Runs this parsed query against +graph+ and returns the formatted output. +format+ may be
- * +:table+ (default) or +:json+. Raises ArgumentError on an execution or format error.
+ * Runs this parsed query against +graph+ exactly once and returns the result set. Read it as Ruby
+ * objects with Rubydex::Query::Result#rows, or format it with Rubydex::Query::Result#render. Raises
+ * Rubydex::QueryExecutionError when the query fails against the graph.
  */
-static VALUE rdxr_query_render(int argc, VALUE *argv, VALUE self) {
-    VALUE graph_obj, format;
-    rb_scan_args(argc, argv, "11", &graph_obj, &format);
-
+static VALUE rdxr_query_run(VALUE self, VALUE graph_obj) {
     void *query;
     TypedData_Get_Struct(self, void *, &query_type, query);
 
-    void *graph = rdxi_graph_from_object(graph_obj);
+    // Wrap first, so the result set has an owner that frees it even if a later step raises.
+    QueryResultData *data;
+    VALUE result = TypedData_Make_Struct(cQueryResult, QueryResultData, &query_result_type, data);
+    data->result_set = NULL;
+    data->graph_obj = graph_obj;
+    data->rows = Qnil;
 
-    struct CQueryResult result = rdx_query_run(query, graph, rdxi_symbol_or_string_cstr(format, "table"));
-
-    if (result.error != NULL) {
-        VALUE message = rb_utf8_str_new_cstr(result.error);
-        free_c_string(result.error);
-        rb_raise(rb_eArgError, "%s", StringValueCStr(message));
+    struct CExecuteResult executed = rdx_query_execute(query, rdxi_graph_from_object(graph_obj));
+    if (executed.error != NULL) {
+        raise_query_error(executed.error, executed.error_kind);
     }
 
-    VALUE output = result.output == NULL ? rb_utf8_str_new_cstr("") : rb_utf8_str_new_cstr(result.output);
-    if (result.output != NULL) {
-        free_c_string(result.output);
-    }
+    data->result_set = executed.result_set;
 
-    return output;
+    return result;
 }
 
 // Converts a structured result cell into a Ruby value. Node cells become real graph handles
@@ -148,10 +227,10 @@ static VALUE cypher_cell_to_value(VALUE graph_obj, const struct CCell *cell) {
     }
 }
 
-// Body function for rb_ensure in Query#run — walks the iterator and builds the rows array.
-// May raise if cell conversion (e.g. handle construction) fails; the ensure function frees the
-// iterator regardless.
-static VALUE query_run_yield(VALUE args) {
+// Body function for rb_ensure in Rubydex::Query::Result#rows — walks the iterator and builds the
+// rows array. May raise if cell conversion (e.g. handle construction) fails; the ensure function
+// frees the iterator regardless.
+static VALUE query_rows_yield(VALUE args) {
     VALUE graph_obj = rb_ary_entry(args, 0);
     struct CRowsIter *iter = (struct CRowsIter *)(uintptr_t)NUM2ULL(rb_ary_entry(args, 1));
 
@@ -172,8 +251,8 @@ static VALUE query_run_yield(VALUE args) {
     return rows;
 }
 
-// Ensure function for rb_ensure in Query#run to always free the iterator.
-static VALUE query_run_ensure(VALUE args) {
+// Ensure function for rb_ensure in Rubydex::Query::Result#rows to always free the iterator.
+static VALUE query_rows_ensure(VALUE args) {
     struct CRowsIter *iter = (struct CRowsIter *)(uintptr_t)NUM2ULL(rb_ary_entry(args, 1));
     rdx_rows_iter_free(iter);
     return Qnil;
@@ -181,36 +260,147 @@ static VALUE query_run_ensure(VALUE args) {
 
 /*
  * call-seq:
- *   run(graph) -> Array[Hash[String, Object]]
+ *   rows -> Array[Hash[String, Object]]
  *
- * Runs this parsed query against +graph+ and returns the rows as Ruby objects: each row is a Hash
- * keyed by RETURN column name. Scalar cells become String/Integer/true/false/nil, lists become
- * Arrays, and node cells become Declaration / Definition / Document handles. Raises ArgumentError
- * on an execution error.
+ * Returns the rows as Ruby objects: a frozen Array in which each row is a Hash keyed by RETURN
+ * column name. Scalar cells become String/Integer/true/false/nil, lists become Arrays, maps become
+ * Hashes, and node cells become Declaration / Definition / Document handles. The array is built on
+ * the first call and reused afterwards.
  */
-static VALUE rdxr_query_run(VALUE self, VALUE graph_obj) {
-    void *query;
-    TypedData_Get_Struct(self, void *, &query_type, query);
+static VALUE rdxr_query_result_rows(VALUE self) {
+    QueryResultData *data = query_result_data(self);
 
-    void *graph = rdxi_graph_from_object(graph_obj);
+    if (!NIL_P(data->rows)) {
+        return data->rows;
+    }
 
-    struct CRunRows run = rdx_query_run_rows(query, graph);
+    struct CRowsIter *iter = rdx_result_set_rows(data->result_set, rdxi_graph_from_object(data->graph_obj));
+    if (iter == NULL) {
+        rb_raise(rb_eRuntimeError, "failed to create iterator");
+    }
 
-    if (run.error != NULL) {
-        VALUE message = rb_utf8_str_new_cstr(run.error);
-        free_c_string(run.error);
+    VALUE args = rb_ary_new_from_args(2, data->graph_obj, ULL2NUM((uintptr_t)iter));
+    data->rows = rb_ary_freeze(rb_ensure(query_rows_yield, args, query_rows_ensure, args));
+
+    return data->rows;
+}
+
+/*
+ * call-seq:
+ *   columns -> Array[String]
+ *
+ * Returns the RETURN column names, in order. The names are known even when the query matched no
+ * rows.
+ */
+static VALUE rdxr_query_result_columns(VALUE self) {
+    QueryResultData *data = query_result_data(self);
+
+    size_t count = rdx_result_set_column_count(data->result_set);
+    VALUE columns = rb_ary_new_capa((long)count);
+
+    for (size_t i = 0; i < count; i++) {
+        rb_ary_push(columns, rdxi_owned_c_string_to_ruby(rdx_result_set_column(data->result_set, i)));
+    }
+
+    return columns;
+}
+
+/*
+ * call-seq:
+ *   each { |row| ... } -> self
+ *   each -> Enumerator
+ *
+ * Yields every row as a Hash keyed by RETURN column name. Rubydex::Query::Result is Enumerable, so
+ * +map+, +select+, and the rest of Enumerable work on the rows.
+ */
+static VALUE rdxr_query_result_each(VALUE self) {
+    RETURN_ENUMERATOR(self, 0, 0);
+
+    VALUE rows = rdxr_query_result_rows(self);
+    long length = RARRAY_LEN(rows);
+
+    for (long i = 0; i < length; i++) {
+        rb_yield(RARRAY_AREF(rows, i));
+    }
+
+    return self;
+}
+
+/*
+ * call-seq:
+ *   size -> Integer
+ *   length -> Integer
+ *
+ * Returns the number of rows, without building the row objects.
+ */
+static VALUE rdxr_query_result_size(VALUE self) {
+    return SIZET2NUM(rdx_result_set_row_count(query_result_data(self)->result_set));
+}
+
+/*
+ * call-seq:
+ *   empty? -> bool
+ *
+ * Returns +true+ when the query matched no rows.
+ */
+static VALUE rdxr_query_result_empty_p(VALUE self) {
+    return rdx_result_set_row_count(query_result_data(self)->result_set) == 0 ? Qtrue : Qfalse;
+}
+
+/*
+ * call-seq:
+ *   render(format = :table) -> String
+ *
+ * Returns the result set as formatted output. +format+ may be +:table+ (default) or +:json+. The
+ * query is not run again. Raises ArgumentError on an unknown format.
+ */
+static VALUE rdxr_query_result_render(int argc, VALUE *argv, VALUE self) {
+    VALUE format;
+    rb_scan_args(argc, argv, "01", &format);
+
+    QueryResultData *data = query_result_data(self);
+    struct CQueryResult result = rdx_result_set_format(data->result_set, rdxi_symbol_or_string_cstr(format, "table"));
+
+    if (result.error != NULL) {
+        VALUE message = rb_utf8_str_new_cstr(result.error);
+        free_c_string(result.error);
         rb_raise(rb_eArgError, "%s", StringValueCStr(message));
     }
 
-    VALUE args = rb_ary_new_from_args(2, graph_obj, ULL2NUM((uintptr_t)run.iter));
-    return rb_ensure(query_run_yield, args, query_run_ensure, args);
+    VALUE output = result.output == NULL ? rb_utf8_str_new_cstr("") : rb_utf8_str_new_cstr(result.output);
+    if (result.output != NULL) {
+        free_c_string(result.output);
+    }
+
+    return output;
 }
 
-void rdxi_initialize_query(VALUE mRubydex) {
+void rdxi_initialize_query(VALUE moduleRubydex) {
+    mRubydex = moduleRubydex;
+
     VALUE cQuery = rb_define_class_under(mRubydex, "Query", rb_cObject);
     rb_undef_alloc_func(cQuery);
     rb_define_singleton_method(cQuery, "parse", rdxr_query_parse, 1);
     rb_define_singleton_method(cQuery, "schema", rdxr_cypher_schema, -1);
-    rb_define_method(cQuery, "render", rdxr_query_render, -1);
     rb_define_method(cQuery, "run", rdxr_query_run, 1);
+
+    /*
+     * The result of running a Rubydex::Query against a graph: the columns and rows produced by one
+     * execution. Enumerable over its rows.
+     */
+    cQueryResult = rb_define_class_under(cQuery, "Result", rb_cObject);
+    rb_undef_alloc_func(cQueryResult);
+
+    // A result can only be obtained from `Query#run`; `new` would create an object with no Rust
+    // data behind it.
+    rb_undef_method(rb_singleton_class(cQueryResult), "new");
+
+    rb_include_module(cQueryResult, rb_mEnumerable);
+    rb_define_method(cQueryResult, "columns", rdxr_query_result_columns, 0);
+    rb_define_method(cQueryResult, "rows", rdxr_query_result_rows, 0);
+    rb_define_method(cQueryResult, "each", rdxr_query_result_each, 0);
+    rb_define_method(cQueryResult, "size", rdxr_query_result_size, 0);
+    rb_define_alias(cQueryResult, "length", "size");
+    rb_define_method(cQueryResult, "empty?", rdxr_query_result_empty_p, 0);
+    rb_define_method(cQueryResult, "render", rdxr_query_result_render, -1);
 }

--- a/lib/rubydex/cli/command/query.rb
+++ b/lib/rubydex/cli/command/query.rb
@@ -47,7 +47,13 @@ module Rubydex
           # Progress goes to stderr so stdout carries only the result (e.g. for piping a query's JSON).
           graph = build_graph($stderr)
 
-          render(parsed, graph, format)
+          begin
+            result = parsed.run(graph)
+          rescue Rubydex::QueryExecutionError => e
+            abort(e.message)
+          end
+
+          print(result.render(format))
         end
 
         private
@@ -55,14 +61,7 @@ module Rubydex
         #: (String query) -> Rubydex::Query
         def parse_query(query)
           Rubydex::Query.parse(query)
-        rescue ArgumentError => e
-          abort(e.message)
-        end
-
-        #: (Rubydex::Query parsed, Rubydex::Graph graph, String format) -> void
-        def render(parsed, graph, format)
-          print(parsed.render(graph, format))
-        rescue ArgumentError => e
+        rescue Rubydex::QuerySyntaxError => e
           abort(e.message)
         end
       end

--- a/lib/rubydex/errors.rb
+++ b/lib/rubydex/errors.rb
@@ -21,4 +21,15 @@ module Rubydex
 
   # Raised by `SkillRegistry.load` when the skill directory doesn't exist.
   class UnknownSkillDirectoryError < SkillError; end
+
+  # Raised when a Cypher query cannot be parsed or cannot run. `Rubydex::Query` raises one of its
+  # subclasses; rescue this class to catch either.
+  class QueryError < Error; end
+
+  # Raised by `Query.parse` when the query is not valid Cypher.
+  class QuerySyntaxError < QueryError; end
+
+  # Raised by `Query#run` when a parsed query fails while it runs against a graph, for example
+  # because it names an unknown property or relationship type.
+  class QueryExecutionError < QueryError; end
 end

--- a/rbi/rubydex.rbi
+++ b/rbi/rubydex.rbi
@@ -464,6 +464,9 @@ end
 class Rubydex::Error < StandardError; end
 class Rubydex::AliasCycleError < Rubydex::Error; end
 class Rubydex::ConfigError < Rubydex::Error; end
+class Rubydex::QueryError < Rubydex::Error; end
+class Rubydex::QuerySyntaxError < Rubydex::QueryError; end
+class Rubydex::QueryExecutionError < Rubydex::QueryError; end
 
 # The configuration of a workspace, parsed from its `rubydex.toml`. It carries both the settings that are global to
 # every built-in tool, such as the workspace being analyzed, and the typed settings of each tool's own section (e.g.
@@ -529,11 +532,46 @@ class Rubydex::Query
     def schema(format = :table); end
   end
 
-  sig { params(graph: Rubydex::Graph).returns(T::Array[T::Hash[String, T.untyped]]) }
+  sig { params(graph: Rubydex::Graph).returns(Rubydex::Query::Result) }
   def run(graph); end
+end
 
-  sig { params(graph: Rubydex::Graph, format: T.any(String, Symbol)).returns(String) }
-  def render(graph, format = :table); end
+# The columns and rows produced by one run of a query. Enumerable over its rows.
+class Rubydex::Query::Result
+  include Enumerable
+  extend T::Generic
+
+  Elem = type_member { { fixed: T::Hash[String, T.untyped] } }
+
+  class << self
+    private
+
+    # A result only comes from `Query#run`. The C extension undefines `new`, so a call raises.
+    sig { returns(T.noreturn) }
+    def new; end
+  end
+
+  sig { returns(T::Array[String]) }
+  def columns; end
+
+  sig { returns(T::Array[T::Hash[String, T.untyped]]) }
+  def rows; end
+
+  sig { override.params(block: T.proc.params(row: T::Hash[String, T.untyped]).void).returns(T.self_type) }
+  sig { override.returns(T::Enumerator[T::Hash[String, T.untyped]]) }
+  def each(&block); end
+
+  sig { returns(Integer) }
+  def size; end
+
+  sig { returns(Integer) }
+  def length; end
+
+  sig { returns(T::Boolean) }
+  def empty?; end
+
+  sig { params(format: T.any(String, Symbol)).returns(String) }
+  def render(format = :table); end
 end
 
 class Rubydex::Graph

--- a/rust/rubydex-sys/src/cypher_api.rs
+++ b/rust/rubydex-sys/src/cypher_api.rs
@@ -12,7 +12,30 @@ use rubydex::query::cypher::{self, CypherValue, OutputFormat};
 use std::ffi::CString;
 use std::ptr;
 
-/// The result of running a Cypher query, carrying either the formatted output or an error message.
+/// Which layer of the Cypher pipeline rejected a call, so callers can raise a matching error class.
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CQueryErrorKind {
+    /// No failure: the `error` field of the containing struct is null.
+    None,
+    /// The caller passed an invalid argument, such as a null pointer or a string that is not UTF-8.
+    Argument,
+    /// The query text is not valid Cypher.
+    Syntax,
+    /// The query parsed, but it failed while it ran against the graph.
+    Execution,
+}
+
+impl CQueryErrorKind {
+    fn of(error: &cypher::CypherError) -> Self {
+        match error {
+            cypher::CypherError::Syntax { .. } => Self::Syntax,
+            cypher::CypherError::Execution { .. } => Self::Execution,
+        }
+    }
+}
+
+/// The formatted output of a Cypher result set, or the argument error that prevented it.
 #[repr(C)]
 pub struct CQueryResult {
     /// Non-null on success; null on error. Caller must free with `free_c_string`.
@@ -49,13 +72,15 @@ pub struct CParseResult {
     pub query: *mut c_void,
     /// Non-null on error; null on success. Caller must free with `free_c_string`.
     pub error: *const c_char,
+    /// Which kind of failure `error` describes; `None` when `error` is null.
+    pub error_kind: CQueryErrorKind,
 }
 
 /// Parses a Cypher query string into an opaque parsed-query object, without needing a graph.
 ///
 /// On success, `query` is a heap-allocated parsed query that can be executed against a graph with
-/// `rdx_query_run` and must eventually be freed with `rdx_cypher_query_free`. On failure, `error`
-/// holds the message.
+/// `rdx_query_execute` and must eventually be freed with `rdx_cypher_query_free`. On failure,
+/// `error` holds the message and `error_kind` tells the caller which error to raise.
 ///
 /// # Safety
 ///
@@ -66,6 +91,7 @@ pub unsafe extern "C" fn rdx_cypher_parse(query: *const c_char) -> CParseResult 
         return CParseResult {
             query: ptr::null_mut(),
             error: utils::cstring_raw("query is not valid UTF-8"),
+            error_kind: CQueryErrorKind::Argument,
         };
     };
 
@@ -73,10 +99,12 @@ pub unsafe extern "C" fn rdx_cypher_parse(query: *const c_char) -> CParseResult 
         Ok(parsed) => CParseResult {
             query: Box::into_raw(Box::new(parsed)).cast::<c_void>(),
             error: ptr::null(),
+            error_kind: CQueryErrorKind::None,
         },
         Err(error) => CParseResult {
             query: ptr::null_mut(),
             error: utils::cstring_raw(&error.to_string()),
+            error_kind: CQueryErrorKind::of(&error),
         },
     }
 }
@@ -219,21 +247,26 @@ pub struct CResultRow {
 }
 
 /// Iterator over structured query result rows. Opaque from the C side — use
-/// `rdx_rows_iter_column_count`, `rdx_rows_iter_columns`, `rdx_rows_iter_len`, `rdx_rows_iter_next`,
-/// and `rdx_rows_iter_free`.
+/// `rdx_rows_iter_*` methods to work with it.
 pub struct CRowsIter {
     columns: Box<[*const c_char]>,
     rows: Box<[CResultRow]>,
     index: usize,
 }
 
-/// The result of running a query for structured rows: either a row iterator or an error message.
+/// An executed query's result set: the column names and rows that `rdx_query_execute` produced.
+/// Opaque from the C side — use `rdx_result_set_*` methods to work with it.
+pub struct CResultSet(cypher::ResultSet);
+
+/// The result of executing a parsed query against a graph.
 #[repr(C)]
-pub struct CRunRows {
-    /// Non-null on success; free with `rdx_rows_iter_free`.
-    pub iter: *mut CRowsIter,
-    /// Non-null on error; free with `free_c_string`.
+pub struct CExecuteResult {
+    /// Non-null on success; free with `rdx_result_set_free`.
+    pub result_set: *mut CResultSet,
+    /// Non-null on error; null on success. Caller must free with `free_c_string`.
     pub error: *const c_char,
+    /// Which kind of failure `error` describes; `None` when `error` is null.
+    pub error_kind: CQueryErrorKind,
 }
 
 /// Converts a `CypherValue` into a `CCell`, resolving node identity to a handle-buildable category +
@@ -342,35 +375,132 @@ fn build_node_cell(graph: &Graph, encoded_id: &str) -> Option<CCell> {
     }
 }
 
-/// Runs a previously parsed query and returns a row iterator (column names + typed rows),
-/// so callers can build their own value/handle objects instead of a formatted string.
+/// Executes a previously parsed query against the graph and returns its result set. Format the
+/// result set with `rdx_result_set_format`, or read it as structured rows with
+/// `rdx_result_set_rows`; either way the query runs only once.
 ///
 /// # Safety
 ///
 /// - `query` must be a valid pointer returned by `rdx_cypher_parse`.
 /// - `pointer` must be a valid `GraphPointer` previously returned by this crate.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn rdx_query_run_rows(query: *const c_void, pointer: GraphPointer) -> CRunRows {
+pub unsafe extern "C" fn rdx_query_execute(query: *const c_void, pointer: GraphPointer) -> CExecuteResult {
     if query.is_null() {
-        return CRunRows {
-            iter: ptr::null_mut(),
+        return CExecuteResult {
+            result_set: ptr::null_mut(),
             error: utils::cstring_raw("query is null"),
+            error_kind: CQueryErrorKind::Argument,
         };
     }
 
     let parsed = unsafe { &*query.cast::<cypher::Query>() };
 
-    with_graph(pointer, |graph| {
-        let result_set = match cypher::execute(graph, parsed) {
-            Ok(result_set) => result_set,
-            Err(error) => {
-                return CRunRows {
-                    iter: ptr::null_mut(),
-                    error: utils::cstring_raw(&error.to_string()),
-                };
-            }
-        };
+    with_graph(pointer, |graph| match cypher::execute(graph, parsed) {
+        Ok(result_set) => CExecuteResult {
+            result_set: Box::into_raw(Box::new(CResultSet(result_set))),
+            error: ptr::null(),
+            error_kind: CQueryErrorKind::None,
+        },
+        Err(error) => CExecuteResult {
+            result_set: ptr::null_mut(),
+            error: utils::cstring_raw(&error.to_string()),
+            error_kind: CQueryErrorKind::of(&error),
+        },
+    })
+}
 
+/// Formats an executed result set as `format` (`"table"` or `"json"`) without running the query
+/// again. A non-null `error` always describes an invalid argument.
+///
+/// # Safety
+///
+/// - `result_set` must be a valid pointer returned by `rdx_query_execute`, or null.
+/// - `format` must be a valid, null-terminated UTF-8 string.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rdx_result_set_format(result_set: *const CResultSet, format: *const c_char) -> CQueryResult {
+    if result_set.is_null() {
+        return CQueryResult::error("result set is null");
+    }
+
+    let Ok(format_str) = (unsafe { utils::convert_char_ptr_to_string(format) }) else {
+        return CQueryResult::error("format is not valid UTF-8");
+    };
+
+    let output_format = match format_str.as_str() {
+        "table" => OutputFormat::Table,
+        "json" => OutputFormat::Json,
+        other => {
+            return CQueryResult::error(&format!("unknown query format `{other}` (expected `table` or `json`)"));
+        }
+    };
+
+    let result_set = unsafe { &*result_set };
+    CQueryResult::success(&cypher::render(&result_set.0, output_format))
+}
+
+/// Returns the number of columns in an executed result set.
+///
+/// # Safety
+///
+/// - `result_set` must be a valid pointer returned by `rdx_query_execute`, or null.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rdx_result_set_column_count(result_set: *const CResultSet) -> usize {
+    if result_set.is_null() {
+        return 0;
+    }
+
+    unsafe { &*result_set }.0.columns.len()
+}
+
+/// Returns the name of the column at `index`, or null when `index` is out of range. The caller must
+/// free the returned string with `free_c_string`.
+///
+/// # Safety
+///
+/// - `result_set` must be a valid pointer returned by `rdx_query_execute`, or null.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rdx_result_set_column(result_set: *const CResultSet, index: usize) -> *const c_char {
+    if result_set.is_null() {
+        return ptr::null();
+    }
+
+    match unsafe { &*result_set }.0.columns.get(index) {
+        Some(name) => utils::cstring_raw(name),
+        None => ptr::null(),
+    }
+}
+
+/// Returns the number of rows in an executed result set.
+///
+/// # Safety
+///
+/// - `result_set` must be a valid pointer returned by `rdx_query_execute`, or null.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rdx_result_set_row_count(result_set: *const CResultSet) -> usize {
+    if result_set.is_null() {
+        return 0;
+    }
+
+    unsafe { &*result_set }.0.rows.len()
+}
+
+/// Materializes an executed result set as a row iterator (column names + typed rows), so callers
+/// can build their own value/handle objects instead of formatted text. Returns null when
+/// `result_set` is null.
+///
+/// # Safety
+///
+/// - `result_set` must be a valid pointer returned by `rdx_query_execute`, or null.
+/// - `pointer` must be a valid `GraphPointer` previously returned by this crate.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rdx_result_set_rows(result_set: *const CResultSet, pointer: GraphPointer) -> *mut CRowsIter {
+    if result_set.is_null() {
+        return ptr::null_mut();
+    }
+
+    let result_set = &unsafe { &*result_set }.0;
+
+    with_graph(pointer, |graph| {
         let columns: Box<[*const c_char]> = result_set.columns.iter().map(|name| utils::cstring_raw(name)).collect();
 
         let rows: Box<[CResultRow]> = result_set
@@ -388,22 +518,34 @@ pub unsafe extern "C" fn rdx_query_run_rows(query: *const c_void, pointer: Graph
             })
             .collect();
 
-        CRunRows {
-            iter: Box::into_raw(Box::new(CRowsIter {
-                columns,
-                rows,
-                index: 0,
-            })),
-            error: ptr::null(),
-        }
+        Box::into_raw(Box::new(CRowsIter {
+            columns,
+            rows,
+            index: 0,
+        }))
     })
+}
+
+/// Frees a result set previously returned by `rdx_query_execute`.
+///
+/// # Safety
+///
+/// - `result_set` must be a pointer returned by `rdx_query_execute`, or null. It must not be used
+///   after.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rdx_result_set_free(result_set: *mut CResultSet) {
+    if result_set.is_null() {
+        return;
+    }
+
+    let _ = unsafe { Box::from_raw(result_set) };
 }
 
 /// Returns the number of columns in the result set.
 ///
 /// # Safety
 ///
-/// - `iter` must be a valid pointer returned by `rdx_query_run_rows`, or null.
+/// - `iter` must be a valid pointer returned by `rdx_result_set_rows`, or null.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rdx_rows_iter_column_count(iter: *const CRowsIter) -> usize {
     if iter.is_null() {
@@ -418,7 +560,7 @@ pub unsafe extern "C" fn rdx_rows_iter_column_count(iter: *const CRowsIter) -> u
 ///
 /// # Safety
 ///
-/// - `iter` must be a valid pointer returned by `rdx_query_run_rows`, or null.
+/// - `iter` must be a valid pointer returned by `rdx_result_set_rows`, or null.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rdx_rows_iter_columns(iter: *const CRowsIter) -> *const *const c_char {
     if iter.is_null() {
@@ -432,7 +574,7 @@ pub unsafe extern "C" fn rdx_rows_iter_columns(iter: *const CRowsIter) -> *const
 ///
 /// # Safety
 ///
-/// - `iter` must be a valid pointer returned by `rdx_query_run_rows`, or null.
+/// - `iter` must be a valid pointer returned by `rdx_result_set_rows`, or null.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rdx_rows_iter_len(iter: *const CRowsIter) -> usize {
     if iter.is_null() {
@@ -448,7 +590,7 @@ pub unsafe extern "C" fn rdx_rows_iter_len(iter: *const CRowsIter) -> usize {
 ///
 /// # Safety
 ///
-/// - `iter` must be a valid pointer returned by `rdx_query_run_rows`, or null.
+/// - `iter` must be a valid pointer returned by `rdx_result_set_rows`, or null.
 /// - `out` must be a valid, writable pointer, or null.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rdx_rows_iter_next(iter: *mut CRowsIter, out: *mut CResultRow) -> bool {
@@ -514,12 +656,12 @@ unsafe fn free_cell(cell: &CCell) {
     }
 }
 
-/// Frees a `CRowsIter` previously returned by `rdx_query_run_rows`, including all column strings,
+/// Frees a `CRowsIter` previously returned by `rdx_result_set_rows`, including all column strings,
 /// row cells, and nested allocations.
 ///
 /// # Safety
 ///
-/// - `iter` must be a pointer returned by `rdx_query_run_rows`, or null. It must not be used after.
+/// - `iter` must be a pointer returned by `rdx_result_set_rows`, or null. It must not be used after.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rdx_rows_iter_free(iter: *mut CRowsIter) {
     if iter.is_null() {

--- a/rust/rubydex-sys/src/graph_api.rs
+++ b/rust/rubydex-sys/src/graph_api.rs
@@ -1,7 +1,6 @@
 //! This file provides the C API for the Graph object
 
 use crate::config_api::ConfigPointer;
-use crate::cypher_api::CQueryResult;
 use crate::declaration_api::CDeclaration;
 use crate::declaration_api::DeclarationsIter;
 use crate::declaration_api::decl_id_from_char_ptr;
@@ -17,7 +16,6 @@ use rubydex::model::ids::{DeclarationId, NameId, UriId, declaration_id_from_look
 use rubydex::model::keywords;
 use rubydex::model::name::NameRef;
 use rubydex::model::visibility::Visibility;
-use rubydex::query::cypher::{self, OutputFormat};
 use rubydex::query::{CompletionCandidate, CompletionContext, CompletionReceiver};
 use rubydex::resolution::Resolver;
 use rubydex::{indexing, integrity, listing, query};
@@ -1024,46 +1022,6 @@ pub unsafe extern "C" fn rdx_keyword_get(name: *const c_char) -> *const CKeyword
         }
         None => ptr::null(),
     }
-}
-
-/// Executes a previously parsed query (from `rdx_cypher_parse`) against the graph and returns the
-/// formatted output or an error message. `format` must be `"table"` or `"json"`.
-///
-/// # Safety
-///
-/// - `query` must be a valid pointer returned by `rdx_cypher_parse`.
-/// - `pointer` must be a valid `GraphPointer` previously returned by this crate.
-/// - `format` must be a valid, null-terminated UTF-8 string.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn rdx_query_run(
-    query: *const c_void,
-    pointer: GraphPointer,
-    format: *const c_char,
-) -> CQueryResult {
-    if query.is_null() {
-        return CQueryResult::error("query is null");
-    }
-
-    let Ok(format_str) = (unsafe { utils::convert_char_ptr_to_string(format) }) else {
-        return CQueryResult::error("format is not valid UTF-8");
-    };
-
-    let output_format = match format_str.as_str() {
-        "table" => OutputFormat::Table,
-        "json" => OutputFormat::Json,
-        other => {
-            return CQueryResult::error(&format!("unknown query format `{other}` (expected `table` or `json`)"));
-        }
-    };
-
-    let parsed = unsafe { &*query.cast::<cypher::Query>() };
-
-    with_graph(pointer, |graph| {
-        match cypher::run_parsed(graph, parsed, output_format) {
-            Ok(output) => CQueryResult::success(&output),
-            Err(error) => CQueryResult::error(&error.to_string()),
-        }
-    })
 }
 
 #[repr(u8)]

--- a/rust/rubydex/src/query/cypher.rs
+++ b/rust/rubydex/src/query/cypher.rs
@@ -18,7 +18,8 @@
 // `Graph` (in `schema`) and the static schema description (in `schema_info`).
 //
 // `Query` is the opaque parsed-query object: callers can `parse` a query string once (failing fast
-// on syntax errors), then `run_parsed` it against a graph that was built afterwards.
+// on syntax errors), `execute` it against a graph that was built afterwards, and `render` the
+// resulting [`ResultSet`] without running the query again.
 pub use cypher_parser::{CypherError, CypherValue, OutputFormat, Query, ResultSet, execute, parse};
 
 pub mod schema;
@@ -35,15 +36,11 @@ pub fn run_query(graph: &Graph, query: &str, output_format: OutputFormat) -> Res
     cypher_parser::run_query(graph, query, output_format)
 }
 
-/// Executes an already-parsed [`Query`] against the graph and formats the result. Pair with
-/// [`parse`] to validate a query before building the graph.
-///
-/// # Errors
-///
-/// Returns a [`CypherError`] if the query cannot be executed.
-pub fn run_parsed(graph: &Graph, query: &Query, output_format: OutputFormat) -> Result<String, CypherError> {
-    let result = cypher_parser::execute(graph, query)?;
-    Ok(cypher_parser::format::format(&result, output_format))
+/// Renders an already-executed [`ResultSet`] in the requested format. Pair with [`execute`] to run a
+/// parsed query once and render its result set as often as needed.
+#[must_use]
+pub fn render(result: &ResultSet, output_format: OutputFormat) -> String {
+    cypher_parser::format::format(result, output_format)
 }
 
 /// Returns a description of the queryable schema (node labels, relationship types, and properties)

--- a/rust/rubydex/src/query/cypher/tests.rs
+++ b/rust/rubydex/src/query/cypher/tests.rs
@@ -1,5 +1,5 @@
-use super::run_query;
 use super::schema::RelType;
+use super::{render, run_query};
 use crate::model::graph::Graph;
 use crate::test_utils::GraphTest;
 use cypher_parser::{CypherValue, OutputFormat, ResultSet, execute, parse};
@@ -195,6 +195,20 @@ fn run_query_json_output() {
     )
     .unwrap();
     assert_eq!(output, "[{\"c.name\":\"Dog\"}]");
+}
+
+#[test]
+fn render_formats_one_result_set_in_both_formats() {
+    // `execute` runs the query once; `render` formats that same result set as often as needed.
+    let graph = fixture_graph();
+    let result = run(&graph, "MATCH (c:Class {name: 'Dog'}) RETURN c.name");
+
+    assert_eq!(render(&result, OutputFormat::Json), "[{\"c.name\":\"Dog\"}]");
+
+    let table = render(&result, OutputFormat::Table);
+    assert!(table.contains("c.name"));
+    assert!(table.contains("Dog"));
+    assert!(table.contains("1 row"));
 }
 
 #[test]

--- a/test/graph_test.rb
+++ b/test/graph_test.rb
@@ -1610,8 +1610,9 @@ class GraphTest < Minitest::Test
       graph.index_all(context.glob("**/*.rb"))
       graph.resolve
 
-      rows = query.run(graph)
-      assert_equal([{ "p.name" => "Animal" }], rows)
+      result = query.run(graph)
+      assert_instance_of(Rubydex::Query::Result, result)
+      assert_equal([{ "p.name" => "Animal" }], result.rows)
     end
   end
 
@@ -1625,7 +1626,7 @@ class GraphTest < Minitest::Test
       graph.index_all(context.glob("**/*.rb"))
       graph.resolve
 
-      rows = query.run(graph)
+      rows = query.run(graph).rows
       assert_equal(1, rows.length)
       node = rows.first["c"]
       assert_kind_of(Rubydex::Declaration, node)
@@ -1645,7 +1646,7 @@ class GraphTest < Minitest::Test
       graph.index_all(context.glob("**/*.rb"))
       graph.resolve
 
-      assert_equal([{ "p.name" => "Animal", "subclasses" => 2 }], query.run(graph))
+      assert_equal([{ "p.name" => "Animal", "subclasses" => 2 }], query.run(graph).rows)
     end
   end
 
@@ -1659,7 +1660,7 @@ class GraphTest < Minitest::Test
       graph.index_all(context.glob("**/*.rb"))
       graph.resolve
 
-      rows = query.run(graph)
+      rows = query.run(graph).rows
       assert_equal(1, rows.length)
       projection = rows.first.values.first
       assert_kind_of(Hash, projection)
@@ -1684,13 +1685,31 @@ class GraphTest < Minitest::Test
       graph.index_all(context.glob("**/*.rb"))
       graph.resolve
 
-      assert_equal([{ "n.name" => "Animal" }, { "n.name" => "Walkable" }], query.run(graph))
+      assert_equal([{ "n.name" => "Animal" }, { "n.name" => "Walkable" }], query.run(graph).rows)
     end
   end
 
   def test_parse_raises_on_syntax_error
-    error = assert_raises(ArgumentError) { Rubydex::Query.parse("MATCH (c RETURN c") }
+    error = assert_raises(Rubydex::QuerySyntaxError) { Rubydex::Query.parse("MATCH (c RETURN c") }
     assert_match(/Cypher syntax error/, error.message)
+    assert_kind_of(Rubydex::QueryError, error)
+  end
+
+  def test_run_raises_on_execution_error
+    with_context do |context|
+      context.write!("zoo.rb", "class Dog; end\n")
+
+      # An unknown relationship type parses, but the executor rejects it against the graph.
+      query = Rubydex::Query.parse("MATCH (a)-[:BOGUS]->(b) RETURN a")
+
+      graph = Rubydex::Graph.new
+      graph.index_all(context.glob("**/*.rb"))
+      graph.resolve
+
+      error = assert_raises(Rubydex::QueryExecutionError) { query.run(graph) }
+      assert_match(/Cypher execution error/, error.message)
+      assert_kind_of(Rubydex::QueryError, error)
+    end
   end
 
   def test_parsed_query_reusable_across_graphs
@@ -1702,7 +1721,35 @@ class GraphTest < Minitest::Test
       graph.index_all(context.glob("**/*.rb"))
       graph.resolve
 
-      assert_equal([{ "c.name" => "Dog" }], query.run(graph))
+      assert_equal([{ "c.name" => "Dog" }], query.run(graph).rows)
+    end
+  end
+
+  def test_result_reports_columns_rows_and_emptiness
+    with_context do |context|
+      context.write!("zoo.rb", "class Animal; end\nclass Dog < Animal; end\n")
+
+      graph = Rubydex::Graph.new
+      graph.index_all(context.glob("**/*.rb"))
+      graph.resolve
+
+      result = Rubydex::Query.parse(
+        "MATCH (c:Class) WHERE c.name IN ['Animal', 'Dog'] RETURN c.name, c.kind ORDER BY c.name",
+      ).run(graph)
+      assert_equal(["c.name", "c.kind"], result.columns)
+      assert_equal(2, result.size)
+      assert_equal(2, result.length)
+      refute_empty(result)
+
+      # Enumerable comes from `each`, which walks the same memoized rows.
+      assert_equal(["Animal", "Dog"], result.map { |row| row["c.name"] })
+      assert_same(result.rows, result.rows)
+
+      empty = Rubydex::Query.parse("MATCH (c:Class {name: 'Nope'}) RETURN c.name").run(graph)
+      assert_empty(empty)
+      assert_equal(0, empty.size)
+      # The columns of a query that matched nothing are still known.
+      assert_equal(["c.name"], empty.columns)
     end
   end
 
@@ -1719,7 +1766,7 @@ class GraphTest < Minitest::Test
       graph.resolve
 
       query = Rubydex::Query.parse("MATCH (c:Class)-[:HAS_PARENT]->(p:Class) WHERE p.name = 'Animal' RETURN c.name ORDER BY c.name")
-      output = query.render(graph)
+      output = query.run(graph).render
 
       assert_match(/c\.name/, output)
       assert_match(/Cat/, output)
@@ -1736,9 +1783,11 @@ class GraphTest < Minitest::Test
       graph.index_all(context.glob("**/*.rb"))
       graph.resolve
 
-      query = Rubydex::Query.parse("MATCH (c:Class {name: 'Dog'}) RETURN c.name")
-      assert_equal("[{\"c.name\":\"Dog\"}]", query.render(graph, :json))
-      assert_equal("[{\"c.name\":\"Dog\"}]", query.render(graph, "json"))
+      # One execution renders as many times, and in as many formats, as the caller wants.
+      result = Rubydex::Query.parse("MATCH (c:Class {name: 'Dog'}) RETURN c.name").run(graph)
+      assert_equal("[{\"c.name\":\"Dog\"}]", result.render(:json))
+      assert_equal("[{\"c.name\":\"Dog\"}]", result.render("json"))
+      assert_match(/1 row/, result.render)
     end
   end
 
@@ -1750,8 +1799,8 @@ class GraphTest < Minitest::Test
       graph.index_all(context.glob("**/*.rb"))
       graph.resolve
 
-      query = Rubydex::Query.parse("MATCH (c:Class) RETURN c.name")
-      error = assert_raises(ArgumentError) { query.render(graph, :yaml) }
+      result = Rubydex::Query.parse("MATCH (c:Class) RETURN c.name").run(graph)
+      error = assert_raises(ArgumentError) { result.render(:yaml) }
       assert_match(/unknown query format/, error.message)
     end
   end


### PR DESCRIPTION
This addresses two review comments on the Cypher blog post in [rails-at-scale#431](https://github.com/Shopify/rails-at-scale/pull/431):

- [`ArgumentError` on a syntax error should be a more specific error](https://github.com/Shopify/rails-at-scale/pull/431#discussion_r3729283405)
- [`render` mixes execution and rendering; the API should be `query.run(graph).render(:json)`](https://github.com/Shopify/rails-at-scale/pull/431#discussion_r3729343006)

## Execution and rendering are separate

`Rubydex::Query#render(graph, format)` is gone. The new shape is:

```ruby
query = Rubydex::Query.parse("MATCH (c:Class) RETURN c.name")
result = query.run(graph)

result.rows.each { |row| puts row["c.name"] }
puts result.render(:json)
```

`Query#run` returns a `Rubydex::Query::Result`. That object owns the executed result set, so `render` never runs the query again. It is `Enumerable` over its rows, and it answers `columns`, `rows`, `each`, `size`, `length`, `empty?`, and `render`.

## Specific errors

| Class | Raised by |
| --- | --- |
| `Rubydex::QueryError` | The base class. Rescue it to catch either failure. |
| `Rubydex::QuerySyntaxError` | `Query.parse`, on invalid Cypher. |
| `Rubydex::QueryExecutionError` | `Query#run`, when the query fails against the graph. |

`ArgumentError` remains for true argument faults, such as an unknown output format.

The Rust FFI reports the failure kind through a new `CQueryErrorKind`, so the C extension raises the matching class.

## Verification

- `bundle exec rake test`: 300 Ruby runs and the full Rust suite. 0 failures.
- `cargo fmt --check` and `rubocop`: clean. `cargo clippy` reports no new warnings.
- CLI smoke test: the table and JSON output are unchanged. A syntax error still fails before indexing. An execution error aborts with its message.
- Compaction stress: `Rubydex::Query::Result` marks `graph_obj` and `rows` movable and implements `dcompact`, so `GC.verify_compaction_references` followed by `GC.compact` keeps every reference valid.

## Follow-up

The blog post in rails-at-scale#431 still describes the old API. It needs the two snippets updated once this merges.
