### PR TITLE
Expose built-in rules in Ruby

### DIFF
--- a/ext/rubydex/diagnostic.c
+++ b/ext/rubydex/diagnostic.c
@@ -6,7 +6,10 @@
  * mRubydex = rb_define_module("Rubydex")
  */
 
+static VALUE mRubydex;
 VALUE cDiagnostic;
+static VALUE cRuleDefinition;
+static ID id_default_severity;
 
 VALUE rdxi_build_diagnostic_severity_value(VALUE mRubydex, DiagnosticSeverity severity) {
     VALUE mSeverity = rb_const_get(mRubydex, rb_intern("Severity"));
@@ -27,4 +30,50 @@ VALUE rdxi_build_diagnostic_severity_value(VALUE mRubydex, DiagnosticSeverity se
     return Qnil;
 }
 
-void rdxi_initialize_diagnostic(VALUE mRubydex) { cDiagnostic = rb_define_class_under(mRubydex, "Diagnostic", rb_cObject); }
+/*
+ * call-seq:
+ *   default_severity -> Rubydex::Severity::Base
+ *
+ * Returns the Rubydex::Severity subclass the diagnostics of this rule get unless the configuration overrides it.
+ */
+static VALUE rdxr_generated_rule_default_severity(VALUE self) {
+    VALUE severity = rb_attr_get(self, id_default_severity);
+
+    // Class-level instance variables are not inherited, so a class inheriting from a generated rule reaches this without
+    // a severity of its own.
+    if (NIL_P(severity)) {
+        rb_raise(rb_eRuntimeError, "Rule definition %s has no default severity", rb_class2name(self));
+    }
+
+    return severity;
+}
+
+// Generates a rule definition for every rule the graph can report. Severities are resolved here rather than when they are
+// read, which is why Rubydex::Severity is loaded before this extension (see `lib/rubydex.rb`).
+static void define_generated_rules(VALUE mRules) {
+    CRuleDefinitionArray definition_array = rdx_rule_definitions();
+    VALUE definitions = rb_ary_new_capa((long)definition_array.len);
+
+    for (size_t i = 0; i < definition_array.len; i++) {
+        CRuleDefinition definition = definition_array.items[i];
+        VALUE name = rb_utf8_str_new(definition.name, (long)definition.name_length);
+        VALUE rule = rb_define_class_under(mRules, StringValueCStr(name), cRuleDefinition);
+        VALUE severity = rdxi_build_diagnostic_severity_value(mRubydex, definition.default_severity);
+
+        rb_ivar_set(rule, id_default_severity, severity);
+        rb_define_singleton_method(rule, "default_severity", rdxr_generated_rule_default_severity, 0);
+        rb_ary_push(definitions, rule);
+    }
+
+    rdx_rule_definitions_free(definition_array);
+    rb_define_const(mRules, "ALL", rb_obj_freeze(definitions));
+}
+
+void rdxi_initialize_diagnostic(VALUE moduleRubydex) {
+    mRubydex = moduleRubydex;
+    id_default_severity = rb_intern("@default_severity");
+
+    cDiagnostic = rb_define_class_under(mRubydex, "Diagnostic", rb_cObject);
+    cRuleDefinition = rb_define_class_under(mRubydex, "RuleDefinition", rb_cObject);
+    define_generated_rules(rb_define_module_under(mRubydex, "Rules"));
+}

--- a/lib/rubydex.rb
+++ b/lib/rubydex.rb
@@ -2,8 +2,11 @@
 
 require "bundler"
 require "uri"
+
+# Files that must be loaded before the C extension
 require "rubydex/version"
 require "rubydex/mixin"
+require "rubydex/severity"
 
 begin
   # Load the precompiled version of the library
@@ -19,7 +22,6 @@ require "rubydex/failures"
 require "rubydex/config"
 require "rubydex/location"
 require "rubydex/comment"
-require "rubydex/severity"
 require "rubydex/rule_definition"
 require "rubydex/related_information"
 require "rubydex/diagnostic"

--- a/lib/rubydex/cli/command/lint.rb
+++ b/lib/rubydex/cli/command/lint.rb
@@ -57,7 +57,7 @@ module Rubydex
 
         #: (Rubydex::LinterConfig config, Array[singleton(Rubydex::Linter::Rule)] known_rule_classes) -> void
         def warn_unknown_rules(config, known_rule_classes)
-          known_rule_names = known_rule_classes.map(&:rule_name).uniq.sort
+          known_rule_names = (Rubydex::Rules::ALL + known_rule_classes).map(&:rule_name).uniq.sort
           unknown_rule_names = config.rules.keys.reject { |name| known_rule_names.include?(name) }.sort
           return if unknown_rule_names.empty?
 

--- a/rbi/rubydex.rbi
+++ b/rbi/rubydex.rbi
@@ -331,6 +331,80 @@ class Rubydex::RuleDefinition
   end
 end
 
+module Rubydex::Rules
+  ALL = T.let(T.unsafe(nil), T::Array[T.class_of(Rubydex::RuleDefinition)])
+end
+
+class Rubydex::Rules::ParseError < Rubydex::RuleDefinition
+  class << self
+    sig { override.returns(T.class_of(Rubydex::Severity::Base)) }
+    def default_severity; end
+  end
+end
+
+class Rubydex::Rules::ParseWarning < Rubydex::RuleDefinition
+  class << self
+    sig { override.returns(T.class_of(Rubydex::Severity::Base)) }
+    def default_severity; end
+  end
+end
+
+class Rubydex::Rules::DynamicConstantReference < Rubydex::RuleDefinition
+  class << self
+    sig { override.returns(T.class_of(Rubydex::Severity::Base)) }
+    def default_severity; end
+  end
+end
+
+class Rubydex::Rules::DynamicSingletonDefinition < Rubydex::RuleDefinition
+  class << self
+    sig { override.returns(T.class_of(Rubydex::Severity::Base)) }
+    def default_severity; end
+  end
+end
+
+class Rubydex::Rules::DynamicAncestor < Rubydex::RuleDefinition
+  class << self
+    sig { override.returns(T.class_of(Rubydex::Severity::Base)) }
+    def default_severity; end
+  end
+end
+
+class Rubydex::Rules::TopLevelMixinSelf < Rubydex::RuleDefinition
+  class << self
+    sig { override.returns(T.class_of(Rubydex::Severity::Base)) }
+    def default_severity; end
+  end
+end
+
+class Rubydex::Rules::InvalidConstantVisibility < Rubydex::RuleDefinition
+  class << self
+    sig { override.returns(T.class_of(Rubydex::Severity::Base)) }
+    def default_severity; end
+  end
+end
+
+class Rubydex::Rules::InvalidMethodVisibility < Rubydex::RuleDefinition
+  class << self
+    sig { override.returns(T.class_of(Rubydex::Severity::Base)) }
+    def default_severity; end
+  end
+end
+
+class Rubydex::Rules::UndefinedMethodVisibilityTarget < Rubydex::RuleDefinition
+  class << self
+    sig { override.returns(T.class_of(Rubydex::Severity::Base)) }
+    def default_severity; end
+  end
+end
+
+class Rubydex::Rules::UndefinedConstantVisibilityTarget < Rubydex::RuleDefinition
+  class << self
+    sig { override.returns(T.class_of(Rubydex::Severity::Base)) }
+    def default_severity; end
+  end
+end
+
 class Rubydex::RelatedInformation
   sig { params(message: String, location: Rubydex::Location).void }
   def initialize(message, location); end

--- a/rust/rubydex-sys/src/diagnostic_api.rs
+++ b/rust/rubydex-sys/src/diagnostic_api.rs
@@ -3,7 +3,7 @@
 use crate::graph_api::{GraphPointer, with_graph};
 use crate::location_api::{Location, create_location_for_uri_and_offset};
 use libc::c_char;
-use rubydex::diagnostic::Severity;
+use rubydex::diagnostic::{Rule, Severity};
 use std::{ffi::CString, mem, ptr};
 
 /// C-compatible enum representing diagnostic severity levels.
@@ -24,6 +24,63 @@ impl From<Severity> for DiagnosticSeverity {
             Severity::Information => DiagnosticSeverity::Information,
             Severity::Hint => DiagnosticSeverity::Hint,
         }
+    }
+}
+
+#[repr(C)]
+#[derive(Debug)]
+pub struct CRuleDefinition {
+    pub name: *const c_char,
+    pub name_length: usize,
+    pub default_severity: DiagnosticSeverity,
+}
+
+impl From<Rule> for CRuleDefinition {
+    fn from(rule: Rule) -> Self {
+        let name = rule.name();
+
+        Self {
+            name: name.as_ptr().cast::<c_char>(),
+            name_length: name.len(),
+            default_severity: DiagnosticSeverity::from(rule.default_severity()),
+        }
+    }
+}
+
+#[repr(C)]
+pub struct CRuleDefinitionArray {
+    pub items: *mut CRuleDefinition,
+    pub len: usize,
+}
+
+/// Returns a definition for every rule the graph can report. Caller must free it with `rdx_rule_definitions_free`.
+#[unsafe(no_mangle)]
+pub extern "C" fn rdx_rule_definitions() -> CRuleDefinitionArray {
+    let items = Rule::all()
+        .iter()
+        .copied()
+        .map(CRuleDefinition::from)
+        .collect::<Box<[CRuleDefinition]>>();
+
+    CRuleDefinitionArray {
+        len: items.len(),
+        items: Box::into_raw(items).cast::<CRuleDefinition>(),
+    }
+}
+
+/// Frees an array previously returned by `rdx_rule_definitions`.
+///
+/// # Safety
+///
+/// - `definitions` must have been returned by `rdx_rule_definitions` and must not be used afterwards.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rdx_rule_definitions_free(definitions: CRuleDefinitionArray) {
+    if definitions.items.is_null() {
+        return;
+    }
+
+    unsafe {
+        let _ = Box::from_raw(ptr::slice_from_raw_parts_mut(definitions.items, definitions.len));
     }
 }
 

--- a/rust/rubydex/src/diagnostic.rs
+++ b/rust/rubydex/src/diagnostic.rs
@@ -63,8 +63,23 @@ pub enum Severity {
     Hint,
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub enum Rule {
+macro_rules! rules {
+    ($($(#[$attribute:meta])* $rule:ident),+ $(,)?) => {
+        #[derive(Debug, Copy, Clone, PartialEq, Eq)]
+        pub enum Rule {
+            $($(#[$attribute])* $rule,)+
+        }
+
+        impl Rule {
+            #[must_use]
+            pub fn all() -> &'static [Self] {
+                &[$(Self::$rule,)+]
+            }
+        }
+    };
+}
+
+rules! {
     // Parsing
     ParseError,
     ParseWarning,


### PR DESCRIPTION
Fourth step towards #1000

This PR makes sure we automatically create `RuleDefinition` classes for all built-in diagnostics. This allows us to treat rule definitions consistently between the linter and the graph, since they are all just classes that inherit from `RuleDefinition`.

The idea is basically to have an `all` method in Rust that returns all rules and we use the names to create classes like `class ParseError < RuleDefinition`, which registers the identity of that rule in the Ruby side consistently with linting rules.