### PR TITLE
Filter built-in and linter diagnostics uniformly

### DIFF
--- a/lib/rubydex/linter/helpers/path_helpers.rb
+++ b/lib/rubydex/linter/helpers/path_helpers.rb
@@ -8,8 +8,7 @@ module Rubydex
     module Helpers
       # @requires_ancestor: Rubydex::Linter::CustomRule
       module PathHelpers
-        RUBOCOP_EXCLUDE_FNMATCH_FLAGS =
-          File::FNM_PATHNAME | File::FNM_EXTGLOB | File::FNM_DOTMATCH #: Integer
+        EXCLUDE_FNMATCH_FLAGS = File::FNM_PATHNAME | File::FNM_EXTGLOB | File::FNM_DOTMATCH #: Integer
         TEST_PATHS = ["test/**", "**/test/**", "**/*_test.rb"].freeze
 
         class << self

--- a/lib/rubydex/linter/runner.rb
+++ b/lib/rubydex/linter/runner.rb
@@ -16,60 +16,40 @@ module Rubydex
         @graph = graph
         @config = config
         @custom_rules = custom_rules.select { |rule| config.rule_enabled?(rule) }.sort_by(&:rule_name)
-        @dependency_paths = Gem.path #: Array[String]
+        @dependency_patterns = Gem.path.map { |path| "#{path}/**/*" } #: Array[String]
       end
 
       #: () -> Array[Diagnostic]
       def run
-        rule_diagnostics = @custom_rules.flat_map do |rule_class|
+        diagnostics = @graph.diagnostics
+
+        @custom_rules.each do |rule_class|
           rule = rule_class.new(@graph, config: @config)
           rule.lint
-          filter_diagnostics(rule.diagnostics, @config.excludes_for(rule_class))
+          diagnostics.concat(rule.diagnostics)
         end
 
-        graph_diagnostics = filter_diagnostics(@graph.diagnostics, [])
-        (graph_diagnostics + rule_diagnostics).select do |diagnostic|
-          diagnostic_in_workspace?(diagnostic)
-        end
-      end
+        # Make sure we have the forward/back slash at the end to avoid accidentally matching sibling directories that
+        # share a prefix.
+        workspace_path = File.join(@graph.workspace_path, "")
 
-      private
+        # Filter out diagnostics that are excluded, inside dependencies or otherwise not a part of the workspace.
+        diagnostics.select! do |diagnostic|
+          rule = diagnostic.rule
+          next false unless @config.rule_enabled?(rule)
 
-      #: (Array[Diagnostic], Array[String]) -> Array[Diagnostic]
-      def filter_diagnostics(diagnostics, exclude_patterns)
-        diagnostics.reject do |diagnostic|
-          location_excluded?(diagnostic.location, exclude_patterns)
-        end
-      end
+          excluded_patterns = @config.excludes_for(rule).map { |pattern| "#{workspace_path}#{pattern}" }
+          excluded_patterns.concat(@dependency_patterns)
 
-      #: (Location, Array[String]) -> bool
-      def location_excluded?(location, patterns)
-        path = location.to_file_path
-        return true if @dependency_paths.any? do |dependency_path|
-          path == dependency_path || path.start_with?("#{dependency_path}/")
+          path = diagnostic.location.to_file_path
+
+          path.start_with?(workspace_path) &&
+            excluded_patterns.none? { |p| File.fnmatch?(p, path, Helpers::PathHelpers::EXCLUDE_FNMATCH_FLAGS) }
+        rescue Location::NotFileUriError
+          true
         end
 
-        Helpers::PathHelpers.path_matches_patterns?(
-          path,
-          patterns,
-          workspace: @graph.workspace_path,
-          flags: Helpers::PathHelpers::RUBOCOP_EXCLUDE_FNMATCH_FLAGS,
-        )
-      rescue Location::NotFileUriError
-        false
-      end
-
-      #: (Diagnostic) -> bool
-      def diagnostic_in_workspace?(diagnostic)
-        path = diagnostic.location.to_file_path
-        workspace_path = Pathname.new(File.expand_path(@graph.workspace_path))
-        relative_path = Pathname.new(File.expand_path(path)).relative_path_from(workspace_path)
-
-        relative_path.each_filename.first != ".."
-      rescue Location::NotFileUriError
-        true
-      rescue ArgumentError
-        false
+        diagnostics
       end
     end
   end

--- a/lib/rubydex_linter/rules/rule_structure.rb
+++ b/lib/rubydex_linter/rules/rule_structure.rb
@@ -116,7 +116,7 @@ module Rubydex
             path,
             patterns,
             workspace: graph.workspace_path,
-            flags: Helpers::PathHelpers::RUBOCOP_EXCLUDE_FNMATCH_FLAGS,
+            flags: Helpers::PathHelpers::EXCLUDE_FNMATCH_FLAGS,
           )
         end
       end

--- a/rbi/rubydex.rbi
+++ b/rbi/rubydex.rbi
@@ -455,7 +455,7 @@ module Rubydex::Linter::Helpers::PathHelpers
 
   requires_ancestor { Rubydex::Linter::CustomRule }
 
-  RUBOCOP_EXCLUDE_FNMATCH_FLAGS = T.let(T.unsafe(nil), Integer)
+  EXCLUDE_FNMATCH_FLAGS = T.let(T.unsafe(nil), Integer)
   TEST_PATHS = T.let(T.unsafe(nil), T::Array[String])
 
   sig do

--- a/test/rubydex_linter/runner_test.rb
+++ b/test/rubydex_linter/runner_test.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "helpers/context"
+require "rubydex/linter"
+
+module Rubydex
+  module Linter
+    class RunnerTest < Minitest::Test
+      include Test::Helpers::WithContext
+
+      def test_built_in_diagnostics_can_be_filtered_through_config
+        with_context do |context|
+          context.write!("rubydex.toml", <<~TOML)
+            [linter.rules.ParseError]
+            exclude = ["**/foo.rb"]
+          TOML
+          graph = index(context)
+
+          config = Config.load(context.absolute_path)
+          diagnostics = Runner.new(graph, custom_rules: [], config: config.linter).run
+          assert_empty(diagnostics)
+        end
+      end
+
+      def test_built_in_diagnostics_can_be_disabled
+        with_context do |context|
+          context.write!("rubydex.toml", <<~TOML)
+            [linter.rules.ParseError]
+            enabled = false
+          TOML
+          graph = index(context)
+
+          config = Config.load(context.absolute_path)
+          diagnostics = Runner.new(graph, custom_rules: [], config: config.linter).run
+          assert_empty(diagnostics)
+        end
+      end
+
+      def test_changing_severity_of_built_in_diagnostics
+        with_context do |context|
+          context.write!("rubydex.toml", <<~TOML)
+            [linter.rules.ParseError]
+            severity = "hint"
+          TOML
+          graph = index(context)
+          config = Config.load(context.absolute_path)
+
+          diagnostics = Runner.new(graph, custom_rules: [], config: config.linter).run
+          rules = diagnostics.map(&:rule).uniq
+          assert_equal([Severity::Hint], rules.map { |rule| rule.severity(config.linter) })
+        end
+      end
+
+      private
+
+      #: (Test::Helpers::Context) -> Graph
+      def index(context)
+        graph = Graph.configure_for_workspace(context.absolute_path)
+
+        context.write!("foo.rb", "module Foo")
+        graph.index_all([context.absolute_path_to("foo.rb")])
+        graph.resolve
+        graph
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes #1000

This PR unifies the diagnostic filtering, so that built-in (graph) and linter diagnostics are treated consistently.

I also noticed that we were filtering based on path exclusions/inclusions separately 3 times, so I simplified the code to do it within the same loop, which is a bit easier to follow.

Lastly, I also renamed the glob flags constant. Not sure why we had a `RUBOCOP` prefix, but we can probably remove it.