### PR TITLE
Resolve constants using definition lexical nesting

### DIFF
--- a/ext/rubydex/definition.c
+++ b/ext/rubydex/definition.c
@@ -19,6 +19,8 @@ static VALUE cInclude;
 static VALUE cPrepend;
 static VALUE cExtend;
 static VALUE cDocument;
+static VALUE cDefinitionConstantReference;
+static VALUE mConstantHelper;
 VALUE cComment;
 VALUE cDefinition;
 VALUE cClassDefinition;
@@ -151,6 +153,59 @@ static VALUE rdxr_definition_name(VALUE self) {
 
     const char *name = rdx_definition_name(graph, data->id);
     return rdxi_owned_c_string_to_ruby(name);
+}
+
+/*
+ * call-seq:
+ *   constant_path -> Rubydex::ConstantReference
+ *
+ * Returns the constant path used to name this definition.
+ */
+static VALUE rdxr_definition_constant_path(VALUE self) {
+    HandleData *data;
+    TypedData_Get_Struct(self, HandleData, &handle_type, data);
+
+    VALUE argv[] = {data->graph_obj, ULL2NUM(data->id)};
+    return rb_class_new_instance(2, argv, cDefinitionConstantReference);
+}
+
+static VALUE rdxr_definition_constant_path_raw_name(VALUE self) {
+    HandleData *data;
+    void *graph = rdxi_graph_from_handle(self, &data);
+
+    const char *name = rdx_definition_constant_path_raw_name(graph, data->id);
+    if (name == NULL) {
+        rb_raise(rb_eRuntimeError, "Definition must have a constant path");
+    }
+    return rdxi_owned_c_string_to_ruby(name);
+}
+
+static VALUE rdxr_definition_constant_path_location(VALUE self) {
+    HandleData *data;
+    void *graph = rdxi_graph_from_handle(self, &data);
+
+    Location *loc = rdx_definition_constant_path_location(graph, data->id);
+    if (loc == NULL) {
+        rb_raise(rb_eRuntimeError, "Definition must have a constant path");
+    }
+    VALUE location = rdxi_build_location_value(loc);
+    rdx_location_free(loc);
+    return location;
+}
+
+static VALUE rdxr_definition_constant_path_document(VALUE self) {
+    HandleData *data;
+    void *graph = rdxi_graph_from_handle(self, &data);
+
+    const uint64_t *uri_id = rdx_definition_document(graph, data->id);
+    if (uri_id == NULL) {
+        rb_raise(rb_eRuntimeError, "Definition not found");
+    }
+
+    VALUE argv[] = {data->graph_obj, ULL2NUM(*uri_id)};
+    free_u64(uri_id);
+
+    return rb_class_new_instance(2, argv, cDocument);
 }
 
 /*
@@ -424,6 +479,9 @@ void rdxi_initialize_definition(VALUE mod) {
     cPrepend = rb_const_get(mRubydex, rb_intern("Prepend"));
     cExtend = rb_const_get(mRubydex, rb_intern("Extend"));
     cDocument = rb_const_get(mRubydex, rb_intern("Document"));
+    mConstantHelper = rb_const_get(mRubydex, rb_intern("ConstantHelper"));
+
+    rb_define_method(mConstantHelper, "constant_path", rdxr_definition_constant_path, 0);
 
     cComment = rb_define_class_under(mRubydex, "Comment", rb_cObject);
 
@@ -442,6 +500,7 @@ void rdxi_initialize_definition(VALUE mod) {
     rb_define_method(cDefinition, "document", rdxr_definition_document, 0);
 
     cClassDefinition = rb_define_class_under(mRubydex, "ClassDefinition", cDefinition);
+    rb_include_module(cClassDefinition, mConstantHelper);
     rb_define_method(cClassDefinition, "superclass", rdxr_class_definition_superclass, 0);
     rb_define_method(cClassDefinition, "mixins", rdxr_definition_mixins, 0);
 
@@ -449,10 +508,13 @@ void rdxi_initialize_definition(VALUE mod) {
     rb_define_method(cSingletonClassDefinition, "mixins", rdxr_definition_mixins, 0);
 
     cModuleDefinition = rb_define_class_under(mRubydex, "ModuleDefinition", cDefinition);
+    rb_include_module(cModuleDefinition, mConstantHelper);
     rb_define_method(cModuleDefinition, "mixins", rdxr_definition_mixins, 0);
 
     cConstantDefinition = rb_define_class_under(mRubydex, "ConstantDefinition", cDefinition);
+    rb_include_module(cConstantDefinition, mConstantHelper);
     cConstantAliasDefinition = rb_define_class_under(mRubydex, "ConstantAliasDefinition", cDefinition);
+    rb_include_module(cConstantAliasDefinition, mConstantHelper);
     cConstantVisibilityDefinition = rb_define_class_under(mRubydex, "ConstantVisibilityDefinition", cDefinition);
     cMethodVisibilityDefinition = rb_define_class_under(mRubydex, "MethodVisibilityDefinition", cDefinition);
     cMethodDefinition = rb_define_class_under(mRubydex, "MethodDefinition", cDefinition);
@@ -467,4 +529,20 @@ void rdxi_initialize_definition(VALUE mod) {
     rb_define_method(cMethodAliasDefinition, "signatures", rdxr_method_alias_definition_signatures, 0);
     rb_define_method(cMethodAliasDefinition, "target", rdxr_method_alias_definition_target, 0);
     cGlobalVariableAliasDefinition = rb_define_class_under(mRubydex, "GlobalVariableAliasDefinition", cDefinition);
+}
+
+void rdxi_initialize_definition_constant_reference(VALUE mod) {
+    cDefinitionConstantReference = rb_define_class_under(mod, "DefinitionConstantReference", cConstantReference);
+    rb_define_alloc_func(cDefinitionConstantReference, rdxr_handle_alloc);
+    rb_define_method(cDefinitionConstantReference, "initialize", rdxr_handle_initialize, 2);
+    rb_define_method(cDefinitionConstantReference, "raw_name", rdxr_definition_constant_path_raw_name, 0);
+    rb_define_method(cDefinitionConstantReference, "location", rdxr_definition_constant_path_location, 0);
+    rb_define_method(cDefinitionConstantReference, "document", rdxr_definition_constant_path_document, 0);
+    rb_funcall(
+        rb_singleton_class(cDefinitionConstantReference),
+        rb_intern("private"),
+        1,
+        ID2SYM(rb_intern("new"))
+    );
+    rb_funcall(mod, rb_intern("private_constant"), 1, ID2SYM(rb_intern("DefinitionConstantReference")));
 }

--- a/ext/rubydex/definition.h
+++ b/ext/rubydex/definition.h
@@ -21,6 +21,7 @@ extern VALUE cMethodAliasDefinition;
 extern VALUE cGlobalVariableAliasDefinition;
 
 void rdxi_initialize_definition(VALUE mRubydex);
+void rdxi_initialize_definition_constant_reference(VALUE mRubydex);
 
 // Returns the Ruby class for a given DefinitionKind without calling back into Rust
 VALUE rdxi_definition_class_for_kind(DefinitionKind kind);

--- a/ext/rubydex/reference.c
+++ b/ext/rubydex/reference.c
@@ -38,6 +38,23 @@ static VALUE rdxr_constant_reference_name(VALUE self) {
 
 /*
  * call-seq:
+ *   raw_name -> String
+ *
+ * Returns the constant path as it appeared in source, preserving explicit parent scopes and a leading `::`.
+ */
+static VALUE rdxr_constant_reference_raw_name(VALUE self) {
+    HandleData *data;
+    void *graph = rdxi_graph_from_handle(self, &data);
+
+    const char *name = rdx_constant_reference_raw_name(graph, data->id);
+    if (name == NULL) {
+        rb_raise(rb_eRuntimeError, "Constant reference must exist for a valid id");
+    }
+    return rdxi_owned_c_string_to_ruby(name);
+}
+
+/*
+ * call-seq:
  *   location -> Rubydex::Location
  *
  * Returns the source location for this constant reference.
@@ -189,6 +206,7 @@ void rdxi_initialize_reference(VALUE mRubydex) {
     cConstantReference = rb_define_class_under(mRubydex, "ConstantReference", cReference);
     rb_define_alloc_func(cConstantReference, rdxr_handle_alloc);
     rb_define_method(cConstantReference, "initialize", rdxr_handle_initialize, 2);
+    rb_define_method(cConstantReference, "raw_name", rdxr_constant_reference_raw_name, 0);
     rb_define_method(cConstantReference, "location", rdxr_constant_reference_location, 0);
     rb_define_method(cConstantReference, "document", rdxr_constant_reference_document, 0);
     rb_funcall(rb_singleton_class(cConstantReference), rb_intern("private"), 1, ID2SYM(rb_intern("new")));

--- a/ext/rubydex/rubydex.c
+++ b/ext/rubydex/rubydex.c
@@ -29,5 +29,6 @@ void Init_rubydex(void) {
     rdxi_initialize_location(mRubydex);
     rdxi_initialize_diagnostic(mRubydex);
     rdxi_initialize_reference(mRubydex);
+    rdxi_initialize_definition_constant_reference(mRubydex);
     rdxi_initialize_signature(mRubydex);
 }

--- a/lib/rubydex.rb
+++ b/lib/rubydex.rb
@@ -5,6 +5,7 @@ require "uri"
 
 # Files that must be loaded before the C extension
 require "rubydex/version"
+require "rubydex/constant_helper"
 require "rubydex/mixin"
 require "rubydex/severity"
 

--- a/lib/rubydex/constant_helper.rb
+++ b/lib/rubydex/constant_helper.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module Rubydex
+  # Common constant path behavior for definitions that introduce a constant.
+  module ConstantHelper; end
+end

--- a/lib/rubydex/graph.rb
+++ b/lib/rubydex/graph.rb
@@ -25,6 +25,20 @@ module Rubydex
       index_all(workspace_paths)
     end
 
+    alias_method :resolve_constant_with_names, :resolve_constant
+    private :resolve_constant_with_names
+
+    # Resolves a constant from either an explicit outer-to-inner name stack or a lexical nesting returned by a
+    # definition.
+    #: (String, Array[String] | Array[ConstantHelper]) -> Declaration?
+    def resolve_constant(name, nesting)
+      if nesting.is_a?(Array) && nesting.all? { |frame| frame.is_a?(ConstantHelper) }
+        nesting = nesting.reverse.map { |frame| frame.constant_path.raw_name }
+      end
+
+      resolve_constant_with_names(name, nesting)
+    end
+
     # Returns all workspace paths that should be indexed
     #
     #: -> Array[String]

--- a/rbi/rubydex.rbi
+++ b/rbi/rubydex.rbi
@@ -33,6 +33,13 @@ class Rubydex::ConstantReference < Rubydex::Reference
   end
 end
 
+module Rubydex::ConstantHelper
+  interface!
+
+  sig { abstract.returns(Rubydex::ConstantReference) }
+  def constant_path; end
+end
+
 class Rubydex::UnresolvedConstantReference < Rubydex::ConstantReference
   sig { returns(String) }
   def name; end
@@ -178,8 +185,15 @@ class Rubydex::AttrAccessorDefinition < Rubydex::Definition; end
 class Rubydex::AttrReaderDefinition < Rubydex::Definition; end
 class Rubydex::AttrWriterDefinition < Rubydex::Definition; end
 class Rubydex::ClassVariableDefinition < Rubydex::Definition; end
-class Rubydex::ConstantAliasDefinition < Rubydex::Definition; end
-class Rubydex::ConstantDefinition < Rubydex::Definition; end
+
+class Rubydex::ConstantAliasDefinition < Rubydex::Definition
+  include Rubydex::ConstantHelper
+end
+
+class Rubydex::ConstantDefinition < Rubydex::Definition
+  include Rubydex::ConstantHelper
+end
+
 class Rubydex::GlobalVariableAliasDefinition < Rubydex::Definition; end
 class Rubydex::GlobalVariableDefinition < Rubydex::Definition; end
 class Rubydex::InstanceVariableDefinition < Rubydex::Definition; end
@@ -272,6 +286,8 @@ class Rubydex::Signature::ForwardParameter < Rubydex::Signature::Parameter; end
 class Rubydex::Signature::BlockParameter < Rubydex::Signature::Parameter; end
 
 class Rubydex::ModuleDefinition < Rubydex::Definition
+  include Rubydex::ConstantHelper
+
   sig { returns(T::Array[Rubydex::Mixin]) }
   def mixins; end
 end
@@ -282,6 +298,8 @@ class Rubydex::SingletonClassDefinition < Rubydex::Definition
 end
 
 class Rubydex::ClassDefinition < Rubydex::Definition
+  include Rubydex::ConstantHelper
+
   sig { returns(T.nilable(Rubydex::ConstantReference)) }
   def superclass; end
 
@@ -906,7 +924,12 @@ class Rubydex::Graph
   sig { returns(T.self_type) }
   def resolve; end
 
-  sig { params(name: String, nesting: T::Array[String]).returns(T.nilable(Rubydex::Declaration)) }
+  sig do
+    params(
+      name: String,
+      nesting: T.any(T::Array[String], T::Array[Rubydex::ConstantHelper]),
+    ).returns(T.nilable(Rubydex::Declaration))
+  end
   def resolve_constant(name, nesting); end
 
   sig { params(require_path: String, load_paths: T::Array[String]).returns(T.nilable(Rubydex::Document)) }

--- a/rbi/rubydex.rbi
+++ b/rbi/rubydex.rbi
@@ -17,6 +17,9 @@ end
 class Rubydex::ConstantReference < Rubydex::Reference
   abstract!
 
+  sig { returns(String) }
+  def raw_name; end
+
   sig { returns(Rubydex::Location) }
   def location; end
 

--- a/rust/rubydex-sys/src/definition_api.rs
+++ b/rust/rubydex-sys/src/definition_api.rs
@@ -3,10 +3,11 @@
 use crate::declaration_api::CDeclaration;
 use crate::graph_api::{GraphPointer, with_graph};
 use crate::location_api::{Location, create_location_for_uri_and_offset};
+use crate::name_api::raw_name_for_name_id;
 use crate::reference_api::CConstantReference;
 use libc::c_char;
 use rubydex::model::definitions::{Definition, Mixin};
-use rubydex::model::ids::DefinitionId;
+use rubydex::model::ids::{DefinitionId, NameId};
 use rubydex::query::AliasResolutionError;
 use std::ffi::CString;
 use std::ptr;
@@ -107,6 +108,84 @@ pub unsafe extern "C" fn rdx_definition_name(pointer: GraphPointer, definition_i
         } else {
             ptr::null()
         }
+    })
+}
+
+fn definition_constant_path_name_id(definition: &Definition) -> Option<NameId> {
+    match definition {
+        Definition::Class(definition) => Some(*definition.name_id()),
+        Definition::Module(definition) => Some(*definition.name_id()),
+        Definition::Constant(definition) => Some(*definition.name_id()),
+        Definition::ConstantAlias(definition) => Some(*definition.name_id()),
+        _ => None,
+    }
+}
+
+/// Returns the constant path as it appeared in source for a definition id, or NULL if the definition has no constant
+/// path. Caller must free with `free_c_string`.
+///
+/// # Safety
+///
+/// Assumes pointer is valid.
+///
+/// # Panics
+///
+/// This function will panic if the definition's name cannot be reconstructed or contains an interior null byte.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rdx_definition_constant_path_raw_name(
+    pointer: GraphPointer,
+    definition_id: u64,
+) -> *const c_char {
+    with_graph(pointer, |graph| {
+        let def_id = DefinitionId::new(definition_id);
+        let Some(definition) = graph.definitions().get(&def_id) else {
+            return ptr::null();
+        };
+        let Some(name_id) = definition_constant_path_name_id(definition) else {
+            return ptr::null();
+        };
+
+        CString::new(raw_name_for_name_id(graph, name_id))
+            .unwrap()
+            .into_raw()
+            .cast_const()
+    })
+}
+
+/// Returns the location of the final name in a definition's constant path, or NULL if the definition has no constant
+/// path. Caller must free with `rdx_location_free`.
+///
+/// # Safety
+///
+/// Assumes pointer is valid.
+///
+/// # Panics
+///
+/// This function will panic if the definition's document cannot be found.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rdx_definition_constant_path_location(
+    pointer: GraphPointer,
+    definition_id: u64,
+) -> *mut Location {
+    with_graph(pointer, |graph| {
+        let def_id = DefinitionId::new(definition_id);
+        let Some(definition) = graph.definitions().get(&def_id) else {
+            return ptr::null_mut();
+        };
+
+        let offset = match definition {
+            Definition::Class(definition) => definition.name_offset(),
+            Definition::Module(definition) => definition.name_offset(),
+            Definition::Constant(definition) => definition.offset(),
+            Definition::ConstantAlias(definition) => definition.offset(),
+            _ => return ptr::null_mut(),
+        };
+        let document = graph
+            .documents()
+            .get(definition.uri_id())
+            .expect("document should exist");
+
+        create_location_for_uri_and_offset(graph, document, offset)
     })
 }
 

--- a/rust/rubydex-sys/src/name_api.rs
+++ b/rust/rubydex-sys/src/name_api.rs
@@ -1,5 +1,35 @@
 use rubydex::model::{graph::Graph, ids::NameId, name::ParentScope};
 
+/// Reconstructs the constant path represented by a name, without including its lexical nesting.
+pub(crate) fn raw_name_for_name_id(graph: &Graph, name_id: NameId) -> String {
+    let mut raw_name = String::new();
+    append_raw_name(graph, name_id, &mut raw_name);
+    raw_name
+}
+
+fn append_raw_name(graph: &Graph, name_id: NameId, raw_name: &mut String) {
+    let name = graph
+        .names()
+        .get(&name_id)
+        .expect("name should exist while building a raw name");
+    let simple_name = graph
+        .strings()
+        .get(name.str())
+        .expect("string should exist while building a raw name")
+        .as_str();
+
+    match name.parent_scope() {
+        ParentScope::None => {}
+        ParentScope::TopLevel => raw_name.push_str("::"),
+        ParentScope::Some(parent_id) | ParentScope::Attached(parent_id) => {
+            append_raw_name(graph, *parent_id, raw_name);
+            raw_name.push_str("::");
+        }
+    }
+
+    raw_name.push_str(simple_name);
+}
+
 /// Takes a constant name and a nesting stack (e.g.: `["Foo", "Bar::Baz", "Qux"]`) and transforms it into a `NameId`,
 /// registering each required part in the graph. Returns the `NameId` and a list of name ids that need to be untracked
 /// afterwards. Returns `None` if the constant name contains no valid identifier parts (e.g.: `""`, `"::"`, `"Foo::"`).
@@ -181,5 +211,14 @@ mod tests {
         assert_eq!(StringId::from("Foo"), *foo_name.str());
         assert!(foo_name.parent_scope().is_none());
         assert!(foo_name.nesting().is_none());
+    }
+
+    #[test]
+    fn raw_name_preserves_parent_scope_without_lexical_nesting() {
+        let mut graph = Graph::new();
+
+        let (name_id, _) = nesting_stack_to_name_id(&mut graph, "::Foo::Bar", vec!["LexicalOwner".into()]).unwrap();
+
+        assert_eq!("::Foo::Bar", raw_name_for_name_id(&graph, name_id));
     }
 }

--- a/rust/rubydex-sys/src/reference_api.rs
+++ b/rust/rubydex-sys/src/reference_api.rs
@@ -6,6 +6,7 @@ use std::ptr;
 use crate::declaration_api::CDeclaration;
 use crate::graph_api::{GraphPointer, with_graph};
 use crate::location_api::{Location, create_location_for_uri_and_offset};
+use crate::name_api::raw_name_for_name_id;
 use libc::c_char;
 use rubydex::model::graph::Graph;
 use rubydex::model::ids::{ConstantReferenceId, MethodReferenceId};
@@ -145,6 +146,31 @@ pub unsafe extern "C" fn rdx_constant_reference_name(pointer: GraphPointer, refe
             .expect("String ID should exist")
             .to_string();
         CString::new(name_string).unwrap().into_raw().cast_const()
+    })
+}
+
+/// Returns the constant path as it appeared in source for a constant reference id, or NULL if the reference cannot be
+/// found. Caller must free with `free_c_string`.
+///
+/// # Safety
+///
+/// Assumes pointer is valid.
+///
+/// # Panics
+///
+/// This function will panic if the reference's name cannot be reconstructed or contains an interior null byte.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rdx_constant_reference_raw_name(pointer: GraphPointer, reference_id: u64) -> *const c_char {
+    with_graph(pointer, |graph| {
+        let ref_id = ConstantReferenceId::new(reference_id);
+        let Some(reference) = graph.constant_references().get(&ref_id) else {
+            return ptr::null();
+        };
+
+        CString::new(raw_name_for_name_id(graph, *reference.name_id()))
+            .unwrap()
+            .into_raw()
+            .cast_const()
     })
 }
 

--- a/test/definition_test.rb
+++ b/test/definition_test.rb
@@ -808,6 +808,47 @@ class DefinitionTest < Minitest::Test
     end
   end
 
+  def test_definition_constant_path
+    with_context do |context|
+      context.write!("file1.rb", <<~RUBY)
+        module Foo
+          class Bar; end
+          class ::Rooted; end
+          module Baz::Qux; end
+          CONST = 1
+          ALIAS_CONST = Bar
+
+          def foo; end
+        end
+      RUBY
+
+      graph = Rubydex::Graph.new
+      graph.index_all(context.glob("**/*.rb"))
+      graph.resolve
+
+      definitions = graph.documents.find { |document| document.uri == context.uri_to("file1.rb") }.definitions.to_a
+      paths = definitions
+        .select { |definition| definition.is_a?(Rubydex::ConstantHelper) }
+        .to_h { |definition| [[definition.class, definition.name], definition.constant_path] }
+
+      assert_equal("Foo", paths.fetch([Rubydex::ModuleDefinition, "Foo"]).raw_name)
+      assert_equal("Bar", paths.fetch([Rubydex::ClassDefinition, "Bar"]).raw_name)
+      assert_equal("::Rooted", paths.fetch([Rubydex::ClassDefinition, "Rooted"]).raw_name)
+      assert_equal("Baz::Qux", paths.fetch([Rubydex::ModuleDefinition, "Qux"]).raw_name)
+      assert_equal("CONST", paths.fetch([Rubydex::ConstantDefinition, "CONST"]).raw_name)
+      assert_equal("ALIAS_CONST", paths.fetch([Rubydex::ConstantAliasDefinition, "ALIAS_CONST"]).raw_name)
+
+      paths.each_value do |constant_path|
+        assert_kind_of(Rubydex::ConstantReference, constant_path)
+        assert_equal(context.uri_to("file1.rb"), constant_path.document.uri)
+        assert_equal(context.uri_to("file1.rb"), constant_path.location.uri)
+      end
+
+      method_definition = definitions.find { |definition| definition.is_a?(Rubydex::MethodDefinition) }
+      refute_kind_of(Rubydex::ConstantHelper, method_definition)
+    end
+  end
+
   def test_definition_declaration
     with_context do |context|
       context.write!("file1.rb", <<~RUBY)

--- a/test/graph_test.rb
+++ b/test/graph_test.rb
@@ -387,6 +387,37 @@ class GraphTest < Minitest::Test
     end
   end
 
+  def test_graph_resolve_constant_with_definition_lexical_nesting
+    with_context do |context|
+      context.write!("foo.rb", <<~RUBY)
+        class Bar
+          class Baz; end
+        end
+
+        class Foo
+          class Baz; end
+
+          class ::Bar
+            def target; end
+          end
+        end
+      RUBY
+
+      graph = Rubydex::Graph.new
+      graph.index_all(context.glob("**/*.rb"))
+      graph.resolve
+
+      definitions = graph.documents.find { |document| document.uri == context.uri_to("foo.rb") }.definitions
+      target_definition = definitions.find do |definition|
+        definition.is_a?(Rubydex::MethodDefinition) && definition.name == "target()"
+      end
+
+      declaration = graph.resolve_constant("Baz", target_definition.lexical_nesting)
+
+      assert_equal("Bar::Baz", declaration.name)
+    end
+  end
+
   def test_graph_resolve_with_invalid_argument
     graph = Rubydex::Graph.new
 

--- a/test/references_test.rb
+++ b/test/references_test.rb
@@ -6,6 +6,37 @@ require "helpers/context"
 class ReferencesTest < Minitest::Test
   include Test::Helpers::WithContext
 
+  def test_constant_reference_raw_name
+    with_context do |context|
+      context.write!("file1.rb", <<~RUBY)
+        module Foo
+          class Bar; end
+        end
+
+        Foo::Bar
+        ::Foo::Bar
+        Unknown::Thing
+      RUBY
+
+      graph = Rubydex::Graph.new
+      graph.index_all(context.glob("**/*.rb"))
+      graph.resolve
+
+      file_uri = context.uri_to("file1.rb")
+      references = graph.constant_references.select { |reference| reference.location.uri == file_uri }.to_h do |reference|
+        [reference.location.to_display.to_s, reference]
+      end
+      path = context.absolute_path_to("file1.rb")
+
+      assert_equal("Foo", references.fetch("#{path}:5:1-5:4").raw_name)
+      assert_equal("Foo::Bar", references.fetch("#{path}:5:6-5:9").raw_name)
+      assert_equal("::Foo", references.fetch("#{path}:6:3-6:6").raw_name)
+      assert_equal("::Foo::Bar", references.fetch("#{path}:6:8-6:11").raw_name)
+      assert_equal("Unknown", references.fetch("#{path}:7:1-7:8").raw_name)
+      assert_equal("Unknown::Thing", references.fetch("#{path}:7:10-7:15").raw_name)
+    end
+  end
+
   def test_graph_constant_references_enumerator
     with_context do |context|
       context.write!("file1.rb", <<~RUBY)


### PR DESCRIPTION
`Definition#lexical_nesting` returns definitions, while `Graph#resolve_constant` previously accepted only strings. Mapping those frames through `Definition#name` loses source qualification such as `::Bar`, so the resulting nesting can resolve against the wrong namespace.

Add `ConstantHelper#constant_path` and `ConstantReference#raw_name` to preserve the source-level path for class, module, constant, and constant alias definitions. `Graph#resolve_constant` now accepts a definition lexical nesting directly while preserving existing `Array[String]` calls.

Fixes #1912.