### PR TITLE
Make diagnostic hold rule identity

### DIFF
--- a/ext/rubydex/diagnostic.c
+++ b/ext/rubydex/diagnostic.c
@@ -7,6 +7,7 @@
  */
 
 static VALUE mRubydex;
+static VALUE mRules;
 VALUE cDiagnostic;
 static VALUE cRule;
 static ID id_default_severity;
@@ -50,7 +51,7 @@ static VALUE rdxr_generated_rule_default_severity(VALUE self) {
 
 // Generates a rule class for every rule the graph can report. Severities are resolved here rather than when they are
 // read, which is why Rubydex::Severity is loaded before this extension (see `lib/rubydex.rb`).
-static void define_generated_rules(VALUE mRules) {
+static void define_generated_rules(void) {
     CRuleArray rule_array = rdx_rules();
     VALUE rules = rb_ary_new_capa((long)rule_array.len);
 
@@ -69,11 +70,16 @@ static void define_generated_rules(VALUE mRules) {
     rb_define_const(mRules, "ALL", rb_obj_freeze(rules));
 }
 
+VALUE rdxi_rule_class_from_name(const char *name, size_t length) {
+    return rb_const_get_at(mRules, rb_intern2(name, (long)length));
+}
+
 void rdxi_initialize_diagnostic(VALUE moduleRubydex) {
     mRubydex = moduleRubydex;
     id_default_severity = rb_intern("@default_severity");
 
     cDiagnostic = rb_define_class_under(mRubydex, "Diagnostic", rb_cObject);
     cRule = rb_define_class_under(mRubydex, "Rule", rb_cObject);
-    define_generated_rules(rb_define_module_under(mRubydex, "Rules"));
+    mRules = rb_define_module_under(mRubydex, "Rules");
+    define_generated_rules();
 }

--- a/ext/rubydex/diagnostic.h
+++ b/ext/rubydex/diagnostic.h
@@ -8,5 +8,6 @@ extern VALUE cDiagnostic;
 
 void rdxi_initialize_diagnostic(VALUE mRubydex);
 VALUE rdxi_build_diagnostic_severity_value(VALUE mRubydex, DiagnosticSeverity severity);
+VALUE rdxi_rule_class_from_name(const char *name, size_t length);
 
 #endif // RUBYDEX_DIAGNOSTIC_H

--- a/ext/rubydex/graph.c
+++ b/ext/rubydex/graph.c
@@ -633,9 +633,9 @@ static VALUE rdxr_graph_diagnostics(VALUE self) {
     for (size_t i = 0; i < array->len; i++) {
         DiagnosticEntry entry = array->items[i];
         VALUE message = entry.message == NULL ? Qnil : rb_utf8_str_new_cstr(entry.message);
-        VALUE rule = rb_utf8_str_new_cstr(entry.rule);
+        VALUE rule = rdxi_rule_class_from_name(entry.rule.name, entry.rule.name_length);
         VALUE location = rdxi_build_location_value(entry.location);
-        VALUE severity = rdxi_build_diagnostic_severity_value(mRubydex, entry.severity);
+        VALUE severity = rdxi_build_diagnostic_severity_value(mRubydex, entry.rule.default_severity);
 
         VALUE kwargs = rb_hash_new();
         rb_hash_aset(kwargs, ID2SYM(rb_intern("rule")), rule);

--- a/lib/ruby_lsp/rubydex/addon.rb
+++ b/lib/ruby_lsp/rubydex/addon.rb
@@ -177,7 +177,7 @@ module Rubydex
           ::RubyLsp::Interface::Diagnostic.new(
             message: diagnostic.message,
             source: "Rubydex",
-            code: diagnostic.rule,
+            code: diagnostic.rule.rule_name,
             severity: DIAGNOSTIC_SEVERITIES.fetch(diagnostic.severity),
             range: lsp_range(location),
             related_information: diagnostic.related_information.map do |information|

--- a/lib/rubydex/cli/command/lint.rb
+++ b/lib/rubydex/cli/command/lint.rb
@@ -101,7 +101,7 @@ module Rubydex
         #: (Diagnostic diagnostic, workspace_path: String) -> String
         def format_linter_diagnostic(diagnostic, workspace_path:)
           content = +"#{format_linter_location(diagnostic.location, workspace_path:)}: " \
-            "#{diagnostic.severity.value}: #{diagnostic.rule}: #{diagnostic.message}"
+            "#{diagnostic.severity.value}: #{diagnostic.rule.rule_name}: #{diagnostic.message}"
 
           diagnostic.related_information.each do |information|
             content << "\n  #{format_linter_location(information.location, workspace_path:)}: #{information.message}"

--- a/lib/rubydex/diagnostic.rb
+++ b/lib/rubydex/diagnostic.rb
@@ -2,7 +2,7 @@
 
 module Rubydex
   class Diagnostic
-    #: String
+    #: singleton(Rule)
     attr_reader :rule
 
     #: String
@@ -18,7 +18,7 @@ module Rubydex
     attr_reader :related_information
 
     #: (
-    #|   rule: String,
+    #|   rule: singleton(Rule),
     #|   message: String,
     #|   location: Location,
     #|   severity: singleton(Severity::Base),

--- a/lib/rubydex/linter/custom_rule.rb
+++ b/lib/rubydex/linter/custom_rule.rb
@@ -81,7 +81,7 @@ module Rubydex
       #| ) -> void
       def add_diagnostic(message, location, related_information: [])
         @diagnostics << Diagnostic.new(
-          rule: self.class.rule_name,
+          rule: self.class,
           message: message,
           location: location,
           severity: verified_severity,

--- a/lib/rubydex/linter/runner.rb
+++ b/lib/rubydex/linter/runner.rb
@@ -38,7 +38,7 @@ module Rubydex
             location.start_column,
             location.end_line,
             location.end_column,
-            diagnostic.rule,
+            diagnostic.rule.rule_name,
             diagnostic.message,
           ]
         end

--- a/rbi/rubydex.rbi
+++ b/rbi/rubydex.rbi
@@ -419,7 +419,7 @@ end
 class Rubydex::Diagnostic
   sig do
     params(
-      rule: String,
+      rule: T.class_of(Rubydex::Rule),
       message: String,
       location: Rubydex::Location,
       severity: T.class_of(Rubydex::Severity::Base),
@@ -434,7 +434,7 @@ class Rubydex::Diagnostic
   sig { returns(String) }
   def message; end
 
-  sig { returns(String) }
+  sig { returns(T.class_of(Rubydex::Rule)) }
   def rule; end
 
   sig { returns(T.class_of(Rubydex::Severity::Base)) }

--- a/rust/rubydex-sys/src/diagnostic_api.rs
+++ b/rust/rubydex-sys/src/diagnostic_api.rs
@@ -83,10 +83,9 @@ pub unsafe extern "C" fn rdx_rules_free(rules: CRuleArray) {
 /// C-compatible struct representing a diagnostic entry.
 #[repr(C)]
 pub struct DiagnosticEntry {
-    pub rule: *const c_char,
+    pub rule: CRule,
     pub message: *const c_char,
     pub location: *mut Location,
-    pub severity: DiagnosticSeverity,
 }
 
 /// C-compatible array wrapper for diagnostics.
@@ -126,13 +125,9 @@ pub unsafe extern "C" fn rdx_graph_diagnostics(pointer: GraphPointer) -> *mut Di
                 let location = create_location_for_uri_and_offset(graph, document, diagnostic.offset());
 
                 DiagnosticEntry {
-                    rule: CString::new(diagnostic.rule().to_string())
-                        .unwrap()
-                        .into_raw()
-                        .cast_const(),
+                    rule: CRule::from(*diagnostic.rule()),
                     message: CString::new(diagnostic.message()).unwrap().into_raw().cast_const(),
                     location,
-                    severity: DiagnosticSeverity::from(diagnostic.rule().default_severity()),
                 }
             })
             .collect::<Vec<DiagnosticEntry>>();
@@ -159,9 +154,6 @@ pub unsafe extern "C" fn rdx_diagnostics_free(ptr: *mut DiagnosticArray) {
         let mut boxed_slice: Box<[DiagnosticEntry]> = unsafe { Box::from_raw(slice_ptr) };
 
         for entry in &mut *boxed_slice {
-            if !entry.rule.is_null() {
-                let _ = unsafe { CString::from_raw(entry.rule.cast_mut()) };
-            }
             if !entry.message.is_null() {
                 let _ = unsafe { CString::from_raw(entry.message.cast_mut()) };
             }

--- a/test/diagnostic_test.rb
+++ b/test/diagnostic_test.rb
@@ -3,6 +3,12 @@
 require "test_helper"
 
 class DiagnosticTest < Minitest::Test
+  class ExampleRule < Rubydex::Rule
+    class << self
+      def default_severity = Rubydex::Severity::Warning
+    end
+  end
+
   def test_severity_from_value
     {
       error: Rubydex::Severity::Error,
@@ -27,7 +33,7 @@ class DiagnosticTest < Minitest::Test
 
   def test_diagnostic_requires_severity
     error = assert_raises(ArgumentError) do
-      Rubydex::Diagnostic.new(rule: "Example", message: "Example", location: location)
+      Rubydex::Diagnostic.new(rule: ExampleRule, message: "Example", location: location)
     end
 
     assert_match(/missing keyword: :severity/, error.message)
@@ -36,14 +42,14 @@ class DiagnosticTest < Minitest::Test
   def test_diagnostic_exposes_severity_and_related_information
     related = Rubydex::RelatedInformation.new("Also defined here", location(uri: "file:///related.rb"))
     diagnostic = Rubydex::Diagnostic.new(
-      rule: "Example",
+      rule: ExampleRule,
       message: "Example",
       location: location,
       severity: Rubydex::Severity::Warning,
       related_information: [related],
     )
 
-    assert_equal("Example", diagnostic.rule)
+    assert_equal(ExampleRule, diagnostic.rule)
     assert_equal("Example", diagnostic.message)
     assert_equal(location, diagnostic.location)
     assert_same(Rubydex::Severity::Warning, diagnostic.severity)
@@ -52,7 +58,7 @@ class DiagnosticTest < Minitest::Test
 
   def test_diagnostic_defaults_to_no_related_information
     diagnostic = Rubydex::Diagnostic.new(
-      rule: "Example",
+      rule: ExampleRule,
       message: "Example",
       location: location,
       severity: Rubydex::Severity::Information,

--- a/test/graph_test.rb
+++ b/test/graph_test.rb
@@ -89,14 +89,14 @@ class GraphTest < Minitest::Test
       assert_diagnostics(
         [
           {
-            rule: "ParseError",
+            rule: Rubydex::Rules::ParseError,
             path: "file.rb",
             message: "expected an `end` to close the `class` statement",
             severity: Rubydex::Severity::Error,
             related_information: [],
           },
           {
-            rule: "ParseError",
+            rule: Rubydex::Rules::ParseError,
             path: "file.rb",
             message: "unexpected end-of-input, assuming it is closing the parent top level context",
             severity: Rubydex::Severity::Error,

--- a/test/linter_test.rb
+++ b/test/linter_test.rb
@@ -134,7 +134,7 @@ class LinterTest < Minitest::Test
     result = Rubydex::Linter::Runner.new(Rubydex::Graph.new, custom_rules: [WarningRule], config: linter_config).run
     diagnostic = result.diagnostics.fetch(0)
 
-    assert_equal("WarningRule", diagnostic.rule)
+    assert_equal(WarningRule, diagnostic.rule)
     assert_equal("A warning.", diagnostic.message)
     assert_equal(Rubydex::Severity::Warning, diagnostic.severity)
     assert_equal(["Related context."], diagnostic.related_information.map(&:message))
@@ -163,7 +163,7 @@ class LinterTest < Minitest::Test
     )
 
     assert_equal([ErrorRule], runner.custom_rules)
-    assert_equal(["ErrorRule"], runner.run.diagnostics.map(&:rule))
+    assert_equal([ErrorRule], runner.run.diagnostics.map(&:rule))
   end
 
   def test_runner_allows_every_rule_to_be_disabled
@@ -196,7 +196,7 @@ class LinterTest < Minitest::Test
 
     result = Rubydex::Linter::Runner.new(graph, custom_rules: [SilentRule], config: linter_config).run
 
-    assert_equal(["ParseError", "ParseError"], result.diagnostics.map(&:rule))
+    assert_equal([Rubydex::Rules::ParseError, Rubydex::Rules::ParseError], result.diagnostics.map(&:rule))
     assert(result.diagnostics.all? { |diagnostic| diagnostic.severity == Rubydex::Severity::Error })
     refute_predicate(result, :success?)
   end
@@ -314,7 +314,7 @@ class LinterTest < Minitest::Test
   #: (singleton(Rubydex::Severity::Base) severity) -> Rubydex::Diagnostic
   def diagnostic(severity)
     Rubydex::Diagnostic.new(
-      rule: "TestRule",
+      rule: SilentRule,
       message: "Test diagnostic.",
       location: Rubydex::Location.new(
         uri: "untitled:test",


### PR DESCRIPTION
Another step for #1000

Now that we have unified the concept of a rule identity under `Rule`, we should revert the previous decision and store the `Rule` singleton in diagnostics. This allows us to make the modelling consistent with the Rust side and easily move the severity resolution after the collection (this will be relevant because we now have diagnostics that are collected differently, but we want to apply configuration to all of them in an uniform way).

This PR changes diagnostics to hold a `Rule` singleton instead of just the name, so that we have access to the default severity and the name.