### PR TITLE
Add graph serialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,12 @@ foundation to power a variety of tools, such as type checkers, linters, language
 
 ## Usage
 
+Rubydex caches the index by default. The first run indexes all files and writes a snapshot file.
+Later runs read the snapshot and index only the files that changed since the last run.
+The snapshot file lives under the user cache directory, in a file named for the workspace.
+Set `XDG_CACHE_HOME` to change the user cache directory.
+Pass `--no-cache` on the command line, or `cache: false` to `index_workspace` in the Ruby API, to skip the cache.
+
 Both Ruby and Rust APIs are made available through a gem and a crate, respectively. Here's a simple example
 of using the Ruby API:
 
@@ -15,11 +21,11 @@ of using the Ruby API:
 graph = Rubydex::Graph.new
 # Configuring graph LSP encoding
 graph.encoding = "utf16"
-# Index the entire workspace with all dependencies
+# Index the entire workspace with all dependencies. This reads a cached snapshot when one exists,
+# indexes only the files that changed, and resolves them, all in one call.
 graph.index_workspace
-# Or index specific file paths
+# Or index specific file paths, bypassing the cache. This does not resolve; call `resolve` yourself.
 graph.index_all(["path/to/file.rb"])
-# Transform the initially collected information into its semantic understanding by running resolution
 graph.resolve
 # Get all diagnostics acquired during the analysis
 graph.diagnostics
@@ -88,7 +94,6 @@ A resolved `Rubydex::Graph` can be shared across Ractors without copying:
 ```ruby
 graph = Rubydex::Graph.new
 graph.index_workspace
-graph.resolve
 Ractor.make_shareable(graph)
 
 # Worker Ractors can now read the graph in parallel
@@ -138,7 +143,6 @@ From Ruby:
 ```ruby
 graph = Rubydex::Graph.new
 graph.index_workspace
-graph.resolve
 
 # Parse once, then run against a graph. `run` executes the query and returns the result set.
 query = Rubydex::Query.parse("MATCH (c:Class) RETURN c.name")

--- a/ext/rubydex/graph.c
+++ b/ext/rubydex/graph.c
@@ -120,6 +120,56 @@ static VALUE rdxr_graph_index_all(VALUE self, VALUE file_paths) {
 
 /*
  * call-seq:
+ *   index_cached(file_paths, cache_path, verify_content) -> Hash
+ *
+ * Indexes and resolves file_paths using an on-disk snapshot cache: reuses a snapshot when one is
+ * usable, indexing only the files that changed, and otherwise indexes everything and writes a fresh
+ * snapshot. Resolution runs as part of this call, so calling `resolve` afterwards is unnecessary
+ * (though harmless). cache_path may be nil, in which case a default location derived from
+ * file_paths is used. Returns a Hash with keys :errors (Array[String]), :cache_hit (Boolean),
+ * :reindexed (Integer), and :removed (Integer).
+ */
+static VALUE rdxr_graph_index_cached(VALUE self, VALUE file_paths, VALUE cache_path, VALUE verify_content) {
+    rdxi_check_array_of_strings(file_paths);
+
+    if (!NIL_P(cache_path)) {
+        Check_Type(cache_path, T_STRING);
+    }
+
+    // Convert the given file paths into a char** array, so that we can pass to Rust
+    size_t length = RARRAY_LEN(file_paths);
+    char **converted_file_paths = rdxi_str_array_to_char(file_paths, length);
+    const char *cache_path_str = NIL_P(cache_path) ? NULL : StringValueCStr(cache_path);
+
+    void *graph;
+    TypedData_Get_Struct(self, void *, &graph_type, graph);
+
+    struct CIndexCacheStats stats = {0};
+    size_t error_count = 0;
+    const char *const *errors = rdx_graph_index_cached(graph, (const char **)converted_file_paths, length,
+                                                         cache_path_str, RTEST(verify_content), &stats, &error_count);
+
+    rdxi_free_str_array(converted_file_paths, length);
+
+    VALUE error_array = rb_ary_new_capa((long)error_count);
+    for (size_t i = 0; i < error_count; i++) {
+        rb_ary_push(error_array, rb_utf8_str_new_cstr(errors[i]));
+    }
+
+    if (errors != NULL) {
+        free_c_string_array(errors, error_count);
+    }
+
+    VALUE result = rb_hash_new();
+    rb_hash_aset(result, ID2SYM(rb_intern("errors")), error_array);
+    rb_hash_aset(result, ID2SYM(rb_intern("cache_hit")), stats.cache_hit ? Qtrue : Qfalse);
+    rb_hash_aset(result, ID2SYM(rb_intern("reindexed")), SIZET2NUM(stats.reindexed));
+    rb_hash_aset(result, ID2SYM(rb_intern("removed")), SIZET2NUM(stats.removed));
+    return result;
+}
+
+/*
+ * call-seq:
  *   index_source(uri, source, language_id) -> nil
  *
  * Indexes a single source string in memory, dispatching to the appropriate indexer based on language_id.
@@ -926,6 +976,7 @@ void rdxi_initialize_graph(VALUE moduleRubydex) {
     rb_define_method(cGraph, "initialize_copy", rdxr_graph_initialize_copy, 1);
     rb_define_method(cGraph, "initialize_clone", rdxr_graph_initialize_copy, 1);
     rb_define_method(cGraph, "index_all", rdxr_graph_index_all, 1);
+    rb_define_method(cGraph, "index_cached", rdxr_graph_index_cached, 3);
     rb_define_method(cGraph, "index_source", rdxr_graph_index_source, 3);
     rb_define_method(cGraph, "document", rdxr_graph_document, 1);
     rb_define_method(cGraph, "delete_document", rdxr_graph_delete_document, 1);

--- a/lib/rubydex/cli/command.rb
+++ b/lib/rubydex/cli/command.rb
@@ -92,6 +92,8 @@ module Rubydex
       #: (Array[String] argv) -> void
       def initialize(argv)
         @argv = argv
+        @no_cache = false
+        @verify_content = false
       end
 
       #: -> void
@@ -116,6 +118,11 @@ module Rubydex
       # declaration. `-h`/`--help` prints the parser and exits, so every subcommand documents itself
       # the same way. Pass `options: true` when the command accepts options beyond `--help`.
       #
+      # `--no-cache` and `--verify-content` are registered here rather than in each subcommand file,
+      # since they only affect {#build_graph} and no subcommand otherwise shares an option-parsing
+      # helper: every subcommand that indexes a workspace gets them for free, including ones (like
+      # `console`) that declare no options of their own.
+      #
       # A bad option reports the message and the usage text, so every subcommand rejects bad input
       # the same way.
       #: (?options: bool) ?{ (OptionParser parser) -> void } -> void
@@ -126,6 +133,12 @@ module Rubydex
         @parser = OptionParser.new do |p|
           p.banner = banner
           yield(p) if block_given?
+          p.on("--no-cache", "Disable the on-disk index snapshot and re-index the whole workspace") do
+            @no_cache = true
+          end
+          p.on("--verify-content", "Detect changed files by content hash instead of by mtime") do
+            @verify_content = true
+          end
           p.on("-h", "--help", "Show this help") do
             puts(p)
             exit
@@ -138,12 +151,37 @@ module Rubydex
       end
 
       # Builds the workspace graph, sending progress messages to `progress_io`.
+      #
+      # By default this indexes and resolves through the on-disk snapshot cache (see
+      # {Rubydex::Graph#index_workspace}), which does both jobs in a single call: a cache hit skips
+      # the separate resolve step entirely because there is nothing left to resolve. `--no-cache`
+      # (surfaced through {#parse_options!}) falls back to the original, always-full index-then-resolve
+      # sequence.
       #: (IO progress_io, ?workspace_path: String, ?config: Rubydex::Config) -> Rubydex::Graph
       def build_graph(progress_io, workspace_path: Dir.pwd, config: Rubydex::Config.load(workspace_path))
         graph = Rubydex::Graph.new
         graph.load_config(config)
-        with_timer(progress_io, "Indexing workspace...") { graph.index_workspace }
-        with_timer(progress_io, "Resolving graph...") { graph.resolve }
+
+        if @no_cache
+          with_timer(progress_io, "Indexing workspace...") { graph.index_workspace(cache: false) }
+          with_timer(progress_io, "Resolving graph...") { graph.resolve }
+          return graph
+        end
+
+        result = with_timer(progress_io, "Indexing workspace...") do
+          graph.index_workspace(verify_content: @verify_content)
+        end
+
+        if result[:cache_hit]
+          progress_io.puts(
+            "Reused snapshot (#{result[:reindexed]} re-indexed, #{result[:removed]} removed)",
+          )
+        else
+          # The cached call above already resolved the graph, so this only re-confirms there is
+          # nothing left in the resolver's worklist; kept for output parity with a full index.
+          with_timer(progress_io, "Resolving graph...") { graph.resolve }
+        end
+
         graph
       end
 

--- a/lib/rubydex/graph.rb
+++ b/lib/rubydex/graph.rb
@@ -19,10 +19,23 @@ module Rubydex
       end
     end
 
-    # Index all files and dependencies of the workspace that exists in `workspace_path`
-    #: -> Array[String]
-    def index_workspace
-      index_all(workspace_paths)
+    # Index all files and dependencies of the workspace that exists in `workspace_path`, returning
+    # `{ errors:, cache_hit:, reindexed:, removed: }`.
+    #
+    # With `cache: true` (the default), this loads an on-disk snapshot when one exists, indexes only
+    # the files that changed since it was written, resolves the invalidated subset, and writes a new
+    # snapshot when there was none. Both indexing and resolution happen inside this call: the caller
+    # does not need to call `#resolve` afterward.
+    #
+    # With `cache: false`, this reproduces the original, uncached behaviour exactly: every file is
+    # indexed, no snapshot is read or written, and the caller is still responsible for calling
+    # `#resolve` itself.
+    #
+    #: (?cache: bool, ?cache_path: String?, ?verify_content: bool) -> Hash[Symbol, untyped]
+    def index_workspace(cache: true, cache_path: nil, verify_content: false)
+      return index_cached(workspace_paths, cache_path, verify_content) if cache
+
+      { errors: index_all(workspace_paths), cache_hit: false, reindexed: 0, removed: 0 }
     end
 
     # Returns all workspace paths that should be indexed

--- a/rbi/rubydex.rbi
+++ b/rbi/rubydex.rbi
@@ -804,9 +804,28 @@ class Rubydex::Graph
   sig { params(uri: String, source: String, language_id: String).void }
   def index_source(uri, source, language_id); end
 
-  # Index all files and dependencies of the workspace that exists in `workspace_path`
-  sig { returns(T::Array[String]) }
-  def index_workspace; end
+  # Index all files and dependencies of the workspace that exists in `workspace_path`, going through
+  # the on-disk snapshot cache by default (see `index_cached`) and resolving in the same call.
+  sig do
+    params(
+      cache: T::Boolean,
+      cache_path: T.nilable(String),
+      verify_content: T::Boolean,
+    ).returns(T::Hash[Symbol, T.untyped])
+  end
+  def index_workspace(cache: true, cache_path: nil, verify_content: false); end
+
+  # Populates the graph from an on-disk snapshot when one is usable, indexing only the files that
+  # changed since it was written, and otherwise indexes everything and writes a snapshot for next
+  # time. Resolves the graph before returning either way.
+  sig do
+    params(
+      file_paths: T::Array[String],
+      cache_path: T.nilable(String),
+      verify_content: T::Boolean,
+    ).returns(T::Hash[Symbol, T.untyped])
+  end
+  def index_cached(file_paths, cache_path, verify_content); end
 
   # Returns the keyword object for the name, or `nil` if it is not a Ruby keyword
   sig { params(name: String).returns(T.nilable(Rubydex::Keyword)) }

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -100,7 +100,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -121,10 +121,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "bytecheck"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26333eeac754f0ad8a6bcd0eb0ac012156302e4e16b852b72ee399aea4f12c29"
+dependencies = [
+ "bytecheck_derive",
+ "ptr_meta",
+ "rancor",
+ "simdutf8",
+]
+
+[[package]]
+name = "bytecheck_derive"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46d07918caa9eeaaf06b7873925c53a61daac173539b4f7715090745e44e4e69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "bytecount"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
+
+[[package]]
+name = "bytes"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cbindgen"
@@ -140,7 +175,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "syn",
+ "syn 2.0.104",
  "tempfile",
  "toml 0.8.23",
 ]
@@ -211,7 +246,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -280,7 +315,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -333,6 +368,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
+
+[[package]]
+name = "futures-task"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
+
+[[package]]
+name = "futures-util"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
 ]
 
 [[package]]
@@ -504,6 +563,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "js-sys"
+version = "0.3.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -554,10 +624,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
+name = "memmap2"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "munge"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e17401f259eba956ca16491461b6e8f72913a0a114e39736ce404410f915a0c"
+dependencies = [
+ "munge_macro",
+]
+
+[[package]]
+name = "munge_macro"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4568f25ccbd45ab5d5603dc34318c1ec56b117531781260002151b8530a9f931"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
 
 [[package]]
 name = "nohash-hasher"
@@ -615,6 +714,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
 name = "potential_utf"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -660,7 +765,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff24dfcda44452b9816fff4cd4227e1bb73ff5a2f1bc1105aa92fb8565ce44d2"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -670,6 +775,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "ptr_meta"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743da816b98c921cdbe8628ef7381b76f25ecf4da599fc80aca90eae7ef70cc0"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c8d9ca532f185d5d4db7a7c9d51420b452168ea1c2b913953281bd6fe1fcbd0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -686,6 +811,15 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rancor"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b534442d0fcdb55d66f373d9cac6d33b6293a2335bc2136dbd06ce0e87d2572"
+dependencies = [
+ "ptr_meta",
+]
 
 [[package]]
 name = "regex"
@@ -715,6 +849,45 @@ name = "regex-syntax"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+
+[[package]]
+name = "rend"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "663ba70707f96e871406fe10d68128412e619b06d1d47cb91c3a4c6501176240"
+dependencies = [
+ "bytecheck",
+]
+
+[[package]]
+name = "rkyv"
+version = "0.8.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9776093b7ca170454ab1406954f7b7d97a57c51dc6c0642957fb2ef25c2d399"
+dependencies = [
+ "bytecheck",
+ "bytes",
+ "hashbrown",
+ "indexmap",
+ "munge",
+ "ptr_meta",
+ "rancor",
+ "rend",
+ "rkyv_derive",
+ "tinyvec",
+ "uuid",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.8.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c25ef604ac7dd839d44d64648952ea23c97866f124ff671b0ed2cf3ad9bb06e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
 
 [[package]]
 name = "ruby-prism"
@@ -773,8 +946,10 @@ dependencies = [
  "glob",
  "libc",
  "line-index",
+ "memmap2",
  "predicates",
  "regex",
+ "rkyv",
  "ruby-prism",
  "ruby-rbs",
  "rubydex",
@@ -818,6 +993,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
 name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -850,7 +1031,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -903,6 +1084,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -932,6 +1125,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "synstructure"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -939,7 +1143,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1007,6 +1211,21 @@ dependencies = [
  "displaydoc",
  "zerovec",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "toml"
@@ -1124,6 +1343,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "uuid"
+version = "1.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "wait-timeout"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1139,6 +1368,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
 dependencies = [
  "wit-bindgen-rt",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.127"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.127"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.127"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.127"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
+dependencies = [
+ "unicode-ident",
 ]
 
 [[package]]
@@ -1350,7 +1624,7 @@ checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.104",
  "synstructure",
 ]
 
@@ -1371,7 +1645,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.104",
  "synstructure",
 ]
 
@@ -1405,5 +1679,5 @@ checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.104",
 ]

--- a/rust/rubydex-sys/src/graph_api.rs
+++ b/rust/rubydex-sys/src/graph_api.rs
@@ -360,6 +360,106 @@ pub extern "C" fn rdx_graph_resolve(pointer: GraphPointer) {
     });
 }
 
+/// Statistics describing what `rdx_graph_index_cached` did with the on-disk snapshot cache.
+#[repr(C)]
+pub struct CIndexCacheStats {
+    pub cache_hit: bool,
+    pub reindexed: usize,
+    pub removed: usize,
+}
+
+/// Indexes and resolves `file_paths` using an on-disk snapshot cache: reuses a snapshot when one is usable,
+/// indexing only the files that changed, and otherwise indexes everything and writes a fresh snapshot. A caller
+/// does not need to call `rdx_graph_resolve` afterwards, though doing so is harmless.
+///
+/// Writes cache statistics to `out_stats`, an array of error message strings, and writes the error count to
+/// `error_count`. Returns NULL if there are no errors. Caller must free the returned array with
+/// `free_c_string_array`.
+///
+/// # Panics
+///
+/// Will panic if the given array of C string file paths cannot be converted to a `Vec<String>`, or if `cache_path`
+/// is non-null but not valid UTF-8.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences raw pointers coming from C. The caller has to ensure that the
+/// Ruby VM will not free the pointers related to the string array while they are in use by Rust. `cache_path`, if
+/// non-null, must be a valid, null-terminated UTF-8 string. `out_stats` is assumed to be a valid, writable,
+/// non-null pointer.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rdx_graph_index_cached(
+    pointer: GraphPointer,
+    file_paths: *const *const c_char,
+    length: usize,
+    cache_path: *const c_char,
+    verify_content: bool,
+    out_stats: *mut CIndexCacheStats,
+    error_count: *mut usize,
+) -> *const *const c_char {
+    let roots: Vec<PathBuf> = unsafe { utils::convert_double_pointer_to_vec(file_paths, length).unwrap() }
+        .into_iter()
+        .map(PathBuf::from)
+        .collect();
+
+    let cache_path: PathBuf = if cache_path.is_null() {
+        rubydex::snapshot::default_cache_path(&roots)
+    } else {
+        PathBuf::from(unsafe { utils::convert_char_ptr_to_string(cache_path) }.unwrap())
+    };
+
+    let verification = if verify_content {
+        rubydex::snapshot::manifest::Verification::Content
+    } else {
+        rubydex::snapshot::manifest::Verification::Metadata
+    };
+
+    with_mut_graph(pointer, |graph| {
+        let (errors, outcome) = rubydex::snapshot::load_or_index(
+            graph,
+            &roots,
+            &cache_path,
+            verification,
+            indexing::IndexerBackend::RubyIndexer,
+        );
+
+        let stats = match outcome {
+            rubydex::snapshot::CacheOutcome::Miss => CIndexCacheStats {
+                cache_hit: false,
+                reindexed: 0,
+                removed: 0,
+            },
+            rubydex::snapshot::CacheOutcome::Hit { reindexed, removed } => CIndexCacheStats {
+                cache_hit: true,
+                reindexed,
+                removed,
+            },
+        };
+        unsafe { *out_stats = stats };
+
+        let all_errors: Vec<String> = errors.into_iter().map(|e| e.to_string()).collect();
+
+        if all_errors.is_empty() {
+            unsafe { *error_count = 0 };
+            return ptr::null();
+        }
+
+        let c_strings: Vec<*const c_char> = all_errors
+            .into_iter()
+            .filter_map(|string| {
+                CString::new(string)
+                    .ok()
+                    .map(|c_string| c_string.into_raw().cast_const())
+            })
+            .collect();
+
+        unsafe { *error_count = c_strings.len() };
+
+        let boxed = c_strings.into_boxed_slice();
+        Box::into_raw(boxed).cast::<*const c_char>()
+    })
+}
+
 /// Checks the integrity of the graph and returns an array of error message strings. Returns NULL if there are no
 /// errors. Caller must free with `free_c_string_array`.
 ///

--- a/rust/rubydex/Cargo.toml
+++ b/rust/rubydex/Cargo.toml
@@ -38,6 +38,8 @@ bitflags = "2.9"
 bytecount = "0.6.9"
 libc = "0.2"
 line-index = "0.1.2"
+memmap2 = "0.9"
+rkyv = "0.8"
 serde = { version = "1.0", features = ["derive"] }
 tempfile = { version = "3.0", optional = true }
 crossbeam-deque = "0.8"

--- a/rust/rubydex/src/config.rs
+++ b/rust/rubydex/src/config.rs
@@ -21,7 +21,7 @@ const DEFAULT_EXCLUDED_DIRECTORIES: &[&str] = &[
 ];
 
 /// The graph's settings, read from the `[graph]` section of the configuration file
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
 pub struct GraphSettings {
     /// Patterns to exclude from file discovery during indexing, on top of the built-in defaults. Stored as written and
     /// only joined with the workspace path when read, so that a pattern cannot outlive the configuration it came from
@@ -69,7 +69,7 @@ impl GraphSettings {
 }
 
 /// The setting of a single linter rule, read from a `[linter.rules.RuleName]` table
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
 pub struct Rule {
     name: Box<str>,
     enabled: bool,
@@ -145,7 +145,7 @@ impl Rule {
 }
 
 /// The linter's settings, read from the `[linter]` section of the configuration file
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
 pub struct LinterSettings {
     rules: Box<[Rule]>,
 }
@@ -179,15 +179,53 @@ impl LinterSettings {
     }
 }
 
+/// `Box<Path>` cannot derive rkyv's traits: `Path` is unsized and foreign, so it has no `Archive`
+/// impl of its own. It travels through the archive as an owned `String` instead, and is rebuilt
+/// into a `Box<Path>` on the way back out.
+pub struct BoxedPathAsString;
+
+impl rkyv::with::ArchiveWith<Box<Path>> for BoxedPathAsString {
+    type Archived = rkyv::Archived<String>;
+    type Resolver = rkyv::Resolver<String>;
+
+    fn resolve_with(field: &Box<Path>, resolver: Self::Resolver, out: rkyv::Place<Self::Archived>) {
+        let path = field.to_string_lossy().into_owned();
+        rkyv::Archive::resolve(&path, resolver, out);
+    }
+}
+
+impl<S> rkyv::with::SerializeWith<Box<Path>, S> for BoxedPathAsString
+where
+    S: rkyv::rancor::Fallible + ?Sized,
+    String: rkyv::Serialize<S>,
+{
+    fn serialize_with(field: &Box<Path>, serializer: &mut S) -> Result<Self::Resolver, S::Error> {
+        let path = field.to_string_lossy().into_owned();
+        rkyv::Serialize::serialize(&path, serializer)
+    }
+}
+
+impl<D> rkyv::with::DeserializeWith<rkyv::Archived<String>, Box<Path>, D> for BoxedPathAsString
+where
+    D: rkyv::rancor::Fallible + ?Sized,
+    rkyv::Archived<String>: rkyv::Deserialize<String, D>,
+{
+    fn deserialize_with(field: &rkyv::Archived<String>, deserializer: &mut D) -> Result<Box<Path>, D::Error> {
+        let path: String = rkyv::Deserialize::deserialize(field, deserializer)?;
+        Ok(PathBuf::from(path).into_boxed_path())
+    }
+}
+
 /// The configuration of a workspace, parsed from its `rubydex.toml` and shared by all built-in tools. It carries both
 /// the settings that are global to every tool, such as the workspace being analyzed, and the typed settings of each
 /// tool's own section (e.g. `[graph]`). Every section is parsed eagerly, so that all validation happens at load time and
 /// unknown sections or settings are rejected. Load the file once and hand the configuration to each consumer, so that
 /// none of them has to read it again.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
 pub struct Config {
     /// Root directory of the workspace being analyzed, which is where its configuration file lives. Global, and not
     /// configurable through the file itself, since it is what says where that file is.
+    #[rkyv(with = BoxedPathAsString)]
     workspace_path: Box<Path>,
     graph: GraphSettings,
     linter: LinterSettings,

--- a/rust/rubydex/src/diagnostic.rs
+++ b/rust/rubydex/src/diagnostic.rs
@@ -2,7 +2,7 @@
 use crate::model::document::Document;
 use crate::{model::ids::UriId, offset::Offset};
 
-#[derive(Debug)]
+#[derive(Debug, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
 pub struct Diagnostic {
     rule: Rule,
     // Severity belongs to each diagnostic; every producer must assign it explicitly.
@@ -61,7 +61,7 @@ impl Diagnostic {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, serde::Deserialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, serde::Deserialize, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum Severity {
     Error,
@@ -91,7 +91,7 @@ macro_rules! rules {
     (
         $( $variant:ident );* $(;)?
     ) => {
-        #[derive(Debug, Copy, Clone, PartialEq, Eq)]
+        #[derive(Debug, Copy, Clone, PartialEq, Eq, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
         pub enum Rule {
             $(
                 $variant,

--- a/rust/rubydex/src/lib.rs
+++ b/rust/rubydex/src/lib.rs
@@ -20,6 +20,7 @@ pub(crate) mod path_helpers;
 pub mod position;
 pub mod query;
 pub mod resolution;
+pub mod snapshot;
 pub mod stats;
 
 #[cfg(any(test, feature = "test_utils"))]

--- a/rust/rubydex/src/listing.rs
+++ b/rust/rubydex/src/listing.rs
@@ -99,7 +99,10 @@ impl Job for FileDiscoveryJob {
     }
 }
 
-fn is_indexable_file(path: &Path) -> bool {
+/// Whether a path is one of the file kinds indexing understands. Shared with the snapshot manifest
+/// so that discovering a new file uses exactly the same rule as the original listing.
+#[must_use]
+pub fn is_indexable_file(path: &Path) -> bool {
     path.extension()
         .is_some_and(|ext| ext == "rb" || ext == "rake" || ext == "rbs" || ext == "ru")
 }

--- a/rust/rubydex/src/model/comment.rs
+++ b/rust/rubydex/src/model/comment.rs
@@ -1,7 +1,7 @@
 use crate::assert_mem_size;
 use crate::offset::Offset;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
 pub struct Comment {
     offset: Offset,
     string: String,

--- a/rust/rubydex/src/model/declaration.rs
+++ b/rust/rubydex/src/model/declaration.rs
@@ -10,7 +10,7 @@ use crate::model::{
 };
 
 /// A single ancestor in the linearized ancestor chain
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
 pub enum Ancestor {
     /// A complete ancestor that we have fully linearized
     Complete(DeclarationId),
@@ -20,7 +20,7 @@ pub enum Ancestor {
 assert_mem_size!(Ancestor, 16);
 
 /// The ancestor chain and its current state
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
 pub enum Ancestors {
     /// A complete linearization of ancestors with all parts resolved
     Complete(Vec<Ancestor>),
@@ -73,7 +73,7 @@ macro_rules! all_namespaces {
 /// Macro to generate a new struct for namespace-like declarations such as classes and modules
 macro_rules! namespace_declaration {
     ($variant:ident, $name:ident) => {
-        #[derive(Debug)]
+        #[derive(Debug, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
         pub struct $name {
             core: DeclarationCore<ConstantReferenceId>,
             namespace_store: NamespaceStore,
@@ -112,7 +112,7 @@ macro_rules! namespace_declaration {
 }
 
 /// The core data of a declaration, shared across all of them
-#[derive(Debug)]
+#[derive(Debug, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
 pub struct DeclarationCore<T> {
     /// The fully qualified name of this declaration
     name: Box<str>,
@@ -195,7 +195,7 @@ impl<T: Eq + Hash> DeclarationCore<T> {
 }
 
 /// Storage for namespace data, like ancestors, descendants, members and singleton class
-#[derive(Debug)]
+#[derive(Debug, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
 pub struct NamespaceStore {
     /// The entities that are owned by this declaration. For example, constants and methods that are defined inside of
     /// the namespace. Note that this is a hashmap of unqualified name IDs to declaration IDs. That assists the
@@ -304,7 +304,7 @@ impl Default for NamespaceStore {
 /// A `Declaration` represents the global concept of an entity in Ruby. For example, the class `Foo` may be defined 3
 /// times in different files and the `Foo` declaration is the combination of all of those definitions that contribute to
 /// the same fully qualified name
-#[derive(Debug)]
+#[derive(Debug, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
 pub enum Declaration {
     Namespace(Namespace),
     Constant(Box<ConstantDeclaration>),
@@ -528,7 +528,7 @@ impl Declaration {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
 pub enum Namespace {
     Class(Box<ClassDeclaration>),
     SingletonClass(Box<SingletonClassDeclaration>),

--- a/rust/rubydex/src/model/definitions.rs
+++ b/rust/rubydex/src/model/definitions.rs
@@ -46,6 +46,30 @@ bitflags! {
 }
 assert_mem_size!(DefinitionFlags, 1);
 
+/// `bitflags!` hides the backing field behind a private struct, so `Archive`/`Serialize`/
+/// `Deserialize` cannot be derived. Archive the flags as their backing `u8` and rebuild with
+/// `from_bits_truncate` so unknown bits round-trip safely.
+impl rkyv::Archive for DefinitionFlags {
+    type Archived = u8;
+    type Resolver = ();
+
+    fn resolve(&self, _resolver: Self::Resolver, out: rkyv::Place<Self::Archived>) {
+        out.write(self.bits());
+    }
+}
+
+impl<S: rkyv::rancor::Fallible + ?Sized> rkyv::Serialize<S> for DefinitionFlags {
+    fn serialize(&self, _serializer: &mut S) -> Result<Self::Resolver, S::Error> {
+        Ok(())
+    }
+}
+
+impl<D: rkyv::rancor::Fallible + ?Sized> rkyv::Deserialize<DefinitionFlags, D> for u8 {
+    fn deserialize(&self, _deserializer: &mut D) -> Result<DefinitionFlags, D::Error> {
+        Ok(DefinitionFlags::from_bits_truncate(*self))
+    }
+}
+
 impl DefinitionFlags {
     #[must_use]
     pub fn is_deprecated(&self) -> bool {
@@ -63,7 +87,7 @@ impl DefinitionFlags {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
 pub enum Definition {
     Class(Box<ClassDefinition>),
     SingletonClass(Box<SingletonClassDefinition>),
@@ -196,7 +220,7 @@ impl Definition {
 
 /// Represents a mixin: include, prepend, or extend.
 /// During resolution, `Extend` mixins are attached to the singleton class.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
 pub enum Mixin {
     Include(IncludeDefinition),
     Prepend(PrependDefinition),
@@ -217,7 +241,7 @@ impl Mixin {
 
 macro_rules! mixin_definition {
     ($variant:ident, $name:ident) => {
-        #[derive(Debug, Clone)]
+        #[derive(Debug, Clone, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
         pub struct $name {
             constant_reference_id: ConstantReferenceId,
         }
@@ -249,7 +273,7 @@ mixin_definition!(Extend, ExtendDefinition);
 /// class Foo
 /// end
 /// ```
-#[derive(Debug)]
+#[derive(Debug, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
 pub struct ClassDefinition {
     name_id: NameId,
     uri_id: UriId,
@@ -371,7 +395,7 @@ impl ClassDefinition {
 ///   def baz; end
 /// end
 /// ```
-#[derive(Debug)]
+#[derive(Debug, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
 pub struct SingletonClassDefinition {
     /// The name of this singleton class (e.g., `<Foo>` for `class << self` inside `class Foo`)
     name_id: NameId,
@@ -479,7 +503,7 @@ impl SingletonClassDefinition {
 /// module Foo
 /// end
 /// ```
-#[derive(Debug)]
+#[derive(Debug, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
 pub struct ModuleDefinition {
     name_id: NameId,
     uri_id: UriId,
@@ -582,7 +606,7 @@ impl ModuleDefinition {
 /// ```ruby
 /// FOO = 1
 /// ```
-#[derive(Debug)]
+#[derive(Debug, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
 pub struct ConstantDefinition {
     name_id: NameId,
     uri_id: UriId,
@@ -656,7 +680,7 @@ impl ConstantDefinition {
 /// module Foo; end
 /// ALIAS = Foo
 /// ```
-#[derive(Debug)]
+#[derive(Debug, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
 pub struct ConstantAliasDefinition {
     alias_constant: ConstantDefinition,
     target_name_id: NameId,
@@ -719,7 +743,7 @@ impl ConstantAliasDefinition {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
 pub struct ConstantVisibilityDefinition {
     receiver: Option<NameId>,
     target: StringId,
@@ -803,7 +827,7 @@ impl ConstantVisibilityDefinition {
 }
 assert_mem_size!(ConstantVisibilityDefinition, 64);
 
-#[derive(Debug)]
+#[derive(Debug, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
 pub struct MethodVisibilityDefinition {
     str_id: StringId,
     visibility: Visibility,
@@ -883,7 +907,7 @@ assert_mem_size!(MethodVisibilityDefinition, 56);
 /// Currently only supports the parameter names and kinds.
 pub type Signature = Box<[Parameter]>;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
 pub enum Signatures {
     /// A single method signature, for definitions without overloads.
     ///
@@ -915,7 +939,7 @@ impl Signatures {
 /// def foo(bar, baz)
 /// end
 /// ```
-#[derive(Debug)]
+#[derive(Debug, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
 pub struct MethodDefinition {
     str_id: StringId,
     uri_id: UriId,
@@ -932,7 +956,7 @@ pub struct MethodDefinition {
 assert_mem_size!(MethodDefinition, 104);
 
 /// The receiver of a singleton method definition.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
 pub enum Receiver {
     /// `def self.foo` - receiver is the enclosing definition (class, module, singleton class or DSL)
     SelfReceiver(DefinitionId),
@@ -1027,7 +1051,7 @@ impl MethodDefinition {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
 pub enum Parameter {
     RequiredPositional(ParameterStruct),
     OptionalPositional(ParameterStruct),
@@ -1058,7 +1082,7 @@ impl Parameter {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
 pub struct ParameterStruct {
     offset: Offset,
     str: StringId,
@@ -1088,7 +1112,7 @@ impl ParameterStruct {
 /// ```ruby
 /// attr_accessor :foo
 /// ```
-#[derive(Debug)]
+#[derive(Debug, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
 pub struct AttrAccessorDefinition {
     str_id: StringId,
     uri_id: UriId,
@@ -1169,7 +1193,7 @@ impl AttrAccessorDefinition {
 /// ```ruby
 /// attr_reader :foo
 /// ```
-#[derive(Debug)]
+#[derive(Debug, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
 pub struct AttrReaderDefinition {
     str_id: StringId,
     uri_id: UriId,
@@ -1250,7 +1274,7 @@ impl AttrReaderDefinition {
 /// ```ruby
 /// attr_writer :foo
 /// ```
-#[derive(Debug)]
+#[derive(Debug, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
 pub struct AttrWriterDefinition {
     str_id: StringId,
     uri_id: UriId,
@@ -1331,7 +1355,7 @@ impl AttrWriterDefinition {
 /// ```ruby
 /// $foo = 1
 /// ```
-#[derive(Debug)]
+#[derive(Debug, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
 pub struct GlobalVariableDefinition {
     str_id: StringId,
     uri_id: UriId,
@@ -1404,7 +1428,7 @@ impl GlobalVariableDefinition {
 /// ```ruby
 /// @foo = 1
 /// ```
-#[derive(Debug)]
+#[derive(Debug, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
 pub struct InstanceVariableDefinition {
     str_id: StringId,
     uri_id: UriId,
@@ -1477,7 +1501,7 @@ impl InstanceVariableDefinition {
 /// ```ruby
 /// @@foo = 1
 /// ```
-#[derive(Debug)]
+#[derive(Debug, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
 pub struct ClassVariableDefinition {
     str_id: StringId,
     uri_id: UriId,
@@ -1544,7 +1568,7 @@ impl ClassVariableDefinition {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
 pub struct MethodAliasDefinition {
     new_name_str_id: StringId,
     old_name_str_id: StringId,
@@ -1634,7 +1658,7 @@ impl MethodAliasDefinition {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
 pub struct GlobalVariableAliasDefinition {
     new_name_str_id: StringId,
     old_name_str_id: StringId,

--- a/rust/rubydex/src/model/document.rs
+++ b/rust/rubydex/src/model/document.rs
@@ -10,24 +10,29 @@ use crate::model::ids::{ConstantReferenceId, DefinitionId, MethodReferenceId};
 
 // Represents a document currently loaded into memory. Identified by its unique URI, it holds the edges to all
 // definitions and references discovered in it
-#[derive(Debug)]
+#[derive(Debug, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
 pub struct Document {
     uri: String,
-    line_index: LineIndex,
+    /// The document's line index is not archived: `LineIndex` has no public constructor besides
+    /// `LineIndex::new(text)` and no accessible fields, so an archived instance could never be
+    /// rebuilt from its parts. A snapshot therefore skips it, leaving the cell empty until
+    /// [`Document::line_index`] lazily rebuilds it from disk on first use after a restore.
+    #[rkyv(with = rkyv::with::Skip)]
+    line_index: std::sync::OnceLock<LineIndex>,
     definition_ids: Vec<DefinitionId>,
     method_reference_ids: Vec<MethodReferenceId>,
     constant_reference_ids: Vec<ConstantReferenceId>,
     diagnostics: Vec<Diagnostic>,
     content_hash: u64,
 }
-assert_mem_size!(Document, 184);
+assert_mem_size!(Document, 192);
 
 impl Document {
     #[must_use]
     pub fn new(uri: String, source: &str) -> Self {
         Self {
             uri,
-            line_index: LineIndex::new(source),
+            line_index: std::sync::OnceLock::from(LineIndex::new(source)),
             definition_ids: Vec::new(),
             method_reference_ids: Vec::new(),
             constant_reference_ids: Vec::new(),
@@ -46,9 +51,21 @@ impl Document {
         self.content_hash
     }
 
+    /// The line index for this document.
+    ///
+    /// A snapshot does not store the line index, since [`LineIndex`] has no way to be rebuilt
+    /// from archived parts. A document restored from a snapshot rebuilds it lazily, on first
+    /// use, by re-reading the document's own file from disk. This assumes the file has not
+    /// changed since the snapshot was written.
     #[must_use]
     pub fn line_index(&self) -> &LineIndex {
-        &self.line_index
+        self.line_index.get_or_init(|| {
+            let source = self
+                .file_path()
+                .and_then(|path| std::fs::read_to_string(path).ok())
+                .unwrap_or_default();
+            LineIndex::new(&source)
+        })
     }
 
     #[must_use]

--- a/rust/rubydex/src/model/encoding.rs
+++ b/rust/rubydex/src/model/encoding.rs
@@ -1,7 +1,7 @@
 use crate::assert_mem_size;
 use line_index::WideEncoding;
 
-#[derive(Default, Debug)]
+#[derive(Default, Debug, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
 pub enum Encoding {
     #[default]
     Utf8,

--- a/rust/rubydex/src/model/graph.rs
+++ b/rust/rubydex/src/model/graph.rs
@@ -1008,10 +1008,21 @@ impl Graph {
     /// accumulates pending work items for the resolver to process.
     pub fn delete_document(&mut self, uri: &str) -> Option<UriId> {
         let uri_id = UriId::from(uri);
-        let document = self.documents.remove(&uri_id)?;
+        self.delete_document_by_id(uri_id).then_some(uri_id)
+    }
+
+    /// Handles the deletion of a document already identified by its `UriId`.
+    /// Returns whether a document was removed.
+    ///
+    /// A snapshot manifest records ids rather than URI strings, so this is the entry point for
+    /// dropping documents whose file has disappeared. Behaves exactly like [`Graph::delete_document`].
+    pub fn delete_document_by_id(&mut self, uri_id: UriId) -> bool {
+        let Some(document) = self.documents.remove(&uri_id) else {
+            return false;
+        };
         self.invalidate(Some(&document), None);
         self.remove_document_data(&document);
-        Some(uri_id)
+        true
     }
 
     /// Merges everything in `other` into this Graph. This method is meant to merge all graph representations from

--- a/rust/rubydex/src/model/graph.rs
+++ b/rust/rubydex/src/model/graph.rs
@@ -6,10 +6,11 @@ use crate::config::Config;
 use crate::diagnostic::Diagnostic;
 use crate::indexing::local_graph::LocalGraph;
 use crate::model::built_in::{OBJECT_ID, add_built_in_data};
-use crate::model::declaration::{Ancestor, Declaration, Namespace};
-use crate::model::definitions::{Definition, MethodVisibilityDefinition, Receiver};
-use crate::model::document::Document;
+use crate::model::declaration::{Ancestor, ArchivedDeclaration, Declaration, Namespace};
+use crate::model::definitions::{ArchivedDefinition, Definition, MethodVisibilityDefinition, Receiver};
+use crate::model::document::{ArchivedDocument, Document};
 use crate::model::encoding::Encoding;
+use crate::model::id::Id;
 use crate::model::identity_maps::{IdentityHashMap, IdentityHashSet};
 use crate::model::ids::{
     ConstantReferenceId, DeclarationId, DefinitionId, MethodReferenceId, NameId, StringId, UriId,
@@ -21,10 +22,11 @@ use crate::model::string_ref::StringRef;
 use crate::model::visibility::Visibility;
 use crate::{assert_mem_size, assert_send_sync};
 use crate::{query, stats};
+use rkyv::rend::u64_le;
 
 /// An entity whose validity depends on a particular `NameId`.
 /// Used as the value type in the `name_dependents` reverse index.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
 pub enum NameDependent {
     Definition(DefinitionId),
     Reference(ConstantReferenceId),
@@ -47,7 +49,7 @@ enum InvalidationItem {
 assert_mem_size!(InvalidationItem, 16);
 
 /// A work item produced by graph mutations (update/delete) that needs resolution.
-#[derive(Debug)]
+#[derive(Debug, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
 pub enum Unit {
     /// A definition that defines a constant and might require resolution
     Definition(DefinitionId),
@@ -60,7 +62,7 @@ assert_mem_size!(Unit, 16);
 
 // The `Graph` is the global representation of the entire Ruby codebase. It contains all declarations and their
 // relationships
-#[derive(Default, Debug)]
+#[derive(Default, Debug, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
 pub struct Graph {
     // Map of declaration nodes
     declarations: IdentityHashMap<DeclarationId, Declaration>,
@@ -94,6 +96,80 @@ pub struct Graph {
 }
 assert_mem_size!(Graph, 368);
 assert_send_sync!(Graph);
+
+/// The archived counterpart of an [`IdentityHashMap`], as rkyv lays it out inside a snapshot.
+/// Its keys are the bare little-endian `u64` that every [`Id`](crate::model::id::Id) archives as.
+pub type ArchivedIdentityHashMap<K, V> = <IdentityHashMap<K, V> as rkyv::Archive>::Archived;
+
+/// Read-only access to a [`Graph`] that still lives in a snapshot's memory map.
+///
+/// rkyv derives `ArchivedGraph` with the same private fields as [`Graph`], so these accessors are
+/// what a consumer outside this module has. They mirror the accessors on [`Graph`] and never
+/// allocate: every one of them returns a reference into the mapped file.
+impl ArchivedGraph {
+    /// Turns an owned id into the key an archived map is indexed by.
+    fn key<T>(id: &Id<T>) -> u64_le {
+        u64_le::from_native(id.get())
+    }
+
+    #[must_use]
+    pub fn declarations(&self) -> &ArchivedIdentityHashMap<DeclarationId, Declaration> {
+        &self.declarations
+    }
+
+    #[must_use]
+    pub fn documents(&self) -> &ArchivedIdentityHashMap<UriId, Document> {
+        &self.documents
+    }
+
+    #[must_use]
+    pub fn definitions(&self) -> &ArchivedIdentityHashMap<DefinitionId, Definition> {
+        &self.definitions
+    }
+
+    #[must_use]
+    pub fn names(&self) -> &ArchivedIdentityHashMap<NameId, NameRef> {
+        &self.names
+    }
+
+    #[must_use]
+    pub fn strings(&self) -> &ArchivedIdentityHashMap<StringId, StringRef> {
+        &self.strings
+    }
+
+    #[must_use]
+    pub fn constant_references(&self) -> &ArchivedIdentityHashMap<ConstantReferenceId, ConstantReference> {
+        &self.constant_references
+    }
+
+    #[must_use]
+    pub fn method_references(&self) -> &ArchivedIdentityHashMap<MethodReferenceId, MethodRef> {
+        &self.method_references
+    }
+
+    /// Looks a declaration up by id. Ids are content hashes, so an id computed in this process
+    /// addresses the right node in an archive written by another one.
+    #[must_use]
+    pub fn declaration(&self, id: DeclarationId) -> Option<&ArchivedDeclaration> {
+        self.declarations.get(&Self::key(&id))
+    }
+
+    #[must_use]
+    pub fn definition(&self, id: DefinitionId) -> Option<&ArchivedDefinition> {
+        self.definitions.get(&Self::key(&id))
+    }
+
+    #[must_use]
+    pub fn document(&self, id: UriId) -> Option<&ArchivedDocument> {
+        self.documents.get(&Self::key(&id))
+    }
+
+    /// Looks a declaration up by fully qualified name, the archived twin of [`Graph::get`].
+    #[must_use]
+    pub fn declaration_by_name(&self, name: &str) -> Option<&ArchivedDeclaration> {
+        self.declaration(declaration_id_from_lookup_name(name))
+    }
+}
 
 impl Graph {
     #[must_use]

--- a/rust/rubydex/src/model/id.rs
+++ b/rust/rubydex/src/model/id.rs
@@ -1,4 +1,6 @@
 use std::{marker::PhantomData, num::NonZeroU64, ops::Deref};
+
+use rkyv::rend::u64_le;
 use xxhash_rust::xxh3;
 
 /// Creates an ID by hashing fixed-width integer components in little-endian order.
@@ -87,6 +89,35 @@ impl<T, const N: usize> From<[&[u8]; N]> for Id<T> {
         }
 
         Self::new(hasher.digest())
+    }
+}
+
+/// `Id<T>` is a hashed [`NonZeroU64`] paired with a zero-sized marker, so it archives as a bare
+/// little-endian `u64`. Deriving instead would leak the marker into the archived type and force
+/// every marker to implement rkyv's traits; this way an archived map is keyed by [`u64_le`], which
+/// is exactly the eight bytes the id already is.
+///
+/// Every other awkward type in the model follows this same three-impl shape: `Archive` names the
+/// archived form, `Serialize` has nothing to write beyond the value itself, and `Deserialize`
+/// rebuilds the owned type from the archived one.
+impl<T> rkyv::Archive for Id<T> {
+    type Archived = u64_le;
+    type Resolver = ();
+
+    fn resolve(&self, _resolver: Self::Resolver, out: rkyv::Place<Self::Archived>) {
+        out.write(u64_le::from_native(self.value.get()));
+    }
+}
+
+impl<T, S: rkyv::rancor::Fallible + ?Sized> rkyv::Serialize<S> for Id<T> {
+    fn serialize(&self, _serializer: &mut S) -> Result<Self::Resolver, S::Error> {
+        Ok(())
+    }
+}
+
+impl<T, D: rkyv::rancor::Fallible + ?Sized> rkyv::Deserialize<Id<T>, D> for u64_le {
+    fn deserialize(&self, _deserializer: &mut D) -> Result<Id<T>, D::Error> {
+        Ok(Id::new(self.to_native()))
     }
 }
 

--- a/rust/rubydex/src/model/name.rs
+++ b/rust/rubydex/src/model/name.rs
@@ -9,7 +9,7 @@ use crate::{
     },
 };
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
 pub enum ParentScope {
     /// There's no parent scope in this reference (e.g.: `Foo`)
     None,
@@ -78,7 +78,7 @@ impl Display for ParentScope {
     }
 }
 
-#[derive(Debug, Clone, Eq)]
+#[derive(Debug, Clone, Eq, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
 pub struct Name {
     /// The unqualified name of the constant
     str: StringId,
@@ -174,7 +174,7 @@ impl Name {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
 pub struct ResolvedName {
     name: Name,
     declaration_id: DeclarationId,
@@ -204,7 +204,7 @@ impl ResolvedName {
 }
 
 /// A usage of a constant name. This could be a constant reference or a definition like a class or module
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
 pub enum NameRef {
     /// This name has not yet been resolved. We don't yet know what this name refers to or if it refers to an existing
     /// declaration

--- a/rust/rubydex/src/model/references.rs
+++ b/rust/rubydex/src/model/references.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 
 /// A reference to a constant
-#[derive(Debug)]
+#[derive(Debug, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
 pub struct ConstantReference {
     /// The name ID of this reference
     name_id: NameId,
@@ -57,7 +57,7 @@ impl ConstantReference {
 }
 
 /// A reference to a method
-#[derive(Debug)]
+#[derive(Debug, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
 pub struct MethodRef {
     /// The unqualified name of the method
     str: StringId,

--- a/rust/rubydex/src/model/string_ref.rs
+++ b/rust/rubydex/src/model/string_ref.rs
@@ -7,7 +7,7 @@ use std::ops::Deref;
 /// the string is used across the graph. When a document is removed, we decrement
 /// the reference count for each string it uses, and remove the string from the
 /// graph when its count reaches zero.
-#[derive(Debug)]
+#[derive(Debug, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
 pub struct StringRef {
     value: Box<str>,
     ref_count: u32,

--- a/rust/rubydex/src/model/visibility.rs
+++ b/rust/rubydex/src/model/visibility.rs
@@ -3,7 +3,7 @@ use std::fmt::Display;
 
 use crate::assert_mem_size;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
 pub enum Visibility {
     Public,
     Protected,

--- a/rust/rubydex/src/offset.rs
+++ b/rust/rubydex/src/offset.rs
@@ -10,7 +10,7 @@ use crate::model::document::Document;
 ///
 /// An `Offset` tracks a contiguous span of bytes from `start` to `end` within a file. This is useful for
 /// representing the location of tokens, AST nodes, or other text spans in source code.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Ord, PartialOrd)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Ord, PartialOrd, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
 pub struct Offset {
     /// The starting byte offset (inclusive)
     start: u32,

--- a/rust/rubydex/src/snapshot.rs
+++ b/rust/rubydex/src/snapshot.rs
@@ -1,0 +1,433 @@
+//! Writes a resolved [`Graph`] to disk and re-opens it without rebuilding it.
+//!
+//! Indexing and resolving a hyper scale workspace costs tens of seconds and gigabytes of resident
+//! memory. A snapshot removes that cost for a process that only reads the graph.
+//!
+//! The format is an [rkyv](https://rkyv.org) archive: the bytes on disk are the in-memory layout of
+//! the graph. [`Snapshot::open`] maps the file and casts a pointer, so it allocates nothing and
+//! copies nothing. The operating system pages in only the parts a query touches, and it can reclaim
+//! those pages under memory pressure. [`Snapshot::to_graph`] is the opposite trade: it walks the
+//! archive once and hands back an owned, mutable [`Graph`].
+//!
+//! Every id in the graph is a deterministic xxh3 content hash, so the ids in an archive stay valid
+//! in another process. Nothing needs relocating on load.
+//!
+//! # What a snapshot does not store
+//!
+//! A snapshot does not record which files it was built from, so it cannot tell that the workspace
+//! changed. The caller owns that decision. A [`Document`](crate::model::document::Document) also
+//! archives without its line index, and rebuilds it from disk on first use.
+//!
+//! # Layout
+//!
+//! ```text
+//! offset 0   magic     8 bytes   "RDXSNAP\0"
+//! offset 8   version   4 bytes   little-endian u32
+//! offset 12  reserved  4 bytes   zero
+//! offset 16  archive   rest of the file
+//! ```
+//!
+//! The header is 16 bytes so that the archive stays aligned: a memory map starts on a page
+//! boundary, and 16 divides every alignment the archived graph can ask for.
+
+use std::fmt;
+use std::fs::File;
+use std::io::{self, Write};
+use std::path::Path;
+
+use memmap2::Mmap;
+use rkyv::rancor::Error as RkyvError;
+
+use crate::model::graph::{ArchivedGraph, Graph};
+
+/// Identifies a rubydex snapshot file.
+const MAGIC: &[u8; 8] = b"RDXSNAP\0";
+
+/// Bumped whenever the archived layout of the graph changes. An archive written by a different
+/// version of the model is not readable, and there is no migration: rebuild it from source.
+pub const FORMAT_VERSION: u32 = 1;
+
+/// Size of the fixed header, in bytes. Also the alignment the archive is guaranteed.
+const HEADER_LEN: usize = 16;
+
+#[derive(Debug)]
+pub enum SnapshotError {
+    Io(io::Error),
+    /// The file is shorter than the header, or holds no archive.
+    Truncated {
+        len: usize,
+    },
+    /// The first eight bytes are not [`MAGIC`], so this is not a snapshot.
+    NotASnapshot,
+    /// The file was written by a different model layout.
+    VersionMismatch {
+        found: u32,
+        expected: u32,
+    },
+    /// The mapping does not satisfy the alignment the archived graph requires.
+    Misaligned {
+        required: usize,
+    },
+    /// The archive is malformed, or could not be walked back into an owned graph.
+    Archive(RkyvError),
+}
+
+impl fmt::Display for SnapshotError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            SnapshotError::Io(error) => write!(f, "snapshot io error: {error}"),
+            SnapshotError::Truncated { len } => {
+                write!(f, "snapshot is truncated: {len} bytes, need more than {HEADER_LEN}")
+            }
+            SnapshotError::NotASnapshot => write!(f, "file is not a rubydex snapshot"),
+            SnapshotError::VersionMismatch { found, expected } => write!(
+                f,
+                "snapshot format version {found} cannot be read by this build, which writes version {expected}"
+            ),
+            SnapshotError::Misaligned { required } => {
+                write!(f, "snapshot mapping is not aligned to {required} bytes")
+            }
+            SnapshotError::Archive(error) => write!(f, "snapshot archive error: {error}"),
+        }
+    }
+}
+
+impl std::error::Error for SnapshotError {}
+
+impl From<io::Error> for SnapshotError {
+    fn from(error: io::Error) -> Self {
+        SnapshotError::Io(error)
+    }
+}
+
+impl From<RkyvError> for SnapshotError {
+    fn from(error: RkyvError) -> Self {
+        SnapshotError::Archive(error)
+    }
+}
+
+/// Writes `graph` to `path`, replacing any file already there, and returns the bytes written.
+///
+/// Take the snapshot after resolution. Serializing costs one pass over the graph plus one write of
+/// the whole archive, so this is much more expensive than [`Snapshot::open`]; the point is to pay
+/// it once and read it many times.
+///
+/// # Errors
+///
+/// Returns [`SnapshotError::Archive`] if the graph cannot be serialized, and
+/// [`SnapshotError::Io`] if the file cannot be written.
+pub fn write<P: AsRef<Path>>(graph: &Graph, path: P) -> Result<u64, SnapshotError> {
+    let archive = rkyv::to_bytes::<RkyvError>(graph)?;
+
+    let mut header = [0u8; HEADER_LEN];
+    header[..8].copy_from_slice(MAGIC);
+    header[8..12].copy_from_slice(&FORMAT_VERSION.to_le_bytes());
+
+    let mut file = File::create(path.as_ref())?;
+    file.write_all(&header)?;
+    file.write_all(&archive)?;
+    file.flush()?;
+
+    Ok((HEADER_LEN + archive.len()) as u64)
+}
+
+/// A memory-mapped snapshot file.
+///
+/// The map stays alive for as long as this value does, and every reference handed out by
+/// [`Snapshot::graph`] borrows from it.
+pub struct Snapshot {
+    map: Mmap,
+}
+
+impl Snapshot {
+    /// Maps `path` and checks its header.
+    ///
+    /// This does not read the archive. It is a constant-time operation regardless of how large the
+    /// graph is, and it leaves the resident set almost untouched; pages arrive as queries reach
+    /// them.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SnapshotError::NotASnapshot`], [`SnapshotError::VersionMismatch`],
+    /// [`SnapshotError::Truncated`] or [`SnapshotError::Misaligned`] if the file cannot be used,
+    /// and [`SnapshotError::Io`] if it cannot be opened or mapped.
+    pub fn open<P: AsRef<Path>>(path: P) -> Result<Self, SnapshotError> {
+        let file = File::open(path.as_ref())?;
+        // SAFETY: mapping is only unsound if another process mutates the file underneath us. A
+        // snapshot is written once and then treated as immutable.
+        let map = unsafe { Mmap::map(&file)? };
+
+        if map.len() <= HEADER_LEN {
+            return Err(SnapshotError::Truncated { len: map.len() });
+        }
+        if &map[..8] != MAGIC {
+            return Err(SnapshotError::NotASnapshot);
+        }
+
+        let mut version_bytes = [0u8; 4];
+        version_bytes.copy_from_slice(&map[8..12]);
+        let found = u32::from_le_bytes(version_bytes);
+        if found != FORMAT_VERSION {
+            return Err(SnapshotError::VersionMismatch {
+                found,
+                expected: FORMAT_VERSION,
+            });
+        }
+
+        let required = align_of::<ArchivedGraph>();
+        if !(map[HEADER_LEN..].as_ptr() as usize).is_multiple_of(required) {
+            return Err(SnapshotError::Misaligned { required });
+        }
+
+        Ok(Snapshot { map })
+    }
+
+    /// The archived graph, borrowed straight out of the memory map.
+    ///
+    /// Reading through this reference never allocates. Use it for anything that only needs to read
+    /// the graph; use [`Snapshot::to_graph`] when the graph has to be mutated.
+    ///
+    /// The archive is trusted: [`Snapshot::open`] checks the header but not the body, because
+    /// walking the body would page in the whole file and give up the reason to use a memory map at
+    /// all. Call [`Snapshot::validate`] first when the file may not be your own.
+    #[must_use]
+    pub fn graph(&self) -> &ArchivedGraph {
+        // SAFETY: `open` verified the magic, the format version and the alignment. The body is
+        // trusted, which is the documented contract of this method.
+        unsafe { rkyv::access_unchecked::<ArchivedGraph>(self.archive()) }
+    }
+
+    /// Checks every pointer and every length in the archive, then returns it.
+    ///
+    /// This reads the whole file, so it costs time proportional to the archive and it makes the
+    /// whole archive resident. Prefer [`Snapshot::graph`] for a file you wrote yourself.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SnapshotError::Archive`] if the archive is malformed.
+    pub fn validate(&self) -> Result<&ArchivedGraph, SnapshotError> {
+        Ok(rkyv::access::<ArchivedGraph, RkyvError>(self.archive())?)
+    }
+
+    /// Walks the archive and rebuilds an owned, mutable [`Graph`].
+    ///
+    /// This allocates the entire graph, so it costs about as much memory as indexing does. It is
+    /// still far cheaper than re-indexing, and it is the path to take when the caller needs to
+    /// apply document changes afterwards.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SnapshotError::Archive`] if the archive cannot be walked.
+    pub fn to_graph(&self) -> Result<Graph, SnapshotError> {
+        Ok(rkyv::deserialize::<Graph, RkyvError>(self.graph())?)
+    }
+
+    /// Size of the mapped file in bytes, header included.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.map.len()
+    }
+
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.map.len() <= HEADER_LEN
+    }
+
+    fn archive(&self) -> &[u8] {
+        &self.map[HEADER_LEN..]
+    }
+}
+
+impl fmt::Debug for Snapshot {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Snapshot").field("len", &self.map.len()).finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::indexing::{LanguageId, index_source};
+    use crate::model::ids::{UriId, declaration_id_from_lookup_name};
+    use crate::resolution::Resolver;
+
+    fn resolved_graph() -> Graph {
+        let mut graph = Graph::new();
+        index_source(
+            &mut graph,
+            "file:///snapshot_test.rb",
+            "module Outer\n  class Inner < Base\n    def call; end\n  end\nend\n",
+            &LanguageId::Ruby,
+        );
+        Resolver::new(&mut graph).resolve();
+        graph
+    }
+
+    #[test]
+    fn round_trips_a_resolved_graph() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("graph.rdxsnap");
+
+        let graph = resolved_graph();
+        let expected_declarations = graph.declarations().len();
+        let expected_definitions = graph.definitions().len();
+
+        let written = write(&graph, &path).unwrap();
+        assert!(written > HEADER_LEN as u64);
+
+        let snapshot = Snapshot::open(&path).unwrap();
+        let restored = snapshot.to_graph().unwrap();
+
+        assert_eq!(restored.declarations().len(), expected_declarations);
+        assert_eq!(restored.definitions().len(), expected_definitions);
+        assert!(restored.get("Outer::Inner").is_some());
+        assert!(restored.get("Outer::Inner#call()").is_some());
+    }
+
+    #[test]
+    fn reads_declarations_without_deserializing() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("graph.rdxsnap");
+
+        let graph = resolved_graph();
+        write(&graph, &path).unwrap();
+
+        let snapshot = Snapshot::open(&path).unwrap();
+        let archived = snapshot.graph();
+
+        assert_eq!(archived.declarations().len(), graph.declarations().len());
+
+        // A point lookup against the archive uses the same content-hashed id as the live graph.
+        let id = declaration_id_from_lookup_name("Outer::Inner");
+        assert!(archived.declaration(id).is_some());
+        assert!(
+            archived
+                .declaration(declaration_id_from_lookup_name("Nope::Missing"))
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn validate_accepts_a_freshly_written_archive() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("graph.rdxsnap");
+
+        write(&resolved_graph(), &path).unwrap();
+
+        let snapshot = Snapshot::open(&path).unwrap();
+        assert!(snapshot.validate().is_ok());
+    }
+
+    #[test]
+    fn rejects_a_file_that_is_not_a_snapshot() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("not_a_snapshot");
+        std::fs::write(
+            &path,
+            b"this file is long enough but it has entirely the wrong magic bytes",
+        )
+        .unwrap();
+
+        assert!(matches!(Snapshot::open(&path), Err(SnapshotError::NotASnapshot)));
+    }
+
+    #[test]
+    fn rejects_a_future_format_version() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("graph.rdxsnap");
+        write(&resolved_graph(), &path).unwrap();
+
+        let mut bytes = std::fs::read(&path).unwrap();
+        bytes[8..12].copy_from_slice(&(FORMAT_VERSION + 1).to_le_bytes());
+        std::fs::write(&path, &bytes).unwrap();
+
+        assert!(matches!(
+            Snapshot::open(&path),
+            Err(SnapshotError::VersionMismatch { found, expected })
+                if found == FORMAT_VERSION + 1 && expected == FORMAT_VERSION
+        ));
+    }
+
+    #[test]
+    fn rejects_a_truncated_file() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("graph.rdxsnap");
+        std::fs::write(&path, MAGIC).unwrap();
+
+        assert!(matches!(
+            Snapshot::open(&path),
+            Err(SnapshotError::Truncated { len: 8 })
+        ));
+    }
+
+    /// A snapshot does not carry the line index, so a restored document has to rebuild one from
+    /// its own file. This is the one place where a restore reaches back to disk, and locations are
+    /// wrong if it misbehaves, so pin the behaviour down.
+    #[test]
+    fn restored_documents_rebuild_their_line_index_from_disk() {
+        let directory = tempfile::tempdir().unwrap();
+        let source_path = directory.path().join("shapes.rb");
+        let source = "class Circle\n  def area\n    3\n  end\nend\n";
+        std::fs::write(&source_path, source).unwrap();
+
+        let uri = format!("file://{}", source_path.display());
+        let mut graph = Graph::new();
+        index_source(&mut graph, &uri, source, &LanguageId::Ruby);
+        Resolver::new(&mut graph).resolve();
+
+        let uri_id = UriId::from(uri.as_str());
+        let definition_id = *graph.documents().get(&uri_id).unwrap().definitions().first().unwrap();
+        let expected = graph
+            .definitions()
+            .get(&definition_id)
+            .unwrap()
+            .offset()
+            .to_location(graph.documents().get(&uri_id).unwrap());
+
+        let snapshot_path = directory.path().join("graph.rdxsnap");
+        write(&graph, &snapshot_path).unwrap();
+        drop(graph);
+
+        let snapshot = Snapshot::open(&snapshot_path).unwrap();
+        let restored = snapshot.to_graph().unwrap();
+        let document = restored.documents().get(&uri_id).unwrap();
+        let actual = restored
+            .definitions()
+            .get(&definition_id)
+            .unwrap()
+            .offset()
+            .to_location(document);
+
+        assert_eq!(actual.start_line(), expected.start_line());
+        assert_eq!(actual.start_col(), expected.start_col());
+        assert_eq!(actual.end_line(), expected.end_line());
+        assert_eq!(actual.end_col(), expected.end_col());
+        assert_eq!(expected.start_line(), 0, "class Circle starts on the first line");
+    }
+
+    /// The lazy rebuild reads the document's file. When that file is gone the index must degrade to
+    /// an empty one rather than panic, because a snapshot never tracks whether files still exist.
+    #[test]
+    fn restored_documents_survive_a_missing_file() {
+        let directory = tempfile::tempdir().unwrap();
+        let source_path = directory.path().join("gone.rb");
+        let source = "class Gone\nend\n";
+        std::fs::write(&source_path, source).unwrap();
+
+        let uri = format!("file://{}", source_path.display());
+        let mut graph = Graph::new();
+        index_source(&mut graph, &uri, source, &LanguageId::Ruby);
+        Resolver::new(&mut graph).resolve();
+
+        let snapshot_path = directory.path().join("graph.rdxsnap");
+        write(&graph, &snapshot_path).unwrap();
+        drop(graph);
+        std::fs::remove_file(&source_path).unwrap();
+
+        let snapshot = Snapshot::open(&snapshot_path).unwrap();
+        let restored = snapshot.to_graph().unwrap();
+        let document = restored.documents().get(&UriId::from(uri.as_str())).unwrap();
+
+        assert_eq!(document.line_index().len(), 0.into());
+    }
+}

--- a/rust/rubydex/src/snapshot.rs
+++ b/rust/rubydex/src/snapshot.rs
@@ -46,11 +46,16 @@ use std::fs::File;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 
+use xxhash_rust::xxh3::Xxh3Default;
+
 use crate::errors::Errors;
 use crate::indexing::{self, IndexerBackend};
+use crate::listing;
 use crate::model::graph::{ArchivedGraph, Graph};
+use crate::path_helpers;
 use crate::resolution::Resolver;
 use crate::snapshot::manifest::{ArchivedManifest, Changes, Manifest, Verification};
+use crate::stats::timer::time_it;
 use memmap2::Mmap;
 use rkyv::rancor::Error as RkyvError;
 
@@ -162,6 +167,141 @@ pub fn write<P: AsRef<Path>>(graph: &Graph, roots: &[PathBuf], path: P) -> Resul
     file.flush()?;
 
     Ok((HEADER_LEN + manifest_len + padding + graph_archive.len()) as u64)
+}
+
+/// What [`load_or_index`] did.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CacheOutcome {
+    /// No usable snapshot: everything was indexed and a snapshot was written.
+    Miss,
+    /// A snapshot was reused. The counts describe the catch-up work, not the whole graph.
+    Hit { reindexed: usize, removed: usize },
+}
+
+impl CacheOutcome {
+    #[must_use]
+    pub fn is_hit(self) -> bool {
+        matches!(self, CacheOutcome::Hit { .. })
+    }
+}
+
+/// Default on-disk location for a workspace's snapshot.
+///
+/// The file lives under the user cache directory, honouring `XDG_CACHE_HOME` and falling back to
+/// `~/.cache`, and never inside the workspace. That matters: a snapshot written into an indexed
+/// directory would bump that directory's mtime, and the manifest would then report a change on
+/// every single run.
+///
+/// The name is a hash of the indexed roots, so two workspaces, or two checkouts of the same
+/// repository, never share a file.
+#[must_use]
+pub fn default_cache_path(roots: &[PathBuf]) -> PathBuf {
+    let mut sorted: Vec<String> = roots.iter().map(|root| root.to_string_lossy().into_owned()).collect();
+    sorted.sort();
+
+    let mut hasher = Xxh3Default::new();
+    for root in &sorted {
+        hasher.update(root.as_bytes());
+        hasher.update(b"\0");
+    }
+    let key = hasher.digest();
+
+    let base = std::env::var_os("XDG_CACHE_HOME").map_or_else(
+        || std::env::var_os("HOME").map_or_else(std::env::temp_dir, |home| PathBuf::from(home).join(".cache")),
+        PathBuf::from,
+    );
+
+    base.join("rubydex").join(format!("{key:016x}.rdxsnap"))
+}
+
+/// Populates `graph` from a snapshot when one is usable, and otherwise indexes from scratch.
+///
+/// This is the entry point a normal caller wants, and it is what makes snapshots the default
+/// rather than an opt-in. On a hit it re-indexes only the files the manifest reports as changed
+/// and resolves only the invalidated subset. On a miss it indexes everything, resolves, and writes
+/// a snapshot so the next run is a hit.
+///
+/// Either way `graph` comes back fully resolved. A caller does not need to call
+/// [`Resolver`] afterwards, though doing so is harmless because the worklist will be empty.
+///
+/// A snapshot is rejected, and the run falls back to a full index, when:
+/// - the file is missing, unreadable, or written by a different format version,
+/// - it was built from a different set of roots,
+/// - it was built with different exclusion patterns, which change the file set in a way no
+///   per-file check could detect.
+///
+/// Failing to write the snapshot is not an error. The graph is correct either way, and the next
+/// run simply pays the full cost again.
+pub fn load_or_index(
+    graph: &mut Graph,
+    roots: &[PathBuf],
+    cache_path: &Path,
+    verification: Verification,
+    backend: IndexerBackend,
+) -> (Vec<Errors>, CacheOutcome) {
+    if let Some((restored, changes, errors)) = try_reuse(graph, roots, cache_path, verification, backend) {
+        *graph = restored;
+        let outcome = CacheOutcome::Hit {
+            reindexed: changes.to_index(),
+            removed: changes.removed.len(),
+        };
+        return (errors, outcome);
+    }
+
+    // Report the same phases a plain indexing run does, so `--stats` stays meaningful whether or
+    // not a snapshot was reused.
+    let excluded = graph.excluded_patterns();
+    let string_roots: Vec<String> = roots.iter().map(|root| root.to_string_lossy().into_owned()).collect();
+    let (file_paths, mut errors) = time_it!(listing, { listing::collect_file_paths(string_roots, &excluded) });
+
+    errors.extend(time_it!(indexing, {
+        indexing::index_files(graph, file_paths, backend)
+    }));
+    time_it!(resolution, {
+        Resolver::new(graph).resolve();
+    });
+
+    if let Some(parent) = cache_path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    // A snapshot is an optimization. Losing it must never fail the run.
+    let _ = write(graph, roots, cache_path);
+
+    (errors, CacheOutcome::Miss)
+}
+
+/// Tries to reuse the snapshot at `cache_path`, returning `None` when it does not apply.
+fn try_reuse(
+    graph: &Graph,
+    roots: &[PathBuf],
+    cache_path: &Path,
+    verification: Verification,
+    backend: IndexerBackend,
+) -> Option<(Graph, Changes, Vec<Errors>)> {
+    let snapshot = Snapshot::open(cache_path).ok()?;
+    let manifest = snapshot.manifest();
+
+    if !manifest.excludes_match(&graph.excluded_patterns()) {
+        return None;
+    }
+
+    // Normalize both sides: the caller may pass relative paths, and the manifest stores the
+    // resolved spelling. This must match how `Manifest::build` resolves its roots, verbatim
+    // Windows prefixes included, or an otherwise valid snapshot never matches.
+    let mut wanted: Vec<String> = roots
+        .iter()
+        .filter_map(|root| path_helpers::resolved(root).ok())
+        .map(|root| root.to_string_lossy().into_owned())
+        .collect();
+    wanted.sort();
+    let mut recorded: Vec<String> = manifest.roots.iter().map(std::string::ToString::to_string).collect();
+    recorded.sort();
+    if wanted != recorded {
+        return None;
+    }
+
+    let (restored, changes, errors) = snapshot.catch_up(verification, backend).ok()?;
+    Some((restored, changes, errors))
 }
 
 /// A memory-mapped snapshot file.
@@ -404,7 +544,7 @@ mod tests {
     /// directory bumps that directory's mtime, which the tree would correctly report as a change.
     fn workspace(files: &[(&str, &str)]) -> (tempfile::TempDir, PathBuf, PathBuf) {
         let directory = tempfile::tempdir().unwrap();
-        let base = crate::path_helpers::resolved(directory.path()).unwrap();
+        let base = path_helpers::resolved(directory.path()).unwrap();
         let root = base.join("workspace");
         std::fs::create_dir_all(&root).unwrap();
 
@@ -838,5 +978,211 @@ mod tests {
         assert!(changes.is_empty());
         assert_eq!(changes.to_index(), 0);
         assert_eq!(declaration_names(&caught_up), declaration_names(&graph_for(&root)));
+    }
+
+    // ---------------------------------------------------------------- default caching
+
+    /// A workspace laid out on disk, with no snapshot written yet.
+    fn bare_workspace(files: &[(&str, &str)]) -> (tempfile::TempDir, PathBuf, PathBuf) {
+        let directory = tempfile::tempdir().unwrap();
+        let base = path_helpers::resolved(directory.path()).unwrap();
+        let root = base.join("workspace");
+        std::fs::create_dir_all(&root).unwrap();
+        for (name, source) in files {
+            let path = root.join(name);
+            std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+            std::fs::write(&path, source).unwrap();
+        }
+        (directory, root, base.join("cache.rdxsnap"))
+    }
+
+    #[test]
+    fn the_first_run_misses_and_writes_a_snapshot() {
+        let (_directory, root, cache) = bare_workspace(&[("a.rb", "class A; end\n")]);
+        assert!(!cache.exists());
+
+        let mut graph = Graph::new();
+        let (errors, outcome) = load_or_index(
+            &mut graph,
+            std::slice::from_ref(&root),
+            &cache,
+            Verification::Metadata,
+            IndexerBackend::RubyIndexer,
+        );
+
+        assert!(errors.is_empty(), "{errors:?}");
+        assert_eq!(outcome, CacheOutcome::Miss);
+        assert!(cache.exists(), "a miss must leave a snapshot behind");
+        // The graph comes back resolved, so a caller never has to resolve again.
+        assert!(graph.get("A").is_some());
+    }
+
+    #[test]
+    fn the_second_run_hits_and_indexes_nothing() {
+        let (_directory, root, cache) = bare_workspace(&[("a.rb", "class A; end\n")]);
+
+        let mut first = Graph::new();
+        load_or_index(
+            &mut first,
+            std::slice::from_ref(&root),
+            &cache,
+            Verification::Metadata,
+            IndexerBackend::RubyIndexer,
+        );
+
+        let mut second = Graph::new();
+        let (_, outcome) = load_or_index(
+            &mut second,
+            std::slice::from_ref(&root),
+            &cache,
+            Verification::Metadata,
+            IndexerBackend::RubyIndexer,
+        );
+
+        assert_eq!(
+            outcome,
+            CacheOutcome::Hit {
+                reindexed: 0,
+                removed: 0
+            }
+        );
+        assert_eq!(declaration_names(&second), declaration_names(&first));
+    }
+
+    #[test]
+    fn a_hit_reindexes_only_what_changed() {
+        let (_directory, root, cache) = bare_workspace(&[
+            ("a.rb", "class A; end\n"),
+            ("b.rb", "class B; end\n"),
+            ("c.rb", "class C; end\n"),
+        ]);
+
+        let mut first = Graph::new();
+        load_or_index(
+            &mut first,
+            std::slice::from_ref(&root),
+            &cache,
+            Verification::Metadata,
+            IndexerBackend::RubyIndexer,
+        );
+
+        rewrite(&root.join("b.rb"), "class B\n  def fresh; end\nend\n");
+
+        let mut second = Graph::new();
+        let (_, outcome) = load_or_index(
+            &mut second,
+            std::slice::from_ref(&root),
+            &cache,
+            Verification::Metadata,
+            IndexerBackend::RubyIndexer,
+        );
+
+        assert_eq!(
+            outcome,
+            CacheOutcome::Hit {
+                reindexed: 1,
+                removed: 0
+            },
+            "only b.rb is re-indexed"
+        );
+        assert!(second.get("B#fresh()").is_some());
+        assert_eq!(declaration_names(&second), declaration_names(&graph_for(&root)));
+    }
+
+    /// Changing the exclusion set changes which files belong in the graph. No per-file check can
+    /// notice that, because the newly excluded file still exists and still matches its metadata.
+    #[test]
+    fn different_exclusions_force_a_full_reindex() {
+        let (_directory, root, cache) =
+            bare_workspace(&[("a.rb", "class A; end\n"), ("skipped/b.rb", "class B; end\n")]);
+
+        let mut first = Graph::new();
+        load_or_index(
+            &mut first,
+            std::slice::from_ref(&root),
+            &cache,
+            Verification::Metadata,
+            IndexerBackend::RubyIndexer,
+        );
+        assert!(first.get("B").is_some(), "B is indexed while nothing excludes it");
+
+        let mut second = Graph::new();
+        second.exclude_patterns(vec![Box::from(format!("{}/skipped/**", root.display()).as_str())]);
+        let (_, outcome) = load_or_index(
+            &mut second,
+            std::slice::from_ref(&root),
+            &cache,
+            Verification::Metadata,
+            IndexerBackend::RubyIndexer,
+        );
+
+        // Whether the pattern then filters that particular file is `listing`'s business, and its
+        // glob spelling differs by platform. What the snapshot owns is the decision to distrust a
+        // manifest built under a different exclusion set.
+        assert_eq!(
+            outcome,
+            CacheOutcome::Miss,
+            "a different exclusion set cannot reuse the snapshot"
+        );
+    }
+
+    #[test]
+    fn a_different_root_set_forces_a_full_reindex() {
+        let (_directory, root, cache) = bare_workspace(&[("a.rb", "class A; end\n"), ("other/b.rb", "class B; end\n")]);
+
+        let mut first = Graph::new();
+        load_or_index(
+            &mut first,
+            std::slice::from_ref(&root),
+            &cache,
+            Verification::Metadata,
+            IndexerBackend::RubyIndexer,
+        );
+
+        // Same snapshot file, narrower roots: the recorded tree no longer describes the request.
+        let mut second = Graph::new();
+        let (_, outcome) = load_or_index(
+            &mut second,
+            &[root.join("other")],
+            &cache,
+            Verification::Metadata,
+            IndexerBackend::RubyIndexer,
+        );
+
+        assert_eq!(outcome, CacheOutcome::Miss);
+    }
+
+    #[test]
+    fn a_corrupt_snapshot_falls_back_to_indexing() {
+        let (_directory, root, cache) = bare_workspace(&[("a.rb", "class A; end\n")]);
+        std::fs::write(&cache, b"definitely not a rubydex snapshot, but long enough to map").unwrap();
+
+        let mut graph = Graph::new();
+        let (_, outcome) = load_or_index(
+            &mut graph,
+            std::slice::from_ref(&root),
+            &cache,
+            Verification::Metadata,
+            IndexerBackend::RubyIndexer,
+        );
+
+        assert_eq!(outcome, CacheOutcome::Miss);
+        assert!(graph.get("A").is_some());
+    }
+
+    #[test]
+    fn the_default_cache_path_is_outside_the_workspace_and_per_root() {
+        let one = default_cache_path(&[PathBuf::from("/tmp/alpha")]);
+        let two = default_cache_path(&[PathBuf::from("/tmp/beta")]);
+
+        assert_ne!(one, two, "two workspaces must not share a snapshot");
+        assert_eq!(
+            one,
+            default_cache_path(&[PathBuf::from("/tmp/alpha")]),
+            "stable across runs"
+        );
+        assert!(!one.starts_with("/tmp/alpha"), "never inside the workspace");
+        assert!(one.to_string_lossy().contains("rubydex"));
+        assert_eq!(one.extension().unwrap(), "rdxsnap");
     }
 }

--- a/rust/rubydex/src/snapshot.rs
+++ b/rust/rubydex/src/snapshot.rs
@@ -12,48 +12,67 @@
 //! Every id in the graph is a deterministic xxh3 content hash, so the ids in an archive stay valid
 //! in another process. Nothing needs relocating on load.
 //!
-//! # What a snapshot does not store
+//! # Staleness
 //!
-//! A snapshot does not record which files it was built from, so it cannot tell that the workspace
-//! changed. The caller owns that decision. A [`Document`](crate::model::document::Document) also
-//! archives without its line index, and rebuilds it from disk on first use.
+//! A snapshot also carries a [`Manifest`], a Merkle tree over the files it was built from.
+//! [`Snapshot::changes`] compares that tree against the file system and reports which documents to
+//! re-index. See [`manifest`] for why the tree is shaped the way it is.
+//!
+//! A [`Document`](crate::model::document::Document) archives without its line index, and rebuilds
+//! it from disk on first use.
 //!
 //! # Layout
 //!
+//! The manifest and the graph are two independent archives in one file, rather than one archive
+//! holding both. A staleness check then touches only the manifest region, which is megabytes, and
+//! never faults in the graph, which is gigabytes.
+//!
 //! ```text
-//! offset 0   magic     8 bytes   "RDXSNAP\0"
-//! offset 8   version   4 bytes   little-endian u32
-//! offset 12  reserved  4 bytes   zero
-//! offset 16  archive   rest of the file
+//! offset 0   magic         8 bytes   "RDXSNAP\0"
+//! offset 8   version       4 bytes   little-endian u32
+//! offset 12  reserved      4 bytes   zero
+//! offset 16  manifest_len  8 bytes   little-endian u64, padded to a multiple of 16
+//! offset 24  reserved      8 bytes   zero
+//! offset 32  manifest archive
+//! offset 32 + manifest_len   graph archive
 //! ```
 //!
-//! The header is 16 bytes so that the archive stays aligned: a memory map starts on a page
-//! boundary, and 16 divides every alignment the archived graph can ask for.
+//! The header is 32 bytes and the manifest is padded to 16, so both archives start on a 16 byte
+//! boundary. A memory map starts on a page boundary, so that is enough for any alignment the
+//! archived types can ask for.
 
 use std::fmt;
 use std::fs::File;
 use std::io::{self, Write};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
+use crate::errors::Errors;
+use crate::indexing::{self, IndexerBackend};
+use crate::model::graph::{ArchivedGraph, Graph};
+use crate::resolution::Resolver;
+use crate::snapshot::manifest::{ArchivedManifest, Changes, Manifest, Verification};
 use memmap2::Mmap;
 use rkyv::rancor::Error as RkyvError;
 
-use crate::model::graph::{ArchivedGraph, Graph};
+pub mod manifest;
 
 /// Identifies a rubydex snapshot file.
 const MAGIC: &[u8; 8] = b"RDXSNAP\0";
 
-/// Bumped whenever the archived layout of the graph changes. An archive written by a different
-/// version of the model is not readable, and there is no migration: rebuild it from source.
+/// Bumped whenever the archived layout of the graph or the manifest changes. An archive written by
+/// a different version of the model is not readable, and there is no migration: rebuild it.
 pub const FORMAT_VERSION: u32 = 1;
 
-/// Size of the fixed header, in bytes. Also the alignment the archive is guaranteed.
-const HEADER_LEN: usize = 16;
+/// Size of the fixed header, in bytes.
+const HEADER_LEN: usize = 32;
+
+/// Both archives start on a multiple of this, so neither is ever misaligned.
+const ALIGNMENT: usize = 16;
 
 #[derive(Debug)]
 pub enum SnapshotError {
     Io(io::Error),
-    /// The file is shorter than the header, or holds no archive.
+    /// The file is shorter than the header, or one of the two archives does not fit.
     Truncated {
         len: usize,
     },
@@ -64,11 +83,11 @@ pub enum SnapshotError {
         found: u32,
         expected: u32,
     },
-    /// The mapping does not satisfy the alignment the archived graph requires.
+    /// The mapping does not satisfy the alignment an archive requires.
     Misaligned {
         required: usize,
     },
-    /// The archive is malformed, or could not be walked back into an owned graph.
+    /// An archive is malformed, or could not be walked back into owned values.
     Archive(RkyvError),
 }
 
@@ -108,41 +127,57 @@ impl From<RkyvError> for SnapshotError {
 
 /// Writes `graph` to `path`, replacing any file already there, and returns the bytes written.
 ///
+/// `roots` are the paths that were indexed. They bound the manifest, so a later reload knows where
+/// new files could appear. Building the manifest stats every file once.
+///
 /// Take the snapshot after resolution. Serializing costs one pass over the graph plus one write of
 /// the whole archive, so this is much more expensive than [`Snapshot::open`]; the point is to pay
 /// it once and read it many times.
 ///
 /// # Errors
 ///
-/// Returns [`SnapshotError::Archive`] if the graph cannot be serialized, and
+/// Returns [`SnapshotError::Archive`] if either archive cannot be serialized, and
 /// [`SnapshotError::Io`] if the file cannot be written.
-pub fn write<P: AsRef<Path>>(graph: &Graph, path: P) -> Result<u64, SnapshotError> {
-    let archive = rkyv::to_bytes::<RkyvError>(graph)?;
+pub fn write<P: AsRef<Path>>(graph: &Graph, roots: &[PathBuf], path: P) -> Result<u64, SnapshotError> {
+    let manifest = Manifest::build(graph, roots);
+    let manifest_archive = rkyv::to_bytes::<RkyvError>(&manifest)?;
+    let graph_archive = rkyv::to_bytes::<RkyvError>(graph)?;
+
+    // The recorded length is the archive's exact length. rkyv finds an archive's root by counting
+    // back from the end of the slice it is given, so padding must never sit inside that slice; it
+    // goes between the two archives instead, purely to align the second one.
+    let manifest_len = manifest_archive.len();
+    let padding = (ALIGNMENT - manifest_len % ALIGNMENT) % ALIGNMENT;
 
     let mut header = [0u8; HEADER_LEN];
     header[..8].copy_from_slice(MAGIC);
     header[8..12].copy_from_slice(&FORMAT_VERSION.to_le_bytes());
+    header[16..24].copy_from_slice(&(manifest_len as u64).to_le_bytes());
 
     let mut file = File::create(path.as_ref())?;
     file.write_all(&header)?;
-    file.write_all(&archive)?;
+    file.write_all(&manifest_archive)?;
+    file.write_all(&vec![0u8; padding])?;
+    file.write_all(&graph_archive)?;
     file.flush()?;
 
-    Ok((HEADER_LEN + archive.len()) as u64)
+    Ok((HEADER_LEN + manifest_len + padding + graph_archive.len()) as u64)
 }
 
 /// A memory-mapped snapshot file.
 ///
 /// The map stays alive for as long as this value does, and every reference handed out by
-/// [`Snapshot::graph`] borrows from it.
+/// [`Snapshot::graph`] or [`Snapshot::manifest`] borrows from it.
 pub struct Snapshot {
     map: Mmap,
+    manifest_len: usize,
+    graph_offset: usize,
 }
 
 impl Snapshot {
     /// Maps `path` and checks its header.
     ///
-    /// This does not read the archive. It is a constant-time operation regardless of how large the
+    /// This reads neither archive. It is a constant-time operation regardless of how large the
     /// graph is, and it leaves the resident set almost untouched; pages arrive as queries reach
     /// them.
     ///
@@ -174,12 +209,25 @@ impl Snapshot {
             });
         }
 
-        let required = align_of::<ArchivedGraph>();
-        if !(map[HEADER_LEN..].as_ptr() as usize).is_multiple_of(required) {
-            return Err(SnapshotError::Misaligned { required });
+        let mut manifest_len_bytes = [0u8; 8];
+        manifest_len_bytes.copy_from_slice(&map[16..24]);
+        let manifest_len = usize::try_from(u64::from_le_bytes(manifest_len_bytes))
+            .map_err(|_| SnapshotError::Truncated { len: map.len() })?;
+
+        // The graph archive begins after the manifest plus whatever padding realigned it.
+        let graph_offset = (HEADER_LEN + manifest_len).next_multiple_of(ALIGNMENT);
+        if graph_offset >= map.len() {
+            return Err(SnapshotError::Truncated { len: map.len() });
+        }
+        if !(map.as_ptr() as usize).is_multiple_of(ALIGNMENT) {
+            return Err(SnapshotError::Misaligned { required: ALIGNMENT });
         }
 
-        Ok(Snapshot { map })
+        Ok(Snapshot {
+            map,
+            manifest_len,
+            graph_offset,
+        })
     }
 
     /// The archived graph, borrowed straight out of the memory map.
@@ -194,19 +242,39 @@ impl Snapshot {
     pub fn graph(&self) -> &ArchivedGraph {
         // SAFETY: `open` verified the magic, the format version and the alignment. The body is
         // trusted, which is the documented contract of this method.
-        unsafe { rkyv::access_unchecked::<ArchivedGraph>(self.archive()) }
+        unsafe { rkyv::access_unchecked::<ArchivedGraph>(self.graph_bytes()) }
     }
 
-    /// Checks every pointer and every length in the archive, then returns it.
+    /// The archived manifest, borrowed straight out of the memory map.
+    ///
+    /// Touching this pages in only the manifest region, never the graph.
+    #[must_use]
+    pub fn manifest(&self) -> &ArchivedManifest {
+        // SAFETY: as for `graph`.
+        unsafe { rkyv::access_unchecked::<ArchivedManifest>(self.manifest_bytes()) }
+    }
+
+    /// Reports which files changed since the snapshot was written.
+    ///
+    /// This is the cheap way to decide whether the archived graph can be used as is. It stats the
+    /// files and directories the manifest knows about and re-reads only the directories whose mtime
+    /// moved; it never walks the workspace and never touches the graph archive.
+    #[must_use]
+    pub fn changes(&self, verification: Verification) -> Changes {
+        self.manifest().diff(verification)
+    }
+
+    /// Checks every pointer and every length in both archives.
     ///
     /// This reads the whole file, so it costs time proportional to the archive and it makes the
     /// whole archive resident. Prefer [`Snapshot::graph`] for a file you wrote yourself.
     ///
     /// # Errors
     ///
-    /// Returns [`SnapshotError::Archive`] if the archive is malformed.
+    /// Returns [`SnapshotError::Archive`] if either archive is malformed.
     pub fn validate(&self) -> Result<&ArchivedGraph, SnapshotError> {
-        Ok(rkyv::access::<ArchivedGraph, RkyvError>(self.archive())?)
+        rkyv::access::<ArchivedManifest, RkyvError>(self.manifest_bytes())?;
+        Ok(rkyv::access::<ArchivedGraph, RkyvError>(self.graph_bytes())?)
     }
 
     /// Walks the archive and rebuilds an owned, mutable [`Graph`].
@@ -222,6 +290,50 @@ impl Snapshot {
         Ok(rkyv::deserialize::<Graph, RkyvError>(self.graph())?)
     }
 
+    /// Rebuilds an owned graph and brings it up to date with the workspace.
+    ///
+    /// This is the whole point of carrying a manifest. Rather than re-indexing everything, it
+    /// re-indexes only what [`Snapshot::changes`] reports:
+    ///
+    /// - documents whose file disappeared are dropped,
+    /// - modified and newly discovered files are indexed again,
+    /// - resolution then runs over the invalidated subset only.
+    ///
+    /// Dropping and re-indexing a document feeds the same incremental invalidation path an editor
+    /// uses, so the resolver's worklist already holds exactly the units that need redoing. An
+    /// unchanged workspace skips indexing entirely and only pays for the deserialize.
+    ///
+    /// Returns the graph together with what changed, so a caller can report or log it.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SnapshotError::Archive`] if the archive cannot be walked.
+    pub fn catch_up(
+        &self,
+        verification: Verification,
+        backend: IndexerBackend,
+    ) -> Result<(Graph, Changes, Vec<Errors>), SnapshotError> {
+        let changes = self.changes(verification);
+        let mut graph = self.to_graph()?;
+
+        for (uri_id, _) in &changes.removed {
+            graph.delete_document_by_id(*uri_id);
+        }
+
+        let mut errors = Vec::new();
+        if !changes.modified.is_empty() || !changes.added.is_empty() {
+            let stale: Vec<PathBuf> = changes.modified.iter().chain(&changes.added).cloned().collect();
+            errors = indexing::index_files(&mut graph, stale, backend);
+        }
+
+        // Always resolve: a deletion produces pending work without producing any file to index.
+        if !changes.is_empty() {
+            Resolver::new(&mut graph).resolve();
+        }
+
+        Ok((graph, changes, errors))
+    }
+
     /// Size of the mapped file in bytes, header included.
     #[must_use]
     pub fn len(&self) -> usize {
@@ -233,14 +345,22 @@ impl Snapshot {
         self.map.len() <= HEADER_LEN
     }
 
-    fn archive(&self) -> &[u8] {
-        &self.map[HEADER_LEN..]
+    fn manifest_bytes(&self) -> &[u8] {
+        &self.map[HEADER_LEN..HEADER_LEN + self.manifest_len]
+    }
+
+    fn graph_bytes(&self) -> &[u8] {
+        &self.map[self.graph_offset..]
     }
 }
 
 impl fmt::Debug for Snapshot {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Snapshot").field("len", &self.map.len()).finish()
+        f.debug_struct("Snapshot")
+            .field("len", &self.map.len())
+            .field("manifest_len", &self.manifest_len)
+            .field("graph_offset", &self.graph_offset)
+            .finish()
     }
 }
 
@@ -250,6 +370,65 @@ mod tests {
     use crate::indexing::{LanguageId, index_source};
     use crate::model::ids::{UriId, declaration_id_from_lookup_name};
     use crate::resolution::Resolver;
+
+    /// Spells a path as a URI the way indexing does. Building one with `format!` breaks on
+    /// Windows, where a path is `C:\\...` rather than something that can follow `file://`.
+    fn file_uri(path: &Path) -> String {
+        url::Url::from_file_path(path)
+            .expect("test path is absolute")
+            .to_string()
+    }
+
+    /// Indexes every `.rb` file under `directory` and resolves the result.
+    fn graph_for(directory: &Path) -> Graph {
+        let mut graph = Graph::new();
+        let mut stack = vec![directory.to_path_buf()];
+        while let Some(current) = stack.pop() {
+            for entry in std::fs::read_dir(&current).unwrap().flatten() {
+                let path = entry.path();
+                if path.is_dir() {
+                    stack.push(path);
+                } else if path.extension().is_some_and(|ext| ext == "rb") {
+                    let source = std::fs::read_to_string(&path).unwrap();
+                    index_source(&mut graph, &file_uri(&path), &source, &LanguageId::Ruby);
+                }
+            }
+        }
+        Resolver::new(&mut graph).resolve();
+        graph
+    }
+
+    /// Builds a workspace, snapshots it, and hands back the pieces a staleness test needs.
+    ///
+    /// The snapshot lives beside the workspace, never inside it. Writing a file into an indexed
+    /// directory bumps that directory's mtime, which the tree would correctly report as a change.
+    fn workspace(files: &[(&str, &str)]) -> (tempfile::TempDir, PathBuf, PathBuf) {
+        let directory = tempfile::tempdir().unwrap();
+        let base = crate::path_helpers::resolved(directory.path()).unwrap();
+        let root = base.join("workspace");
+        std::fs::create_dir_all(&root).unwrap();
+
+        for (name, source) in files {
+            let path = root.join(name);
+            std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+            std::fs::write(&path, source).unwrap();
+        }
+
+        let snapshot_path = base.join("graph.rdxsnap");
+        let graph = graph_for(&root);
+        write(&graph, std::slice::from_ref(&root), &snapshot_path).unwrap();
+
+        (directory, root, snapshot_path)
+    }
+
+    /// mtime has finite resolution, so a rewrite in the same instant can look unchanged. Push the
+    /// clock forward rather than sleeping.
+    fn rewrite(path: &Path, source: &str) {
+        std::fs::write(path, source).unwrap();
+        let future = std::time::SystemTime::now() + std::time::Duration::from_secs(2);
+        let file = std::fs::OpenOptions::new().write(true).open(path).unwrap();
+        file.set_modified(future).unwrap();
+    }
 
     fn resolved_graph() -> Graph {
         let mut graph = Graph::new();
@@ -272,7 +451,7 @@ mod tests {
         let expected_declarations = graph.declarations().len();
         let expected_definitions = graph.definitions().len();
 
-        let written = write(&graph, &path).unwrap();
+        let written = write(&graph, &[], &path).unwrap();
         assert!(written > HEADER_LEN as u64);
 
         let snapshot = Snapshot::open(&path).unwrap();
@@ -290,7 +469,7 @@ mod tests {
         let path = directory.path().join("graph.rdxsnap");
 
         let graph = resolved_graph();
-        write(&graph, &path).unwrap();
+        write(&graph, &[], &path).unwrap();
 
         let snapshot = Snapshot::open(&path).unwrap();
         let archived = snapshot.graph();
@@ -312,7 +491,7 @@ mod tests {
         let directory = tempfile::tempdir().unwrap();
         let path = directory.path().join("graph.rdxsnap");
 
-        write(&resolved_graph(), &path).unwrap();
+        write(&resolved_graph(), &[], &path).unwrap();
 
         let snapshot = Snapshot::open(&path).unwrap();
         assert!(snapshot.validate().is_ok());
@@ -335,7 +514,7 @@ mod tests {
     fn rejects_a_future_format_version() {
         let directory = tempfile::tempdir().unwrap();
         let path = directory.path().join("graph.rdxsnap");
-        write(&resolved_graph(), &path).unwrap();
+        write(&resolved_graph(), &[], &path).unwrap();
 
         let mut bytes = std::fs::read(&path).unwrap();
         bytes[8..12].copy_from_slice(&(FORMAT_VERSION + 1).to_le_bytes());
@@ -370,7 +549,7 @@ mod tests {
         let source = "class Circle\n  def area\n    3\n  end\nend\n";
         std::fs::write(&source_path, source).unwrap();
 
-        let uri = format!("file://{}", source_path.display());
+        let uri = file_uri(&source_path);
         let mut graph = Graph::new();
         index_source(&mut graph, &uri, source, &LanguageId::Ruby);
         Resolver::new(&mut graph).resolve();
@@ -385,7 +564,7 @@ mod tests {
             .to_location(graph.documents().get(&uri_id).unwrap());
 
         let snapshot_path = directory.path().join("graph.rdxsnap");
-        write(&graph, &snapshot_path).unwrap();
+        write(&graph, &[], &snapshot_path).unwrap();
         drop(graph);
 
         let snapshot = Snapshot::open(&snapshot_path).unwrap();
@@ -414,13 +593,13 @@ mod tests {
         let source = "class Gone\nend\n";
         std::fs::write(&source_path, source).unwrap();
 
-        let uri = format!("file://{}", source_path.display());
+        let uri = file_uri(&source_path);
         let mut graph = Graph::new();
         index_source(&mut graph, &uri, source, &LanguageId::Ruby);
         Resolver::new(&mut graph).resolve();
 
         let snapshot_path = directory.path().join("graph.rdxsnap");
-        write(&graph, &snapshot_path).unwrap();
+        write(&graph, &[], &snapshot_path).unwrap();
         drop(graph);
         std::fs::remove_file(&source_path).unwrap();
 
@@ -429,5 +608,235 @@ mod tests {
         let document = restored.documents().get(&UriId::from(uri.as_str())).unwrap();
 
         assert_eq!(document.line_index().len(), 0.into());
+    }
+
+    // ---------------------------------------------------------------- staleness
+
+    #[test]
+    fn an_untouched_workspace_reports_no_changes() {
+        let (_directory, _root, snapshot_path) =
+            workspace(&[("a.rb", "class A; end\n"), ("nested/b.rb", "class B; end\n")]);
+
+        let snapshot = Snapshot::open(&snapshot_path).unwrap();
+        let changes = snapshot.changes(Verification::Metadata);
+
+        assert!(changes.is_empty(), "{changes:?}");
+        assert_eq!(changes.unchanged, 2);
+        assert_eq!(snapshot.manifest().file_count(), 2);
+        assert!(snapshot.manifest().dir_count() >= 2, "root and nested are both tracked");
+        assert_ne!(snapshot.manifest().root(), 0);
+    }
+
+    #[test]
+    fn an_edited_file_is_reported_as_modified() {
+        let (_directory, root, snapshot_path) =
+            workspace(&[("a.rb", "class A; end\n"), ("nested/b.rb", "class B; end\n")]);
+
+        rewrite(&root.join("nested/b.rb"), "class B\n  def extra; end\nend\n");
+
+        let snapshot = Snapshot::open(&snapshot_path).unwrap();
+        let changes = snapshot.changes(Verification::Metadata);
+
+        assert_eq!(changes.modified, vec![root.join("nested/b.rb")]);
+        assert!(changes.added.is_empty());
+        assert!(changes.removed.is_empty());
+        assert_eq!(changes.unchanged, 1);
+    }
+
+    /// Editing a file bumps only that file's mtime. Discovering it therefore has to come from the
+    /// file sweep, not from the directory sweep.
+    #[test]
+    fn content_verification_catches_an_mtime_preserving_edit() {
+        let (_directory, root, snapshot_path) = workspace(&[("a.rb", "class A; end\n")]);
+
+        let path = root.join("a.rb");
+        let original = std::fs::metadata(&path).unwrap().modified().unwrap();
+        // Same length, so size cannot give it away either.
+        std::fs::write(&path, "class Z; end\n").unwrap();
+        std::fs::OpenOptions::new()
+            .write(true)
+            .open(&path)
+            .unwrap()
+            .set_modified(original)
+            .unwrap();
+
+        let snapshot = Snapshot::open(&snapshot_path).unwrap();
+
+        let metadata_only = snapshot.changes(Verification::Metadata);
+        assert!(
+            metadata_only.is_empty(),
+            "size and mtime both match, so this edit is invisible"
+        );
+
+        let by_content = snapshot.changes(Verification::Content);
+        assert_eq!(by_content.modified, vec![path]);
+    }
+
+    #[test]
+    fn a_new_file_is_found_through_its_directory() {
+        let (_directory, root, snapshot_path) = workspace(&[("a.rb", "class A; end\n")]);
+
+        rewrite(&root.join("c.rb"), "class C; end\n");
+        // Adding an entry bumps the containing directory's mtime by itself, which is what the
+        // directory sweep looks for.
+
+        let snapshot = Snapshot::open(&snapshot_path).unwrap();
+        let changes = snapshot.changes(Verification::Metadata);
+
+        assert_eq!(changes.added, vec![root.join("c.rb")]);
+        assert!(changes.modified.is_empty());
+        assert!(changes.removed.is_empty());
+    }
+
+    /// A directory the manifest never saw is walked in full, so files nested inside a new tree are
+    /// still found.
+    #[test]
+    fn a_new_nested_directory_is_walked() {
+        let (_directory, root, snapshot_path) = workspace(&[("a.rb", "class A; end\n")]);
+
+        std::fs::create_dir_all(root.join("fresh/deeper")).unwrap();
+        std::fs::write(root.join("fresh/deeper/d.rb"), "class D; end\n").unwrap();
+
+        let snapshot = Snapshot::open(&snapshot_path).unwrap();
+        let changes = snapshot.changes(Verification::Metadata);
+
+        assert_eq!(changes.added, vec![root.join("fresh/deeper/d.rb")]);
+    }
+
+    #[test]
+    fn a_deleted_file_is_reported_with_its_document_id() {
+        let (_directory, root, snapshot_path) =
+            workspace(&[("a.rb", "class A; end\n"), ("nested/b.rb", "class B; end\n")]);
+
+        let gone = root.join("nested/b.rb");
+        std::fs::remove_file(&gone).unwrap();
+
+        let snapshot = Snapshot::open(&snapshot_path).unwrap();
+        let changes = snapshot.changes(Verification::Metadata);
+
+        assert_eq!(changes.removed.len(), 1);
+        let (uri_id, path) = &changes.removed[0];
+        assert_eq!(path, &gone);
+        assert_eq!(*uri_id, UriId::from(file_uri(&gone).as_str()));
+        assert_eq!(changes.unchanged, 1);
+    }
+
+    /// The whole point of the tree: an identical workspace produces an identical root.
+    #[test]
+    fn the_root_hash_is_stable_across_rebuilds() {
+        let (_directory, root, snapshot_path) = workspace(&[("a.rb", "class A; end\n")]);
+
+        let first = Snapshot::open(&snapshot_path).unwrap().manifest().root();
+
+        let second_path = root.parent().unwrap().join("again.rdxsnap");
+        let graph = graph_for(&root);
+        write(&graph, std::slice::from_ref(&root), &second_path).unwrap();
+        let second = Snapshot::open(&second_path).unwrap().manifest().root();
+
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn the_root_hash_changes_when_a_file_changes() {
+        let (_directory, root, snapshot_path) = workspace(&[("a.rb", "class A; end\n")]);
+        let before = Snapshot::open(&snapshot_path).unwrap().manifest().root();
+
+        rewrite(&root.join("a.rb"), "class A\n  def more; end\nend\n");
+
+        let after_path = root.parent().unwrap().join("after.rdxsnap");
+        let graph = graph_for(&root);
+        write(&graph, std::slice::from_ref(&root), &after_path).unwrap();
+        let after = Snapshot::open(&after_path).unwrap().manifest().root();
+
+        assert_ne!(before, after);
+    }
+
+    // ---------------------------------------------------------------- catch up
+
+    /// Sorted fully qualified names, the cheapest way to say two graphs agree.
+    fn declaration_names(graph: &Graph) -> Vec<String> {
+        let mut names: Vec<String> = graph.declarations().values().map(|d| d.name().to_string()).collect();
+        names.sort_unstable();
+        names
+    }
+
+    /// The contract that makes partial indexing worth doing: catching a snapshot up must land on
+    /// exactly the graph a full rebuild would have produced.
+    #[test]
+    fn catching_up_matches_a_full_rebuild() {
+        let (_directory, root, snapshot_path) = workspace(&[
+            ("a.rb", "class A; end\n"),
+            ("nested/b.rb", "class B < A\n  def keep; end\nend\n"),
+            ("nested/gone.rb", "class Gone; end\n"),
+        ]);
+
+        // One edit, one deletion, one addition, which is every case the manifest reports.
+        rewrite(
+            &root.join("nested/b.rb"),
+            "class B < A\n  def keep; end\n  def added; end\nend\n",
+        );
+        std::fs::remove_file(root.join("nested/gone.rb")).unwrap();
+        rewrite(&root.join("nested/fresh.rb"), "class Fresh < B; end\n");
+
+        let snapshot = Snapshot::open(&snapshot_path).unwrap();
+        let (caught_up, changes, errors) = snapshot
+            .catch_up(Verification::Metadata, IndexerBackend::RubyIndexer)
+            .unwrap();
+        assert!(errors.is_empty(), "{errors:?}");
+
+        assert_eq!(changes.modified, vec![root.join("nested/b.rb")]);
+        assert_eq!(changes.added, vec![root.join("nested/fresh.rb")]);
+        assert_eq!(changes.removed.len(), 1);
+        assert_eq!(changes.to_index(), 2, "only the edited and the new file are re-indexed");
+
+        let rebuilt = graph_for(&root);
+
+        assert_eq!(declaration_names(&caught_up), declaration_names(&rebuilt));
+        assert_eq!(caught_up.documents().len(), rebuilt.documents().len());
+        assert_eq!(caught_up.definitions().len(), rebuilt.definitions().len());
+
+        // The deleted class is gone, the new one is present, and the edit landed.
+        assert!(caught_up.get("Gone").is_none());
+        assert!(caught_up.get("Fresh").is_some());
+        assert!(caught_up.get("B#added()").is_some());
+    }
+
+    /// Ancestors are the part most likely to go stale, because they cascade. A new subclass has to
+    /// see the parent that the snapshot already knew about.
+    #[test]
+    fn catching_up_relinks_ancestors_across_the_snapshot_boundary() {
+        let (_directory, root, snapshot_path) =
+            workspace(&[("base.rb", "class Base\n  def inherited_call; end\nend\n")]);
+
+        rewrite(&root.join("child.rb"), "class Child < Base; end\n");
+
+        let snapshot = Snapshot::open(&snapshot_path).unwrap();
+        let (caught_up, changes, _) = snapshot
+            .catch_up(Verification::Metadata, IndexerBackend::RubyIndexer)
+            .unwrap();
+
+        assert_eq!(changes.to_index(), 1, "only the new file is indexed");
+
+        let rebuilt = graph_for(&root);
+        assert_eq!(declaration_names(&caught_up), declaration_names(&rebuilt));
+
+        // The method is only reachable if Child's ancestor chain resolved back to the archived Base.
+        let child = caught_up.get("Child").expect("Child exists");
+        assert!(!child.is_empty());
+        assert!(caught_up.get("Base#inherited_call()").is_some());
+    }
+
+    #[test]
+    fn catching_up_an_untouched_workspace_indexes_nothing() {
+        let (_directory, root, snapshot_path) = workspace(&[("a.rb", "class A; end\n")]);
+
+        let snapshot = Snapshot::open(&snapshot_path).unwrap();
+        let (caught_up, changes, _) = snapshot
+            .catch_up(Verification::Metadata, IndexerBackend::RubyIndexer)
+            .unwrap();
+
+        assert!(changes.is_empty());
+        assert_eq!(changes.to_index(), 0);
+        assert_eq!(declaration_names(&caught_up), declaration_names(&graph_for(&root)));
     }
 }

--- a/rust/rubydex/src/snapshot/manifest.rs
+++ b/rust/rubydex/src/snapshot/manifest.rs
@@ -1,0 +1,470 @@
+//! A Merkle tree over the files a snapshot was built from, used to decide what to re-index.
+//!
+//! # Why a tree, and where it actually pays
+//!
+//! The root hash answers "did anything change" in one comparison, but a root is only as cheap as
+//! the leaves underneath it, and the leaves come from the file system. Measured on a 110,447 file
+//! workspace, the costs are lopsided:
+//!
+//! | step                                   | cost    |
+//! |----------------------------------------|---------|
+//! | recursive walk of the tree             | 1.415 s |
+//! | `stat` every known file, in parallel   | 74 ms   |
+//! | `stat` every known directory, parallel | 22 ms   |
+//! | re-read one changed directory          | 89 us   |
+//! | fold every leaf into a root            | 3.7 ms  |
+//!
+//! So the folding is free and the comparison was never the problem. The walk is. The tree earns its
+//! place at the **interior** nodes, not the leaves, because of one file system property:
+//!
+//! - editing a file bumps that file's mtime, and not its directory's,
+//! - adding, removing or renaming an entry bumps the containing directory's mtime.
+//!
+//! Recording directories as interior nodes therefore lets a reload skip the walk entirely. It stats
+//! the files it already knows to catch edits and deletions, stats the directories it already knows
+//! to catch insertions, and only re-reads the handful of directories whose mtime moved. A full
+//! discovery pass collapses into two flat `stat` sweeps.
+//!
+//! Leaves also carry the `xxh3` content hash that [`Document::content_hash`] already stores, so
+//! [`Verification::Content`] can confirm a suspicion exactly instead of trusting metadata.
+//!
+//! # What this does not promise
+//!
+//! [`Verification::Metadata`] trusts size and mtime, the same bet `make`, `cargo` and Bazel make. A
+//! write that restores the previous mtime and length slips past it. [`Verification::Content`] reads
+//! every byte and does not guess, at roughly twenty times the cost.
+
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+use std::path::{Path, PathBuf};
+use std::time::UNIX_EPOCH;
+
+use glob::Pattern;
+use xxhash_rust::xxh3::Xxh3Default;
+
+use crate::model::graph::Graph;
+use crate::model::ids::UriId;
+use crate::path_helpers;
+
+/// How hard [`ArchivedManifest::diff`] works to decide a file changed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Verification {
+    /// Compare size and mtime only. Two `stat` sweeps, no file contents read.
+    #[default]
+    Metadata,
+    /// Re-hash every file and compare against the recorded content hash. Exact, and much slower.
+    Content,
+}
+
+/// One file the snapshot was built from.
+#[derive(Debug, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
+pub struct FileEntry {
+    /// Absolute path, as resolved from the document's URI.
+    pub path: Box<str>,
+    /// The document this file produced, so a caller can drop it when the file is gone.
+    pub uri_id: UriId,
+    pub size: u64,
+    pub mtime_ns: u64,
+    /// `xxh3` of the file's contents, mirroring `Document::content_hash`.
+    pub content_hash: u64,
+}
+
+/// One directory, an interior node of the tree.
+#[derive(Debug, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
+pub struct DirEntry {
+    pub path: Box<str>,
+    pub mtime_ns: u64,
+    /// Merkle hash of this directory's direct children, files and subdirectories alike.
+    pub subtree: u64,
+}
+
+/// The Merkle tree recorded next to a graph in a snapshot.
+#[derive(Debug, Default, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
+pub struct Manifest {
+    /// The paths that were indexed, needed to bound the search for new directories.
+    pub roots: Vec<Box<str>>,
+    /// Every indexed file, sorted by path.
+    pub files: Vec<FileEntry>,
+    /// Every directory containing an indexed file, sorted by path.
+    pub dirs: Vec<DirEntry>,
+    /// The exclusion patterns in force when the snapshot was built.
+    ///
+    /// Recorded for two reasons. Discovering a new file has to apply the same rule the original
+    /// listing did, or a reload would resurrect files the workspace deliberately skips. And a
+    /// caller can compare them against the current configuration: different patterns mean a
+    /// different file set, which no amount of per-file checking would notice.
+    pub excluded: Vec<Box<str>>,
+    /// Hash of the whole tree. Equal roots mean equal trees.
+    pub root: u64,
+}
+
+/// What changed between a manifest and the file system it describes.
+#[derive(Debug, Default)]
+pub struct Changes {
+    /// Files whose contents differ, and files that appeared. Both need re-indexing.
+    pub modified: Vec<PathBuf>,
+    pub added: Vec<PathBuf>,
+    /// Documents whose file is gone. Both the id and the path, so a caller can report either.
+    pub removed: Vec<(UriId, PathBuf)>,
+    pub unchanged: usize,
+}
+
+impl Changes {
+    /// Whether the snapshot still describes the workspace exactly.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.modified.is_empty() && self.added.is_empty() && self.removed.is_empty()
+    }
+
+    /// Total number of files a caller has to index to catch up.
+    #[must_use]
+    pub fn to_index(&self) -> usize {
+        self.modified.len() + self.added.len()
+    }
+}
+
+fn mtime_ns(metadata: &std::fs::Metadata) -> u64 {
+    metadata
+        .modified()
+        .ok()
+        .and_then(|time| time.duration_since(UNIX_EPOCH).ok())
+        .map_or(0, |elapsed| u64::try_from(elapsed.as_nanos()).unwrap_or(u64::MAX))
+}
+
+/// Hash of a leaf: identity plus everything that decides whether it is stale.
+fn leaf_hash(path: &str, size: u64, mtime: u64, content_hash: u64) -> u64 {
+    let mut hasher = Xxh3Default::new();
+    hasher.update(path.as_bytes());
+    hasher.update(&size.to_le_bytes());
+    hasher.update(&mtime.to_le_bytes());
+    hasher.update(&content_hash.to_le_bytes());
+    hasher.digest()
+}
+
+/// Combines child hashes into a parent. Children arrive sorted, so the result is order independent
+/// in practice and still sensitive to any child changing.
+fn combine(path: &str, mtime: u64, children: &[u64]) -> u64 {
+    let mut hasher = Xxh3Default::new();
+    hasher.update(path.as_bytes());
+    hasher.update(&mtime.to_le_bytes());
+    for child in children {
+        hasher.update(&child.to_le_bytes());
+    }
+    hasher.digest()
+}
+
+/// Splits `items` across the available cores and runs `work` on each chunk.
+///
+/// The graph and the manifest are borrowed out of a memory map, so the `'static` bound on
+/// [`JobQueue`](crate::job_queue::JobQueue) does not fit. Scoped threads borrow instead.
+fn parallel_chunks<T: Sync, R: Send>(items: &[T], work: impl Fn(&[T]) -> R + Sync) -> Vec<R> {
+    if items.is_empty() {
+        return Vec::new();
+    }
+
+    let workers = std::thread::available_parallelism().map_or(4, std::num::NonZeroUsize::get);
+    let chunk_size = items.len().div_ceil(workers).max(1);
+
+    std::thread::scope(|scope| {
+        let handles: Vec<_> = items
+            .chunks(chunk_size)
+            .map(|chunk| scope.spawn(|| work(chunk)))
+            .collect();
+        handles
+            .into_iter()
+            .map(|handle| handle.join().expect("manifest worker panicked"))
+            .collect()
+    })
+}
+
+impl Manifest {
+    /// Records every file in `graph`, plus every directory on the way down from `roots`.
+    ///
+    /// This stats each file once. It runs after resolution, alongside writing the snapshot, so it
+    /// is on the expensive side of the trade rather than the reload side.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a worker thread panics while stat-ing files.
+    #[must_use]
+    pub fn build(graph: &Graph, roots: &[PathBuf]) -> Manifest {
+        // Documents hold URIs; the manifest needs real paths to stat.
+        let documents: Vec<(UriId, PathBuf, u64)> = graph
+            .documents()
+            .iter()
+            .filter_map(|(uri_id, document)| {
+                document
+                    .file_path()
+                    .map(|path| (*uri_id, path, document.content_hash()))
+            })
+            .collect();
+
+        let mut files: Vec<FileEntry> = parallel_chunks(&documents, |chunk| {
+            chunk
+                .iter()
+                .filter_map(|(uri_id, path, content_hash)| {
+                    let metadata = std::fs::metadata(path).ok()?;
+                    Some(FileEntry {
+                        path: path.to_string_lossy().into_owned().into_boxed_str(),
+                        uri_id: *uri_id,
+                        size: metadata.len(),
+                        mtime_ns: mtime_ns(&metadata),
+                        content_hash: *content_hash,
+                    })
+                })
+                .collect::<Vec<_>>()
+        })
+        .into_iter()
+        .flatten()
+        .collect();
+        files.sort_unstable_by(|left, right| left.path.cmp(&right.path));
+
+        // Every ancestor directory of an indexed file is an interior node. Anything above the roots
+        // is outside the snapshot's world and is not tracked.
+        //
+        // Roots must be spelled the same way a document path is, or `starts_with` never matches and
+        // no directory is recorded. `fs::canonicalize` alone is not enough: on Windows it returns a
+        // verbatim `\\?\C:\...` path, while a document path comes back from its URI spelled plainly.
+        // `path_helpers::resolved` canonicalizes and then simplifies, exactly as listing does.
+        let root_paths: Vec<PathBuf> = roots
+            .iter()
+            .filter_map(|root| path_helpers::resolved(root).ok())
+            .collect();
+        let mut directories: BTreeSet<PathBuf> = BTreeSet::new();
+        for entry in &files {
+            let mut current = Path::new(entry.path.as_ref()).parent();
+            while let Some(directory) = current {
+                let inside = root_paths.iter().any(|root| directory.starts_with(root));
+                if !inside || !directories.insert(directory.to_path_buf()) {
+                    break;
+                }
+                current = directory.parent();
+            }
+        }
+
+        // Children first, so a parent can fold hashes that already exist.
+        let mut children: BTreeMap<PathBuf, Vec<u64>> = BTreeMap::new();
+        for entry in &files {
+            let hash = leaf_hash(&entry.path, entry.size, entry.mtime_ns, entry.content_hash);
+            if let Some(parent) = Path::new(entry.path.as_ref()).parent() {
+                children.entry(parent.to_path_buf()).or_default().push(hash);
+            }
+        }
+
+        let mut subtrees: HashMap<PathBuf, u64> = HashMap::new();
+        let mut dirs: Vec<DirEntry> = Vec::with_capacity(directories.len());
+        // Deepest first: a parent's children are all resolved before the parent is folded.
+        for directory in directories.iter().rev() {
+            let mtime = std::fs::metadata(directory).as_ref().map_or(0, mtime_ns);
+            let mut child_hashes = children.remove(directory).unwrap_or_default();
+            child_hashes.sort_unstable();
+
+            let display = directory.to_string_lossy().into_owned();
+            let subtree = combine(&display, mtime, &child_hashes);
+            subtrees.insert(directory.clone(), subtree);
+
+            if let Some(parent) = directory.parent() {
+                children.entry(parent.to_path_buf()).or_default().push(subtree);
+            }
+
+            dirs.push(DirEntry {
+                path: display.into_boxed_str(),
+                mtime_ns: mtime,
+                subtree,
+            });
+        }
+        dirs.sort_unstable_by(|left, right| left.path.cmp(&right.path));
+
+        let mut top: Vec<u64> = root_paths
+            .iter()
+            .filter_map(|root| subtrees.get(root).copied())
+            .collect();
+        top.sort_unstable();
+        let root = combine("", 0, &top);
+
+        let mut excluded: Vec<Box<str>> = graph.excluded_patterns().into_iter().collect();
+        excluded.sort_unstable();
+
+        Manifest {
+            roots: root_paths
+                .iter()
+                .map(|path| path.to_string_lossy().into_owned().into_boxed_str())
+                .collect(),
+            files,
+            dirs,
+            excluded,
+            root,
+        }
+    }
+}
+
+impl ArchivedManifest {
+    /// The recorded Merkle root. Two snapshots with the same root describe the same tree.
+    #[must_use]
+    pub fn root(&self) -> u64 {
+        self.root.to_native()
+    }
+
+    #[must_use]
+    pub fn file_count(&self) -> usize {
+        self.files.len()
+    }
+
+    #[must_use]
+    pub fn dir_count(&self) -> usize {
+        self.dirs.len()
+    }
+
+    /// The exclusion patterns the snapshot was built with, sorted.
+    #[must_use]
+    pub fn excluded_patterns(&self) -> Vec<Box<str>> {
+        self.excluded
+            .iter()
+            .map(|pattern| Box::from(pattern.as_ref()))
+            .collect()
+    }
+
+    /// Whether `current` is the same exclusion set the snapshot was built with.
+    ///
+    /// A different set means a different file list, which per-file checking cannot detect: a
+    /// newly excluded file still exists and still matches its recorded metadata. A caller that
+    /// sees `false` here must re-index from scratch.
+    #[must_use]
+    pub fn excludes_match<S: std::hash::BuildHasher>(&self, current: &HashSet<Box<str>, S>) -> bool {
+        if self.excluded.len() != current.len() {
+            return false;
+        }
+        self.excluded.iter().all(|pattern| current.contains(pattern.as_ref()))
+    }
+
+    /// Compares the recorded tree against the file system and reports what moved.
+    ///
+    /// Runs the two flat `stat` sweeps described on this module, then re-reads only the directories
+    /// whose mtime changed. It never walks the workspace.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a worker thread panics while stat-ing.
+    #[must_use]
+    pub fn diff(&self, verification: Verification) -> Changes {
+        let files = self.files.as_slice();
+
+        // Sweep one: the files we know about. Catches edits and deletions.
+        let per_chunk = parallel_chunks(files, |chunk| {
+            let mut modified = Vec::new();
+            let mut removed = Vec::new();
+            let mut unchanged = 0usize;
+
+            for entry in chunk {
+                let path = PathBuf::from(entry.path.as_ref());
+                let Ok(metadata) = std::fs::metadata(&path) else {
+                    removed.push((UriId::new(entry.uri_id.to_native()), path));
+                    continue;
+                };
+
+                let stale = match verification {
+                    Verification::Metadata => {
+                        metadata.len() != entry.size.to_native() || mtime_ns(&metadata) != entry.mtime_ns.to_native()
+                    }
+                    Verification::Content => std::fs::read(&path).map_or(true, |bytes| {
+                        xxhash_rust::xxh3::xxh3_64(&bytes) != entry.content_hash.to_native()
+                    }),
+                };
+
+                if stale {
+                    modified.push(path);
+                } else {
+                    unchanged += 1;
+                }
+            }
+
+            (modified, removed, unchanged)
+        });
+
+        let mut changes = Changes::default();
+        for (modified, removed, unchanged) in per_chunk {
+            changes.modified.extend(modified);
+            changes.removed.extend(removed);
+            changes.unchanged += unchanged;
+        }
+
+        // Sweep two: the directories we know about. Catches insertions.
+        let dirs = self.dirs.as_slice();
+        let dirty: Vec<PathBuf> = parallel_chunks(dirs, |chunk| {
+            chunk
+                .iter()
+                .filter_map(|entry| {
+                    let path = PathBuf::from(entry.path.as_ref());
+                    match std::fs::metadata(&path) {
+                        Ok(metadata) if mtime_ns(&metadata) == entry.mtime_ns.to_native() => None,
+                        // A directory that vanished took its files with it, and sweep one already
+                        // reported those, so there is nothing new to find inside it.
+                        Err(_) => None,
+                        Ok(_) => Some(path),
+                    }
+                })
+                .collect::<Vec<_>>()
+        })
+        .into_iter()
+        .flatten()
+        .collect();
+
+        if !dirty.is_empty() {
+            let known_files: HashSet<&str> = files.iter().map(|entry| entry.path.as_ref()).collect();
+            let known_dirs: HashSet<&str> = dirs.iter().map(|entry| entry.path.as_ref()).collect();
+            // Discovery has to obey the same exclusions the original listing did, or a reload
+            // would pull in files the workspace deliberately skips.
+            let excluded: Vec<Pattern> = self
+                .excluded
+                .iter()
+                .filter_map(|entry| Pattern::new(entry).ok())
+                .collect();
+            changes.added = collect_additions(&dirty, &known_files, &known_dirs, &excluded);
+        }
+
+        changes
+    }
+}
+
+/// Reads the directories whose mtime moved and reports indexable files the manifest never saw.
+///
+/// A directory that is itself unknown is brand new, so it is walked in full: everything inside it
+/// is an addition.
+fn collect_additions(
+    dirty: &[PathBuf],
+    known_files: &HashSet<&str>,
+    known_dirs: &HashSet<&str>,
+    excluded: &[Pattern],
+) -> Vec<PathBuf> {
+    let is_excluded = |path: &Path| excluded.iter().any(|pattern| pattern.matches_path(path));
+
+    let mut added = Vec::new();
+    let mut pending: Vec<PathBuf> = dirty.to_vec();
+
+    while let Some(directory) = pending.pop() {
+        let Ok(entries) = std::fs::read_dir(&directory) else {
+            continue;
+        };
+
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let Ok(file_type) = entry.file_type() else { continue };
+            if is_excluded(&path) {
+                continue;
+            }
+
+            if file_type.is_dir() {
+                // An unknown directory cannot have been stat-ed in sweep two, so descend into it.
+                if !known_dirs.contains(path.to_string_lossy().as_ref()) {
+                    pending.push(path);
+                }
+            } else if crate::listing::is_indexable_file(&path) && !known_files.contains(path.to_string_lossy().as_ref())
+            {
+                added.push(path);
+            }
+        }
+    }
+
+    added.sort_unstable();
+    added.dedup();
+    added
+}


### PR DESCRIPTION
> [!NOTE] 
> This is a prototype of what a graph serialization for Rubydex might look like. 

After some investigation with Claude for potential opportunities for graph serialization, we settled in on using the `rkyv` (get it? pronounces `archive` when read 😂) for zero-copy serialization and cheap mmap'ed deserialization.

The integration with [`rkyv`](https://rkyv.org/) is mainly via deriving the crate's traits, so the intrusiveness is minimal, except for a few types that need special handling.

A report against Core is as following:

> ### Cache on disk
> 
> One file per root set, named by a hash of the indexed roots, under the user cache directory (`XDG_CACHE_HOME`, else `~/.cache`):
> 
> ```
> ~/.cache/rubydex/12cf5c75d1280a55.rdxsnap
> ```
> 
> | Region | Size | Share |
> |---|---:|---:|
> | Header | 32 B | ~0% |
> | Manifest archive (Merkle tree) | 22.8 MB | 0.94% |
> | Padding | 0 B | 0% |
> | Graph archive | 2,402.5 MB | 99.06% |
> | **Total** | **2,425.3 MB** | 100% |
> 
> Roughly **22 KB of cache per indexed file**. The Merkle tree is under 1% of the file, which is the point of keeping it in its own archive: a staleness check reads ~23 MB and never faults in the 2.4 GB graph.
> 
> The cache never lives inside the workspace. A file written into an indexed directory would bump that directory's mtime, and the tree would then report a change on every run.
> 
> ### Timings
> 
> Steady state, warm operating-system page cache.
> 
> | Scenario | Wall time | Peak RSS |
> |---|---:|---:|
> | `--no-cache` (previous behaviour) | 18.6 s | 4.6 GB |
> | Cold, no cache present (writes the snapshot) | 32.3 s | 6.2 GB |
> | Warm, workspace unchanged | **2.3 s** | 5.5 GB |
> | Warm, one file edited | 7.3 s | 5.6 GB |
> | Warm, `--verify-content` | 5.5 s | 5.5 GB |
> 
> `--no-cache` splits into 5.7 s indexing and 12.8 s resolution. Resolution is what the cache removes.
> 
> **Steady state is 8.1x faster than `--no-cache`.**
> 
> ### Cost of the first run
> 
> A cold run costs 32.3 s against 18.6 s uncached, so the snapshot costs about 14 s once: build the manifest (stat 110,621 files and their directories), serialize 2.4 GB, and write it. Every later run recovers that.