### PR TITLE
Expose core RBS definition paths as public API

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,9 @@ graph = Rubydex::Graph.new
 graph.encoding = "utf16"
 # Index the entire workspace with all dependencies
 graph.index_workspace
-# Or index specific file paths
-graph.index_all(["path/to/file.rb"])
+# Or index specific file paths. Include the core and standard library RBS definition paths, otherwise the graph
+# will have no definitions for Ruby's own core classes
+graph.index_all(["path/to/file.rb", *Rubydex::Graph.core_rbs_definition_paths])
 # Transform the initially collected information into its semantic understanding by running resolution
 graph.resolve
 # Get all diagnostics acquired during the analysis

--- a/lib/rubydex/graph.rb
+++ b/lib/rubydex/graph.rb
@@ -17,6 +17,25 @@ module Rubydex
         graph.load_config(Config.load(workspace_path))
         graph
       end
+
+      # Returns the paths for the core and standard library RBS definitions of the latest installation of the `rbs` gem,
+      # which are the definitions for Ruby itself. Tools that build their own list of paths and index it with
+      # `index_all` must append these paths, otherwise the graph will have no definitions for core classes like `Object`
+      # or `Kernel`.
+      #
+      # This method does not require `rbs` to be a part of the bundle. It searches for whatever latest installation of
+      # `rbs` exists in the system and returns an empty array if we can't find one
+      #
+      #: -> Array[String]
+      def core_rbs_definition_paths
+        rbs_gem_path = Gem.path
+          .flat_map { |path| Dir.glob(File.join(path, "gems", "rbs-[0-9]*/")) }
+          .max_by { |path| Gem::Version.new(File.basename(path).delete_prefix("rbs-")) }
+
+        return [] unless rbs_gem_path
+
+        [File.join(rbs_gem_path, "core"), File.join(rbs_gem_path, "stdlib")]
+      end
     end
 
     # Index all files and dependencies of the workspace that exists in `workspace_path`
@@ -69,20 +88,12 @@ module Rubydex
       end
     end
 
-    # Searches for the latest installation of the `rbs` gem and adds the paths for the core and stdlib RBS definitions
-    # to the list of paths. This method does not require `rbs` to be a part of the bundle. It searches for whatever
-    # latest installation of `rbs` exists in the system and fails silently if we can't find one
+    # Adds the paths for the core and stdlib RBS definitions to the list of paths. Fails silently if no installation of
+    # the `rbs` gem can be found. See `Graph.core_rbs_definition_paths`
     #
     #: (Array[String]) -> void
     def add_core_rbs_definition_paths(paths)
-      rbs_gem_path = Gem.path
-        .flat_map { |path| Dir.glob(File.join(path, "gems", "rbs-[0-9]*/")) }
-        .max_by { |path| Gem::Version.new(File.basename(path).delete_prefix("rbs-")) }
-
-      return unless rbs_gem_path
-
-      paths << File.join(rbs_gem_path, "core")
-      paths << File.join(rbs_gem_path, "stdlib")
+      paths.concat(Graph.core_rbs_definition_paths)
     end
   end
 end

--- a/rbi/rubydex.rbi
+++ b/rbi/rubydex.rbi
@@ -856,6 +856,16 @@ class Rubydex::Graph
     # different tools, do not use this. Create and own a `Config` object instead.
     sig { params(workspace_path: String).returns(T.attached_class) }
     def configure_for_workspace(workspace_path); end
+
+    # Returns the paths for the core and standard library RBS definitions of the latest installation of the `rbs` gem,
+    # which are the definitions for Ruby itself. Tools that build their own list of paths and index it with
+    # `index_all` must append these paths, otherwise the graph will have no definitions for core classes like `Object`
+    # or `Kernel`.
+    #
+    # This method does not require `rbs` to be a part of the bundle. It searches for whatever latest installation of
+    # `rbs` exists in the system and returns an empty array if we can't find one
+    sig { returns(T::Array[String]) }
+    def core_rbs_definition_paths; end
   end
 
   sig { params(fully_qualified_name: String).returns(T.nilable(Rubydex::Declaration)) }

--- a/test/graph_test.rb
+++ b/test/graph_test.rb
@@ -2,6 +2,7 @@
 
 require "test_helper"
 require "helpers/context"
+require "mocha/minitest"
 require "json"
 
 class GraphTest < Minitest::Test
@@ -890,6 +891,53 @@ class GraphTest < Minitest::Test
       end
 
       assert_equal(paths.length, paths.uniq.length)
+    end
+  end
+
+  def test_core_rbs_definition_paths
+    paths = Rubydex::Graph.core_rbs_definition_paths
+    core_path, stdlib_path = paths
+
+    assert_equal(2, paths.length)
+    assert_equal("core", File.basename(core_path))
+    assert_equal("stdlib", File.basename(stdlib_path))
+    assert_equal(File.dirname(core_path), File.dirname(stdlib_path))
+    assert_match(/rbs-[0-9]/, File.basename(File.dirname(core_path)))
+    assert(File.directory?(core_path), "Expected `#{core_path}` to be a directory")
+    assert(File.directory?(stdlib_path), "Expected `#{stdlib_path}` to be a directory")
+  end
+
+  def test_core_rbs_definition_paths_uses_the_latest_installation
+    with_context do |context|
+      ["rbs-3.9.4", "rbs-3.10.0", "rbs-3.10.0.pre.1", "rbs-inline-0.11.0"].each do |gem_directory|
+        context.write!("gems/#{gem_directory}/core/object.rbs", "class Object; end")
+        context.write!("gems/#{gem_directory}/stdlib/set/0/set.rbs", "class Set; end")
+      end
+
+      Gem.stubs(:path).returns([context.absolute_path])
+
+      assert_equal(
+        [context.absolute_path_to("gems/rbs-3.10.0/core"), context.absolute_path_to("gems/rbs-3.10.0/stdlib")],
+        Rubydex::Graph.core_rbs_definition_paths,
+      )
+    end
+  end
+
+  def test_core_rbs_definition_paths_without_an_rbs_installation
+    with_context do |context|
+      Gem.stubs(:path).returns([context.absolute_path])
+
+      assert_empty(Rubydex::Graph.core_rbs_definition_paths)
+    end
+  end
+
+  def test_workspace_paths_include_the_core_rbs_definition_paths
+    with_context do |context|
+      paths = graph_for(context).workspace_paths
+
+      Rubydex::Graph.core_rbs_definition_paths.each do |rbs_path|
+        assert_includes(paths, rbs_path)
+      end
     end
   end
 


### PR DESCRIPTION
Tools that build their own list of paths and index it with `index_all` instead of `index_workspace` (RuboCop's `AllCops/UseProjectIndex` does this, so that its own `Include`/`Exclude` configuration governs the index) ended up with a graph that has no definitions for Ruby's core classes. The core definitions come from indexing the `rbs` gem's `core` and `stdlib` signature directories, which only `index_workspace` did, through the private `add_core_rbs_definition_paths`.

Add `Rubydex::Graph.core_rbs_definition_paths`, which returns those paths, so callers can append them to their own list without reaching for a private method. `add_core_rbs_definition_paths` now delegates to it, keeping a single source of truth as well as the existing semantics: the latest installation of `rbs` in the system wins, `rbs` does not have to be part of the bundle and no installation being found is not an error.

-----

@vinistock this is to address what we discussed in #1027; rubocop can't really use `graph_workspace` as that'd mean indexing the 3rd party gems too; the easiest workaround I got to was to use this method to expose the rbs sigs there, which would be better served as a public API.