### PR TITLE
Accept definitions as constant resolution contexts

### DIFF
--- a/ext/rubydex/definition.c
+++ b/ext/rubydex/definition.c
@@ -38,6 +38,17 @@ VALUE cClassVariableDefinition;
 VALUE cMethodAliasDefinition;
 VALUE cGlobalVariableAliasDefinition;
 
+uint64_t rdxi_definition_id_for_graph(VALUE definition, VALUE graph_obj) {
+    HandleData *data;
+    TypedData_Get_Struct(definition, HandleData, &handle_type, data);
+
+    if (data->graph_obj != graph_obj) {
+        rb_raise(rb_eArgError, "definition must belong to this graph");
+    }
+
+    return data->id;
+}
+
 // Keep this in sync with definition.rs
 VALUE rdxi_definition_class_for_kind(DefinitionKind kind) {
     switch (kind) {

--- a/ext/rubydex/definition.h
+++ b/ext/rubydex/definition.h
@@ -22,6 +22,9 @@ extern VALUE cGlobalVariableAliasDefinition;
 
 void rdxi_initialize_definition(VALUE mRubydex);
 
+// Returns the definition ID after verifying that the definition belongs to `graph_obj`.
+uint64_t rdxi_definition_id_for_graph(VALUE definition, VALUE graph_obj);
+
 // Returns the Ruby class for a given DefinitionKind without calling back into Rust
 VALUE rdxi_definition_class_for_kind(DefinitionKind kind);
 

--- a/ext/rubydex/graph.c
+++ b/ext/rubydex/graph.c
@@ -1,6 +1,7 @@
 #include "graph.h"
 #include "config.h"
 #include "declaration.h"
+#include "definition.h"
 #include "diagnostic.h"
 #include "document.h"
 #include "location.h"
@@ -510,26 +511,48 @@ static VALUE rdxr_graph_set_encoding(VALUE self, VALUE encoding) {
 
 /*
  * call-seq:
- *   resolve_constant(name, nesting) -> Rubydex::Declaration?
+ *   resolve_constant(name, context) -> Rubydex::Declaration?
  *
- * Runs the resolver on a single constant reference to determine what it points to.
+ * Runs the resolver on a single constant reference using an array of nesting names or a namespace definition as its
+ * context.
  */
-static VALUE rdxr_graph_resolve_constant(VALUE self, VALUE const_name, VALUE nesting) {
+static VALUE rdxr_graph_resolve_constant(VALUE self, VALUE const_name, VALUE context) {
     Check_Type(const_name, T_STRING);
-    rdxi_check_array_of_strings(nesting);
     const char *const_name_string = StringValueCStr(const_name);
-
-    // Convert the given file paths into a char** array, so that we can pass to Rust
-    size_t length = RARRAY_LEN(nesting);
-    char **converted_file_paths = rdxi_str_array_to_char(nesting, length);
 
     void *graph;
     TypedData_Get_Struct(self, void *, &graph_type, graph);
 
-    const CDeclaration *decl =
-        rdx_graph_resolve_constant(graph, const_name_string, (const char **)converted_file_paths, length);
+    const CDeclaration *decl;
+    if (RB_TYPE_P(context, T_ARRAY)) {
+        rdxi_check_array_of_strings(context);
 
-    rdxi_free_str_array(converted_file_paths, length);
+        size_t length = RARRAY_LEN(context);
+        char **converted_names = rdxi_str_array_to_char(context, length);
+        decl = rdx_graph_resolve_constant(graph, const_name_string, (const char **)converted_names, length);
+        rdxi_free_str_array(converted_names, length);
+    } else if (rb_obj_is_kind_of(context, cClassDefinition) ||
+               rb_obj_is_kind_of(context, cSingletonClassDefinition) ||
+               rb_obj_is_kind_of(context, cModuleDefinition)) {
+        uint64_t definition_id = rdxi_definition_id_for_graph(context, self);
+        CDefinitionConstantResolutionResult result =
+            rdx_graph_resolve_constant_from_definition(graph, const_name_string, definition_id);
+
+        if (result.status == CDefinitionConstantResolution_DefinitionNotFound) {
+            rb_raise(rb_eRuntimeError, "Definition not found");
+        }
+        if (result.status == CDefinitionConstantResolution_InvalidDefinitionKind) {
+            // This is unreachable because the rb_obj_is_kind_of checks above only accept supported definition kinds.
+            rb_raise(rb_eRuntimeError, "Unexpected definition kind");
+        }
+
+        decl = result.declaration;
+    } else {
+        rb_raise(
+            rb_eTypeError,
+            "context must be an Array of Strings, ClassDefinition, SingletonClassDefinition, or ModuleDefinition"
+        );
+    }
 
     if (decl == NULL) {
         return Qnil;

--- a/rbi/rubydex.rbi
+++ b/rbi/rubydex.rbi
@@ -906,8 +906,18 @@ class Rubydex::Graph
   sig { returns(T.self_type) }
   def resolve; end
 
-  sig { params(name: String, nesting: T::Array[String]).returns(T.nilable(Rubydex::Declaration)) }
-  def resolve_constant(name, nesting); end
+  sig do
+    params(
+      name: String,
+      context: T.any(
+        T::Array[String],
+        Rubydex::ClassDefinition,
+        Rubydex::SingletonClassDefinition,
+        Rubydex::ModuleDefinition,
+      ),
+    ).returns(T.nilable(Rubydex::Declaration))
+  end
+  def resolve_constant(name, context); end
 
   sig { params(require_path: String, load_paths: T::Array[String]).returns(T.nilable(Rubydex::Document)) }
   def resolve_require_path(require_path, load_paths); end

--- a/rust/rubydex-sys/src/graph_api.rs
+++ b/rust/rubydex-sys/src/graph_api.rs
@@ -10,9 +10,10 @@ use crate::{name_api, utils};
 use libc::{c_char, c_void};
 use rubydex::config::Config;
 use rubydex::indexing::LanguageId;
+use rubydex::model::definitions::Definition;
 use rubydex::model::encoding::Encoding;
 use rubydex::model::graph::Graph;
-use rubydex::model::ids::{DeclarationId, NameId, UriId, declaration_id_from_lookup_name};
+use rubydex::model::ids::{DeclarationId, DefinitionId, NameId, UriId, declaration_id_from_lookup_name};
 use rubydex::model::keywords;
 use rubydex::model::name::NameRef;
 use rubydex::model::visibility::Visibility;
@@ -176,22 +177,101 @@ pub unsafe extern "C" fn rdx_graph_resolve_constant(
             return ptr::null();
         };
 
-        let mut resolver = Resolver::new(graph);
+        resolve_constant_name(graph, name_id, names_to_untrack)
+    })
+}
 
-        let declaration = match resolver.resolve_constant(name_id) {
-            Some(id) => {
-                let decl = graph.declarations().get(&id).unwrap();
-                Box::into_raw(Box::new(CDeclaration::from_declaration(id, decl))).cast_const()
+/// Result of resolving a constant using a namespace definition as its lexical context.
+#[repr(u8)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CDefinitionConstantResolution {
+    Resolved = 0,
+    NotFound = 1,
+    DefinitionNotFound = 2,
+    InvalidDefinitionKind = 3,
+}
+
+#[repr(C)]
+#[derive(Debug)]
+pub struct CDefinitionConstantResolutionResult {
+    pub status: CDefinitionConstantResolution,
+    pub declaration: *const CDeclaration,
+}
+
+/// Resolves a constant using a namespace definition as its lexical context.
+///
+/// # Panics
+///
+/// Panics if `const_name` cannot be converted to a string.
+///
+/// # Safety
+///
+/// Assumes that `pointer` and `const_name` are valid.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rdx_graph_resolve_constant_from_definition(
+    pointer: GraphPointer,
+    const_name: *const c_char,
+    definition_id: u64,
+) -> CDefinitionConstantResolutionResult {
+    with_mut_graph(pointer, |graph| {
+        let const_name: String = unsafe { utils::convert_char_ptr_to_string(const_name).unwrap() };
+        let nesting = match class_or_module_definition_name_id(graph, DefinitionId::new(definition_id)) {
+            Ok(nesting) => nesting,
+            Err(status) => {
+                return CDefinitionConstantResolutionResult {
+                    status,
+                    declaration: ptr::null(),
+                };
             }
-            None => ptr::null(),
         };
 
-        for name_id in names_to_untrack {
-            graph.untrack_name(name_id);
-        }
+        let Some((name_id, names_to_untrack)) = name_api::name_in_nesting_to_name_id(graph, &const_name, Some(nesting))
+        else {
+            return CDefinitionConstantResolutionResult {
+                status: CDefinitionConstantResolution::NotFound,
+                declaration: ptr::null(),
+            };
+        };
 
-        declaration
+        let declaration = resolve_constant_name(graph, name_id, names_to_untrack);
+        let status = if declaration.is_null() {
+            CDefinitionConstantResolution::NotFound
+        } else {
+            CDefinitionConstantResolution::Resolved
+        };
+
+        CDefinitionConstantResolutionResult { status, declaration }
     })
+}
+
+fn class_or_module_definition_name_id(
+    graph: &Graph,
+    definition_id: DefinitionId,
+) -> Result<NameId, CDefinitionConstantResolution> {
+    let Some(definition) = graph.definitions().get(&definition_id) else {
+        return Err(CDefinitionConstantResolution::DefinitionNotFound);
+    };
+
+    match definition {
+        Definition::Class(definition) => Ok(*definition.name_id()),
+        Definition::SingletonClass(definition) => Ok(*definition.name_id()),
+        Definition::Module(definition) => Ok(*definition.name_id()),
+        _ => Err(CDefinitionConstantResolution::InvalidDefinitionKind),
+    }
+}
+
+fn resolve_constant_name(graph: &mut Graph, name_id: NameId, names_to_untrack: Vec<NameId>) -> *const CDeclaration {
+    let declaration_id = Resolver::new(graph).resolve_constant(name_id);
+    let declaration = declaration_id.map_or(ptr::null(), |id| {
+        let declaration = graph.declarations().get(&id).unwrap();
+        Box::into_raw(Box::new(CDeclaration::from_declaration(id, declaration))).cast_const()
+    });
+
+    for name_id in names_to_untrack {
+        graph.untrack_name(name_id);
+    }
+
+    declaration
 }
 
 /// Adds glob patterns to exclude from file discovery during indexing.

--- a/rust/rubydex-sys/src/name_api.rs
+++ b/rust/rubydex-sys/src/name_api.rs
@@ -27,6 +27,33 @@ pub fn nesting_stack_to_name_id(
     );
 
     let (ParentScope::Some(name_id) | ParentScope::Attached(name_id)) = current_name else {
+        // Invalid names may leave temporary parts in the graph (e.g. `Foo` from `Foo::`).
+        for name_id in names_to_untrack {
+            graph.untrack_name(name_id);
+        }
+        return None;
+    };
+
+    Some((name_id, names_to_untrack))
+}
+
+/// Takes a constant name and an existing lexical nesting and transforms it into a `NameId`, registering each required
+/// part in the graph. Returns the `NameId` and a list of name ids that need to be untracked afterwards.
+pub fn name_in_nesting_to_name_id(
+    graph: &mut Graph,
+    const_name: &str,
+    nesting: Option<NameId>,
+) -> Option<(NameId, Vec<NameId>)> {
+    let mut current_name = ParentScope::None;
+    let mut names_to_untrack = Vec::new();
+
+    process_qualified_name(graph, const_name, nesting, &mut current_name, &mut names_to_untrack);
+
+    let (ParentScope::Some(name_id) | ParentScope::Attached(name_id)) = current_name else {
+        // Invalid names may leave temporary parts in the graph (e.g. `Foo` from `Foo::`).
+        for name_id in names_to_untrack {
+            graph.untrack_name(name_id);
+        }
         return None;
     };
 
@@ -175,5 +202,20 @@ mod tests {
         assert_eq!(StringId::from("Foo"), *foo_name.str());
         assert!(foo_name.parent_scope().is_none());
         assert!(foo_name.nesting().is_none());
+    }
+
+    #[test]
+    fn invalid_names_are_untracked() {
+        let mut graph = Graph::new();
+        let name_count = graph.names().len();
+        let string_count = graph.strings().len();
+
+        assert!(nesting_stack_to_name_id(&mut graph, "Foo::", vec!["Bar".into()]).is_none());
+        assert_eq!(name_count, graph.names().len());
+        assert_eq!(string_count, graph.strings().len());
+
+        assert!(name_in_nesting_to_name_id(&mut graph, "Foo::", None).is_none());
+        assert_eq!(name_count, graph.names().len());
+        assert_eq!(string_count, graph.strings().len());
     }
 }

--- a/rust/rubydex-sys/src/name_api.rs
+++ b/rust/rubydex-sys/src/name_api.rs
@@ -13,13 +13,7 @@ pub fn nesting_stack_to_name_id(
     let mut names_to_untrack = Vec::new();
 
     for entry in nesting {
-        process_qualified_name(
-            graph,
-            &entry,
-            &mut current_name,
-            &mut current_nesting,
-            &mut names_to_untrack,
-        );
+        process_qualified_name(graph, &entry, current_nesting, &mut current_name, &mut names_to_untrack);
         current_nesting = current_name.as_ref().copied();
         current_name = ParentScope::None;
     }
@@ -27,8 +21,8 @@ pub fn nesting_stack_to_name_id(
     process_qualified_name(
         graph,
         const_name,
+        current_nesting,
         &mut current_name,
-        &mut current_nesting,
         &mut names_to_untrack,
     );
 
@@ -47,8 +41,8 @@ pub fn nesting_stack_to_name_id(
 fn process_qualified_name(
     graph: &mut Graph,
     qualified_name: &str,
+    current_nesting: Option<NameId>,
     current_name: &mut ParentScope,
-    current_nesting: &mut Option<NameId>,
     names_to_untrack: &mut Vec<NameId>,
 ) {
     for part in qualified_name.split("::") {
@@ -60,13 +54,13 @@ fn process_qualified_name(
         let (parent_scope, nesting_for_part) = if part.starts_with('<') {
             let attached_id = match *current_name {
                 ParentScope::Some(id) | ParentScope::Attached(id) => Some(id),
-                _ => *current_nesting,
+                _ => current_nesting,
             };
 
             let attached = attached_id.map_or(ParentScope::None, ParentScope::Attached);
             (attached, attached_id)
         } else {
-            (*current_name, *current_nesting)
+            (*current_name, current_nesting)
         };
 
         let str_id = graph.intern_string(part.to_owned());

--- a/test/graph_test.rb
+++ b/test/graph_test.rb
@@ -401,6 +401,121 @@ class GraphTest < Minitest::Test
     end
   end
 
+  def test_graph_resolve_constant_with_definition_context
+    with_context do |context|
+      context.write!("foo.rb", <<~RUBY)
+        module Foo
+          OUTER_CONST = 1
+
+          class Bar
+            INNER_CONST = 2
+
+            class << self
+              SINGLETON_CONST = 3
+            end
+            def target; end
+          end
+        end
+      RUBY
+
+      graph = Rubydex::Graph.new
+      graph.index_all(context.glob("**/*.rb"))
+      graph.resolve
+
+      definitions = graph.document(context.uri_to("foo.rb")).definitions
+      foo_definition = definitions.find do |definition|
+        definition.is_a?(Rubydex::ModuleDefinition) && definition.name == "Foo"
+      end
+      bar_definition = definitions.find do |definition|
+        definition.is_a?(Rubydex::ClassDefinition) && definition.name == "Bar"
+      end
+      method_definition = definitions.find do |definition|
+        definition.is_a?(Rubydex::MethodDefinition) && definition.name == "target()"
+      end
+      singleton_definition = definitions.find do |definition|
+        definition.is_a?(Rubydex::SingletonClassDefinition)
+      end
+
+      assert_equal("Foo::OUTER_CONST", graph.resolve_constant("OUTER_CONST", foo_definition).name)
+      assert_equal("Foo::Bar::INNER_CONST", graph.resolve_constant("INNER_CONST", bar_definition).name)
+      assert_equal("Foo::OUTER_CONST", graph.resolve_constant("OUTER_CONST", bar_definition).name)
+      assert_equal("Foo::Bar::<Bar>::SINGLETON_CONST", graph.resolve_constant("SINGLETON_CONST", singleton_definition).name)
+      assert_equal("Foo::Bar::INNER_CONST", graph.resolve_constant("INNER_CONST", singleton_definition).name)
+      assert_raises(TypeError) do
+        graph.resolve_constant("INNER_CONST", method_definition)
+      end
+    end
+  end
+
+  def test_graph_resolve_constant_with_external_singleton_definition_context
+    with_context do |context|
+      context.write!("foo.rb", <<~RUBY)
+        class Foo; end
+
+        class Bar
+          OUTER_CONST = 1
+
+          class << Foo
+            SINGLETON_CONST = 2
+          end
+        end
+      RUBY
+
+      graph = Rubydex::Graph.new
+      graph.index_all(context.glob("**/*.rb"))
+      graph.resolve
+
+      singleton_definition = graph.document(context.uri_to("foo.rb")).definitions.find do |definition|
+        definition.is_a?(Rubydex::SingletonClassDefinition)
+      end
+
+      assert_equal("Foo::<Foo>::SINGLETON_CONST", graph.resolve_constant("SINGLETON_CONST", singleton_definition).name)
+      assert_equal("Bar::OUTER_CONST", graph.resolve_constant("OUTER_CONST", singleton_definition).name)
+    end
+  end
+
+  def test_graph_resolve_constant_with_deleted_definition_context
+    graph = Rubydex::Graph.new
+    graph.index_source("file:///foo.rb", "class Foo; end", "ruby")
+    graph.resolve
+    definition = graph.document("file:///foo.rb").definitions.first
+
+    graph.delete_document("file:///foo.rb")
+
+    error = assert_raises(RuntimeError) do
+      graph.resolve_constant("CONST", definition)
+    end
+    assert_equal("Definition not found", error.message)
+  end
+
+  def test_graph_resolve_constant_with_rooted_definition_context
+    with_context do |context|
+      context.write!("foo.rb", <<~RUBY)
+        class Bar
+          class Baz; end
+        end
+
+        module Foo
+          OUTER_CONST = 1
+
+          class ::Bar; end
+        end
+      RUBY
+
+      graph = Rubydex::Graph.new
+      graph.index_all(context.glob("**/*.rb"))
+      graph.resolve
+
+      definitions = graph.document(context.uri_to("foo.rb")).definitions
+      rooted_bar_definition = definitions.find do |definition|
+        definition.is_a?(Rubydex::ClassDefinition) && definition.name == "Bar" && definition.lexical_owner&.name == "Foo"
+      end
+
+      assert_equal("Bar::Baz", graph.resolve_constant("Baz", rooted_bar_definition).name)
+      assert_equal("Foo::OUTER_CONST", graph.resolve_constant("OUTER_CONST", rooted_bar_definition).name)
+    end
+  end
+
   def test_graph_resolve_with_invalid_argument
     graph = Rubydex::Graph.new
 


### PR DESCRIPTION
`Graph#resolve_constant` currently requires callers to reconstruct lexical nesting as an array of strings. Definitions already retain the exact `NameId` needed by the resolver, including explicit qualification and singleton class context.

The Ruby API now accepts `graph.resolve_constant("CONST", definition)` for `ClassDefinition`, `ModuleDefinition`, and `SingletonClassDefinition` while preserving the existing `Array[String]` API. Definitions from another graph, deleted definitions, and unsupported definition types are reported separately.