### PR TITLE
Add dead code candidates endpoint

### DIFF
--- a/ext/rubydex/graph.c
+++ b/ext/rubydex/graph.c
@@ -260,14 +260,10 @@ static VALUE rdxr_graph_fuzzy_search(int argc, VALUE *argv, VALUE self) {
  * call-seq:
  *   dead_code_candidates -> Enumerator[Rubydex::Declaration]
  *
- * Returns an enumerator that yields constant-like declarations (namespace, constant, or constant alias) that have zero
- * resolved constant references and at least one definition. Declarations with a rubydex-seeded built-in definition are
- * excluded, even when user code reopens them. Requires a resolved graph and covers everything indexed, including
- * dependencies.
+ * Returns an enumerator over declarations that may be unused because the analysis could not find any references to
+ * them. This misses metaprogramming or untyped code, which is why the term candidates is used.
  *
- * The result is a working set, not an inventory. Deleting a reported declaration can leave its container unreferenced,
- * so re-index and call again until the result comes back empty. Accuracy follows the graph's reference data, so
- * whatever the indexer cannot see goes uncounted.
+ * Currently, only supports constants.
  */
 static VALUE rdxr_graph_dead_code_candidates(VALUE self) {
     if (!rb_block_given_p()) {

--- a/ext/rubydex/graph.c
+++ b/ext/rubydex/graph.c
@@ -256,6 +256,32 @@ static VALUE rdxr_graph_fuzzy_search(int argc, VALUE *argv, VALUE self) {
     return rdxr_graph_yield_search_results(self, iter);
 }
 
+/*
+ * call-seq:
+ *   dead_code_candidates -> Enumerator[Rubydex::Declaration]
+ *
+ * Returns an enumerator that yields constant-like declarations (namespace, constant, or constant alias) that have zero
+ * resolved constant references. Requires a resolved graph and covers everything indexed, including dependencies.
+ *
+ * The result is a working set, not an inventory. Deleting a reported declaration can leave its container unreferenced,
+ * so re-index and call again until the result comes back empty. Accuracy follows the graph's reference data, so
+ * whatever the indexer cannot see goes uncounted.
+ */
+static VALUE rdxr_graph_dead_code_candidates(VALUE self) {
+    if (!rb_block_given_p()) {
+        return rb_enumeratorize(self, rb_str_new2("dead_code_candidates"), 0, NULL);
+    }
+
+    void *graph;
+    TypedData_Get_Struct(self, void *, &graph_type, graph);
+
+    void *iter = rdx_graph_dead_code_candidates(graph);
+    VALUE args = rb_ary_new_from_args(2, self, ULL2NUM((uintptr_t)iter));
+    rb_ensure(rdxi_declarations_yield, args, rdxi_declarations_ensure, args);
+
+    return self;
+}
+
 // Body function for rb_ensure in Graph#documents
 static VALUE graph_documents_yield(VALUE args) {
     VALUE self = rb_ary_entry(args, 0);
@@ -938,6 +964,7 @@ void rdxi_initialize_graph(VALUE moduleRubydex) {
     rb_define_method(cGraph, "[]", rdxr_graph_aref, 1);
     rb_define_method(cGraph, "search", rdxr_graph_search, -1);
     rb_define_method(cGraph, "fuzzy_search", rdxr_graph_fuzzy_search, -1);
+    rb_define_method(cGraph, "dead_code_candidates", rdxr_graph_dead_code_candidates, 0);
     rb_define_method(cGraph, "encoding=", rdxr_graph_set_encoding, 1);
     rb_define_method(cGraph, "resolve_require_path", rdxr_graph_resolve_require_path, 2);
     rb_define_method(cGraph, "require_paths", rdxr_graph_require_paths, 1);

--- a/ext/rubydex/graph.c
+++ b/ext/rubydex/graph.c
@@ -261,7 +261,9 @@ static VALUE rdxr_graph_fuzzy_search(int argc, VALUE *argv, VALUE self) {
  *   dead_code_candidates -> Enumerator[Rubydex::Declaration]
  *
  * Returns an enumerator that yields constant-like declarations (namespace, constant, or constant alias) that have zero
- * resolved constant references. Requires a resolved graph and covers everything indexed, including dependencies.
+ * resolved constant references and at least one definition. Declarations with a rubydex-seeded built-in definition are
+ * excluded, even when user code reopens them. Requires a resolved graph and covers everything indexed, including
+ * dependencies.
  *
  * The result is a working set, not an inventory. Deleting a reported declaration can leave its container unreferenced,
  * so re-index and call again until the result comes back empty. Accuracy follows the graph's reference data, so

--- a/rbi/rubydex.rbi
+++ b/rbi/rubydex.rbi
@@ -903,6 +903,9 @@ class Rubydex::Graph
   sig { params(queries: String).returns(T::Enumerable[Rubydex::Declaration]) }
   def fuzzy_search(*queries); end
 
+  sig { returns(T::Enumerable[Rubydex::Declaration]) }
+  def dead_code_candidates; end
+
   sig { params(encoding: String).void }
   def encoding=(encoding); end
 

--- a/rust/rubydex-sys/src/graph_api.rs
+++ b/rust/rubydex-sys/src/graph_api.rs
@@ -133,6 +133,27 @@ pub unsafe extern "C" fn rdx_graph_declarations_fuzzy_search(
     DeclarationsIter::new(entries)
 }
 
+/// Returns an iterator over all dead code candidates in the graph.
+///
+/// # Safety
+///
+/// Expects `pointer` to be a valid graph. The returned iterator must be freed with `rdx_graph_declarations_iter_free`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rdx_graph_dead_code_candidates(pointer: GraphPointer) -> *mut DeclarationsIter {
+    let entries = with_graph(pointer, |graph| {
+        query::dead_code_candidates(graph)
+            .into_iter()
+            .filter_map(|id| {
+                let decl = graph.declarations().get(&id)?;
+                Some(CDeclaration::from_declaration(id, decl))
+            })
+            .collect::<Vec<CDeclaration>>()
+            .into_boxed_slice()
+    });
+
+    DeclarationsIter::new(entries)
+}
+
 /// # Panics
 ///
 /// Will panic if the nesting cannot be transformed into a vector of strings

--- a/rust/rubydex/src/query.rs
+++ b/rust/rubydex/src/query.rs
@@ -5,7 +5,7 @@ use std::thread;
 
 use url::Url;
 
-use crate::model::built_in::OBJECT_ID;
+use crate::model::built_in::{BUILT_IN_URI_ID, OBJECT_ID};
 use crate::model::declaration::{Ancestor, Declaration, Namespace};
 use crate::model::definitions::{Definition, Parameter};
 use crate::model::graph::Graph;
@@ -833,8 +833,23 @@ pub fn follow_method_alias(graph: &Graph, alias_id: DefinitionId) -> Result<Decl
     }
 }
 
-/// Returns every constant-like declaration (namespace, constant or constant alias) with zero resolved constant
-/// references. Methods and variables are never included, they cannot be the target of a constant reference.
+/// Returns `true` when any definition of `declaration` was seeded by rubydex rather than read from indexed source.
+///
+/// Candidates are reported at declaration granularity, so a seeded definition disqualifies the declaration even when
+/// user code also reopens it.
+fn is_built_in(graph: &Graph, declaration: &Declaration) -> bool {
+    declaration.definitions().iter().any(|definition_id| {
+        graph
+            .definitions()
+            .get(definition_id)
+            .is_some_and(|definition| definition.uri_id() == &*BUILT_IN_URI_ID)
+    })
+}
+
+/// Returns every constant-like declaration (namespace, constant or constant alias) that has zero resolved constant
+/// references and at least one definition. Declarations with a rubydex-seeded built-in definition are excluded, even
+/// when user code reopens them. Methods and variables are never included, they cannot be the target of a constant
+/// reference.
 ///
 /// Expects a resolved graph, and covers everything indexed, including dependencies.
 ///
@@ -868,6 +883,8 @@ pub fn dead_code_candidates(graph: &Graph) -> Vec<DeclarationId> {
                             // Methods and variables are excluded here: rubydex cannot attribute method
                             // calls to declarations, so called and uncalled both report zero references.
                             decl.constant_references().is_some_and(HashSet::is_empty)
+                                && !decl.has_no_definitions()
+                                && !is_built_in(graph, decl)
                         })
                         .copied()
                         .collect::<Vec<_>>()
@@ -4149,6 +4166,60 @@ mod tests {
         assert!(
             !names.contains(&"Target".to_string()),
             "Target unexpectedly present in {names:?}"
+        );
+    }
+
+    #[test]
+    fn dead_code_candidates_excludes_built_ins_and_definitionless_declarations() {
+        let mut context = GraphTest::new();
+        context.index_uri(
+            "file:///foo.rb",
+            r"
+            class Unused
+              def self.class_method; end
+            end
+
+            class Class
+            end
+            ",
+        );
+        context.resolve();
+
+        // Exact equality catches over-inclusion. Reopening `Class` guards against relying on definition order.
+        assert_eq!(vec!["Unused"], candidate_names(&context));
+    }
+
+    #[test]
+    fn dead_code_candidates_includes_unreferenced_explicit_singleton() {
+        let mut context = GraphTest::new();
+        context.index_uri(
+            "file:///foo.rb",
+            r"
+            class Referenced; end
+            class Unreferenced; end
+
+            class << Referenced
+              def call_me; end
+            end
+
+            class << Unreferenced
+              def never_called; end
+            end
+
+            Referenced.call_me
+            ",
+        );
+        context.resolve();
+
+        // Explicit singleton definitions are actionable, and class-level calls make their reference count non-zero.
+        let names = candidate_names(&context);
+        assert!(
+            names.contains(&"Unreferenced::<Unreferenced>".to_string()),
+            "dead explicit singleton missing from {names:?}"
+        );
+        assert!(
+            !names.contains(&"Referenced::<Referenced>".to_string()),
+            "called explicit singleton unexpectedly present in {names:?}"
         );
     }
 }

--- a/rust/rubydex/src/query.rs
+++ b/rust/rubydex/src/query.rs
@@ -846,16 +846,11 @@ fn is_built_in(graph: &Graph, declaration: &Declaration) -> bool {
     })
 }
 
-/// Returns every constant-like declaration (namespace, constant or constant alias) that has zero resolved constant
-/// references and at least one definition. Declarations with a rubydex-seeded built-in definition are excluded, even
-/// when user code reopens them. Methods and variables are never included, they cannot be the target of a constant
-/// reference.
+/// Returns a list of declaration that may be unused in the codebase, which means
+/// that the analysis could not find any references to them. This misses
+/// meta-programming or untyped code, which is why the term candidates is used.
 ///
-/// Expects a resolved graph, and covers everything indexed, including dependencies.
-///
-/// The result is a working set, not an inventory. Deleting a reported declaration can leave its container
-/// unreferenced, so re-index and call again until the result comes back empty. Accuracy follows the graph's reference
-/// data, so whatever the indexer cannot see (metaprogramming, autoloading) goes uncounted.
+/// Currently, only supports constants.
 ///
 /// # Panics
 ///
@@ -880,9 +875,8 @@ pub fn dead_code_candidates(graph: &Graph) -> Vec<DeclarationId> {
                         .iter()
                         .filter(|id| {
                             let decl = declarations.get(id).unwrap();
-                            // Methods and variables are excluded here: rubydex cannot attribute method
-                            // calls to declarations, so called and uncalled both report zero references.
                             decl.constant_references().is_some_and(HashSet::is_empty)
+                                && !matches!(decl, Declaration::Namespace(Namespace::SingletonClass(_)))
                                 && !decl.has_no_definitions()
                                 && !is_built_in(graph, decl)
                         })
@@ -4190,36 +4184,21 @@ mod tests {
     }
 
     #[test]
-    fn dead_code_candidates_includes_unreferenced_explicit_singleton() {
+    fn dead_code_candidates_excludes_singleton_classes() {
         let mut context = GraphTest::new();
         context.index_uri(
             "file:///foo.rb",
             r"
-            class Referenced; end
-            class Unreferenced; end
+            class Unused; end
+            class Attached; end
 
-            class << Referenced
-              def call_me; end
-            end
-
-            class << Unreferenced
+            class << Attached
               def never_called; end
             end
-
-            Referenced.call_me
             ",
         );
         context.resolve();
 
-        // Explicit singleton definitions are actionable, and class-level calls make their reference count non-zero.
-        let names = candidate_names(&context);
-        assert!(
-            names.contains(&"Unreferenced::<Unreferenced>".to_string()),
-            "dead explicit singleton missing from {names:?}"
-        );
-        assert!(
-            !names.contains(&"Referenced::<Referenced>".to_string()),
-            "called explicit singleton unexpectedly present in {names:?}"
-        );
+        assert_eq!(vec!["Unused"], candidate_names(&context));
     }
 }

--- a/rust/rubydex/src/query.rs
+++ b/rust/rubydex/src/query.rs
@@ -835,8 +835,8 @@ pub fn follow_method_alias(graph: &Graph, alias_id: DefinitionId) -> Result<Decl
 
 /// Returns `true` when any definition of `declaration` was seeded by rubydex rather than read from indexed source.
 ///
-/// Candidates are reported at declaration granularity, so a seeded definition disqualifies the declaration even when
-/// user code also reopens it.
+/// Dead code candidates are reported at declaration granularity, so a seeded definition disqualifies the declaration
+/// even when user code also reopens it.
 fn is_built_in(graph: &Graph, declaration: &Declaration) -> bool {
     declaration.definitions().iter().any(|definition_id| {
         graph
@@ -846,7 +846,7 @@ fn is_built_in(graph: &Graph, declaration: &Declaration) -> bool {
     })
 }
 
-/// Returns a list of declaration that may be unused in the codebase, which means
+/// Returns a list of declarations that may be unused in the codebase, which means
 /// that the analysis could not find any references to them. This misses
 /// meta-programming or untyped code, which is why the term candidates is used.
 ///
@@ -971,6 +971,21 @@ mod tests {
             actual.sort();
 
             let mut expected: Vec<String> = $expected.into_iter().map(String::from).collect();
+            expected.sort();
+
+            assert_eq!(expected, actual);
+        };
+    }
+
+    macro_rules! assert_dead_code_candidates {
+        ($context:expr, [$($expected:expr),* $(,)?]) => {
+            let mut actual: Vec<String> = dead_code_candidates($context.graph())
+                .iter()
+                .map(|id| $context.graph().declarations().get(id).unwrap().name().to_string())
+                .collect();
+            actual.sort();
+
+            let mut expected: Vec<String> = vec![$(String::from($expected)),*];
             expected.sort();
 
             assert_eq!(expected, actual);
@@ -4040,15 +4055,6 @@ mod tests {
         );
     }
 
-    fn candidate_names(context: &GraphTest) -> Vec<String> {
-        let mut names: Vec<String> = dead_code_candidates(context.graph())
-            .iter()
-            .map(|id| context.graph().declarations().get(id).unwrap().name().to_string())
-            .collect();
-        names.sort();
-        names
-    }
-
     #[test]
     fn dead_code_candidates_returns_unreferenced_constants() {
         let mut context = GraphTest::new();
@@ -4062,13 +4068,7 @@ mod tests {
         );
         context.resolve();
 
-        let names = candidate_names(&context);
-        for expected in ["UnusedClass", "UnusedModule", "UNUSED_CONSTANT"] {
-            assert!(
-                names.contains(&expected.to_string()),
-                "{expected} missing from {names:?}"
-            );
-        }
+        assert_dead_code_candidates!(context, ["UnusedClass", "UnusedModule", "UNUSED_CONSTANT"]);
     }
 
     #[test]
@@ -4090,13 +4090,7 @@ mod tests {
         );
         context.resolve();
 
-        let names = candidate_names(&context);
-        for unexpected in ["UsedClass", "USED_CONSTANT"] {
-            assert!(
-                !names.contains(&unexpected.to_string()),
-                "{unexpected} unexpectedly present in {names:?}"
-            );
-        }
+        assert_dead_code_candidates!(context, []);
     }
 
     #[test]
@@ -4120,22 +4114,7 @@ mod tests {
         );
         context.resolve();
 
-        let unexpected: Vec<&str> = dead_code_candidates(context.graph())
-            .iter()
-            .map(|id| context.graph().declarations().get(id).unwrap())
-            .filter(|decl| {
-                !matches!(
-                    decl,
-                    Declaration::Namespace(_) | Declaration::Constant(_) | Declaration::ConstantAlias(_)
-                )
-            })
-            .map(Declaration::name)
-            .collect();
-
-        assert!(
-            unexpected.is_empty(),
-            "candidates that are not constant-like: {unexpected:?}"
-        );
+        assert_dead_code_candidates!(context, ["Holder"]);
     }
 
     #[test]
@@ -4152,15 +4131,7 @@ mod tests {
 
         // `AliasName` is itself dead, but it still references `Target`, giving `Target` a non-zero count.
         // A single pass only peels the outermost layer of a dead subgraph.
-        let names = candidate_names(&context);
-        assert!(
-            names.contains(&"AliasName".to_string()),
-            "AliasName missing from {names:?}"
-        );
-        assert!(
-            !names.contains(&"Target".to_string()),
-            "Target unexpectedly present in {names:?}"
-        );
+        assert_dead_code_candidates!(context, ["AliasName"]);
     }
 
     #[test]
@@ -4179,8 +4150,8 @@ mod tests {
         );
         context.resolve();
 
-        // Exact equality catches over-inclusion. Reopening `Class` guards against relying on definition order.
-        assert_eq!(vec!["Unused"], candidate_names(&context));
+        // A reopened built-in remains excluded regardless of definition order.
+        assert_dead_code_candidates!(context, ["Unused"]);
     }
 
     #[test]
@@ -4199,6 +4170,6 @@ mod tests {
         );
         context.resolve();
 
-        assert_eq!(vec!["Unused"], candidate_names(&context));
+        assert_dead_code_candidates!(context, ["Unused"]);
     }
 }

--- a/rust/rubydex/src/query.rs
+++ b/rust/rubydex/src/query.rs
@@ -833,6 +833,52 @@ pub fn follow_method_alias(graph: &Graph, alias_id: DefinitionId) -> Result<Decl
     }
 }
 
+/// Returns every constant-like declaration (namespace, constant or constant alias) with zero resolved constant
+/// references. Methods and variables are never included, they cannot be the target of a constant reference.
+///
+/// Expects a resolved graph, and covers everything indexed, including dependencies.
+///
+/// The result is a working set, not an inventory. Deleting a reported declaration can leave its container
+/// unreferenced, so re-index and call again until the result comes back empty. Accuracy follows the graph's reference
+/// data, so whatever the indexer cannot see (metaprogramming, autoloading) goes uncounted.
+///
+/// # Panics
+///
+/// Will panic if any of the threads panic
+pub fn dead_code_candidates(graph: &Graph) -> Vec<DeclarationId> {
+    let num_threads = thread::available_parallelism().map_or(4, std::num::NonZero::get);
+    let declarations = graph.declarations();
+
+    let ids: Vec<DeclarationId> = declarations.keys().copied().collect();
+    let chunk_size = ids.len().div_ceil(num_threads);
+
+    if chunk_size == 0 {
+        return Vec::new();
+    }
+
+    thread::scope(|s| {
+        let handles: Vec<_> = ids
+            .chunks(chunk_size)
+            .map(|chunk| {
+                s.spawn(|| {
+                    chunk
+                        .iter()
+                        .filter(|id| {
+                            let decl = declarations.get(id).unwrap();
+                            // Methods and variables are excluded here: rubydex cannot attribute method
+                            // calls to declarations, so called and uncalled both report zero references.
+                            decl.constant_references().is_some_and(HashSet::is_empty)
+                        })
+                        .copied()
+                        .collect::<Vec<_>>()
+                })
+            })
+            .collect();
+
+        handles.into_iter().flat_map(|h| h.join().unwrap()).collect()
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use std::str::FromStr;
@@ -3980,6 +4026,129 @@ mod tests {
                 false,
             ),
             Err(FindMemberError::DeclarationNotFound),
+        );
+    }
+
+    fn candidate_names(context: &GraphTest) -> Vec<String> {
+        let mut names: Vec<String> = dead_code_candidates(context.graph())
+            .iter()
+            .map(|id| context.graph().declarations().get(id).unwrap().name().to_string())
+            .collect();
+        names.sort();
+        names
+    }
+
+    #[test]
+    fn dead_code_candidates_returns_unreferenced_constants() {
+        let mut context = GraphTest::new();
+        context.index_uri(
+            "file:///foo.rb",
+            r"
+            class UnusedClass; end
+            module UnusedModule; end
+            UNUSED_CONSTANT = 1
+            ",
+        );
+        context.resolve();
+
+        let names = candidate_names(&context);
+        for expected in ["UnusedClass", "UnusedModule", "UNUSED_CONSTANT"] {
+            assert!(
+                names.contains(&expected.to_string()),
+                "{expected} missing from {names:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn dead_code_candidates_excludes_referenced_constants() {
+        let mut context = GraphTest::new();
+        context.index_uri(
+            "file:///foo.rb",
+            r"
+            class UsedClass; end
+            USED_CONSTANT = 1
+            ",
+        );
+        context.index_uri(
+            "file:///bar.rb",
+            r"
+            UsedClass
+            USED_CONSTANT
+            ",
+        );
+        context.resolve();
+
+        let names = candidate_names(&context);
+        for unexpected in ["UsedClass", "USED_CONSTANT"] {
+            assert!(
+                !names.contains(&unexpected.to_string()),
+                "{unexpected} unexpectedly present in {names:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn dead_code_candidates_excludes_methods_and_variables() {
+        let mut context = GraphTest::new();
+        context.index_uri(
+            "file:///foo.rb",
+            r"
+            $global_var = 1
+
+            class Holder
+              @@class_var = 1
+
+              def initialize
+                @instance_var = 1
+              end
+
+              def never_called; end
+            end
+            ",
+        );
+        context.resolve();
+
+        let unexpected: Vec<&str> = dead_code_candidates(context.graph())
+            .iter()
+            .map(|id| context.graph().declarations().get(id).unwrap())
+            .filter(|decl| {
+                !matches!(
+                    decl,
+                    Declaration::Namespace(_) | Declaration::Constant(_) | Declaration::ConstantAlias(_)
+                )
+            })
+            .map(Declaration::name)
+            .collect();
+
+        assert!(
+            unexpected.is_empty(),
+            "candidates that are not constant-like: {unexpected:?}"
+        );
+    }
+
+    #[test]
+    fn dead_code_candidates_counts_references_rather_than_reachability() {
+        let mut context = GraphTest::new();
+        context.index_uri(
+            "file:///foo.rb",
+            r"
+            class Target; end
+            AliasName = Target
+            ",
+        );
+        context.resolve();
+
+        // `AliasName` is itself dead, but it still references `Target`, giving `Target` a non-zero count.
+        // A single pass only peels the outermost layer of a dead subgraph.
+        let names = candidate_names(&context);
+        assert!(
+            names.contains(&"AliasName".to_string()),
+            "AliasName missing from {names:?}"
+        );
+        assert!(
+            !names.contains(&"Target".to_string()),
+            "Target unexpectedly present in {names:?}"
         );
     }
 }

--- a/test/graph_test.rb
+++ b/test/graph_test.rb
@@ -299,76 +299,15 @@ class GraphTest < Minitest::Test
 
   def test_graph_dead_code_candidates
     with_context do |context|
-      context.write!("foo.rb", <<~RUBY)
-        class Used; end
-        class Unused; end
-      RUBY
-      context.write!("bar.rb", "Used\n")
-
-      graph = Rubydex::Graph.new
-      graph.index_all(context.glob("**/*.rb"))
-      graph.resolve
-
-      names = graph.dead_code_candidates.map(&:name)
-      assert_includes(names, "Unused")
-      refute_includes(names, "Used")
-    end
-  end
-
-  def test_graph_dead_code_candidates_yields_declarations
-    with_context do |context|
       context.write!("foo.rb", "class Unused; end")
 
       graph = Rubydex::Graph.new
       graph.index_all(context.glob("**/*.rb"))
       graph.resolve
 
-      yielded = []
-      graph.dead_code_candidates { |declaration| yielded << declaration }
-
-      refute_empty(yielded)
-      assert(yielded.all?(Rubydex::Declaration))
-    end
-  end
-
-  def test_graph_dead_code_candidates_without_block_returns_enumerator
-    graph = Rubydex::Graph.new
-
-    assert_instance_of(Enumerator, graph.dead_code_candidates)
-  end
-
-  def test_graph_dead_code_candidates_reflects_reindexed_documents
-    with_context do |context|
-      context.write!("thing.rb", "class Thing; end")
-      context.write!("user.rb", "Thing\n")
-
-      graph = Rubydex::Graph.new
-      graph.index_all(context.glob("**/*.rb"))
-      graph.resolve
-
-      refute_includes(graph.dead_code_candidates.map(&:name), "Thing")
-
-      context.write!("user.rb", "# reference removed\n")
-      graph.index_all([context.absolute_path_to("user.rb")])
-      graph.resolve
-
-      assert_includes(graph.dead_code_candidates.map(&:name), "Thing")
-    end
-  end
-
-  # Exercises the `rb_ensure` cleanup path so the iterator is freed when the block raises. Only `ruby_test:valgrind`
-  # can observe the leak, but the exception must propagate either way.
-  def test_graph_dead_code_candidates_frees_iterator_when_block_raises
-    with_context do |context|
-      context.write!("foo.rb", "class Unused; end")
-
-      graph = Rubydex::Graph.new
-      graph.index_all(context.glob("**/*.rb"))
-      graph.resolve
-
-      assert_raises(RuntimeError) do
-        graph.dead_code_candidates { raise("boom") }
-      end
+      candidates = graph.dead_code_candidates
+      assert_instance_of(Enumerator, candidates)
+      assert_equal(["Unused"], candidates.map(&:name))
     end
   end
 

--- a/test/graph_test.rb
+++ b/test/graph_test.rb
@@ -297,6 +297,81 @@ class GraphTest < Minitest::Test
     assert_raises(ArgumentError) { graph.fuzzy_search }
   end
 
+  def test_graph_dead_code_candidates
+    with_context do |context|
+      context.write!("foo.rb", <<~RUBY)
+        class Used; end
+        class Unused; end
+      RUBY
+      context.write!("bar.rb", "Used\n")
+
+      graph = Rubydex::Graph.new
+      graph.index_all(context.glob("**/*.rb"))
+      graph.resolve
+
+      names = graph.dead_code_candidates.map(&:name)
+      assert_includes(names, "Unused")
+      refute_includes(names, "Used")
+    end
+  end
+
+  def test_graph_dead_code_candidates_yields_declarations
+    with_context do |context|
+      context.write!("foo.rb", "class Unused; end")
+
+      graph = Rubydex::Graph.new
+      graph.index_all(context.glob("**/*.rb"))
+      graph.resolve
+
+      yielded = []
+      graph.dead_code_candidates { |declaration| yielded << declaration }
+
+      refute_empty(yielded)
+      assert(yielded.all?(Rubydex::Declaration))
+    end
+  end
+
+  def test_graph_dead_code_candidates_without_block_returns_enumerator
+    graph = Rubydex::Graph.new
+
+    assert_instance_of(Enumerator, graph.dead_code_candidates)
+  end
+
+  def test_graph_dead_code_candidates_reflects_reindexed_documents
+    with_context do |context|
+      context.write!("thing.rb", "class Thing; end")
+      context.write!("user.rb", "Thing\n")
+
+      graph = Rubydex::Graph.new
+      graph.index_all(context.glob("**/*.rb"))
+      graph.resolve
+
+      refute_includes(graph.dead_code_candidates.map(&:name), "Thing")
+
+      context.write!("user.rb", "# reference removed\n")
+      graph.index_all([context.absolute_path_to("user.rb")])
+      graph.resolve
+
+      assert_includes(graph.dead_code_candidates.map(&:name), "Thing")
+    end
+  end
+
+  # Exercises the `rb_ensure` cleanup path so the iterator is freed when the block raises. Only `ruby_test:valgrind`
+  # can observe the leak, but the exception must propagate either way.
+  def test_graph_dead_code_candidates_frees_iterator_when_block_raises
+    with_context do |context|
+      context.write!("foo.rb", "class Unused; end")
+
+      graph = Rubydex::Graph.new
+      graph.index_all(context.glob("**/*.rb"))
+      graph.resolve
+
+      assert_raises(RuntimeError) do
+        graph.dead_code_candidates { raise("boom") }
+      end
+    end
+  end
+
   def test_workspace_path_defaults_to_pwd
     graph = Rubydex::Graph.new
     assert_equal(Dir.pwd, File.expand_path(graph.workspace_path))


### PR DESCRIPTION
- Adds `dead_code_candidates` endpoint 
- Adds 2 filters, intentionally as a separate commit so it can be removed if there's disagreement
  - Skip declarations with no definitions (avoids reporting phantom nodes the graph knows about but no source defines).
  - Skip declarations that have any rubydex-seeded built-in definition (avoids flagging `String`, `Array`, etc. even when user code reopens them).