### PR TITLE
Make severity a `Rule` concern

### DIFF
--- a/rust/rubydex-sys/src/config_api.rs
+++ b/rust/rubydex-sys/src/config_api.rs
@@ -128,7 +128,7 @@ impl From<&Rule> for CLinterRule {
             Box::into_raw(exclude_patterns).cast::<CConfigString>().cast_const()
         };
         let severity = rule.severity().map_or(ptr::null(), |severity| {
-            Box::into_raw(Box::new(DiagnosticSeverity::from(severity))).cast_const()
+            Box::into_raw(Box::new(DiagnosticSeverity::from(*severity))).cast_const()
         });
 
         Self {

--- a/rust/rubydex-sys/src/diagnostic_api.rs
+++ b/rust/rubydex-sys/src/diagnostic_api.rs
@@ -16,8 +16,8 @@ pub enum DiagnosticSeverity {
     Hint = 4,
 }
 
-impl From<&Severity> for DiagnosticSeverity {
-    fn from(severity: &Severity) -> Self {
+impl From<Severity> for DiagnosticSeverity {
+    fn from(severity: Severity) -> Self {
         match severity {
             Severity::Error => DiagnosticSeverity::Error,
             Severity::Warning => DiagnosticSeverity::Warning,
@@ -79,7 +79,7 @@ pub unsafe extern "C" fn rdx_graph_diagnostics(pointer: GraphPointer) -> *mut Di
                         .cast_const(),
                     message: CString::new(diagnostic.message()).unwrap().into_raw().cast_const(),
                     location,
-                    severity: DiagnosticSeverity::from(diagnostic.severity()),
+                    severity: DiagnosticSeverity::from(diagnostic.rule().default_severity()),
                 }
             })
             .collect::<Vec<DiagnosticEntry>>();

--- a/rust/rubydex/src/diagnostic.rs
+++ b/rust/rubydex/src/diagnostic.rs
@@ -1,23 +1,21 @@
 #[cfg(any(test, feature = "test_utils"))]
 use crate::model::document::Document;
-use crate::{model::ids::UriId, offset::Offset};
+use crate::{assert_mem_size, model::ids::UriId, offset::Offset};
 
 #[derive(Debug)]
 pub struct Diagnostic {
     rule: Rule,
-    // Severity belongs to each diagnostic; every producer must assign it explicitly.
-    severity: Severity,
     uri_id: UriId,
     offset: Offset,
     message: String,
 }
+assert_mem_size!(Diagnostic, 48);
 
 impl Diagnostic {
     #[must_use]
-    pub fn new(rule: Rule, severity: Severity, uri_id: UriId, offset: Offset, message: String) -> Self {
+    pub fn new(rule: Rule, uri_id: UriId, offset: Offset, message: String) -> Self {
         Self {
             rule,
-            severity,
             uri_id,
             offset,
             message,
@@ -27,11 +25,6 @@ impl Diagnostic {
     #[must_use]
     pub fn rule(&self) -> &Rule {
         &self.rule
-    }
-
-    #[must_use]
-    pub fn severity(&self) -> &Severity {
-        &self.severity
     }
 
     #[must_use]
@@ -70,60 +63,61 @@ pub enum Severity {
     Hint,
 }
 
-fn camel_to_snake(s: &str) -> String {
-    let mut snake = String::new();
-    for (i, ch) in s.chars().enumerate() {
-        if ch.is_uppercase() {
-            if i != 0 {
-                snake.push('-');
-            }
-            for lc in ch.to_lowercase() {
-                snake.push(lc);
-            }
-        } else {
-            snake.push(ch);
-        }
-    }
-    snake
-}
-
-macro_rules! rules {
-    (
-        $( $variant:ident );* $(;)?
-    ) => {
-        #[derive(Debug, Copy, Clone, PartialEq, Eq)]
-        pub enum Rule {
-            $(
-                $variant,
-            )*
-        }
-
-        impl std::fmt::Display for Rule {
-            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                write!(f, "{}", match self {
-                    $(
-                        Rule::$variant => camel_to_snake(stringify!($variant)),
-                    )*
-                })
-            }
-        }
-    }
-}
-
-rules! {
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum Rule {
     // Parsing
-    ParseError;
-    ParseWarning;
+    ParseError,
+    ParseWarning,
 
     // Indexing
-    DynamicConstantReference;
-    DynamicSingletonDefinition;
-    DynamicAncestor;
-    TopLevelMixinSelf;
-    InvalidConstantVisibility;
-    InvalidMethodVisibility;
+    DynamicConstantReference,
+    DynamicSingletonDefinition,
+    DynamicAncestor,
+    TopLevelMixinSelf,
+    InvalidConstantVisibility,
+    InvalidMethodVisibility,
 
     // Resolution
-    UndefinedMethodVisibilityTarget;
-    UndefinedConstantVisibilityTarget;
+    UndefinedMethodVisibilityTarget,
+    UndefinedConstantVisibilityTarget,
+}
+
+impl Rule {
+    #[must_use]
+    pub fn name(&self) -> &'static str {
+        match self {
+            Self::ParseError => "ParseError",
+            Self::ParseWarning => "ParseWarning",
+            Self::DynamicConstantReference => "DynamicConstantReference",
+            Self::DynamicSingletonDefinition => "DynamicSingletonDefinition",
+            Self::DynamicAncestor => "DynamicAncestor",
+            Self::TopLevelMixinSelf => "TopLevelMixinSelf",
+            Self::InvalidConstantVisibility => "InvalidConstantVisibility",
+            Self::InvalidMethodVisibility => "InvalidMethodVisibility",
+            Self::UndefinedMethodVisibilityTarget => "UndefinedMethodVisibilityTarget",
+            Self::UndefinedConstantVisibilityTarget => "UndefinedConstantVisibilityTarget",
+        }
+    }
+
+    #[must_use]
+    pub fn default_severity(&self) -> Severity {
+        match self {
+            Self::ParseError => Severity::Error,
+            Self::ParseWarning
+            | Self::InvalidConstantVisibility
+            | Self::InvalidMethodVisibility
+            | Self::UndefinedMethodVisibilityTarget
+            | Self::UndefinedConstantVisibilityTarget => Severity::Warning,
+            Self::DynamicConstantReference
+            | Self::DynamicSingletonDefinition
+            | Self::DynamicAncestor
+            | Self::TopLevelMixinSelf => Severity::Information,
+        }
+    }
+}
+
+impl std::fmt::Display for Rule {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.name())
+    }
 }

--- a/rust/rubydex/src/indexing/local_graph.rs
+++ b/rust/rubydex/src/indexing/local_graph.rs
@@ -1,6 +1,6 @@
 use std::collections::hash_map::Entry;
 
-use crate::diagnostic::{Diagnostic, Rule, Severity};
+use crate::diagnostic::{Diagnostic, Rule};
 use crate::model::definitions::Definition;
 use crate::model::document::Document;
 use crate::model::graph::NameDependent;
@@ -195,8 +195,8 @@ impl LocalGraph {
         self.document.diagnostics()
     }
 
-    pub fn add_diagnostic(&mut self, rule: Rule, severity: Severity, offset: Offset, message: String) {
-        let diagnostic = Diagnostic::new(rule, severity, self.uri_id, offset, message);
+    pub fn add_diagnostic(&mut self, rule: Rule, offset: Offset, message: String) {
+        let diagnostic = Diagnostic::new(rule, self.uri_id, offset, message);
         self.document.add_diagnostic(diagnostic);
     }
 

--- a/rust/rubydex/src/indexing/rbs_indexer.rs
+++ b/rust/rubydex/src/indexing/rbs_indexer.rs
@@ -7,7 +7,7 @@ use ruby_rbs::node::{
     ModuleNode, Node, NodeList, PrependNode, TypeNameNode, Visit,
 };
 
-use crate::diagnostic::{Rule, Severity};
+use crate::diagnostic::Rule;
 use crate::indexing::local_graph::LocalGraph;
 use crate::model::comment::Comment;
 use crate::model::definitions::{
@@ -54,7 +54,6 @@ impl<'a> RBSIndexer<'a> {
         let Ok(signature) = node::parse(self.source) else {
             self.local_graph.add_diagnostic(
                 Rule::ParseError,
-                Severity::Error,
                 Offset::new(0, 0),
                 "Failed to parse RBS document".to_string(),
             );
@@ -685,7 +684,7 @@ mod tests {
 
         assert_local_diagnostics_eq!(
             &context,
-            ["parse-error: Failed to parse RBS document (1:1-1:1)"],
+            ["ParseError: Failed to parse RBS document (1:1-1:1)"],
             severity: Severity::Error
         );
 

--- a/rust/rubydex/src/indexing/ruby_indexer.rs
+++ b/rust/rubydex/src/indexing/ruby_indexer.rs
@@ -1,6 +1,6 @@
 //! Visit the Ruby AST and create the definitions.
 
-use crate::diagnostic::{Rule, Severity};
+use crate::diagnostic::Rule;
 use crate::indexing::local_graph::LocalGraph;
 use crate::model::comment::Comment;
 use crate::model::definitions::{
@@ -119,7 +119,6 @@ impl<'a> RubyIndexer<'a> {
         for error in result.errors() {
             self.local_graph.add_diagnostic(
                 Rule::ParseError,
-                Severity::Error,
                 Offset::from_prism_location(&error.location()),
                 error.message().to_string(),
             );
@@ -128,7 +127,6 @@ impl<'a> RubyIndexer<'a> {
         for warning in result.warnings() {
             self.local_graph.add_diagnostic(
                 Rule::ParseWarning,
-                Severity::Warning,
                 Offset::from_prism_location(&warning.location()),
                 warning.message().to_string(),
             );
@@ -409,7 +407,6 @@ impl<'a> RubyIndexer<'a> {
                         _ => {
                             self.local_graph.add_diagnostic(
                                 Rule::DynamicConstantReference,
-                                Severity::Information,
                                 Offset::from_prism_location(&parent.location()),
                                 "Dynamic constant reference".to_string(),
                             );
@@ -665,7 +662,6 @@ impl<'a> RubyIndexer<'a> {
         {
             self.local_graph.add_diagnostic(
                 Rule::DynamicAncestor,
-                Severity::Information,
                 Offset::from_prism_location(&superclass_node.location()),
                 "Dynamic superclass".to_string(),
             );
@@ -963,7 +959,6 @@ impl<'a> RubyIndexer<'a> {
                     if parent_nesting_id.is_none() {
                         self.local_graph.add_diagnostic(
                             Rule::TopLevelMixinSelf,
-                            Severity::Information,
                             Offset::from_prism_location(&arg.location()),
                             "Top level mixin self".to_string(),
                         );
@@ -980,7 +975,6 @@ impl<'a> RubyIndexer<'a> {
                 } else {
                     self.local_graph.add_diagnostic(
                         Rule::DynamicAncestor,
-                        Severity::Information,
                         Offset::from_prism_location(&arg.location()),
                         "Dynamic mixin argument".to_string(),
                     );
@@ -1198,7 +1192,6 @@ impl<'a> RubyIndexer<'a> {
                 None => {
                     self.local_graph.add_diagnostic(
                         Rule::InvalidConstantVisibility,
-                        Severity::Warning,
                         Offset::from_prism_location(&node.location()),
                         format!("`{call_name}` called at top level"),
                     );
@@ -1210,7 +1203,6 @@ impl<'a> RubyIndexer<'a> {
             Some(other) => {
                 self.local_graph.add_diagnostic(
                     Rule::InvalidConstantVisibility,
-                    Severity::Warning,
                     Offset::from_prism_location(&other.location()),
                     format!("Dynamic receiver for `{call_name}`"),
                 );
@@ -1227,7 +1219,6 @@ impl<'a> RubyIndexer<'a> {
             let Some((name, location)) = Self::extract_literal_name(&argument) else {
                 self.local_graph.add_diagnostic(
                     Rule::InvalidConstantVisibility,
-                    Severity::Warning,
                     Offset::from_prism_location(&argument.location()),
                     format!("`{call_name}` called with a non-literal argument"),
                 );
@@ -1270,7 +1261,6 @@ impl<'a> RubyIndexer<'a> {
                 None => {
                     self.local_graph.add_diagnostic(
                         Rule::InvalidMethodVisibility,
-                        Severity::Warning,
                         Offset::from_prism_location(&node.location()),
                         format!("`{call_name}` called at top level"),
                     );
@@ -1317,7 +1307,6 @@ impl<'a> RubyIndexer<'a> {
                                 if def_node.receiver().is_none() {
                                     self.local_graph.add_diagnostic(
                                         Rule::InvalidMethodVisibility,
-                                        Severity::Warning,
                                         Offset::from_prism_location(&element.location()),
                                         format!("`{call_name}` requires a singleton method definition"),
                                     );
@@ -1337,7 +1326,6 @@ impl<'a> RubyIndexer<'a> {
                             _ => {
                                 self.local_graph.add_diagnostic(
                                     Rule::InvalidMethodVisibility,
-                                    Severity::Warning,
                                     Offset::from_prism_location(&element.location()),
                                     format!(
                                         "`{call_name}` array element must be a Symbol, String, or method definition"
@@ -1353,7 +1341,6 @@ impl<'a> RubyIndexer<'a> {
                     if def_node.receiver().is_none() {
                         self.local_graph.add_diagnostic(
                             Rule::InvalidMethodVisibility,
-                            Severity::Warning,
                             Offset::from_prism_location(&argument.location()),
                             format!("`{call_name}` requires a singleton method definition"),
                         );
@@ -1373,7 +1360,6 @@ impl<'a> RubyIndexer<'a> {
                 arg if Self::is_attr_call(&arg) => {
                     self.local_graph.add_diagnostic(
                         Rule::InvalidMethodVisibility,
-                        Severity::Warning,
                         Offset::from_prism_location(&arg.location()),
                         format!("`{call_name}` does not accept `attr_*` arguments"),
                     );
@@ -1382,7 +1368,6 @@ impl<'a> RubyIndexer<'a> {
                 ruby_prism::Node::ArrayNode { .. } => {
                     self.local_graph.add_diagnostic(
                         Rule::InvalidMethodVisibility,
-                        Severity::Warning,
                         Offset::from_prism_location(&argument.location()),
                         format!("`{call_name}` array argument must be the only argument"),
                     );
@@ -1391,7 +1376,6 @@ impl<'a> RubyIndexer<'a> {
                 _ => {
                     self.local_graph.add_diagnostic(
                         Rule::InvalidMethodVisibility,
-                        Severity::Warning,
                         Offset::from_prism_location(&argument.location()),
                         format!("`{call_name}` called with a non-literal argument"),
                     );
@@ -1476,7 +1460,7 @@ impl<'a> RubyIndexer<'a> {
                     format!("`{call_name}` called with a non-literal argument")
                 };
                 self.local_graph
-                    .add_diagnostic(Rule::InvalidMethodVisibility, Severity::Warning, arg_offset, message);
+                    .add_diagnostic(Rule::InvalidMethodVisibility, arg_offset, message);
                 self.visit(&arg);
             }
         }
@@ -1626,7 +1610,6 @@ impl Visit<'_> for RubyIndexer<'_> {
             self.visit(&expression);
             self.local_graph.add_diagnostic(
                 Rule::DynamicSingletonDefinition,
-                Severity::Information,
                 Offset::from_prism_location(&node.location()),
                 "Dynamic singleton class definition".to_string(),
             );
@@ -1636,7 +1619,6 @@ impl Visit<'_> for RubyIndexer<'_> {
         let Some(attached_target) = attached_target else {
             self.local_graph.add_diagnostic(
                 Rule::DynamicSingletonDefinition,
-                Severity::Information,
                 Offset::from_prism_location(&node.location()),
                 "Dynamic singleton class definition".to_string(),
             );
@@ -1851,7 +1833,6 @@ impl Visit<'_> for RubyIndexer<'_> {
                 _ => {
                     self.local_graph.add_diagnostic(
                         Rule::DynamicSingletonDefinition,
-                        Severity::Information,
                         Offset::from_prism_location(&node.location()),
                         "Dynamic receiver for singleton method definition".to_string(),
                     );
@@ -2132,7 +2113,6 @@ impl Visit<'_> for RubyIndexer<'_> {
                     let offset = Offset::from_prism_location(&node.location());
                     self.local_graph.add_diagnostic(
                         Rule::InvalidMethodVisibility,
-                        Severity::Warning,
                         offset,
                         format!("`{message}` cannot be called with an explicit receiver"),
                     );
@@ -2147,7 +2127,6 @@ impl Visit<'_> for RubyIndexer<'_> {
                     if visibility == Visibility::ModuleFunction && !self.current_nesting_is_module() {
                         self.local_graph.add_diagnostic(
                             Rule::InvalidMethodVisibility,
-                            Severity::Warning,
                             offset,
                             "`module_function` can only be used in modules".to_string(),
                         );

--- a/rust/rubydex/src/indexing/ruby_indexer_tests.rs
+++ b/rust/rubydex/src/indexing/ruby_indexer_tests.rs
@@ -968,7 +968,7 @@ mod class_and_module_tests {
 
         assert_local_diagnostics_eq!(
             &context,
-            ["dynamic-constant-reference: Dynamic constant reference (1:7-1:10)"],
+            ["DynamicConstantReference: Dynamic constant reference (1:7-1:10)"],
             severity: Severity::Information
         );
         assert!(context.graph().definitions().is_empty());
@@ -1073,7 +1073,7 @@ mod class_and_module_tests {
 
         assert_local_diagnostics_eq!(
             &context,
-            ["dynamic-constant-reference: Dynamic constant reference (1:8-1:11)"]
+            ["DynamicConstantReference: Dynamic constant reference (1:8-1:11)"]
         );
         assert!(context.graph().definitions().is_empty());
     }
@@ -1175,7 +1175,7 @@ mod method_tests {
 
         assert_local_diagnostics_eq!(
             &context,
-            ["dynamic-singleton-definition: Dynamic receiver for singleton method definition (1:1-1:17)"]
+            ["DynamicSingletonDefinition: Dynamic receiver for singleton method definition (1:1-1:17)"]
         );
         assert_eq!(context.graph().definitions().len(), 0);
         assert_method_references_eq!(&context, ["foo"]);
@@ -1418,7 +1418,7 @@ mod singleton_class_tests {
 
         assert_local_diagnostics_eq!(
             &context,
-            ["dynamic-singleton-definition: Dynamic singleton class definition (1:1-3:4)"]
+            ["DynamicSingletonDefinition: Dynamic singleton class definition (1:1-3:4)"]
         );
         assert_eq!(context.graph().definitions().len(), 0);
     }
@@ -1802,11 +1802,11 @@ mod visibility_tests {
         assert_local_diagnostics_eq!(
             &context,
             vec![
-                "invalid-constant-visibility: `private_constant` called at top level (1:1-1:22)",
-                "invalid-constant-visibility: `private_constant` called at top level (2:1-2:27)",
-                "invalid-constant-visibility: Dynamic receiver for `private_constant` (3:1-3:4)",
-                "invalid-constant-visibility: `private_constant` called with a non-literal argument (6:20-6:29)",
-                "invalid-constant-visibility: `private_constant` called with a non-literal argument (6:31-6:42)",
+                "InvalidConstantVisibility: `private_constant` called at top level (1:1-1:22)",
+                "InvalidConstantVisibility: `private_constant` called at top level (2:1-2:27)",
+                "InvalidConstantVisibility: Dynamic receiver for `private_constant` (3:1-3:4)",
+                "InvalidConstantVisibility: `private_constant` called with a non-literal argument (6:20-6:29)",
+                "InvalidConstantVisibility: `private_constant` called with a non-literal argument (6:31-6:42)",
             ],
             severity: Severity::Warning
         );
@@ -1840,11 +1840,11 @@ mod visibility_tests {
         assert_local_diagnostics_eq!(
             &context,
             vec![
-                "invalid-constant-visibility: `public_constant` called at top level (1:1-1:21)",
-                "invalid-constant-visibility: `public_constant` called at top level (2:1-2:26)",
-                "invalid-constant-visibility: Dynamic receiver for `public_constant` (3:1-3:4)",
-                "invalid-constant-visibility: `public_constant` called with a non-literal argument (6:19-6:28)",
-                "invalid-constant-visibility: `public_constant` called with a non-literal argument (6:30-6:41)",
+                "InvalidConstantVisibility: `public_constant` called at top level (1:1-1:21)",
+                "InvalidConstantVisibility: `public_constant` called at top level (2:1-2:26)",
+                "InvalidConstantVisibility: Dynamic receiver for `public_constant` (3:1-3:4)",
+                "InvalidConstantVisibility: `public_constant` called with a non-literal argument (6:19-6:28)",
+                "InvalidConstantVisibility: `public_constant` called with a non-literal argument (6:30-6:41)",
             ]
         );
 
@@ -1921,7 +1921,7 @@ mod visibility_tests {
 
         assert_local_diagnostics_eq!(
             &context,
-            vec!["invalid-method-visibility: `private` called with a non-literal argument (4:17-4:27)"]
+            vec!["InvalidMethodVisibility: `private` called with a non-literal argument (4:17-4:27)"]
         );
 
         // :foo is a literal arg, so visibility is still applied
@@ -1947,7 +1947,7 @@ mod visibility_tests {
 
         assert_local_diagnostics_eq!(
             &context,
-            vec!["invalid-method-visibility: `private` cannot be called with an explicit receiver (4:3-4:19)"]
+            vec!["InvalidMethodVisibility: `private` cannot be called with an explicit receiver (4:3-4:19)"]
         );
 
         for def in context.graph().definitions().values() {
@@ -1972,7 +1972,7 @@ mod visibility_tests {
 
         assert_local_diagnostics_eq!(
             &context,
-            vec!["invalid-method-visibility: `private` called with a non-literal argument (4:11-4:21)"]
+            vec!["InvalidMethodVisibility: `private` called with a non-literal argument (4:11-4:21)"]
         );
 
         // No MethodVisibilityDefinition created
@@ -1996,7 +1996,7 @@ mod visibility_tests {
 
         assert_local_diagnostics_eq!(
             &context,
-            vec!["invalid-method-visibility: `private` called with a non-literal argument (2:11-2:23)"]
+            vec!["InvalidMethodVisibility: `private` called with a non-literal argument (2:11-2:23)"]
         );
 
         // No MethodVisibilityDefinition created
@@ -2020,7 +2020,7 @@ mod visibility_tests {
 
         assert_local_diagnostics_eq!(
             &context,
-            vec!["invalid-method-visibility: `private` called with a non-literal argument (2:11-2:35)"]
+            vec!["InvalidMethodVisibility: `private` called with a non-literal argument (2:11-2:35)"]
         );
 
         // No MethodVisibilityDefinition or AttrReader created from that call
@@ -2063,9 +2063,7 @@ mod visibility_tests {
         // attr_reader(:foo) returns an array in multi-arg context, invalid for `private`
         assert_local_diagnostics_eq!(
             &context,
-            vec![
-                "invalid-method-visibility: `private` with `attr_*` is only supported as a single argument (2:11-2:28)"
-            ]
+            vec!["InvalidMethodVisibility: `private` with `attr_*` is only supported as a single argument (2:11-2:28)"]
         );
 
         // foo reader still defined via side effects, but public
@@ -2128,7 +2126,7 @@ mod visibility_tests {
 
         assert_local_diagnostics_eq!(
             &context,
-            vec!["invalid-method-visibility: `module_function` can only be used in modules (4:3-4:23)"]
+            vec!["InvalidMethodVisibility: `module_function` can only be used in modules (4:3-4:23)"]
         );
 
         for def in context.graph().definitions().values() {
@@ -2200,8 +2198,8 @@ mod visibility_tests {
         assert_local_diagnostics_eq!(
             &context,
             vec![
-                "invalid-method-visibility: `private` called with a non-literal argument (2:25-2:32)",
-                "invalid-method-visibility: `private` called with a non-literal argument (3:11-3:18)",
+                "InvalidMethodVisibility: `private` called with a non-literal argument (2:25-2:32)",
+                "InvalidMethodVisibility: `private` called with a non-literal argument (3:11-3:18)",
             ]
         );
 
@@ -2231,8 +2229,8 @@ mod visibility_tests {
         assert_local_diagnostics_eq!(
             &context,
             vec![
-                "invalid-method-visibility: `private` called with a non-literal argument (2:11-2:18)",
-                "invalid-method-visibility: `private` called with a non-literal argument (2:20-2:27)",
+                "InvalidMethodVisibility: `private` called with a non-literal argument (2:11-2:18)",
+                "InvalidMethodVisibility: `private` called with a non-literal argument (2:20-2:27)",
             ]
         );
 
@@ -2252,7 +2250,7 @@ mod visibility_tests {
         // module_function in a class is always invalid regardless of args
         assert_local_diagnostics_eq!(
             &context,
-            vec!["invalid-method-visibility: `module_function` can only be used in modules (2:3-2:37)"]
+            vec!["InvalidMethodVisibility: `module_function` can only be used in modules (2:3-2:37)"]
         );
 
         for def in context.graph().definitions().values() {
@@ -2338,11 +2336,11 @@ mod visibility_tests {
         assert_local_diagnostics_eq!(
             &context,
             vec![
-                "invalid-method-visibility: `private_class_method` called at top level (1:1-1:34)",
-                "invalid-method-visibility: `private_class_method` called at top level (2:1-2:39)",
-                "invalid-method-visibility: `private_class_method` called with a non-literal argument (6:24-6:35)",
-                "invalid-method-visibility: `private_class_method` does not accept `attr_*` arguments (8:24-8:41)",
-                "invalid-method-visibility: `private_class_method` requires a singleton method definition (9:24-9:39)",
+                "InvalidMethodVisibility: `private_class_method` called at top level (1:1-1:34)",
+                "InvalidMethodVisibility: `private_class_method` called at top level (2:1-2:39)",
+                "InvalidMethodVisibility: `private_class_method` called with a non-literal argument (6:24-6:35)",
+                "InvalidMethodVisibility: `private_class_method` does not accept `attr_*` arguments (8:24-8:41)",
+                "InvalidMethodVisibility: `private_class_method` requires a singleton method definition (9:24-9:39)",
             ],
             severity: Severity::Warning
         );
@@ -2378,7 +2376,7 @@ mod visibility_tests {
 
         assert_local_diagnostics_eq!(
             &context,
-            vec!["invalid-method-visibility: `private_class_method` called with a non-literal argument (5:28-5:40)"]
+            vec!["InvalidMethodVisibility: `private_class_method` called with a non-literal argument (5:28-5:40)"]
         );
 
         assert_definition_at!(&context, "5:25-5:26", MethodVisibility, |def| {
@@ -2399,7 +2397,7 @@ mod visibility_tests {
 
         assert_local_diagnostics_eq!(
             &context,
-            vec!["invalid-method-visibility: `private_class_method` called at top level (1:1-1:32)"]
+            vec!["InvalidMethodVisibility: `private_class_method` called at top level (1:1-1:32)"]
         );
         assert_constant_references_eq!(&context, ["NESTED_REF"]);
     }
@@ -2484,7 +2482,7 @@ mod visibility_tests {
         assert_local_diagnostics_eq!(
             &context,
             vec![
-                "invalid-method-visibility: `private_class_method` array element must be a Symbol, String, or method definition (5:32-5:42)"
+                "InvalidMethodVisibility: `private_class_method` array element must be a Symbol, String, or method definition (5:32-5:42)"
             ]
         );
 
@@ -2512,9 +2510,7 @@ mod visibility_tests {
 
         assert_local_diagnostics_eq!(
             &context,
-            vec![
-                "invalid-method-visibility: `private_class_method` requires a singleton method definition (2:25-2:49)"
-            ]
+            vec!["InvalidMethodVisibility: `private_class_method` requires a singleton method definition (2:25-2:49)"]
         );
 
         for def in context.graph().definitions().values() {
@@ -2546,7 +2542,7 @@ mod visibility_tests {
         assert_local_diagnostics_eq!(
             &context,
             vec![
-                "invalid-method-visibility: `private_class_method` array argument must be the only argument (5:24-5:28)"
+                "InvalidMethodVisibility: `private_class_method` array argument must be the only argument (5:24-5:28)"
             ]
         );
 
@@ -2849,8 +2845,8 @@ mod constant_reference_tests {
         assert_local_diagnostics_eq!(
             &context,
             [
-                "dynamic-constant-reference: Dynamic constant reference (3:6-3:14)",
-                "parse-warning: assigned but unused variable - foo (5:1-5:4)",
+                "DynamicConstantReference: Dynamic constant reference (3:6-3:14)",
+                "ParseWarning: assigned but unused variable - foo (5:1-5:4)",
             ]
         );
 
@@ -3033,7 +3029,7 @@ mod method_reference_tests {
 
         assert_local_diagnostics_eq!(
             &context,
-            ["parse-error: unexpected ... when the parent method is not forwarding (31:5-31:8)"]
+            ["ParseError: unexpected ... when the parent method is not forwarding (31:5-31:8)"]
         );
 
         assert_method_references_eq!(
@@ -3119,18 +3115,18 @@ mod method_reference_tests {
         assert_local_diagnostics_eq!(
             &context,
             [
-                "parse-warning: possibly useless use of != in void context (1:1-1:7)",
-                "parse-warning: possibly useless use of % in void context (2:1-2:6)",
-                "parse-warning: possibly useless use of & in void context (3:1-3:6)",
-                "parse-warning: possibly useless use of * in void context (5:1-5:6)",
-                "parse-warning: possibly useless use of ** in void context (6:1-6:7)",
-                "parse-warning: possibly useless use of + in void context (7:1-7:6)",
-                "parse-warning: possibly useless use of - in void context (8:1-8:6)",
-                "parse-warning: possibly useless use of / in void context (9:1-9:6)",
-                "parse-warning: possibly useless use of == in void context (11:1-11:7)",
-                "parse-warning: possibly useless use of ^ in void context (14:1-14:6)",
-                "parse-warning: possibly useless use of | in void context (15:1-15:6)",
-                "parse-warning: possibly useless use of <=> in void context (17:1-17:8)"
+                "ParseWarning: possibly useless use of != in void context (1:1-1:7)",
+                "ParseWarning: possibly useless use of % in void context (2:1-2:6)",
+                "ParseWarning: possibly useless use of & in void context (3:1-3:6)",
+                "ParseWarning: possibly useless use of * in void context (5:1-5:6)",
+                "ParseWarning: possibly useless use of ** in void context (6:1-6:7)",
+                "ParseWarning: possibly useless use of + in void context (7:1-7:6)",
+                "ParseWarning: possibly useless use of - in void context (8:1-8:6)",
+                "ParseWarning: possibly useless use of / in void context (9:1-9:6)",
+                "ParseWarning: possibly useless use of == in void context (11:1-11:7)",
+                "ParseWarning: possibly useless use of ^ in void context (14:1-14:6)",
+                "ParseWarning: possibly useless use of | in void context (15:1-15:6)",
+                "ParseWarning: possibly useless use of <=> in void context (17:1-17:8)"
             ]
         );
 
@@ -3152,7 +3148,7 @@ mod method_reference_tests {
 
         assert_local_diagnostics_eq!(
             &context,
-            ["parse-warning: possibly useless use of < in void context (1:1-1:6)"]
+            ["ParseWarning: possibly useless use of < in void context (1:1-1:6)"]
         );
 
         assert_method_references_eq!(&context, ["x", "<", "<=>", "y"]);
@@ -3168,7 +3164,7 @@ mod method_reference_tests {
 
         assert_local_diagnostics_eq!(
             &context,
-            ["parse-warning: possibly useless use of <= in void context (1:1-1:7)"]
+            ["ParseWarning: possibly useless use of <= in void context (1:1-1:7)"]
         );
 
         assert_method_references_eq!(&context, ["x", "<=", "<=>", "y"]);
@@ -3184,7 +3180,7 @@ mod method_reference_tests {
 
         assert_local_diagnostics_eq!(
             &context,
-            ["parse-warning: possibly useless use of > in void context (1:1-1:6)"]
+            ["ParseWarning: possibly useless use of > in void context (1:1-1:6)"]
         );
 
         assert_method_references_eq!(&context, ["x", "<=>", ">", "y"]);
@@ -3200,7 +3196,7 @@ mod method_reference_tests {
 
         assert_local_diagnostics_eq!(
             &context,
-            ["parse-warning: possibly useless use of >= in void context (1:1-1:7)"]
+            ["ParseWarning: possibly useless use of >= in void context (1:1-1:7)"]
         );
 
         assert_method_references_eq!(&context, ["x", "<=>", ">=", "y"]);
@@ -3704,10 +3700,10 @@ mod superclass_tests {
         assert_local_diagnostics_eq!(
             &context,
             [
-                "dynamic-ancestor: Dynamic superclass (1:13-1:24)",
-                "dynamic-ancestor: Dynamic superclass (2:13-2:16)",
-                "dynamic-constant-reference: Dynamic constant reference (4:13-4:16)",
-                "dynamic-ancestor: Dynamic superclass (4:13-4:21)",
+                "DynamicAncestor: Dynamic superclass (1:13-1:24)",
+                "DynamicAncestor: Dynamic superclass (2:13-2:16)",
+                "DynamicConstantReference: Dynamic constant reference (4:13-4:16)",
+                "DynamicAncestor: Dynamic superclass (4:13-4:21)",
             ]
         );
 
@@ -3890,15 +3886,15 @@ mod mixin_tests {
         assert_local_diagnostics_eq!(
             &context,
             [
-                "dynamic-constant-reference: Dynamic constant reference (1:9-1:12)",
-                "dynamic-ancestor: Dynamic mixin argument (1:9-1:17)",
-                "dynamic-constant-reference: Dynamic constant reference (2:9-2:12)",
-                "dynamic-ancestor: Dynamic mixin argument (2:9-2:17)",
-                "dynamic-constant-reference: Dynamic constant reference (3:8-3:11)",
-                "dynamic-ancestor: Dynamic mixin argument (3:8-3:16)",
-                "dynamic-ancestor: Dynamic mixin argument (5:9-5:12)",
-                "dynamic-ancestor: Dynamic mixin argument (6:9-6:12)",
-                "dynamic-ancestor: Dynamic mixin argument (7:8-7:11)"
+                "DynamicConstantReference: Dynamic constant reference (1:9-1:12)",
+                "DynamicAncestor: Dynamic mixin argument (1:9-1:17)",
+                "DynamicConstantReference: Dynamic constant reference (2:9-2:12)",
+                "DynamicAncestor: Dynamic mixin argument (2:9-2:17)",
+                "DynamicConstantReference: Dynamic constant reference (3:8-3:11)",
+                "DynamicAncestor: Dynamic mixin argument (3:8-3:16)",
+                "DynamicAncestor: Dynamic mixin argument (5:9-5:12)",
+                "DynamicAncestor: Dynamic mixin argument (6:9-6:12)",
+                "DynamicAncestor: Dynamic mixin argument (7:8-7:11)"
             ]
         );
         assert!(context.graph().definitions().is_empty());
@@ -3917,9 +3913,9 @@ mod mixin_tests {
         assert_local_diagnostics_eq!(
             &context,
             [
-                "top-level-mixin-self: Top level mixin self (1:9-1:13)",
-                "top-level-mixin-self: Top level mixin self (2:9-2:13)",
-                "top-level-mixin-self: Top level mixin self (3:8-3:12)"
+                "TopLevelMixinSelf: Top level mixin self (1:9-1:13)",
+                "TopLevelMixinSelf: Top level mixin self (2:9-2:13)",
+                "TopLevelMixinSelf: Top level mixin self (3:8-3:12)"
             ]
         );
 
@@ -5316,8 +5312,8 @@ mod diagnostic_tests {
         assert_local_diagnostics_eq!(
             &context,
             [
-                "parse-error: expected an `end` to close the `class` statement (1:1-1:6)",
-                "parse-error: unexpected end-of-input, assuming it is closing the parent top level context (1:10-2:1)"
+                "ParseError: expected an `end` to close the `class` statement (1:1-1:6)",
+                "ParseError: unexpected end-of-input, assuming it is closing the parent top level context (1:10-2:1)"
             ],
             severity: Severity::Error
         );
@@ -5339,7 +5335,7 @@ mod diagnostic_tests {
 
         assert_local_diagnostics_eq!(
             &context,
-            ["parse-warning: assigned but unused variable - foo (1:1-1:4)"],
+            ["ParseWarning: assigned but unused variable - foo (1:1-1:4)"],
             severity: Severity::Warning
         );
     }

--- a/rust/rubydex/src/model/graph.rs
+++ b/rust/rubydex/src/model/graph.rs
@@ -2185,9 +2185,9 @@ mod tests {
 
         assert_eq!(
             vec![
-                "parse-error: expected an `end` to close the `class` statement (file:///foo1.rb)",
-                "parse-error: unexpected end-of-input, assuming it is closing the parent top level context (file:///foo1.rb)",
-                "parse-warning: assigned but unused variable - foo (file:///foo2.rb)",
+                "ParseError: expected an `end` to close the `class` statement (file:///foo1.rb)",
+                "ParseError: unexpected end-of-input, assuming it is closing the parent top level context (file:///foo1.rb)",
+                "ParseWarning: assigned but unused variable - foo (file:///foo2.rb)",
             ],
             diagnostics,
         );

--- a/rust/rubydex/src/operation/ruby_builder.rs
+++ b/rust/rubydex/src/operation/ruby_builder.rs
@@ -5,7 +5,7 @@
 
 use std::collections::hash_map::Entry;
 
-use crate::diagnostic::{Diagnostic, Rule, Severity};
+use crate::diagnostic::{Diagnostic, Rule};
 use crate::model::comment::Comment;
 use crate::model::definitions::{DefinitionFlags, Parameter, ParameterStruct, Signatures};
 use crate::model::document::Document;
@@ -111,7 +111,6 @@ impl<'a> RubyOperationBuilder<'a> {
         for error in result.errors() {
             self.add_diagnostic(
                 Rule::ParseError,
-                Severity::Error,
                 Offset::from_prism_location(&error.location()),
                 error.message().to_string(),
             );
@@ -120,7 +119,6 @@ impl<'a> RubyOperationBuilder<'a> {
         for warning in result.warnings() {
             self.add_diagnostic(
                 Rule::ParseWarning,
-                Severity::Warning,
                 Offset::from_prism_location(&warning.location()),
                 warning.message().to_string(),
             );
@@ -173,8 +171,8 @@ impl<'a> RubyOperationBuilder<'a> {
         name_id
     }
 
-    fn add_diagnostic(&mut self, rule: Rule, severity: Severity, offset: Offset, message: String) {
-        let diagnostic = Diagnostic::new(rule, severity, self.uri_id, offset, message);
+    fn add_diagnostic(&mut self, rule: Rule, offset: Offset, message: String) {
+        let diagnostic = Diagnostic::new(rule, self.uri_id, offset, message);
         self.document.add_diagnostic(diagnostic);
     }
 
@@ -290,7 +288,6 @@ impl<'a> RubyOperationBuilder<'a> {
                         _ => {
                             self.add_diagnostic(
                                 Rule::DynamicConstantReference,
-                                Severity::Information,
                                 Offset::from_prism_location(&parent.location()),
                                 "Dynamic constant reference".to_string(),
                             );
@@ -670,7 +667,6 @@ impl<'a> RubyOperationBuilder<'a> {
         {
             self.add_diagnostic(
                 Rule::DynamicAncestor,
-                Severity::Information,
                 Offset::from_prism_location(&superclass_node.location()),
                 "Dynamic superclass".to_string(),
             );
@@ -837,7 +833,6 @@ impl<'a> RubyOperationBuilder<'a> {
                     if !has_owner {
                         self.add_diagnostic(
                             Rule::TopLevelMixinSelf,
-                            Severity::Information,
                             Offset::from_prism_location(&arg.location()),
                             "Top level mixin self".to_string(),
                         );
@@ -853,7 +848,6 @@ impl<'a> RubyOperationBuilder<'a> {
                 } else {
                     self.add_diagnostic(
                         Rule::DynamicAncestor,
-                        Severity::Information,
                         Offset::from_prism_location(&arg.location()),
                         "Dynamic mixin argument".to_string(),
                     );
@@ -895,7 +889,6 @@ impl<'a> RubyOperationBuilder<'a> {
                 None => {
                     self.add_diagnostic(
                         Rule::InvalidConstantVisibility,
-                        Severity::Warning,
                         Offset::from_prism_location(&node.location()),
                         format!("`{call_name}` called at top level"),
                     );
@@ -906,7 +899,6 @@ impl<'a> RubyOperationBuilder<'a> {
             Some(other) => {
                 self.add_diagnostic(
                     Rule::InvalidConstantVisibility,
-                    Severity::Warning,
                     Offset::from_prism_location(&other.location()),
                     format!("Dynamic receiver for `{call_name}`"),
                 );
@@ -922,7 +914,6 @@ impl<'a> RubyOperationBuilder<'a> {
             let Some((name, location)) = Self::extract_literal_name(&argument) else {
                 self.add_diagnostic(
                     Rule::InvalidConstantVisibility,
-                    Severity::Warning,
                     Offset::from_prism_location(&argument.location()),
                     format!("`{call_name}` called with a non-literal argument"),
                 );
@@ -1125,7 +1116,7 @@ impl<'a> RubyOperationBuilder<'a> {
                 } else {
                     format!("`{call_name}` called with a non-literal argument")
                 };
-                self.add_diagnostic(Rule::InvalidMethodVisibility, Severity::Warning, arg_offset, message);
+                self.add_diagnostic(Rule::InvalidMethodVisibility, arg_offset, message);
                 self.visit(&arg);
             }
         }
@@ -1190,7 +1181,6 @@ impl<'a> RubyOperationBuilder<'a> {
                 None => {
                     self.add_diagnostic(
                         Rule::InvalidMethodVisibility,
-                        Severity::Warning,
                         Offset::from_prism_location(&node.location()),
                         format!("`{call_name}` called at top level"),
                     );
@@ -1237,7 +1227,6 @@ impl<'a> RubyOperationBuilder<'a> {
                                 if def_node.receiver().is_none() {
                                     self.add_diagnostic(
                                         Rule::InvalidMethodVisibility,
-                                        Severity::Warning,
                                         Offset::from_prism_location(&element.location()),
                                         format!("`{call_name}` requires a singleton method definition"),
                                     );
@@ -1257,7 +1246,6 @@ impl<'a> RubyOperationBuilder<'a> {
                             _ => {
                                 self.add_diagnostic(
                                     Rule::InvalidMethodVisibility,
-                                    Severity::Warning,
                                     Offset::from_prism_location(&element.location()),
                                     format!(
                                         "`{call_name}` array element must be a Symbol, String, or method definition"
@@ -1273,7 +1261,6 @@ impl<'a> RubyOperationBuilder<'a> {
                     if def_node.receiver().is_none() {
                         self.add_diagnostic(
                             Rule::InvalidMethodVisibility,
-                            Severity::Warning,
                             Offset::from_prism_location(&argument.location()),
                             format!("`{call_name}` requires a singleton method definition"),
                         );
@@ -1293,7 +1280,6 @@ impl<'a> RubyOperationBuilder<'a> {
                 arg if Self::is_attr_call(&arg) => {
                     self.add_diagnostic(
                         Rule::InvalidMethodVisibility,
-                        Severity::Warning,
                         Offset::from_prism_location(&arg.location()),
                         format!("`{call_name}` does not accept `attr_*` arguments"),
                     );
@@ -1302,7 +1288,6 @@ impl<'a> RubyOperationBuilder<'a> {
                 ruby_prism::Node::ArrayNode { .. } => {
                     self.add_diagnostic(
                         Rule::InvalidMethodVisibility,
-                        Severity::Warning,
                         Offset::from_prism_location(&argument.location()),
                         format!("`{call_name}` array argument must be the only argument"),
                     );
@@ -1311,7 +1296,6 @@ impl<'a> RubyOperationBuilder<'a> {
                 _ => {
                     self.add_diagnostic(
                         Rule::InvalidMethodVisibility,
-                        Severity::Warning,
                         Offset::from_prism_location(&argument.location()),
                         format!("`{call_name}` called with a non-literal argument"),
                     );
@@ -1466,7 +1450,6 @@ impl Visit<'_> for RubyOperationBuilder<'_> {
             self.visit(&expression);
             self.add_diagnostic(
                 Rule::DynamicSingletonDefinition,
-                Severity::Information,
                 Offset::from_prism_location(&node.location()),
                 "Dynamic singleton class definition".to_string(),
             );
@@ -1476,7 +1459,6 @@ impl Visit<'_> for RubyOperationBuilder<'_> {
         let Some(attached_target) = attached_target else {
             self.add_diagnostic(
                 Rule::DynamicSingletonDefinition,
-                Severity::Information,
                 Offset::from_prism_location(&node.location()),
                 "Dynamic singleton class definition".to_string(),
             );
@@ -1572,7 +1554,6 @@ impl Visit<'_> for RubyOperationBuilder<'_> {
                 _ => {
                     self.add_diagnostic(
                         Rule::DynamicSingletonDefinition,
-                        Severity::Information,
                         Offset::from_prism_location(&node.location()),
                         "Dynamic receiver for singleton method definition".to_string(),
                     );
@@ -1923,7 +1904,6 @@ impl Visit<'_> for RubyOperationBuilder<'_> {
                     let offset = Offset::from_prism_location(&node.location());
                     self.add_diagnostic(
                         Rule::InvalidMethodVisibility,
-                        Severity::Warning,
                         offset,
                         format!("`{message}` cannot be called with an explicit receiver"),
                     );
@@ -1938,7 +1918,6 @@ impl Visit<'_> for RubyOperationBuilder<'_> {
                     if visibility == Visibility::ModuleFunction && !self.current_nesting_is_module() {
                         self.add_diagnostic(
                             Rule::InvalidMethodVisibility,
-                            Severity::Warning,
                             offset,
                             "`module_function` can only be used in modules".to_string(),
                         );

--- a/rust/rubydex/src/resolution.rs
+++ b/rust/rubydex/src/resolution.rs
@@ -1,6 +1,6 @@
 use std::collections::{HashSet, VecDeque, hash_map::Entry};
 
-use crate::diagnostic::{Diagnostic, Rule, Severity};
+use crate::diagnostic::{Diagnostic, Rule};
 use crate::model::{
     built_in::{BASIC_OBJECT_ID, CLASS_ID, KERNEL_ID, MODULE_ID, OBJECT_ID},
     declaration::{
@@ -654,7 +654,6 @@ impl<'a> Resolver<'a> {
                     } else {
                         let diagnostic = Diagnostic::new(
                             Rule::UndefinedConstantVisibilityTarget,
-                            Severity::Warning,
                             uri_id,
                             offset,
                             format!(
@@ -776,7 +775,6 @@ impl<'a> Resolver<'a> {
             let owner_name = self.graph.declarations().get(&namespace_id).unwrap().name().to_string();
             let diagnostic = Diagnostic::new(
                 Rule::UndefinedMethodVisibilityTarget,
-                Severity::Warning,
                 uri_id,
                 offset,
                 format!("undefined method `{owner_name}#{method_name}` for visibility change"),

--- a/rust/rubydex/src/resolution_tests.rs
+++ b/rust/rubydex/src/resolution_tests.rs
@@ -3094,7 +3094,7 @@ mod variable_tests {
 
         assert_diagnostics_eq!(
             &context,
-            ["dynamic-singleton-definition: Dynamic receiver for singleton method definition (2:3-4:6)",]
+            ["DynamicSingletonDefinition: Dynamic receiver for singleton method definition (2:3-4:6)",]
         );
 
         // Instance variable in method with unresolved receiver should not create a declaration
@@ -5422,7 +5422,7 @@ mod visibility_resolution_tests {
         assert_diagnostics_eq!(
             context,
             &[
-                "undefined-method-visibility-target: undefined method `Foo#nonexistent()` for visibility change (2:12-2:23)"
+                "UndefinedMethodVisibilityTarget: undefined method `Foo#nonexistent()` for visibility change (2:12-2:23)"
             ],
             severity: Severity::Warning
         );
@@ -5558,8 +5558,8 @@ mod visibility_resolution_tests {
         assert_diagnostics_eq!(
             context,
             &[
-                "undefined-constant-visibility-target: undefined constant `NOPE_ONE` for visibility change in `Foo` (2:21-2:29)",
-                "undefined-constant-visibility-target: undefined constant `NOPE_TWO` for visibility change in `Foo` (2:32-2:40)",
+                "UndefinedConstantVisibilityTarget: undefined constant `NOPE_ONE` for visibility change in `Foo` (2:21-2:29)",
+                "UndefinedConstantVisibilityTarget: undefined constant `NOPE_TWO` for visibility change in `Foo` (2:32-2:40)",
             ],
             severity: Severity::Warning
         );
@@ -5585,7 +5585,7 @@ mod visibility_resolution_tests {
         assert_diagnostics_eq!(
             context,
             &[
-                "undefined-constant-visibility-target: undefined constant `CONST` for visibility change in `Child` (6:21-6:26)"
+                "UndefinedConstantVisibilityTarget: undefined constant `CONST` for visibility change in `Child` (6:21-6:26)"
             ]
         );
         assert_visibility_eq!(context, "Parent::CONST", Visibility::Public);
@@ -5727,7 +5727,7 @@ mod visibility_resolution_tests {
         assert_diagnostics_eq!(
             context,
             &[
-                "undefined-method-visibility-target: undefined method `Foo::<Foo>#nonexistent()` for visibility change (2:25-2:36)"
+                "UndefinedMethodVisibilityTarget: undefined method `Foo::<Foo>#nonexistent()` for visibility change (2:25-2:36)"
             ]
         );
     }
@@ -5755,7 +5755,7 @@ mod visibility_resolution_tests {
         assert_diagnostics_eq!(
             context,
             &[
-                "undefined-method-visibility-target: undefined method `Foo::<Foo>#missing()` for visibility change (2:25-2:32)"
+                "UndefinedMethodVisibilityTarget: undefined method `Foo::<Foo>#missing()` for visibility change (2:25-2:32)"
             ]
         );
 
@@ -5781,7 +5781,7 @@ mod visibility_resolution_tests {
         assert_diagnostics_eq!(
             context,
             &[
-                "undefined-method-visibility-target: undefined method `Foo::<Foo>#missing()` for visibility change (2:25-2:32)"
+                "UndefinedMethodVisibilityTarget: undefined method `Foo::<Foo>#missing()` for visibility change (2:25-2:32)"
             ]
         );
 
@@ -5921,7 +5921,7 @@ mod visibility_resolution_tests {
         // The singleton-side def stays silent; only the instance-side def emits.
         assert_diagnostics_eq!(
             context,
-            &["undefined-method-visibility-target: undefined method `Foo#missing()` for visibility change (2:20-2:27)"]
+            &["UndefinedMethodVisibilityTarget: undefined method `Foo#missing()` for visibility change (2:20-2:27)"]
         );
         assert_declaration_does_not_exist!(context, "Foo::<Foo>#missing()");
         assert_declaration_does_not_exist!(context, "Foo::<Foo>");

--- a/rust/rubydex/src/test_utils/graph_test.rs
+++ b/rust/rubydex/src/test_utils/graph_test.rs
@@ -671,7 +671,7 @@ macro_rules! assert_diagnostics_eq {
             .graph()
             .all_diagnostics()
             .iter()
-            .map(|diagnostic| *diagnostic.severity())
+            .map(|diagnostic| diagnostic.rule().default_severity())
             .collect::<Vec<_>>();
         assert_eq!(
             vec![expected_severity; actual_severities.len()],

--- a/rust/rubydex/src/test_utils/local_graph_test.rs
+++ b/rust/rubydex/src/test_utils/local_graph_test.rs
@@ -566,7 +566,7 @@ macro_rules! assert_local_diagnostics_eq {
             .graph()
             .diagnostics()
             .iter()
-            .map(|diagnostic| *diagnostic.severity())
+            .map(|diagnostic| diagnostic.rule().default_severity())
             .collect::<Vec<_>>();
         assert_eq!(
             vec![expected_severity; actual_severities.len()],

--- a/test/graph_test.rb
+++ b/test/graph_test.rb
@@ -89,14 +89,14 @@ class GraphTest < Minitest::Test
       assert_diagnostics(
         [
           {
-            rule: "parse-error",
+            rule: "ParseError",
             path: "file.rb",
             message: "expected an `end` to close the `class` statement",
             severity: Rubydex::Severity::Error,
             related_information: [],
           },
           {
-            rule: "parse-error",
+            rule: "ParseError",
             path: "file.rb",
             message: "unexpected end-of-input, assuming it is closing the parent top level context",
             severity: Rubydex::Severity::Error,

--- a/test/linter_test.rb
+++ b/test/linter_test.rb
@@ -183,7 +183,7 @@ class LinterTest < Minitest::Test
 
     result = Rubydex::Linter::Runner.new(graph, rules: [SilentRule], config: linter_config).run
 
-    assert_equal(["parse-error", "parse-error"], result.diagnostics.map(&:rule))
+    assert_equal(["ParseError", "ParseError"], result.diagnostics.map(&:rule))
     assert(result.diagnostics.all? { |diagnostic| diagnostic.severity == Rubydex::Severity::Error })
     refute_predicate(result, :success?)
   end


### PR DESCRIPTION
First step towards #1000

We want to be able to configure and treat graph level diagnostics the same way as linter level diagnostics, but they are not implemented consistently right now. This is the first PR in a small series to make sure that the representations of `Rule`, `Diagnostic` and `RelatedInformation` are all uniform across the codebase, so that we can truly treat them similarly.

This PR does 2 primary things:

1. On the Rust side, we made severity a diagnostic concern, when it should really be a `Rule` concern. You configure the severity you desire for a class of mistakes, not for the individual occurrences of the mistake
2. We were using kebab case for the unique rule names, but that doesn't match the unique name used for linter rules. It's easier if we standardize on camel case, so that we have consistent naming