### PR TITLE
Visit `module_function` bodies once in `OperationBuilder`

### DIFF
--- a/rust/rubydex/src/indexing/ruby_indexer_tests.rs
+++ b/rust/rubydex/src/indexing/ruby_indexer_tests.rs
@@ -1558,6 +1558,34 @@ mod visibility_tests {
     }
 
     #[test]
+    fn index_module_function_with_body() {
+        let context = index_source({
+            "
+            module Foo
+              module_function
+
+              def bar
+                @value = CONST
+                baz(1)
+              end
+            end
+            "
+        });
+
+        assert_no_local_diagnostics!(&context);
+        assert_eq!(context.graph().definitions().len(), 4);
+        assert_eq!(context.graph().document().definitions().len(), 4);
+        assert_eq!(context.graph().document().constant_references().len(), 1);
+        assert_eq!(context.graph().document().method_references().len(), 1);
+        assert_constant_references_eq!(&context, ["CONST"]);
+        assert_method_references_eq!(&context, ["baz"]);
+
+        let methods = context.all_definitions_at("4:3-7:6");
+        assert_eq!(methods.len(), 2);
+        assert_definition_at!(&context, "5:5-5:11", InstanceVariable);
+    }
+
+    #[test]
     fn index_def_node_with_visibility_nested() {
         let context = index_source({
             "

--- a/rust/rubydex/src/operation/ruby_builder.rs
+++ b/rust/rubydex/src/operation/ruby_builder.rs
@@ -1352,6 +1352,14 @@ impl<'a> RubyOperationBuilder<'a> {
                 flags,
             }));
     }
+
+    fn visit_method_body(&mut self, receiver: Option<NestingReceiver>, body: Option<&ruby_prism::Node<'_>>) {
+        self.nesting_stack.push(Nesting::Method { receiver });
+        if let Some(body) = body {
+            self.visit(body);
+        }
+        self.nesting_stack.pop();
+    }
 }
 
 struct CommentGroup {
@@ -1573,13 +1581,7 @@ impl Visit<'_> for RubyOperationBuilder<'_> {
                 signatures: Signatures::Simple(parameters.clone().into_boxed_slice()),
                 receiver: singleton_receiver,
             }));
-            self.nesting_stack.push(Nesting::Method {
-                receiver: method_nesting_receiver,
-            });
-            if let Some(ref body) = body {
-                self.visit(body);
-            }
-            self.nesting_stack.pop();
+            self.visit_method_body(method_nesting_receiver, body.as_ref());
             self.operations.push(Operation::ExitScope);
 
             self.operations.push(Operation::EnterMethod(op::EnterMethod {
@@ -1592,13 +1594,7 @@ impl Visit<'_> for RubyOperationBuilder<'_> {
                 signatures: Signatures::Simple(parameters.into_boxed_slice()),
                 receiver,
             }));
-            self.nesting_stack.push(Nesting::Method {
-                receiver: method_nesting_receiver,
-            });
-            if let Some(ref body) = body {
-                self.visit(body);
-            }
-            self.nesting_stack.pop();
+            self.visit_method_body(method_nesting_receiver, body.as_ref());
             self.operations.push(Operation::ExitScope);
         } else {
             // Singleton methods at top level have receiver=None (no class to point self to).
@@ -1627,13 +1623,8 @@ impl Visit<'_> for RubyOperationBuilder<'_> {
                 signatures: Signatures::Simple(parameters.into_boxed_slice()),
                 receiver,
             }));
-            self.nesting_stack.push(Nesting::Method {
-                receiver: method_nesting_receiver,
-            });
-            if let Some(body) = node.body() {
-                self.visit(&body);
-            }
-            self.nesting_stack.pop();
+            let body = node.body();
+            self.visit_method_body(method_nesting_receiver, body.as_ref());
             self.operations.push(Operation::ExitScope);
 
             if let Some(prev) = previous_visibility {

--- a/rust/rubydex/src/operation/ruby_builder.rs
+++ b/rust/rubydex/src/operation/ruby_builder.rs
@@ -1566,8 +1566,10 @@ impl Visit<'_> for RubyOperationBuilder<'_> {
         };
 
         if receiver.is_none() && visibility == Visibility::ModuleFunction {
-            // module_function: emit two EnterMethod/ExitScope pairs (singleton + instance),
-            // each visiting the body so ivars are associated with both methods.
+            // Each EnterMethod creates a method definition, so emit one for the public singleton
+            // method and one for the private instance method. Emit body definitions and references
+            // only under the instance method because emitting them in both scopes would duplicate
+            // their source-based IDs.
             let singleton_receiver = Some(Target::ExplicitSelf);
             let body = node.body();
 
@@ -1581,7 +1583,6 @@ impl Visit<'_> for RubyOperationBuilder<'_> {
                 signatures: Signatures::Simple(parameters.clone().into_boxed_slice()),
                 receiver: singleton_receiver,
             }));
-            self.visit_method_body(method_nesting_receiver, body.as_ref());
             self.operations.push(Operation::ExitScope);
 
             self.operations.push(Operation::EnterMethod(op::EnterMethod {
@@ -2446,14 +2447,15 @@ mod tests {
     }
 
     #[test]
-    fn build_module_function_with_ivar() {
-        assert_operations(
+    fn build_module_function_with_body() {
+        assert_operations_with_references(
             "
             module Foo
               module_function
 
               def bar
-                @x = 1
+                @x = CONST
+                baz(1)
               end
             end
             ",
@@ -2461,10 +2463,11 @@ mod tests {
             EnterModule(Foo)
               SetDefaultVisibility(module_function)
               EnterMethod(self.bar())
-                DefineInstanceVariable(@x)
               ExitScope
               EnterMethod(bar())
                 DefineInstanceVariable(@x)
+                ReferenceConstant(CONST)
+                ReferenceMethod(baz)
               ExitScope
             ExitScope
             ",


### PR DESCRIPTION
### Summary

`RubyIndexer` visits a `module_function` body once, but `OperationBuilder` visited it under both the singleton and instance methods. Definitions and references inside the body use IDs derived from their source locations, so both visits produced the same IDs. Debug builds crashed on the collision, while release builds could append duplicate graph edges.

This PR brings `OperationBuilder` back to parity with `RubyIndexer` by keeping both method definitions but visiting their shared body once.

### Testing

```sh
mkdir -p tmp
cat >tmp/module-function.rb <<'RUBY'
module Foo
  module_function

  def bar
    @value = SOME_CONST
    baz(1)
  end
end
RUBY

# Reproduce on main. Expected: DefinitionId collision in local graph.
git switch main
(cd rust && cargo run --quiet --bin rubydex_cli -- ../tmp/module-function.rb --indexer operation-builder)

# Verify the PR. Expected: the command succeeds.
git fetch origin ar-module-function-operation-builder-parity
git switch ar-module-function-operation-builder-parity
(cd rust && cargo run --quiet --bin rubydex_cli -- ../tmp/module-function.rb --indexer operation-builder)

rm tmp/module-function.rb
```
