### PR TITLE
Expose source-level names for definitions

### DIFF
--- a/ext/rubydex/definition.c
+++ b/ext/rubydex/definition.c
@@ -155,6 +155,25 @@ static VALUE rdxr_definition_name(VALUE self) {
 
 /*
  * call-seq:
+ *   raw_name -> String
+ *
+ * Returns the class, module, or constant name as written in source, preserving explicit parent scopes like "Foo::Bar"
+ * and rooted paths like "::Bar".
+ */
+static VALUE rdxr_definition_raw_name(VALUE self) {
+    HandleData *data;
+    void *graph = rdxi_graph_from_handle(self, &data);
+
+    const char *name = rdx_definition_raw_name(graph, data->id);
+    if (name == NULL) {
+        rb_raise(rb_eRuntimeError, "Definition not found");
+    }
+
+    return rdxi_owned_c_string_to_ruby(name);
+}
+
+/*
+ * call-seq:
  *   deprecated? -> bool
  *
  * Returns whether this definition is marked as deprecated.
@@ -442,6 +461,7 @@ void rdxi_initialize_definition(VALUE mod) {
     rb_define_method(cDefinition, "document", rdxr_definition_document, 0);
 
     cClassDefinition = rb_define_class_under(mRubydex, "ClassDefinition", cDefinition);
+    rb_define_method(cClassDefinition, "raw_name", rdxr_definition_raw_name, 0);
     rb_define_method(cClassDefinition, "superclass", rdxr_class_definition_superclass, 0);
     rb_define_method(cClassDefinition, "mixins", rdxr_definition_mixins, 0);
 
@@ -449,10 +469,13 @@ void rdxi_initialize_definition(VALUE mod) {
     rb_define_method(cSingletonClassDefinition, "mixins", rdxr_definition_mixins, 0);
 
     cModuleDefinition = rb_define_class_under(mRubydex, "ModuleDefinition", cDefinition);
+    rb_define_method(cModuleDefinition, "raw_name", rdxr_definition_raw_name, 0);
     rb_define_method(cModuleDefinition, "mixins", rdxr_definition_mixins, 0);
 
     cConstantDefinition = rb_define_class_under(mRubydex, "ConstantDefinition", cDefinition);
+    rb_define_method(cConstantDefinition, "raw_name", rdxr_definition_raw_name, 0);
     cConstantAliasDefinition = rb_define_class_under(mRubydex, "ConstantAliasDefinition", cDefinition);
+    rb_define_method(cConstantAliasDefinition, "raw_name", rdxr_definition_raw_name, 0);
     cConstantVisibilityDefinition = rb_define_class_under(mRubydex, "ConstantVisibilityDefinition", cDefinition);
     cMethodVisibilityDefinition = rb_define_class_under(mRubydex, "MethodVisibilityDefinition", cDefinition);
     cMethodDefinition = rb_define_class_under(mRubydex, "MethodDefinition", cDefinition);

--- a/rbi/rubydex.rbi
+++ b/rbi/rubydex.rbi
@@ -175,8 +175,17 @@ class Rubydex::AttrAccessorDefinition < Rubydex::Definition; end
 class Rubydex::AttrReaderDefinition < Rubydex::Definition; end
 class Rubydex::AttrWriterDefinition < Rubydex::Definition; end
 class Rubydex::ClassVariableDefinition < Rubydex::Definition; end
-class Rubydex::ConstantAliasDefinition < Rubydex::Definition; end
-class Rubydex::ConstantDefinition < Rubydex::Definition; end
+
+class Rubydex::ConstantAliasDefinition < Rubydex::Definition
+  sig { returns(String) }
+  def raw_name; end
+end
+
+class Rubydex::ConstantDefinition < Rubydex::Definition
+  sig { returns(String) }
+  def raw_name; end
+end
+
 class Rubydex::GlobalVariableAliasDefinition < Rubydex::Definition; end
 class Rubydex::GlobalVariableDefinition < Rubydex::Definition; end
 class Rubydex::InstanceVariableDefinition < Rubydex::Definition; end
@@ -271,6 +280,9 @@ class Rubydex::Signature::BlockParameter < Rubydex::Signature::Parameter; end
 class Rubydex::ModuleDefinition < Rubydex::Definition
   sig { returns(T::Array[Rubydex::Mixin]) }
   def mixins; end
+
+  sig { returns(String) }
+  def raw_name; end
 end
 
 class Rubydex::SingletonClassDefinition < Rubydex::Definition
@@ -284,6 +296,9 @@ class Rubydex::ClassDefinition < Rubydex::Definition
 
   sig { returns(T::Array[Rubydex::Mixin]) }
   def mixins; end
+
+  sig { returns(String) }
+  def raw_name; end
 end
 
 class Rubydex::Mixin

--- a/rust/rubydex-sys/src/definition_api.rs
+++ b/rust/rubydex-sys/src/definition_api.rs
@@ -6,7 +6,9 @@ use crate::location_api::{Location, create_location_for_uri_and_offset};
 use crate::reference_api::CConstantReference;
 use libc::c_char;
 use rubydex::model::definitions::{Definition, Mixin};
-use rubydex::model::ids::DefinitionId;
+use rubydex::model::graph::Graph;
+use rubydex::model::ids::{DefinitionId, NameId};
+use rubydex::model::name::ParentScope;
 use rubydex::query::AliasResolutionError;
 use std::ffi::CString;
 use std::ptr;
@@ -107,6 +109,71 @@ pub unsafe extern "C" fn rdx_definition_name(pointer: GraphPointer, definition_i
         } else {
             ptr::null()
         }
+    })
+}
+
+fn raw_name_for_name(graph: &Graph, name_id: NameId) -> String {
+    let mut raw_name = String::new();
+    append_raw_name(graph, name_id, &mut raw_name);
+    raw_name
+}
+
+fn append_raw_name(graph: &Graph, name_id: NameId, raw_name: &mut String) {
+    let name = graph
+        .names()
+        .get(&name_id)
+        .expect("name should exist while building raw_name");
+    let simple_name = graph
+        .strings()
+        .get(name.str())
+        .expect("string should exist while building raw_name")
+        .as_str();
+
+    match name.parent_scope() {
+        ParentScope::None => {}
+        ParentScope::TopLevel => raw_name.push_str("::"),
+        ParentScope::Some(parent_id) | ParentScope::Attached(parent_id) => {
+            append_raw_name(graph, *parent_id, raw_name);
+            raw_name.push_str("::");
+        }
+    }
+
+    raw_name.push_str(simple_name);
+}
+
+fn raw_name_id(definition: &Definition) -> Option<&NameId> {
+    match definition {
+        Definition::Class(_) | Definition::Module(_) | Definition::Constant(_) | Definition::ConstantAlias(_) => {
+            definition.name_id()
+        }
+        _ => None,
+    }
+}
+
+/// Returns the UTF-8 raw name string for a class, module, constant, or constant-alias definition id.
+///
+/// The raw name is reconstructed from the definition's `Name`, preserving explicit parent scopes like `Foo::Bar` and
+/// rooted paths like `::Bar`. Returns null if the definition cannot be found or does not support raw names. Caller must
+/// free a non-null result with `free_c_string`.
+///
+/// # Panics
+///
+/// Panics if the graph contains an invalid name or string reference, or if the name contains an embedded null byte.
+///
+/// # Safety
+///
+/// Assumes pointer is valid.
+///
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rdx_definition_raw_name(pointer: GraphPointer, definition_id: u64) -> *const c_char {
+    with_graph(pointer, |graph| {
+        let def_id = DefinitionId::new(definition_id);
+        let Some(name_id) = graph.definitions().get(&def_id).and_then(raw_name_id) else {
+            return ptr::null();
+        };
+
+        let name = raw_name_for_name(graph, *name_id);
+        CString::new(name).unwrap().into_raw().cast_const()
     })
 }
 

--- a/test/definition_test.rb
+++ b/test/definition_test.rb
@@ -808,6 +808,95 @@ class DefinitionTest < Minitest::Test
     end
   end
 
+  def test_definition_raw_name
+    with_context do |context|
+      context.write!("file1.rb", <<~RUBY)
+        class Foo
+          class Bar; end
+          class ::Baz; end
+          module Qux::Quux; end
+          module ::Root::Nested; end
+
+          CONST = 1
+          ::ROOT_CONST = 2
+          Foo::NESTED_CONST = 3
+          ALIAS_CONST = Baz
+
+          class << self; end
+          def foo; end
+        end
+      RUBY
+
+      graph = Rubydex::Graph.new
+      graph.index_all(context.glob("**/*.rb"))
+
+      definitions = graph.documents.find { |d| d.uri == context.uri_to("file1.rb") }.definitions.to_a
+      raw_names = definitions
+        .select { |definition| definition.respond_to?(:raw_name) }
+        .map { |definition| [definition.class, definition.name, definition.raw_name] }
+
+      assert_includes(raw_names, [Rubydex::ClassDefinition, "Foo", "Foo"])
+      assert_includes(raw_names, [Rubydex::ClassDefinition, "Bar", "Bar"])
+      assert_includes(raw_names, [Rubydex::ClassDefinition, "Baz", "::Baz"])
+      assert_includes(raw_names, [Rubydex::ModuleDefinition, "Quux", "Qux::Quux"])
+      assert_includes(raw_names, [Rubydex::ModuleDefinition, "Nested", "::Root::Nested"])
+      assert_includes(raw_names, [Rubydex::ConstantDefinition, "CONST", "CONST"])
+      assert_includes(raw_names, [Rubydex::ConstantDefinition, "ROOT_CONST", "::ROOT_CONST"])
+      assert_includes(raw_names, [Rubydex::ConstantDefinition, "NESTED_CONST", "Foo::NESTED_CONST"])
+      assert_includes(raw_names, [Rubydex::ConstantAliasDefinition, "ALIAS_CONST", "ALIAS_CONST"])
+
+      method_def = definitions.find { |definition| definition.is_a?(Rubydex::MethodDefinition) }
+      refute_respond_to(method_def, :raw_name)
+
+      singleton_class_def = definitions.find { |definition| definition.is_a?(Rubydex::SingletonClassDefinition) }
+      refute_respond_to(singleton_class_def, :raw_name)
+    end
+  end
+
+  def test_definition_raw_name_can_build_constant_resolution_nesting
+    with_context do |context|
+      context.write!("file1.rb", <<~RUBY)
+        class Bar
+          class Baz; end
+        end
+
+        class Foo
+          class Baz; end
+
+          class ::Bar; end
+        end
+      RUBY
+
+      graph = Rubydex::Graph.new
+      graph.index_all(context.glob("**/*.rb"))
+      graph.resolve
+
+      definitions = graph.documents.find { |d| d.uri == context.uri_to("file1.rb") }.definitions
+      bar_def = definitions.find do |definition|
+        definition.is_a?(Rubydex::ClassDefinition) && definition.raw_name == "::Bar"
+      end
+      nesting = bar_def.lexical_nesting.reverse.map(&:raw_name) << bar_def.raw_name
+
+      assert_equal(["Foo", "::Bar"], nesting)
+      assert_equal("Bar::Baz", graph.resolve_constant("Baz", nesting).name)
+    end
+  end
+
+  def test_definition_raw_name_raises_when_definition_is_gone
+    with_context do |context|
+      context.write!("file1.rb", "class Foo; end")
+
+      graph = Rubydex::Graph.new
+      graph.index_all(context.glob("**/*.rb"))
+      definition = graph.document(context.uri_to("file1.rb")).definitions.first
+
+      graph.delete_document(context.uri_to("file1.rb"))
+
+      error = assert_raises(RuntimeError) { definition.raw_name }
+      assert_equal("Definition not found", error.message)
+    end
+  end
+
   def test_definition_declaration
     with_context do |context|
       context.write!("file1.rb", <<~RUBY)


### PR DESCRIPTION
`Definition#name` returns an unqualified name, while `definition.declaration.name` returns its resolved fully qualified name. Neither preserves whether a definition was written as `Bar`, `Foo::Bar`, or `::Bar`.

This distinction matters when constructing a nesting stack for `Graph#resolve_constant`: a rooted name such as `::Bar` must remain rooted instead of being resolved relative to its lexical owner.

Add <s>`source_name`</s> `raw_name` to class, module, constant, and constant-alias definitions to expose this source-level qualification.