### PR TITLE
Skip CLI tests in Memleak

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -25,7 +25,7 @@ begin
   namespace(:ruby_test) do
     RubyMemcheck::TestTask.new(valgrind: :compile) do |task|
       test_config.call(task)
-      task.test_files = FileList["test/**/*_test.rb"].exclude("test/integration/**/*_test.rb")
+      task.test_files = FileList["test/**/*_test.rb"].exclude("test/integration/**/*_test.rb", "test/cli_test.rb")
     end
   end
 rescue LoadError


### PR DESCRIPTION
The CLI suite adds substantial time to the Memleak job as it grows. This change excludes `test/cli_test.rb` from `ruby_test:valgrind` and keeps it in the regular `ruby_test` task.

Date | Daily median
-- | --
Jul 24 | 36m
Jul 27–31 | 35m
Aug 3 | 37m
Aug 4 | 41m
Aug 5 | 57m
Aug 6 | 65m
Aug 7 | 65m

