### PR TITLE
Fix extend self in anonymous modules

### DIFF
--- a/rust/rubydex/src/indexing/ruby_indexer.rs
+++ b/rust/rubydex/src/indexing/ruby_indexer.rs
@@ -972,7 +972,7 @@ impl<'a> RubyIndexer<'a> {
                     }
 
                     Some((
-                        self.current_lexical_scope_name_id().unwrap(),
+                        self.current_owner_name_id().unwrap(),
                         Offset::from_prism_location(&arg.location()),
                     ))
                 } else if let Some(name_id) = self.index_constant_reference(&arg, false) {

--- a/rust/rubydex/src/indexing/ruby_indexer_tests.rs
+++ b/rust/rubydex/src/indexing/ruby_indexer_tests.rs
@@ -5201,6 +5201,29 @@ mod dynamic_namespace_tests {
     }
 
     #[test]
+    fn index_extend_self_in_anonymous_module() {
+        let context = index_source({
+            "
+            Module.new do
+              extend self
+            end
+            "
+        });
+        assert_no_local_diagnostics!(&context);
+
+        assert_definition_at!(&context, "1:1-3:4", Module, |anonymous_module| {
+            let extend = anonymous_module.mixins().first().unwrap();
+            let constant_reference = context
+                .graph()
+                .constant_references()
+                .get(extend.constant_reference_id())
+                .unwrap();
+
+            assert_eq!(anonymous_module.name_id(), constant_reference.name_id());
+        });
+    }
+
+    #[test]
     fn index_singleton_method_in_class_new() {
         let context = index_source({
             "

--- a/rust/rubydex/src/operation/ruby_builder.rs
+++ b/rust/rubydex/src/operation/ruby_builder.rs
@@ -845,7 +845,7 @@ impl<'a> RubyOperationBuilder<'a> {
                     }
 
                     Some((
-                        self.current_lexical_scope_name_id().unwrap(),
+                        self.current_owner_name_id().unwrap(),
                         Offset::from_prism_location(&arg.location()),
                     ))
                 } else if let Some(name_id) = self.index_constant_reference(&arg, false) {


### PR DESCRIPTION
## Summary

Fix indexing `extend self` inside anonymous modules:

```ruby
Module.new do
  extend self
end
```

`self` in a `Class.new` or `Module.new` block refers to the newly created class or module. These blocks establish an owner but not a lexical scope. Both indexing backends incorrectly resolved mixin `self` through the lexical scope, causing an `Option::unwrap()` panic.

Resolve `self` through the current owner instead. Ordinary constant mixin arguments continue to use lexical lookup.

Closes #889.