### PR TITLE
Move default_severity to the class level

### DIFF
--- a/lib/rubydex/config.rb
+++ b/lib/rubydex/config.rb
@@ -26,9 +26,9 @@ module Rubydex
       @rules[rule_class.rule_name]&.exclude_patterns || []
     end
 
-    #: (singleton(Linter::Rule) rule_class, default: singleton(Severity::Base)) -> singleton(Severity::Base)
-    def severity_for(rule_class, default:)
-      @rules[rule_class.rule_name]&.severity || default
+    #: (singleton(Linter::Rule) rule_class) -> singleton(Severity::Base)
+    def severity_for(rule_class)
+      @rules[rule_class.rule_name]&.severity || rule_class.default_severity
     end
   end
 

--- a/lib/rubydex/linter/rule.rb
+++ b/lib/rubydex/linter/rule.rb
@@ -11,6 +11,12 @@ module Rubydex
           name #: as !nil
             .split("::").last #: as !nil
         end
+
+        # @abstract
+        #: () -> singleton(Severity::Base)
+        def default_severity
+          raise NotImplementedError, "Subclasses must implement the default_severity method"
+        end
       end
 
       #: Graph
@@ -30,15 +36,9 @@ module Rubydex
         @verified_severity = nil #: singleton(Severity::Base)?
       end
 
-      # @abstract
-      #: () -> singleton(Severity::Base)
-      def severity
-        raise NotImplementedError, "Subclasses must implement the severity method"
-      end
-
       #: () -> singleton(Severity::Base)
       def verified_severity
-        @verified_severity ||= config.severity_for(self.class, default: severity)
+        @verified_severity ||= config.severity_for(self.class)
       end
 
       # @abstract

--- a/lib/rubydex_linter/rules/rule_structure.rb
+++ b/lib/rubydex_linter/rules/rule_structure.rb
@@ -22,10 +22,12 @@ module Rubydex
         ].freeze #: Array[String]
         TEST_FILE_PATTERNS = ["test/**/*", "**/test/**/*"].freeze #: Array[String]
 
-        # @override
-        #: -> singleton(Severity::Base)
-        def severity
-          Severity::Error
+        class << self
+          # @override
+          #: -> singleton(Severity::Base)
+          def default_severity
+            Severity::Error
+          end
         end
 
         # @override

--- a/rbi/rubydex.rbi
+++ b/rbi/rubydex.rbi
@@ -426,8 +426,15 @@ end
 class Rubydex::Linter::Rule
   abstract!
 
-  sig { returns(String) }
-  def self.rule_name; end
+  class << self
+    abstract!
+
+    sig { returns(String) }
+    def rule_name; end
+
+    sig { abstract.returns(T.class_of(Rubydex::Severity::Base)) }
+    def default_severity; end
+  end
 
   sig { params(graph: Rubydex::Graph, config: Rubydex::LinterConfig).void }
   def initialize(graph, config:); end
@@ -460,9 +467,6 @@ class Rubydex::Linter::Rule
 
   sig { returns(String) }
   def rule_name; end
-
-  sig { abstract.returns(T.class_of(Rubydex::Severity::Base)) }
-  def severity; end
 
   sig { returns(T.class_of(Rubydex::Severity::Base)) }
   def verified_severity; end
@@ -505,10 +509,12 @@ class Rubydex::Linter::Rules::RuleStructure < Rubydex::Linter::Rule
   RULE_FILE_PATTERNS = T.let(T.unsafe(nil), T::Array[String])
   TEST_FILE_PATTERNS = T.let(T.unsafe(nil), T::Array[String])
 
-  sig { returns(T.class_of(Rubydex::Severity::Base)) }
-  def severity; end
+  class << self
+    sig { override.returns(T.class_of(Rubydex::Severity::Base)) }
+    def default_severity; end
+  end
 
-  sig { void }
+  sig { override.void }
   def lint; end
 end
 
@@ -674,13 +680,8 @@ class Rubydex::LinterConfig
   sig { params(rule_class: T.class_of(Rubydex::Linter::Rule)).returns(T::Array[String]) }
   def excludes_for(rule_class); end
 
-  sig do
-    params(
-      rule_class: T.class_of(Rubydex::Linter::Rule),
-      default: T.class_of(Rubydex::Severity::Base),
-    ).returns(T.class_of(Rubydex::Severity::Base))
-  end
-  def severity_for(rule_class, default:); end
+  sig { params(rule_class: T.class_of(Rubydex::Linter::Rule)).returns(T.class_of(Rubydex::Severity::Base)) }
+  def severity_for(rule_class); end
 end
 
 # The settings of a single linter rule, read from a `[linter.rules.RuleName]` table.

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -22,7 +22,9 @@ class CLITest < Minitest::Test
   include Test::Helpers::WithContext
 
   class CLITestProjectErrorRule < Rubydex::Linter::Rule
-    def severity = Rubydex::Severity::Error
+    class << self
+      def default_severity = Rubydex::Severity::Error
+    end
 
     def lint
       declaration = graph["Foo"]

--- a/test/linter_test.rb
+++ b/test/linter_test.rb
@@ -9,7 +9,9 @@ class LinterTest < Minitest::Test
   include Test::Helpers::WithContext
 
   class WarningRule < Rubydex::Linter::Rule
-    def severity = Rubydex::Severity::Warning
+    class << self
+      def default_severity = Rubydex::Severity::Warning
+    end
 
     def lint
       add_diagnostic(
@@ -29,7 +31,9 @@ class LinterTest < Minitest::Test
   end
 
   class ErrorRule < Rubydex::Linter::Rule
-    def severity = Rubydex::Severity::Error
+    class << self
+      def default_severity = Rubydex::Severity::Error
+    end
 
     def lint
       add_diagnostic(
@@ -46,12 +50,17 @@ class LinterTest < Minitest::Test
   end
 
   class SilentRule < Rubydex::Linter::Rule
-    def severity = Rubydex::Severity::Hint
+    class << self
+      def default_severity = Rubydex::Severity::Hint
+    end
+
     def lint; end
   end
 
   class OutsideWorkspaceRule < Rubydex::Linter::Rule
-    def severity = Rubydex::Severity::Information
+    class << self
+      def default_severity = Rubydex::Severity::Information
+    end
 
     def lint
       sibling = File.join(File.dirname(graph.workspace_path), "#{File.basename(graph.workspace_path)}-other", "file.rb")
@@ -66,7 +75,9 @@ class LinterTest < Minitest::Test
   end
 
   class DependencyPathRule < Rubydex::Linter::Rule
-    def severity = Rubydex::Severity::Information
+    class << self
+      def default_severity = Rubydex::Severity::Information
+    end
 
     def lint
       path = File.join(graph.workspace_path, "vendor/bundle/gems/example.rb")
@@ -81,7 +92,9 @@ class LinterTest < Minitest::Test
   end
 
   class ExcludedPrimaryRule < Rubydex::Linter::Rule
-    def severity = Rubydex::Severity::Information
+    class << self
+      def default_severity = Rubydex::Severity::Information
+    end
 
     def lint
       add_diagnostic("Excluded primary location.", workspace_location("components/legacy/example.rb"))


### PR DESCRIPTION
Second step for #1000

For unifying graph and linter diagnostics, having the default severity be an instance method is
inconvenient because it would force graph rules to have to be instantiated with a graph and config object.

Graph rules only hold a unique name and default severity, so moving this to the class level makes it easier to create a consistent model across the entire codebase. Conceptually, it's almost correct as the default severity belongs to the definition of a rule and not its execution (instance).

We don't really lose anything in terms of type safety because we can still declare the singleton method as abstract.