### PR TITLE
Index gems that come from a git or path source

### DIFF
--- a/lib/rubydex/graph.rb
+++ b/lib/rubydex/graph.rb
@@ -54,8 +54,12 @@ module Rubydex
       specs = Bundler.locked_gems&.specs
       return unless specs
 
+      source_indexes = {} #: Hash[String, untyped]
+
       specs.each do |lazy_spec|
-        spec = Gem::Specification.find_by_name(lazy_spec.name)
+        spec = resolve_dependency_spec(lazy_spec, source_indexes)
+        next unless spec
+
         spec.require_paths.each do |path|
           # For native extensions, RubyGems inserts an absolute require path pointing to
           # `gems/some-gem-1.0.0/extensions`. Those paths don't actually include any Ruby files inside, so we can skip
@@ -64,9 +68,37 @@ module Rubydex
 
           paths << File.join(spec.full_gem_path, path)
         end
-      rescue Gem::MissingSpecError
-        nil
       end
+    end
+
+    # Finds the installed gem behind a locked specification.
+    #
+    # `Gem::Specification.find_by_name` only knows about gems RubyGems installed, so it raises for a gem the Gemfile
+    # takes from a `git` or `path` source. Those are not rare: a workspace can take its whole framework from a branch.
+    # Bundler keeps an index per source that knows both where it put the checkout and which directories the gemspec
+    # declares, so ask the source directly before giving up.
+    #
+    # The index is built once per source. A multi-gem repository such as rails shares one source across every gem it
+    # provides, and building that index means reading gemspecs off disk.
+    #
+    #: (untyped lazy_spec, Hash[String, untyped] source_indexes) -> untyped
+    def resolve_dependency_spec(lazy_spec, source_indexes)
+      Gem::Specification.find_by_name(lazy_spec.name)
+    rescue Gem::MissingSpecError
+      source = lazy_spec.source
+      return unless source.respond_to?(:specs)
+
+      index = source_indexes.fetch(source.to_s) do
+        source_indexes[source.to_s] = begin
+          source.specs
+        rescue StandardError
+          # A source that is not checked out yet, or is otherwise unusable, leaves its gems unindexed rather than
+          # failing the whole workspace.
+          nil
+        end
+      end
+
+      index&.search(lazy_spec.name)&.last
     end
 
     # Searches for the latest installation of the `rbs` gem and adds the paths for the core and stdlib RBS definitions

--- a/test/graph_test.rb
+++ b/test/graph_test.rb
@@ -764,6 +764,40 @@ class GraphTest < Minitest::Test
     end
   end
 
+  # A gem taken from a `git` or `path` source is never registered with RubyGems, so
+  # `Gem::Specification.find_by_name` raises for it. Bundler keeps an index per source that knows
+  # where the checkout lives and which directories the gemspec declares.
+  def test_dependency_paths_come_from_the_bundler_source_when_rubygems_does_not_know_the_gem
+    spec = FakeSpec.new("gizmo", "/checkout/gizmo", ["src/ruby/lib", "src/ruby/pb"])
+    lazy_spec = FakeLazySpec.new("gizmo", FakeSource.new(FakeIndex.new(spec)))
+
+    found = Rubydex::Graph.new.send(:resolve_dependency_spec, lazy_spec, {})
+
+    assert_equal(spec, found)
+    # Every directory the gemspec declares counts, not just `lib`.
+    assert_equal(["src/ruby/lib", "src/ruby/pb"], found.require_paths)
+  end
+
+  # A source that is not checked out yet must leave its gems unindexed rather than fail the whole
+  # workspace.
+  def test_dependency_paths_tolerate_a_source_that_cannot_be_indexed
+    lazy_spec = FakeLazySpec.new("gizmo", FailingSource.new)
+
+    assert_nil(Rubydex::Graph.new.send(:resolve_dependency_spec, lazy_spec, {}))
+  end
+
+  # A multi-gem repository such as rails shares one source across every gem it provides, and
+  # building that index reads gemspecs off disk, so it must happen once.
+  def test_a_bundler_source_is_indexed_only_once
+    source = FakeSource.new(FakeIndex.new(FakeSpec.new("gizmo", "/checkout/gizmo", ["lib"])))
+    graph = Rubydex::Graph.new
+    cache = {}
+
+    2.times { graph.send(:resolve_dependency_spec, FakeLazySpec.new("gizmo", source), cache) }
+
+    assert_equal(1, source.specs_calls)
+  end
+
   def test_index_workspace_includes_rbs_core_definitions
     graph = Rubydex::Graph.new
     graph.index_workspace
@@ -2162,5 +2196,55 @@ class GraphTest < Minitest::Test
     before = GC.stat(:total_allocated_objects)
     yield
     GC.stat(:total_allocated_objects) - before
+  end
+
+  # Stand-ins for the Bundler objects behind a `git` or `path` source. Building a real one would
+  # mean checking a repository out during the test.
+  FakeSpec = Struct.new(:name, :full_gem_path, :require_paths)
+  FakeLazySpec = Struct.new(:name, :source)
+
+  class FakeIndex
+    #: (FakeSpec) -> void
+    def initialize(spec)
+      @spec = spec
+    end
+
+    #: (String) -> Array[FakeSpec]
+    def search(name)
+      @spec.name == name ? [@spec] : []
+    end
+  end
+
+  class FakeSource
+    attr_reader :specs_calls #: Integer
+
+    #: (FakeIndex) -> void
+    def initialize(index)
+      @index = index
+      @specs_calls = 0 #: Integer
+    end
+
+    #: -> FakeIndex
+    def specs
+      @specs_calls += 1
+      @index
+    end
+
+    #: -> String
+    def to_s
+      "git://example/gizmo"
+    end
+  end
+
+  class FailingSource
+    #: -> untyped
+    def specs
+      raise(Bundler::GitError, "not yet checked out")
+    end
+
+    #: -> String
+    def to_s
+      "git://example/absent"
+    end
   end
 end


### PR DESCRIPTION
## Problem

`Graph#add_workspace_dependency_paths` finds a dependency's code through `Gem::Specification.find_by_name`. That method only knows about gems RubyGems installed. A gem the Gemfile takes from a `git` or `path` source is never registered with RubyGems, so the lookup raises `Gem::MissingSpecError`, the rescue swallows it, and the gem is left out of the workspace without any signal.

This is not a rare corner. On a large workspace that pins its framework to a branch, **204 of 882 locked specs were dropped**: 154 from path sources, 36 from git sources. Every Rails gem was among them, so nothing in the graph defined `ActiveRecord::Base`.

The damage is much wider than the missing gems. Ruby resolves a constant by searching the ancestors of the enclosing namespace. A class that inherits from a missing superclass never linearizes its ancestor chain, and then **no constant inside that class resolves either**, however well defined it is. Constants as ordinary as `Array` and `Hash` were reported unresolved even with the RBS core definitions indexed.

## Change

When RubyGems cannot find the gem, ask Bundler. Bundler keeps an index per source that knows both where it checked the source out and what the gemspec declares.

Two details matter:

- **The directories come from the gemspec, not from a guess.** Assuming `lib` is wrong often enough to matter. Of the gems resolved this way, `grpc` alone declares `src/ruby/lib`, `src/ruby/bin` and `src/ruby/pb`. Across the workspace, 77 gems declare something other than `["lib"]`, including `lib/concurrent-ruby`, `ruby` and `client`.
- **Each source is indexed once.** A multi-gem repository such as rails shares one source across the twelve gems it provides, and building that index reads gemspecs off disk.

A source that is not checked out yet still leaves its gems unindexed rather than failing the whole workspace, which is the behaviour today.

## Effect

Measured on a workspace of about 110,000 files whose Gemfile takes Rails from a branch.

| | Before | After |
|---|---:|---:|
| Locked specs dropped | 204 | 0 |
| Workspace paths indexed | 717 | 909 |
| Unresolved work items | 153,583 | 34,601 |
| Incomplete ancestor chains | 75,028 | 4,009 |

Constants such as `TestCase`, `Arel`, `RecordInvalid` and `RecordNotFound` resolve after the change and did not before.

## Notes for the reviewer

- The silent rescue is kept, because a workspace must still index when one source is unusable. It does mean a workspace can lose a quarter of its dependencies with no diagnostic. Surfacing that needs an error channel this method does not have, so I left it for separate work.
- `Bundler.load.specs` would be the tidier API, but it materializes the whole bundle and raises on a workspace whose lockfile and checkout disagree. The current code deliberately avoids requiring a working bundle, and this change keeps that property.
- The new tests use small doubles for the Bundler objects, so no repository is checked out while testing.