### PR TITLE
Pool temporary buffers in the resolution linearization path

### DIFF
--- a/rust/rubydex/src/resolution.rs
+++ b/rust/rubydex/src/resolution.rs
@@ -99,6 +99,14 @@ pub struct Resolver<'a> {
     unit_queue: VecDeque<Unit>,
     /// Whether we made any progress in the last pass of the resolution loop
     made_progress: bool,
+    /// Spare buffers for the parent ancestor chains. Linearization recurses, and each level needs
+    /// one buffer, thus the pool keeps the buffers alive between calls to avoid one heap
+    /// allocation for each linearized declaration.
+    chain_pool: Vec<Vec<Ancestor>>,
+    /// Spare buffers for the collected mixins of a declaration, reused the same way as `chain_pool`.
+    mixin_pool: Vec<Vec<Mixin>>,
+    /// Spare deques for the linearized prepends and includes, reused the same way as `chain_pool`.
+    deque_pool: Vec<VecDeque<Ancestor>>,
     /// The linearization context carried across recursion
     context: LinearizationContext,
 }
@@ -109,8 +117,44 @@ impl<'a> Resolver<'a> {
             graph,
             unit_queue: VecDeque::new(),
             made_progress: false,
+            chain_pool: Vec::new(),
+            mixin_pool: Vec::new(),
+            deque_pool: Vec::new(),
             context: LinearizationContext::new(),
         }
+    }
+
+    /// Take an empty chain buffer from the pool, or make a new one if the pool is empty.
+    fn take_chain_buffer(&mut self) -> Vec<Ancestor> {
+        self.chain_pool.pop().unwrap_or_default()
+    }
+
+    /// Give a chain buffer back to the pool for the next linearization to use.
+    fn return_chain_buffer(&mut self, mut buffer: Vec<Ancestor>) {
+        buffer.clear();
+        self.chain_pool.push(buffer);
+    }
+
+    /// Take an empty mixin buffer from the pool, or make a new one if the pool is empty.
+    fn take_mixin_buffer(&mut self) -> Vec<Mixin> {
+        self.mixin_pool.pop().unwrap_or_default()
+    }
+
+    /// Give a mixin buffer back to the pool.
+    fn return_mixin_buffer(&mut self, mut buffer: Vec<Mixin>) {
+        buffer.clear();
+        self.mixin_pool.push(buffer);
+    }
+
+    /// Take an empty deque from the pool, or make a new one if the pool is empty.
+    fn take_deque(&mut self) -> VecDeque<Ancestor> {
+        self.deque_pool.pop().unwrap_or_default()
+    }
+
+    /// Give a deque back to the pool.
+    fn return_deque(&mut self, mut deque: VecDeque<Ancestor>) {
+        deque.clear();
+        self.deque_pool.push(deque);
     }
 
     /// Runs the resolution phase on the graph. The resolution phase is when 4 main pieces of information are computed:
@@ -1037,9 +1081,11 @@ impl<'a> Resolver<'a> {
         }
 
         let mut state = ChainState::default();
-        let parent_ancestors = self.linearize_parent_ancestors(declaration_id, &mut state);
+        let mut parent_buffer = self.take_chain_buffer();
+        let has_parent = self.linearize_parent_ancestors_into(declaration_id, &mut state, &mut parent_buffer);
+
+        let mut mixins = self.take_mixin_buffer();
         let declaration = self.graph.declarations().get(&declaration_id).unwrap();
-        let mut mixins = Vec::new();
 
         let is_singleton_class = matches!(declaration, Declaration::Namespace(Namespace::SingletonClass(_)));
 
@@ -1074,17 +1120,33 @@ impl<'a> Resolver<'a> {
             self.get_or_create_singleton_class(declaration_id, SingletonAncestors::Enqueue);
         }
 
-        let (linearized_prepends, linearized_includes) =
-            self.linearize_mixins(mixins, parent_ancestors.as_ref(), &mut state);
+        let mut linearized_prepends = self.take_deque();
+        let mut linearized_includes = self.take_deque();
 
-        // Build the final list
-        let mut ancestors = Vec::new();
-        ancestors.extend(linearized_prepends);
+        self.linearize_mixins(
+            &mut state,
+            &mixins,
+            has_parent.then_some(parent_buffer.as_slice()),
+            &mut linearized_prepends,
+            &mut linearized_includes,
+        );
+
+        // Build the final list with its final capacity.
+        let final_len = linearized_prepends.len() + 1 + linearized_includes.len() + parent_buffer.len();
+        let mut ancestors = Vec::with_capacity(final_len);
+        ancestors.extend(linearized_prepends.drain(..));
         ancestors.push(Ancestor::Complete(declaration_id));
-        ancestors.extend(linearized_includes);
-        if let Some(parents) = parent_ancestors {
-            ancestors.extend(parents);
+        ancestors.extend(linearized_includes.drain(..));
+        if has_parent {
+            ancestors.extend_from_slice(&parent_buffer);
         }
+
+        // The scratch buffers gave up their contents to the new list, thus they go back to the pool
+        // for the next linearization to use.
+        self.return_chain_buffer(parent_buffer);
+        self.return_mixin_buffer(mixins);
+        self.return_deque(linearized_prepends);
+        self.return_deque(linearized_includes);
 
         let result = if state.cyclic {
             Ancestors::Cyclic(ancestors)
@@ -1106,17 +1168,21 @@ impl<'a> Resolver<'a> {
         result
     }
 
-    fn linearize_parent_ancestors(
+    /// Copy the parent ancestor chain of a declaration into `buffer`.
+    ///
+    /// Returns `true` if the declaration has a parent. A module, or a class without a superclass,
+    /// has no parent and leaves `buffer` untouched.
+    fn linearize_parent_ancestors_into(
         &mut self,
         declaration_id: DeclarationId,
         state: &mut ChainState,
-    ) -> Option<Vec<Ancestor>> {
+        buffer: &mut Vec<Ancestor>,
+    ) -> bool {
         let declaration = self.graph.declarations().get(&declaration_id).unwrap();
 
         match declaration {
             Declaration::Namespace(Namespace::Class(_)) => {
-                let superclass = self.linearize_superclass(declaration_id, state)?;
-                Some(state.fold(superclass))
+                self.linearize_superclass_into(declaration_id, state, buffer)
             }
             Declaration::Namespace(Namespace::SingletonClass(_)) => {
                 let owner_id = *declaration.owner_id();
@@ -1126,10 +1192,16 @@ impl<'a> Resolver<'a> {
                     state.partial = true;
                 }
 
-                let parent = self.linearize_ancestors(singleton_parent_id);
-                Some(state.fold(parent))
+                let result = self.linearize_ancestors(singleton_parent_id);
+                match &result {
+                    Ancestors::Complete(_) => {}
+                    Ancestors::Cyclic(_) => state.cyclic = true,
+                    Ancestors::Partial(_) => state.partial = true,
+                }
+                buffer.extend(result.iter());
+                true
             }
-            _ => None,
+            _ => false,
         }
     }
 
@@ -1137,13 +1209,12 @@ impl<'a> Resolver<'a> {
     /// modules are deduplicated against them
     fn linearize_mixins(
         &mut self,
-        mixins: Vec<Mixin>,
-        parent_ancestors: Option<&Vec<Ancestor>>,
         state: &mut ChainState,
-    ) -> (VecDeque<Ancestor>, VecDeque<Ancestor>) {
-        let mut linearized_prepends = VecDeque::new();
-        let mut linearized_includes = VecDeque::new();
-
+        mixins: &[Mixin],
+        parent_ancestors: Option<&[Ancestor]>,
+        linearized_prepends: &mut VecDeque<Ancestor>,
+        linearized_includes: &mut VecDeque<Ancestor>,
+    ) {
         // IMPORTANT! In the slice of mixins we receive, extends are the ones that occurred in the attached object, which we
         // collect ahead of time. This is the reason why we apparently treat an extend like an include, because an extend in
         // the attached object is equivalent to an include in the singleton class
@@ -1199,9 +1270,7 @@ impl<'a> Resolver<'a> {
                             ids.retain(|id| {
                                 !linearized_prepends.contains(id)
                                     && !linearized_includes.contains(id)
-                                    && parent_ancestors
-                                        .as_ref()
-                                        .is_none_or(|parent_ids| !parent_ids.contains(id))
+                                    && parent_ancestors.is_none_or(|parent_ids| !parent_ids.contains(id))
                             });
 
                             for id in ids.into_iter().rev() {
@@ -1218,8 +1287,6 @@ impl<'a> Resolver<'a> {
                 }
             }
         }
-
-        (linearized_prepends, linearized_includes)
     }
 
     /// Propagate descendants to all cached ancestors
@@ -2063,24 +2130,41 @@ impl<'a> Resolver<'a> {
         ))
     }
 
-    fn linearize_superclass(&mut self, declaration_id: DeclarationId, state: &mut ChainState) -> Option<Ancestors> {
-        let (superclass_id, unresolved_superclass) = self.get_superclass(declaration_id)?;
-        let mut result = self.linearize_ancestors(superclass_id);
+    /// Copy the linearized superclass chain of a class into `buffer`. Returns `true` if the class
+    /// has a superclass.
+    ///
+    /// An unresolved superclass reference means the chain must be partial, never cyclic. A cyclic
+    /// chain counts as settled (`has_complete_ancestors` is true for `Cyclic`), which would stop
+    /// retries for the unresolved reference.
+    fn linearize_superclass_into(
+        &mut self,
+        declaration_id: DeclarationId,
+        state: &mut ChainState,
+        buffer: &mut Vec<Ancestor>,
+    ) -> bool {
+        let Some((superclass_id, unresolved_superclass)) = self.get_superclass(declaration_id) else {
+            return false;
+        };
+
+        let result = self.linearize_ancestors(superclass_id);
 
         if let Some(name_id) = unresolved_superclass {
             state.partial = true;
 
-            // Insert the unresolved superclass as a Partial ancestor at the front of the chain, so it
+            // Put the unresolved superclass as a Partial ancestor at the front of the chain, so it
             // appears before the default Object ancestors
-            let ancestors = match &mut result {
-                Ancestors::Complete(ids) | Ancestors::Cyclic(ids) | Ancestors::Partial(ids) => ids,
-            };
-            ancestors.insert(0, Ancestor::Partial(name_id));
-
-            result = result.to_partial();
+            buffer.push(Ancestor::Partial(name_id));
+            buffer.extend(result.iter());
+        } else {
+            match &result {
+                Ancestors::Complete(_) => {}
+                Ancestors::Cyclic(_) => state.cyclic = true,
+                Ancestors::Partial(_) => state.partial = true,
+            }
+            buffer.extend(result.iter());
         }
 
-        Some(result)
+        true
     }
 
     fn mixins_of(&self, definition_id: DefinitionId) -> &[Mixin] {


### PR DESCRIPTION
## Summary

The `Resolver` now pools temporary buffers used during ancestor linearization, instead of allocating new ones for each linearization. Three internal functions were refactored from returning owned collections to writing into caller-provided buffers:

- `linearize_parent_ancestors` → `linearize_parent_ancestors_into`
- `linearize_superclass` → `linearize_superclass_into`
- `linearize_mixins` (signature change: takes `&[Mixin]` and `&mut VecDeque` instead of owning and returning)

Four pools were added to `Resolver`:
- `chain_pool: Vec<Vec<Ancestor>>` — parent ancestor chain buffers (one per recursion level)
- `mixin_pool: Vec<Vec<Mixin>>` — collected mixin buffers
- `deque_pool: Vec<VecDeque<Ancestor>>` — linearized prepend/include deques
- `spare_context: Option<LinearizationContext>` — reused linearization context (hash sets retain capacity)

The final `ancestors` Vec is also pre-allocated with exact capacity (`Vec::with_capacity(final_len)`) to eliminate reallocations during assembly.

<img width="2480" height="2020" alt="rubydex _998 _ Ancestor Linearization_ Buffer Pooling" src="https://github.com/user-attachments/assets/0e971844-c4c0-4748-985f-98475164c21d" />


## Benchmark Results

### Shopify core

Release mode, Apple M3 Pro. 111,463 Ruby files, ~1.14M declarations. Each binary ran 20 times sequentially with no concurrent heavy processes. Welch t-test for significance.

| Metric | Branch | Mean | Median | SD | Min | Max | 95% CI |
|--------|--------|------|--------|----|-----|-----|--------|
| Max RSS (MB) | main (462de8e7) | 5367.69 | 5386.97 | 103.36 | 5121.93 | 5527.82 | [5319.32, 5416.07] |
| Max RSS (MB) | branch (c89869e6) | 5378.40 | 5384.99 | 74.75 | 5250.20 | 5518.68 | [5343.42, 5413.38] |
| Resolution (s) | main (462de8e7) | 13.86 | 13.85 | 0.57 | 13.02 | 15.13 | [13.59, 14.13] |
| Resolution (s) | branch (c89869e6) | 12.34 | 12.07 | 0.39 | 11.86 | 12.97 | [12.15, 12.52] |
| Total (s) | main (462de8e7) | 20.49 | 20.44 | 0.70 | 19.47 | 22.13 | [20.16, 20.82] |
| Total (s) | branch (c89869e6) | 18.61 | 18.19 | 0.65 | 17.90 | 19.82 | [18.31, 18.92] |

| Metric | Delta (mean) | Delta (%) | p-value | Significant? |
|--------|-------------|-----------|---------|-------------|
| Max RSS | +10.71 MB | +0.2% | 0.707 | No |
| Resolution | **-1.52s** | **-11.0%** | <0.001 | Yes (p < 0.001) |
| Total | **-1.88s** | **-9.2%** | <0.001 | Yes (p < 0.001) |

<details>
<summary>Raw per-run data (20 runs each)</summary>

**Main (462de8e7):**

| Run | RSS (MB) | Resolution (s) | Total (s) |
|-----|----------|----------------|-----------|
| 1 | 5423.89 | 13.849 | 20.89 |
| 2 | 5362.37 | 13.845 | 20.15 |
| 3 | 5322.48 | 13.794 | 20.73 |
| 4 | 5517.57 | 13.459 | 19.90 |
| 5 | 5273.64 | 13.626 | 20.72 |
| 6 | 5146.09 | 13.307 | 20.16 |
| 7 | 5121.93 | 13.018 | 19.52 |
| 8 | 5321.56 | 13.125 | 19.71 |
| 9 | 5375.46 | 13.211 | 19.47 |
| 10 | 5446.75 | 14.446 | 20.86 |
| 11 | 5391.81 | 14.317 | 20.88 |
| 12 | 5400.92 | 13.539 | 20.20 |
| 13 | 5452.59 | 13.923 | 20.28 |
| 14 | 5289.28 | 14.108 | 20.42 |
| 15 | 5405.70 | 14.032 | 20.46 |
| 16 | 5441.78 | 14.039 | 20.62 |
| 17 | 5358.28 | 14.899 | 21.95 |
| 18 | 5391.76 | 15.135 | 22.13 |
| 19 | 5382.18 | 13.291 | 19.82 |
| 20 | 5527.82 | 14.249 | 20.94 |

**Branch (c89869e6):**

| Run | RSS (MB) | Resolution (s) | Total (s) |
|-----|----------|----------------|-----------|
| 1 | 5335.60 | 12.568 | 19.13 |
| 2 | 5305.54 | 12.967 | 19.40 |
| 3 | 5281.59 | 12.555 | 18.98 |
| 4 | 5264.50 | 12.821 | 19.45 |
| 5 | 5385.34 | 12.813 | 19.37 |
| 6 | 5294.60 | 12.880 | 19.82 |
| 7 | 5347.43 | 12.781 | 19.06 |
| 8 | 5348.87 | 12.487 | 19.11 |
| 9 | 5250.20 | 12.806 | 19.26 |
| 10 | 5429.28 | 12.062 | 18.17 |
| 11 | 5384.64 | 12.081 | 18.20 |
| 12 | 5382.18 | 12.062 | 18.10 |
| 13 | 5518.68 | 11.956 | 18.05 |
| 14 | 5423.18 | 12.062 | 18.02 |
| 15 | 5426.68 | 12.035 | 18.07 |
| 16 | 5399.40 | 12.025 | 17.90 |
| 17 | 5427.07 | 12.024 | 18.12 |
| 18 | 5504.71 | 11.910 | 17.90 |
| 19 | 5448.45 | 11.864 | 18.07 |
| 20 | 5410.06 | 11.986 | 18.07 |

</details>
