### PR TITLE
Recognize linter rules in nested gems

### DIFF
--- a/lib/rubydex_linter/rules/rule_structure.rb
+++ b/lib/rubydex_linter/rules/rule_structure.rb
@@ -19,7 +19,6 @@ module Rubydex
         RULE_NAMESPACE = "Rubydex::Linter::Rules" #: String
         RULE_FILE_PATTERNS = [
           "rubydex_linter/rules/**/*.rb",
-          "lib/rubydex_linter/rules/**/*.rb",
           "**/lib/rubydex_linter/rules/**/*.rb",
         ].freeze #: Array[String]
         TEST_FILE_PATTERNS = ["test/**/*", "**/test/**/*"].freeze #: Array[String]

--- a/lib/rubydex_linter/rules/rule_structure.rb
+++ b/lib/rubydex_linter/rules/rule_structure.rb
@@ -9,7 +9,8 @@ module Rubydex
       # - Each rule subclass outside a test directory is in a rule directory.
       # - Each checked rule subclass is in the `Rubydex::Linter::Rules` namespace.
       #
-      # The rule directories are `rubydex_linter/rules/` and `lib/rubydex_linter/rules/`.
+      # The rule directories are `rubydex_linter/rules/` and `lib/rubydex_linter/rules/`, including
+      # `lib/rubydex_linter/rules/` directories in nested gems.
       # This rule does not report files in those directories that define no rule subclass.
       class RuleStructure < CustomRule
         include Helpers::SourceAccessHelpers
@@ -19,6 +20,7 @@ module Rubydex
         RULE_FILE_PATTERNS = [
           "rubydex_linter/rules/**/*.rb",
           "lib/rubydex_linter/rules/**/*.rb",
+          "**/lib/rubydex_linter/rules/**/*.rb",
         ].freeze #: Array[String]
         TEST_FILE_PATTERNS = ["test/**/*", "**/test/**/*"].freeze #: Array[String]
 

--- a/test/rubydex_linter/rules/rule_structure_test.rb
+++ b/test/rubydex_linter/rules/rule_structure_test.rb
@@ -29,6 +29,12 @@ module Rubydex
           )
         end
 
+        def test_allows_rule_classes_in_nested_gem_rule_directories
+          assert_no_diagnostics(
+            "gems/example/lib/rubydex_linter/rules/nested_gem_rule.rb" => rule_source("NestedGemRule"),
+          )
+        end
+
         def test_allows_indirect_rule_subclasses_and_helper_classes
           assert_no_diagnostics(
             "rubydex_linter/rules/base_rule.rb" => rule_source("BaseRule"),


### PR DESCRIPTION
`RuleLoader` can discover rules under the `lib` directory of a nested gem, but `RuleStructure` accepts that directory only at the workspace root. This change accepts `lib/rubydex_linter/rules/**/*.rb` at any depth in the workspace, so in-repo gems no longer need a `RuleStructure` exclusion.