### PR TITLE
Linearize ancestors for implicitly created namespaces

### DIFF
--- a/rust/rubydex/src/resolution.rs
+++ b/rust/rubydex/src/resolution.rs
@@ -1435,6 +1435,9 @@ impl<'a> Resolver<'a> {
                 parent_owner_id,
             )))));
             self.graph.add_member(&parent_owner_id, declaration_id, parent_str_id);
+            // A namespace is the first entry of its own ancestor chain, and member lookups only walk that chain. Without
+            // enqueueing this, the Todo keeps an empty `Partial` chain and none of its members can ever be found
+            self.unit_queue.push_back(Unit::Ancestors(declaration_id));
         }
 
         declaration_id

--- a/rust/rubydex/src/resolution_tests.rs
+++ b/rust/rubydex/src/resolution_tests.rs
@@ -3984,6 +3984,41 @@ mod todo_tests {
     }
 
     #[test]
+    fn have_linearized_ancestors() {
+        // Todos are namespaces, so they must be the first entry of their own ancestor chain. Member lookups walk that
+        // chain, so an empty one makes every member of the Todo unreachable
+        let mut context = graph_test();
+        context.index_uri("file:///a.rb", {
+            r"
+            class A::B::C
+              def foo; end
+            end
+            "
+        });
+        context.index_uri("file:///d.rb", "class A::B::D < A::B::C; end");
+        context.resolve();
+
+        assert_declaration_kind_eq!(context, "A", "<TODO>");
+        assert_declaration_kind_eq!(context, "A::B", "<TODO>");
+        assert_ancestors_eq!(context, "A", ["A"]);
+        assert_ancestors_eq!(context, "A::B", ["A::B"]);
+
+        // Every member of a Todo is only reachable because the Todo lists itself in its own chain
+        assert_members_eq!(context, "A", ["B"]);
+        assert_members_eq!(context, "A::B", ["C", "D"]);
+
+        // Classes nested in a Todo still inherit from each other. Both the superclass path `A::B::C` and `D`'s own
+        // owner chain go through the Todos
+        assert_ancestors_eq!(
+            context,
+            "A::B::D",
+            ["A::B::D", "A::B::C", "Object", "Kernel", "BasicObject"]
+        );
+        assert_owner_eq!(context, "A::B::D", "A::B");
+        assert_descendants!(context, "A::B::C", ["A::B::D"]);
+    }
+
+    #[test]
     fn promoted_incrementally() {
         // Index class A::B::C first (creates Todos), then provide real definitions.
         // All Todos should be promoted to real namespaces.


### PR DESCRIPTION
A namespace implied only by compact definitions (`class A::B::C`, with no `module A::B` anywhere) gets a `TodoDeclaration` from `create_todo_for_parent`, which was the one namespace-creating path that never enqueued a `Unit::Ancestors` for it. Its chain stayed at the `Ancestors::Partial([])` default, and since a namespace's own id is pushed onto that chain by `linearize_ancestors`, `find_member_in_ancestors` had nothing to walk: every member lookup returned `MemberNotFound` even though the member table was fully populated.