### PR TITLE
Enforce that linter rules must be documented

### DIFF
--- a/lib/rubydex_linter/rules/rule_structure.rb
+++ b/lib/rubydex_linter/rules/rule_structure.rb
@@ -37,6 +37,8 @@ module Rubydex
           rule_definitions_by_file = {} #: Hash[String, Hash[Rubydex::Class, Definition]]
 
           rules.each do |rule|
+            rule_docs = []
+
             rule.definitions.each do |rule_definition|
               uri = rule_definition.document.uri
               path = path_for_uri(uri)
@@ -48,6 +50,8 @@ module Rubydex
               elsif !test_file?(path)
                 report_wrong_rule_directory(rule.name, rule_definition)
               end
+
+              rule_docs.concat(rule_definition.comments)
             end
 
             rule_definition = rule.definitions.find do |definition|
@@ -55,9 +59,19 @@ module Rubydex
               path_in_workspace?(path) && (rule_file?(path) || !test_file?(path))
             end
             next unless rule_definition
-            next if rule.name.start_with?("#{RULE_NAMESPACE}::")
 
-            report_wrong_rule_namespace(rule.name, rule_definition)
+            rule_name = rule.name
+
+            if rule_docs.empty?
+              add_diagnostic(
+                "`#{rule_name}` is missing documentation.",
+                diagnostic_location(rule_definition),
+              )
+            end
+
+            next if rule_name.start_with?("#{RULE_NAMESPACE}::")
+
+            report_wrong_rule_namespace(rule_name, rule_definition)
           end
 
           rule_definitions_by_file.each do |uri, rule_definitions|

--- a/test/rubydex_linter/rules/rule_structure_test.rb
+++ b/test/rubydex_linter/rules/rule_structure_test.rb
@@ -34,6 +34,8 @@ module Rubydex
             "rubydex_linter/rules/base_rule.rb" => rule_source("BaseRule"),
             "rubydex_linter/rules/indirect_rule.rb" => <<~RUBY,
               class Rubydex::Linter::Rules::Helper; end
+
+              # Documents the IndirectRule rule.
               class Rubydex::Linter::Rules::IndirectRule < Rubydex::Linter::Rules::BaseRule; end
             RUBY
           )
@@ -46,6 +48,8 @@ module Rubydex
               class Rubydex::Linter::Rules::FirstRule; end
               ^{} Each rule file must define only one linter rule; found 2.
                                             ^^^^^^^^^ `Rubydex::Linter::Rules::FirstRule` is defined here.
+
+              # Documents the SecondRule rule.
               class Rubydex::Linter::Rules::SecondRule < Rubydex::Linter::CustomRule; end
                                             ^^^^^^^^^^ `Rubydex::Linter::Rules::SecondRule` is defined here.
             RUBY
@@ -65,6 +69,7 @@ module Rubydex
           assert_diagnostics(
             "rubydex_linter/rules/wrong_namespace.rb" => <<~RUBY,
               module ConsumerRules
+                # Documents the WrongNamespace rule.
                 class WrongNamespace < Rubydex::Linter::CustomRule; end
                       ^^^^^^^^^^^^^^ `ConsumerRules::WrongNamespace` must be defined under `Rubydex::Linter::Rules`.
               end
@@ -75,8 +80,18 @@ module Rubydex
         def test_reports_a_rule_class_outside_a_rule_directory
           assert_diagnostics(
             "app/rules/wrong_place.rb" => <<~RUBY,
+              # Documents the WrongPlace rule.
               class Rubydex::Linter::Rules::WrongPlace < Rubydex::Linter::CustomRule; end
                                             ^^^^^^^^^^ `Rubydex::Linter::Rules::WrongPlace` must be defined under `rubydex_linter/rules/` or `lib/rubydex_linter/rules/`.
+            RUBY
+          )
+        end
+
+        def test_reports_an_undocumented_rule_class
+          assert_diagnostics(
+            "rubydex_linter/rules/undocumented_rule.rb" => <<~RUBY,
+              class Rubydex::Linter::Rules::UndocumentedRule < Rubydex::Linter::CustomRule; end
+                                            ^^^^^^^^^^^^^^^^ `Rubydex::Linter::Rules::UndocumentedRule` is missing documentation.
             RUBY
           )
         end
@@ -95,7 +110,10 @@ module Rubydex
 
         #: (String) -> String
         def rule_source(class_name)
-          "class Rubydex::Linter::Rules::#{class_name} < Rubydex::Linter::CustomRule; end\n"
+          <<~RUBY
+            # Documents the #{class_name} rule.
+            class Rubydex::Linter::Rules::#{class_name} < Rubydex::Linter::CustomRule; end
+          RUBY
         end
       end
     end


### PR DESCRIPTION
I propose that we enforce custom rules are always documented. It's helpful for maintainers to know what the rule is intended for and powers the explain command.

This PR adds a check if any of the definitions includes comments and then adds a violation if the rule is undocumented.