### PR TITLE
Prototype resolution-dependent DSL compiler boundary for #958

### DIFF
--- a/rust/rubydex/src/indexing/local_graph.rs
+++ b/rust/rubydex/src/indexing/local_graph.rs
@@ -5,11 +5,14 @@ use crate::model::definitions::Definition;
 use crate::model::document::Document;
 use crate::model::graph::NameDependent;
 use crate::model::identity_maps::IdentityHashMap;
-use crate::model::ids::{ConstantReferenceId, DefinitionId, MethodReferenceId, NameId, StringId, UriId};
+use crate::model::ids::{
+    ConstantReferenceId, DeferredCallId, DefinitionId, MethodReferenceId, NameId, StringId, UriId,
+};
 use crate::model::name::{Name, NameRef, ParentScope};
 use crate::model::references::{ConstantReference, MethodRef};
 use crate::model::string_ref::StringRef;
 use crate::offset::Offset;
+use crate::operation::deferred::DeferredCall;
 
 type LocalGraphParts = (
     UriId,
@@ -19,6 +22,7 @@ type LocalGraphParts = (
     IdentityHashMap<NameId, NameRef>,
     IdentityHashMap<ConstantReferenceId, ConstantReference>,
     IdentityHashMap<MethodReferenceId, MethodRef>,
+    IdentityHashMap<DeferredCallId, DeferredCall>,
     IdentityHashMap<NameId, Vec<NameDependent>>,
 );
 
@@ -31,6 +35,7 @@ pub struct LocalGraph {
     names: IdentityHashMap<NameId, NameRef>,
     constant_references: IdentityHashMap<ConstantReferenceId, ConstantReference>,
     method_references: IdentityHashMap<MethodReferenceId, MethodRef>,
+    deferred_calls: IdentityHashMap<DeferredCallId, DeferredCall>,
     name_dependents: IdentityHashMap<NameId, Vec<NameDependent>>,
 }
 
@@ -45,6 +50,7 @@ impl LocalGraph {
             names: IdentityHashMap::default(),
             constant_references: IdentityHashMap::default(),
             method_references: IdentityHashMap::default(),
+            deferred_calls: IdentityHashMap::default(),
             name_dependents: IdentityHashMap::default(),
         }
     }
@@ -188,6 +194,25 @@ impl LocalGraph {
         reference_id
     }
 
+    // Deferred calls
+
+    #[must_use]
+    pub fn deferred_calls(&self) -> &IdentityHashMap<DeferredCallId, DeferredCall> {
+        &self.deferred_calls
+    }
+
+    pub fn add_deferred_call(&mut self, call: DeferredCall) {
+        let call_id = call.id();
+        self.name_dependents
+            .entry(call.receiver_name_id())
+            .or_default()
+            .push(NameDependent::DeferredCall(call_id));
+        if self.deferred_calls.insert(call_id, call).is_some() {
+            debug_assert!(false, "DeferredCallId collision in local graph");
+        }
+        self.document.add_deferred_call(call_id);
+    }
+
     // Diagnostics
 
     #[must_use]
@@ -241,6 +266,7 @@ impl LocalGraph {
             names,
             constant_references: IdentityHashMap::default(),
             method_references: IdentityHashMap::default(),
+            deferred_calls: IdentityHashMap::default(),
             name_dependents,
         }
     }
@@ -257,6 +283,7 @@ impl LocalGraph {
             self.names,
             self.constant_references,
             self.method_references,
+            self.deferred_calls,
             self.name_dependents,
         )
     }

--- a/rust/rubydex/src/model/document.rs
+++ b/rust/rubydex/src/model/document.rs
@@ -6,7 +6,7 @@ use xxhash_rust::xxh3::xxh3_64;
 
 use crate::assert_mem_size;
 use crate::diagnostic::Diagnostic;
-use crate::model::ids::{ConstantReferenceId, DefinitionId, MethodReferenceId};
+use crate::model::ids::{ConstantReferenceId, DeferredCallId, DefinitionId, MethodReferenceId};
 
 // Represents a document currently loaded into memory. Identified by its unique URI, it holds the edges to all
 // definitions and references discovered in it
@@ -17,10 +17,11 @@ pub struct Document {
     definition_ids: Vec<DefinitionId>,
     method_reference_ids: Vec<MethodReferenceId>,
     constant_reference_ids: Vec<ConstantReferenceId>,
+    deferred_call_ids: Vec<DeferredCallId>,
     diagnostics: Vec<Diagnostic>,
     content_hash: u64,
 }
-assert_mem_size!(Document, 184);
+assert_mem_size!(Document, 208);
 
 impl Document {
     #[must_use]
@@ -31,6 +32,7 @@ impl Document {
             definition_ids: Vec::new(),
             method_reference_ids: Vec::new(),
             constant_reference_ids: Vec::new(),
+            deferred_call_ids: Vec::new(),
             diagnostics: Vec::new(),
             content_hash: xxh3_64(source.as_bytes()),
         }
@@ -81,6 +83,15 @@ impl Document {
 
     pub fn add_constant_reference(&mut self, reference_id: ConstantReferenceId) {
         self.constant_reference_ids.push(reference_id);
+    }
+
+    #[must_use]
+    pub fn deferred_calls(&self) -> &[DeferredCallId] {
+        &self.deferred_call_ids
+    }
+
+    pub fn add_deferred_call(&mut self, deferred_call_id: DeferredCallId) {
+        self.deferred_call_ids.push(deferred_call_id);
     }
 
     #[must_use]

--- a/rust/rubydex/src/model/graph.rs
+++ b/rust/rubydex/src/model/graph.rs
@@ -12,13 +12,15 @@ use crate::model::document::Document;
 use crate::model::encoding::Encoding;
 use crate::model::identity_maps::{IdentityHashMap, IdentityHashSet};
 use crate::model::ids::{
-    ConstantReferenceId, DeclarationId, DefinitionId, MethodReferenceId, NameId, StringId, UriId,
+    ConstantReferenceId, DeclarationId, DeferredCallId, DefinitionId, MethodReferenceId, NameId, StringId, UriId,
     declaration_id_from_lookup_name,
 };
 use crate::model::name::{Name, NameRef, ParentScope, ResolvedName};
 use crate::model::references::{ConstantReference, MethodRef};
 use crate::model::string_ref::StringRef;
 use crate::model::visibility::Visibility;
+use crate::operation::Operation;
+use crate::operation::deferred::{DeferredArgument, DeferredCall, DeferredCallResolution, DeferredCallResult};
 use crate::{assert_mem_size, assert_send_sync};
 use crate::{query, stats};
 
@@ -32,6 +34,8 @@ pub enum NameDependent {
     ChildName(NameId),
     /// This name's `nesting` is the key name — reference-only dependency.
     NestedName(NameId),
+    /// A deferred call whose compiler selection depends on this resolved name.
+    DeferredCall(DeferredCallId),
 }
 assert_mem_size!(NameDependent, 16);
 
@@ -55,6 +59,8 @@ pub enum Unit {
     ConstantRef(ConstantReferenceId),
     /// A declaration whose ancestors need re-linearization
     Ancestors(DeclarationId),
+    /// A resolution-dependent call that needs semantic matching.
+    DeferredCall(DeferredCallId),
 }
 assert_mem_size!(Unit, 16);
 
@@ -77,6 +83,9 @@ pub struct Graph {
     constant_references: IdentityHashMap<ConstantReferenceId, ConstantReference>,
     // Map of method references that still need to be resolved
     method_references: IdentityHashMap<MethodReferenceId, MethodRef>,
+    // Resolution-dependent source calls and their non-authoritative prototype results
+    deferred_calls: IdentityHashMap<DeferredCallId, DeferredCall>,
+    deferred_call_results: IdentityHashMap<DeferredCallId, DeferredCallResult>,
 
     /// The position encoding used for LSP line/column locations. Not related to the actual encoding of the file
     position_encoding: Encoding,
@@ -92,7 +101,7 @@ pub struct Graph {
     /// Project configuration
     config: Config,
 }
-assert_mem_size!(Graph, 368);
+assert_mem_size!(Graph, 432);
 assert_send_sync!(Graph);
 
 impl Graph {
@@ -106,6 +115,8 @@ impl Graph {
             names: IdentityHashMap::default(),
             constant_references: IdentityHashMap::default(),
             method_references: IdentityHashMap::default(),
+            deferred_calls: IdentityHashMap::default(),
+            deferred_call_results: IdentityHashMap::default(),
             position_encoding: Encoding::default(),
             name_dependents: IdentityHashMap::default(),
             pending_work: Vec::default(),
@@ -636,6 +647,88 @@ impl Graph {
     }
 
     #[must_use]
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(crate) fn deferred_calls(&self) -> &IdentityHashMap<DeferredCallId, DeferredCall> {
+        &self.deferred_calls
+    }
+
+    #[must_use]
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(crate) fn deferred_call_resolution(&self, id: DeferredCallId) -> Option<DeferredCallResolution> {
+        self.deferred_call_results.get(&id).map(DeferredCallResult::resolution)
+    }
+
+    #[must_use]
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(crate) fn deferred_call_expansion(&self, id: DeferredCallId) -> Option<&[Operation]> {
+        self.deferred_call_results.get(&id).map(DeferredCallResult::expansion)
+    }
+
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(crate) fn take_deferred_call_expansion(&mut self, id: DeferredCallId) -> Option<Box<[Operation]>> {
+        self.deferred_call_results
+            .get_mut(&id)
+            .map(DeferredCallResult::take_expansion)
+    }
+
+    /// Records a deferred-call result and exact alias-path `NameId` dependencies.
+    ///
+    /// `alias_path_deps` are the target names traversed while normalizing the receiver
+    /// (not every name that happens to resolve to the terminal owner).
+    pub(crate) fn record_deferred_call_result(
+        &mut self,
+        id: DeferredCallId,
+        resolution: DeferredCallResolution,
+        expansion: Box<[Operation]>,
+        alias_path_deps: &[NameId],
+    ) {
+        self.clear_deferred_call_dependencies(id);
+
+        let receiver_name_id = self.deferred_calls.get(&id).map(DeferredCall::receiver_name_id);
+        let mut dependency_names = Vec::new();
+        for &name_id in alias_path_deps {
+            if receiver_name_id == Some(name_id) || dependency_names.contains(&name_id) {
+                continue;
+            }
+            let deps = self.name_dependents.entry(name_id).or_default();
+            let dependent = NameDependent::DeferredCall(id);
+            if !deps.contains(&dependent) {
+                deps.push(dependent);
+            }
+            dependency_names.push(name_id);
+        }
+
+        self.deferred_call_results.insert(
+            id,
+            DeferredCallResult::new(resolution, expansion, dependency_names.into_boxed_slice()),
+        );
+    }
+
+    fn clear_deferred_call_dependencies(&mut self, id: DeferredCallId) {
+        let Some(dependency_names) = self
+            .deferred_call_results
+            .get(&id)
+            .map(|result| result.dependency_names().to_vec())
+        else {
+            return;
+        };
+        for name_id in dependency_names {
+            self.remove_name_dependent(name_id, NameDependent::DeferredCall(id));
+        }
+    }
+
+    fn invalidate_deferred_call(&mut self, id: DeferredCallId) {
+        if self.deferred_calls.contains_key(&id) {
+            self.clear_deferred_call_dependencies(id);
+            self.deferred_call_results.insert(
+                id,
+                DeferredCallResult::new(DeferredCallResolution::Pending, Box::default(), Box::default()),
+            );
+            self.push_work(Unit::DeferredCall(id));
+        }
+    }
+
+    #[must_use]
     pub fn name_dependents(&self) -> &IdentityHashMap<NameId, Vec<NameDependent>> {
         &self.name_dependents
     }
@@ -941,8 +1034,17 @@ impl Graph {
     /// Merges everything in `other` into this Graph. This method is meant to merge all graph representations from
     /// different threads, but not meant to handle updates to the existing global representation
     pub fn extend(&mut self, local_graph: LocalGraph) {
-        let (uri_id, document, definitions, strings, names, constant_references, method_references, name_dependents) =
-            local_graph.into_parts();
+        let (
+            uri_id,
+            document,
+            definitions,
+            strings,
+            names,
+            constant_references,
+            method_references,
+            deferred_calls,
+            name_dependents,
+        ) = local_graph.into_parts();
 
         if self.documents.insert(uri_id, document).is_some() {
             debug_assert!(false, "UriId collision in global graph");
@@ -991,6 +1093,17 @@ impl Graph {
         for (method_ref_id, method_ref) in method_references {
             if self.method_references.insert(method_ref_id, method_ref).is_some() {
                 debug_assert!(false, "Method ReferenceId collision in global graph");
+            }
+        }
+
+        for (deferred_call_id, deferred_call) in deferred_calls {
+            self.push_work(Unit::DeferredCall(deferred_call_id));
+            self.deferred_call_results.insert(
+                deferred_call_id,
+                DeferredCallResult::new(DeferredCallResolution::Pending, Box::default(), Box::default()),
+            );
+            if self.deferred_calls.insert(deferred_call_id, deferred_call).is_some() {
+                debug_assert!(false, "DeferredCallId collision in global graph");
             }
         }
 
@@ -1096,6 +1209,23 @@ impl Graph {
     /// Removes raw document data (refs, defs, names, strings) from maps.
     /// Does not touch declarations or perform invalidation -- that is handled by `invalidate`.
     fn remove_document_data(&mut self, document: &Document) {
+        for call_id in document.deferred_calls() {
+            if let Some(call) = self.deferred_calls.remove(call_id) {
+                self.remove_name_dependent(call.receiver_name_id(), NameDependent::DeferredCall(*call_id));
+                self.clear_deferred_call_dependencies(*call_id);
+                self.deferred_call_results.remove(call_id);
+
+                // The shadow DeferredCall borrows the assignment NameId owned by the
+                // ordinary DefineConstant. Its literal arguments are the only interned
+                // resources owned exclusively by the deferred-call lifecycle.
+                for argument in call.arguments() {
+                    if let DeferredArgument::LiteralName(str_id) = argument {
+                        self.untrack_string(*str_id);
+                    }
+                }
+            }
+        }
+
         for ref_id in document.method_references() {
             if let Some(method_ref) = self.method_references.remove(ref_id) {
                 self.untrack_string(*method_ref.str());
@@ -1177,6 +1307,21 @@ impl Graph {
         }
     }
 
+    fn invalidate_deferred_calls_for_names(&mut self, name_ids: &IdentityHashSet<NameId>) {
+        let deferred_calls: IdentityHashSet<DeferredCallId> = name_ids
+            .iter()
+            .filter_map(|name_id| self.name_dependents.get(name_id))
+            .flatten()
+            .filter_map(|dependent| match dependent {
+                NameDependent::DeferredCall(call_id) => Some(*call_id),
+                _ => None,
+            })
+            .collect();
+        for call_id in deferred_calls {
+            self.invalidate_deferred_call(call_id);
+        }
+    }
+
     /// Processes a declaration in the invalidation worklist.
     ///
     /// Detaches any pending definitions first, then either:
@@ -1241,9 +1386,18 @@ impl Graph {
                 self.queue_structural_cascade(name_id, queue);
 
                 if let Some(deps) = self.name_dependents.get(&name_id) {
+                    let deps = deps.clone();
                     for dep in deps {
-                        if let NameDependent::Reference(ref_id) = dep {
-                            self.pending_work.push(Unit::ConstantRef(*ref_id));
+                        match dep {
+                            NameDependent::Reference(ref_id) => {
+                                self.pending_work.push(Unit::ConstantRef(ref_id));
+                            }
+                            NameDependent::DeferredCall(call_id) => {
+                                self.invalidate_deferred_call(call_id);
+                            }
+                            NameDependent::Definition(_)
+                            | NameDependent::ChildName(_)
+                            | NameDependent::NestedName(_) => {}
                         }
                     }
                 }
@@ -1293,6 +1447,8 @@ impl Graph {
             if !visited_declarations.insert(decl_id) {
                 return;
             }
+
+            self.invalidate_deferred_calls_for_names(&seed_names);
 
             let Some(namespace) = self.declarations.get_mut(&decl_id).and_then(|d| d.as_namespace_mut()) else {
                 return;
@@ -1355,6 +1511,9 @@ impl Graph {
                             queue.push(InvalidationItem::Declaration(old_decl_id));
                         }
                     }
+                    NameDependent::DeferredCall(call_id) => {
+                        self.invalidate_deferred_call(*call_id);
+                    }
                     NameDependent::ChildName(_) | NameDependent::NestedName(_) => {}
                 }
             }
@@ -1370,11 +1529,15 @@ impl Graph {
         let is_resolved = matches!(self.names.get(&name_id), Some(NameRef::Resolved(_)));
 
         for dep in &dependents {
-            if let NameDependent::Reference(ref_id) = dep {
-                if is_resolved {
-                    self.unresolve_reference(*ref_id);
+            match dep {
+                NameDependent::Reference(ref_id) => {
+                    if is_resolved {
+                        self.unresolve_reference(*ref_id);
+                    }
+                    self.push_work(Unit::ConstantRef(*ref_id));
                 }
-                self.push_work(Unit::ConstantRef(*ref_id));
+                NameDependent::DeferredCall(call_id) => self.invalidate_deferred_call(*call_id),
+                NameDependent::Definition(_) | NameDependent::ChildName(_) | NameDependent::NestedName(_) => {}
             }
         }
     }
@@ -1388,7 +1551,7 @@ impl Graph {
                     NameDependent::ChildName(id) | NameDependent::NestedName(id) => {
                         queue.push(InvalidationItem::Name(*id));
                     }
-                    NameDependent::Reference(_) | NameDependent::Definition(_) => {}
+                    NameDependent::Reference(_) | NameDependent::Definition(_) | NameDependent::DeferredCall(_) => {}
                 }
             }
         }
@@ -1406,7 +1569,7 @@ impl Graph {
                     NameDependent::NestedName(id) => {
                         queue.push(InvalidationItem::References(*id));
                     }
-                    NameDependent::Reference(_) | NameDependent::Definition(_) => {}
+                    NameDependent::Reference(_) | NameDependent::Definition(_) | NameDependent::DeferredCall(_) => {}
                 }
             }
         }
@@ -1451,7 +1614,43 @@ impl Graph {
         &self.position_encoding
     }
 
+    fn deferred_call_stats(&self) -> (usize, usize, usize, usize, usize, usize) {
+        let matched = self
+            .deferred_call_results
+            .values()
+            .filter(|result| matches!(result.resolution(), DeferredCallResolution::Compiler(_)))
+            .count();
+        let fallback = self
+            .deferred_call_results
+            .values()
+            .filter(|result| result.resolution() == DeferredCallResolution::Fallback)
+            .count();
+        let pending = self.deferred_calls.len() - matched - fallback;
+        let mut dep_edges = 0usize;
+        let mut max_deps = 0usize;
+        for (call_id, call) in &self.deferred_calls {
+            // Receiver edge plus exact alias-path owners recorded on the result.
+            let mut edges = 1usize;
+            if let Some(result) = self.deferred_call_results.get(call_id) {
+                edges += result.dependency_names().len();
+            } else {
+                let _ = call;
+            }
+            dep_edges += edges;
+            max_deps = max_deps.max(edges);
+        }
+        (
+            matched,
+            fallback,
+            pending,
+            dep_edges,
+            max_deps,
+            self.deferred_calls.len(),
+        )
+    }
+
     #[allow(clippy::cast_precision_loss)]
+    #[allow(clippy::too_many_lines, clippy::cast_precision_loss)]
     pub fn print_query_statistics(&self) {
         use std::collections::{HashMap, HashSet};
 
@@ -1502,6 +1701,24 @@ impl Graph {
         println!("Query statistics");
         let total_declarations = self.declarations.len();
         println!("  Total declarations:         {total_declarations}");
+        // Prototype-only deferred-call instrumentation (not a supported Graph API).
+        if !self.deferred_calls.is_empty() {
+            let (matched_deferred_calls, fallback_deferred_calls, pending_deferred_calls, dep_edges, max_deps, total) =
+                self.deferred_call_stats();
+            let avg_deps = if total == 0 {
+                0.0
+            } else {
+                dep_edges as f64 / total as f64
+            };
+            println!("  Deferred calls (prototype): {total}");
+            println!("    Matched:                  {matched_deferred_calls}");
+            println!("    Fallback:                 {fallback_deferred_calls}");
+            println!("    Pending:                  {pending_deferred_calls}");
+            println!("    Dependency edges:         {dep_edges}");
+            println!("    Avg deps/call:            {avg_deps:.2}");
+            println!("    Max deps/call:            {max_deps}");
+        }
+        println!("  Pending resolution work:    {}", self.pending_work.len());
         println!(
             "  With documentation:         {} ({:.1}%)",
             declarations_with_docs,

--- a/rust/rubydex/src/model/ids.rs
+++ b/rust/rubydex/src/model/ids.rs
@@ -77,6 +77,17 @@ pub struct NameMarker;
 pub type NameId = Id<NameMarker>;
 assert_mem_size!(NameId, 8);
 
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone, Copy)]
+pub struct DeferredCallMarker;
+/// `DeferredCallId` identifies a resolution-dependent call at a stable source location.
+pub type DeferredCallId = Id<DeferredCallMarker>;
+assert_mem_size!(DeferredCallId, 8);
+
+#[must_use]
+pub fn deferred_call_id(uri_id: UriId, offset: &Offset) -> DeferredCallId {
+    id_from_parts!(DeferredCallId; uri_id.get(), offset.start())
+}
+
 // Reference IDs
 //
 // This section is for specialized IDs for each type of declaration reference

--- a/rust/rubydex/src/operation/applier.rs
+++ b/rust/rubydex/src/operation/applier.rs
@@ -1,8 +1,8 @@
 //! Converts an `OperationBuilderResult` into a `LocalGraph` by walking operations and creating definitions.
 //!
 //! This is the second phase of the two-phase operation pipeline:
-//! 1. `RubyOperationBuilder` parses source → produces ordered operations
-//! 2. `apply_operations` walks operations → creates definitions in a `LocalGraph`
+//! 1. `RubyOperationBuilder` parses source → produces ordered compiled items
+//! 2. `apply_operations` applies semantic operations and stores deferred calls in a `LocalGraph`
 //!
 //! The applier maintains its own scope stack to derive `lexical_nesting_id` for definitions.
 //! Operations carry only their own data; scope context comes from Enter/Exit scope operations.
@@ -22,9 +22,10 @@ use crate::model::references::{ConstantReference, MethodRef};
 use crate::model::visibility::Visibility;
 use crate::operation::ruby_builder::OperationBuilderResult;
 use crate::operation::{
-    AliasConstant, AliasGlobalVariable, AliasMethod, AttrKind, DefineAttribute, DefineClassVariable, DefineConstant,
-    DefineGlobalVariable, DefineInstanceVariable, EnterClass, EnterMethod, EnterModule, EnterSingletonClass, MixinKind,
-    Operation, ReferenceConstant, ReferenceMethod, SetConstantVisibility, SetMethodVisibility, Target,
+    AliasConstant, AliasGlobalVariable, AliasMethod, AttrKind, CompiledItem, DefineAttribute, DefineClassVariable,
+    DefineConstant, DefineGlobalVariable, DefineInstanceVariable, EnterClass, EnterMethod, EnterModule,
+    EnterSingletonClass, MixinKind, Operation, ReferenceConstant, ReferenceMethod, SetConstantVisibility,
+    SetMethodVisibility, Target,
 };
 
 enum ApplierScope {
@@ -483,7 +484,7 @@ pub fn apply_operations(result: OperationBuilderResult) -> LocalGraph {
     let OperationBuilderResult {
         uri_id,
         document,
-        operations,
+        items,
         strings,
         names,
     } = result;
@@ -493,6 +494,37 @@ pub fn apply_operations(result: OperationBuilderResult) -> LocalGraph {
         scope_stack: Vec::new(),
         scope_visibility: HashMap::new(),
         constant_ref_ids: HashMap::new(),
+    };
+
+    for item in items {
+        match item {
+            CompiledItem::Operation(op) => applier.apply_operation(op),
+            CompiledItem::DeferredCall(call) => applier.local_graph.add_deferred_call(call),
+        }
+    }
+
+    applier.local_graph
+}
+
+/// Applies additional semantic operations onto an existing `LocalGraph`.
+///
+/// Rebuilds the applier's `ReferenceConstant` lookup from references already present in the
+/// local graph so generated expansions can be replay-validated against the live stream.
+#[cfg(test)]
+pub(crate) fn apply_additional_operations(
+    local_graph: LocalGraph,
+    operations: impl IntoIterator<Item = Operation>,
+) -> LocalGraph {
+    let mut constant_ref_ids = HashMap::new();
+    for (ref_id, constant_ref) in local_graph.constant_references() {
+        constant_ref_ids.insert(*constant_ref.name_id(), *ref_id);
+    }
+
+    let mut applier = OperationApplier {
+        local_graph,
+        scope_stack: Vec::new(),
+        scope_visibility: HashMap::new(),
+        constant_ref_ids,
     };
 
     for op in operations {

--- a/rust/rubydex/src/operation/deferred.rs
+++ b/rust/rubydex/src/operation/deferred.rs
@@ -1,0 +1,1101 @@
+use crate::{
+    assert_mem_size,
+    model::{
+        definitions::DefinitionFlags,
+        ids::{DeferredCallId, NameId, StringId, UriId, deferred_call_id},
+    },
+    offset::Offset,
+};
+
+#[derive(Debug)]
+pub enum DeferredArgument {
+    LiteralName(StringId),
+    Unsupported,
+}
+assert_mem_size!(DeferredArgument, 8);
+
+#[derive(Debug)]
+pub struct DeferredConstantAssignment {
+    name_id: NameId,
+    offset: Offset,
+    name_offset: Offset,
+    flags: DefinitionFlags,
+}
+assert_mem_size!(DeferredConstantAssignment, 32);
+
+impl DeferredConstantAssignment {
+    #[must_use]
+    pub fn new(name_id: NameId, offset: Offset, name_offset: Offset, flags: DefinitionFlags) -> Self {
+        Self {
+            name_id,
+            offset,
+            name_offset,
+            flags,
+        }
+    }
+
+    #[must_use]
+    pub fn name_id(&self) -> NameId {
+        self.name_id
+    }
+
+    #[must_use]
+    pub fn offset(&self) -> &Offset {
+        &self.offset
+    }
+
+    #[must_use]
+    pub fn name_offset(&self) -> &Offset {
+        &self.name_offset
+    }
+
+    #[must_use]
+    pub fn flags(&self) -> DefinitionFlags {
+        self.flags.clone()
+    }
+}
+
+#[derive(Debug)]
+pub struct DeferredCall {
+    id: DeferredCallId,
+    uri_id: UriId,
+    offset: Offset,
+    receiver_name_id: NameId,
+    method_name: StringId,
+    assignment: DeferredConstantAssignment,
+    arguments: Box<[DeferredArgument]>,
+}
+assert_mem_size!(DeferredCall, 88);
+
+impl DeferredCall {
+    #[must_use]
+    pub fn new(
+        uri_id: UriId,
+        offset: Offset,
+        receiver_name_id: NameId,
+        method_name: StringId,
+        assignment: DeferredConstantAssignment,
+        arguments: Box<[DeferredArgument]>,
+    ) -> Self {
+        let id = deferred_call_id(uri_id, &offset);
+        Self {
+            id,
+            uri_id,
+            offset,
+            receiver_name_id,
+            method_name,
+            assignment,
+            arguments,
+        }
+    }
+
+    #[must_use]
+    pub fn id(&self) -> DeferredCallId {
+        self.id
+    }
+
+    #[must_use]
+    pub fn uri_id(&self) -> UriId {
+        self.uri_id
+    }
+
+    #[must_use]
+    pub fn offset(&self) -> &Offset {
+        &self.offset
+    }
+
+    #[must_use]
+    pub fn receiver_name_id(&self) -> NameId {
+        self.receiver_name_id
+    }
+
+    #[must_use]
+    pub fn method_name(&self) -> StringId {
+        self.method_name
+    }
+
+    #[must_use]
+    pub fn assignment(&self) -> &DeferredConstantAssignment {
+        &self.assignment
+    }
+
+    #[must_use]
+    pub fn arguments(&self) -> &[DeferredArgument] {
+        &self.arguments
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CompilerKind {
+    StructNew,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DeferredCallResolution {
+    Pending,
+    Fallback,
+    Compiler(CompilerKind),
+}
+
+#[derive(Debug)]
+pub(crate) struct DeferredCallResult {
+    resolution: DeferredCallResolution,
+    expansion: Box<[crate::operation::Operation]>,
+    /// Extra `name_dependents` edges beyond the receiver along the alias path.
+    dependency_names: Box<[NameId]>,
+}
+assert_mem_size!(DeferredCallResult, 40);
+
+impl DeferredCallResult {
+    #[must_use]
+    pub(crate) fn new(
+        resolution: DeferredCallResolution,
+        expansion: Box<[crate::operation::Operation]>,
+        dependency_names: Box<[NameId]>,
+    ) -> Self {
+        Self {
+            resolution,
+            expansion,
+            dependency_names,
+        }
+    }
+
+    #[must_use]
+    pub(crate) fn resolution(&self) -> DeferredCallResolution {
+        self.resolution
+    }
+
+    #[must_use]
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(crate) fn expansion(&self) -> &[crate::operation::Operation] {
+        &self.expansion
+    }
+
+    #[must_use]
+    pub(crate) fn dependency_names(&self) -> &[NameId] {
+        &self.dependency_names
+    }
+
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(crate) fn take_expansion(&mut self) -> Box<[crate::operation::Operation]> {
+        std::mem::replace(&mut self.expansion, Box::from([]))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        indexing::{IndexerBackend, LanguageId, build_local_graph},
+        integrity,
+        model::{graph::Graph, ids::DeferredCallId},
+        operation::Operation,
+        resolution::Resolver,
+    };
+
+    fn index(graph: &mut Graph, uri: &str, source: &str) {
+        let local_graph = build_local_graph(
+            uri.to_string(),
+            source,
+            &LanguageId::Ruby,
+            IndexerBackend::OperationBuilder,
+        );
+        graph.consume_document_changes(local_graph);
+    }
+
+    fn resolve(graph: &mut Graph) {
+        Resolver::new(graph).resolve();
+    }
+
+    fn only_call_id(graph: &Graph) -> DeferredCallId {
+        assert_eq!(graph.deferred_calls().len(), 1);
+        *graph.deferred_calls().keys().next().unwrap()
+    }
+
+    fn deferred_dependency_edge_count(graph: &Graph, call_id: DeferredCallId) -> usize {
+        graph
+            .name_dependents()
+            .values()
+            .filter(|dependents| dependents.contains(&crate::model::graph::NameDependent::DeferredCall(call_id)))
+            .count()
+    }
+
+    fn apply_expansion_in_stream(
+        uri: &str,
+        source: &str,
+        call_id: DeferredCallId,
+        assignment_name_id: NameId,
+        expansion: Box<[Operation]>,
+    ) -> Graph {
+        let built = crate::operation::ruby_builder::RubyOperationBuilder::new(uri.to_string(), source).build();
+        let crate::operation::ruby_builder::OperationBuilderResult {
+            uri_id,
+            document,
+            items,
+            strings,
+            names,
+        } = built;
+        let mut expansion = Some(expansion);
+        let mut substituted = Vec::with_capacity(items.len());
+
+        for item in items {
+            match item {
+                crate::operation::CompiledItem::Operation(Operation::DefineConstant(op))
+                    if op.name_id == assignment_name_id => {}
+                crate::operation::CompiledItem::DeferredCall(call) if call.id() == call_id => {
+                    substituted.extend(
+                        expansion
+                            .take()
+                            .expect("deferred call must occur once")
+                            .into_vec()
+                            .into_iter()
+                            .map(crate::operation::CompiledItem::Operation),
+                    );
+                }
+                item => substituted.push(item),
+            }
+        }
+
+        assert!(expansion.is_none(), "deferred call was not found in compiled stream");
+        let local =
+            crate::operation::applier::apply_operations(crate::operation::ruby_builder::OperationBuilderResult {
+                uri_id,
+                document,
+                items: substituted,
+                strings,
+                names,
+            });
+        let mut graph = Graph::new();
+        graph.consume_document_changes(local);
+        resolve(&mut graph);
+        graph
+    }
+
+    fn apply_expansion_out_of_band(
+        uri: &str,
+        source: &str,
+        assignment_name_id: NameId,
+        expansion: Box<[Operation]>,
+    ) -> Graph {
+        let built = crate::operation::ruby_builder::RubyOperationBuilder::new(uri.to_string(), source).build();
+        let crate::operation::ruby_builder::OperationBuilderResult {
+            uri_id,
+            document,
+            items,
+            strings,
+            names,
+        } = built;
+        let items = items
+            .into_iter()
+            .filter(|item| match item {
+                crate::operation::CompiledItem::DeferredCall(_) => false,
+                crate::operation::CompiledItem::Operation(Operation::DefineConstant(op)) => {
+                    op.name_id != assignment_name_id
+                }
+                crate::operation::CompiledItem::Operation(_) => true,
+            })
+            .collect();
+        let local =
+            crate::operation::applier::apply_operations(crate::operation::ruby_builder::OperationBuilderResult {
+                uri_id,
+                document,
+                items,
+                strings,
+                names,
+            });
+        let local = crate::operation::applier::apply_additional_operations(local, expansion);
+        let mut graph = Graph::new();
+        graph.consume_document_changes(local);
+        resolve(&mut graph);
+        graph
+    }
+
+    #[test]
+    fn matches_struct_new_by_resolved_owner() {
+        let mut graph = Graph::new();
+        index(
+            &mut graph,
+            "file:///test.rb",
+            "class Struct; end\nFoo = Struct.new(:name)",
+        );
+        let call_id = only_call_id(&graph);
+
+        resolve(&mut graph);
+
+        assert_eq!(
+            graph.deferred_call_resolution(call_id),
+            Some(DeferredCallResolution::Compiler(CompilerKind::StructNew))
+        );
+    }
+
+    #[test]
+    fn matches_alias_to_struct() {
+        let mut graph = Graph::new();
+        index(
+            &mut graph,
+            "file:///test.rb",
+            "class Struct; end\nAlias = Struct\nFoo = Alias.new(:name)",
+        );
+        let call_id = only_call_id(&graph);
+
+        resolve(&mut graph);
+
+        assert_eq!(
+            graph.deferred_call_resolution(call_id),
+            Some(DeferredCallResolution::Compiler(CompilerKind::StructNew))
+        );
+    }
+
+    #[test]
+    fn shadowed_struct_falls_back() {
+        let mut graph = Graph::new();
+        index(
+            &mut graph,
+            "file:///test.rb",
+            r"
+            class SomethingElse; end
+            module MyNamespace
+              Struct = SomethingElse
+              Foo = Struct.new(:name)
+            end
+            ",
+        );
+        let call_id = only_call_id(&graph);
+
+        resolve(&mut graph);
+
+        assert_eq!(
+            graph.deferred_call_resolution(call_id),
+            Some(DeferredCallResolution::Fallback)
+        );
+    }
+
+    #[test]
+    fn root_qualified_struct_matches_top_level_owner() {
+        let mut graph = Graph::new();
+        index(
+            &mut graph,
+            "file:///test.rb",
+            "class Struct; end\nFoo = ::Struct.new(:name)",
+        );
+        let call_id = only_call_id(&graph);
+
+        resolve(&mut graph);
+
+        assert_eq!(
+            graph.deferred_call_resolution(call_id),
+            Some(DeferredCallResolution::Compiler(CompilerKind::StructNew))
+        );
+    }
+
+    #[test]
+    fn nested_class_named_struct_does_not_match_top_level_owner() {
+        let mut graph = Graph::new();
+        index(
+            &mut graph,
+            "file:///test.rb",
+            r"
+            class Struct; end
+            module X
+              class Struct; end
+              Foo = Struct.new(:name)
+            end
+            ",
+        );
+        let call_id = only_call_id(&graph);
+
+        resolve(&mut graph);
+
+        assert_eq!(
+            graph.deferred_call_resolution(call_id),
+            Some(DeferredCallResolution::Fallback)
+        );
+    }
+
+    #[test]
+    fn reopened_top_level_struct_keeps_one_matching_owner() {
+        let mut graph = Graph::new();
+        index(
+            &mut graph,
+            "file:///test.rb",
+            "class Struct; end\nclass Struct; end\nFoo = Struct.new(:name)",
+        );
+        let call_id = only_call_id(&graph);
+
+        resolve(&mut graph);
+
+        assert_eq!(
+            graph.deferred_call_resolution(call_id),
+            Some(DeferredCallResolution::Compiler(CompilerKind::StructNew))
+        );
+    }
+
+    #[test]
+    fn unsupported_arguments_fall_back() {
+        let mut graph = Graph::new();
+        index(
+            &mut graph,
+            "file:///test.rb",
+            "class Struct; end\nFoo = Struct.new(dynamic_name)",
+        );
+        let call_id = only_call_id(&graph);
+
+        resolve(&mut graph);
+
+        assert_eq!(
+            graph.deferred_call_resolution(call_id),
+            Some(DeferredCallResolution::Fallback)
+        );
+    }
+
+    #[test]
+    fn unresolved_receiver_stays_pending_for_retry() {
+        let mut graph = Graph::new();
+        index(&mut graph, "file:///use.rb", "Foo = Missing.new(:name)");
+        let call_id = only_call_id(&graph);
+
+        resolve(&mut graph);
+
+        assert_eq!(
+            graph.deferred_call_resolution(call_id),
+            Some(DeferredCallResolution::Pending)
+        );
+        assert!(
+            graph
+                .take_pending_work()
+                .iter()
+                .any(|unit| matches!(unit, crate::model::graph::Unit::DeferredCall(id) if *id == call_id))
+        );
+    }
+
+    #[test]
+    fn expansion_uses_only_existing_semantic_operations() {
+        let mut graph = Graph::new();
+        index(
+            &mut graph,
+            "file:///test.rb",
+            "class Struct; end\nFoo = Struct.new(:name, :email)",
+        );
+        let call_id = only_call_id(&graph);
+        let receiver_name_id = graph.deferred_calls()[&call_id].receiver_name_id();
+
+        resolve(&mut graph);
+
+        let expansion = graph.deferred_call_expansion(call_id).unwrap();
+        assert!(matches!(expansion[0], Operation::EnterClass(_)));
+        assert!(matches!(expansion[1], Operation::DefineAttribute(_)));
+        assert!(matches!(expansion[2], Operation::DefineAttribute(_)));
+        assert!(matches!(expansion[3], Operation::ExitScope));
+        let Operation::EnterClass(enter) = &expansion[0] else {
+            panic!("expected EnterClass");
+        };
+        assert_eq!(enter.superclass_name, Some(receiver_name_id));
+    }
+
+    #[test]
+    fn alias_expansion_keeps_source_receiver_name() {
+        let mut graph = Graph::new();
+        index(
+            &mut graph,
+            "file:///test.rb",
+            "class Struct; end\nAlias = Struct\nFoo = Alias.new(:name)",
+        );
+        let call_id = only_call_id(&graph);
+        let receiver_name_id = graph.deferred_calls()[&call_id].receiver_name_id();
+
+        resolve(&mut graph);
+
+        let expansion = graph.deferred_call_expansion(call_id).unwrap();
+        let Operation::EnterClass(enter) = &expansion[0] else {
+            panic!("expected EnterClass expansion");
+        };
+        // Semantic match is Struct, but IR keeps source Alias for applier ReferenceConstant contract.
+        assert_eq!(enter.superclass_name, Some(receiver_name_id));
+        assert_eq!(
+            graph.names().get(&receiver_name_id).and_then(|name| match name {
+                crate::model::name::NameRef::Resolved(resolved) => Some(*resolved.declaration_id()),
+                crate::model::name::NameRef::Unresolved(_) => None,
+            }),
+            Some(crate::model::ids::declaration_id_from_lookup_name("Alias"))
+        );
+    }
+
+    #[test]
+    fn matches_multi_hop_alias_to_struct() {
+        let mut graph = Graph::new();
+        index(
+            &mut graph,
+            "file:///test.rb",
+            "class Struct; end\nAliasB = Struct\nAliasA = AliasB\nFoo = AliasA.new(:name)",
+        );
+        let call_id = only_call_id(&graph);
+
+        resolve(&mut graph);
+
+        assert_eq!(
+            graph.deferred_call_resolution(call_id),
+            Some(DeferredCallResolution::Compiler(CompilerKind::StructNew))
+        );
+    }
+
+    #[test]
+    fn dependency_edges_track_only_the_resolved_alias_path() {
+        for (source, expected_edges) in [
+            ("class Struct; end\nFoo = Struct.new(:name)", 1),
+            ("class Struct; end\nAlias = Struct\nFoo = Alias.new(:name)", 2),
+            (
+                "class Struct; end\nAliasB = Struct\nAliasA = AliasB\nFoo = AliasA.new(:name)",
+                3,
+            ),
+        ] {
+            let mut graph = Graph::new();
+            index(&mut graph, "file:///test.rb", source);
+            let call_id = only_call_id(&graph);
+            resolve(&mut graph);
+
+            assert_eq!(deferred_dependency_edge_count(&graph, call_id), expected_edges);
+        }
+    }
+
+    #[test]
+    fn ambiguous_alias_matches_after_other_target_is_removed() {
+        let mut graph = Graph::new();
+        index(&mut graph, "file:///types.rb", "class Struct; end\nclass Other; end");
+        index(&mut graph, "file:///a.rb", "Alias = Struct");
+        index(&mut graph, "file:///b.rb", "Alias = Other");
+        index(&mut graph, "file:///use.rb", "Foo = Alias.new(:name)");
+        let call_id = only_call_id(&graph);
+
+        resolve(&mut graph);
+        assert_eq!(
+            graph.deferred_call_resolution(call_id),
+            Some(DeferredCallResolution::Fallback)
+        );
+
+        index(&mut graph, "file:///b.rb", "");
+        assert_eq!(
+            graph.deferred_call_resolution(call_id),
+            Some(DeferredCallResolution::Pending)
+        );
+        resolve(&mut graph);
+        assert_eq!(
+            graph.deferred_call_resolution(call_id),
+            Some(DeferredCallResolution::Compiler(CompilerKind::StructNew))
+        );
+    }
+
+    #[test]
+    fn duplicate_aliases_to_same_target_are_not_ambiguous() {
+        let mut graph = Graph::new();
+        index(&mut graph, "file:///types.rb", "class Struct; end");
+        index(&mut graph, "file:///a.rb", "Alias = Struct");
+        index(&mut graph, "file:///b.rb", "Alias = Struct");
+        index(&mut graph, "file:///use.rb", "Foo = Alias.new(:name)");
+        let call_id = only_call_id(&graph);
+
+        resolve(&mut graph);
+
+        assert_eq!(
+            graph.deferred_call_resolution(call_id),
+            Some(DeferredCallResolution::Compiler(CompilerKind::StructNew))
+        );
+    }
+
+    #[test]
+    fn constant_struct_identity_falls_back() {
+        let mut graph = Graph::new();
+        index(&mut graph, "file:///test.rb", "Struct = 123\nFoo = Struct.new(:name)");
+        let call_id = only_call_id(&graph);
+
+        resolve(&mut graph);
+
+        assert_eq!(
+            graph.deferred_call_resolution(call_id),
+            Some(DeferredCallResolution::Fallback)
+        );
+    }
+
+    #[test]
+    fn module_struct_identity_falls_back() {
+        let mut graph = Graph::new();
+        index(
+            &mut graph,
+            "file:///test.rb",
+            "module Struct; end\nFoo = Struct.new(:name)",
+        );
+        let call_id = only_call_id(&graph);
+
+        resolve(&mut graph);
+
+        assert_eq!(
+            graph.deferred_call_resolution(call_id),
+            Some(DeferredCallResolution::Fallback)
+        );
+    }
+
+    #[test]
+    fn owner_kind_transition_re_evaluates_without_reindexing_use_site() {
+        let mut graph = Graph::new();
+        index(&mut graph, "file:///owner.rb", "class Struct; end");
+        index(&mut graph, "file:///use.rb", "Foo = Struct.new(:name)");
+        let call_id = only_call_id(&graph);
+
+        resolve(&mut graph);
+        assert_eq!(
+            graph.deferred_call_resolution(call_id),
+            Some(DeferredCallResolution::Compiler(CompilerKind::StructNew))
+        );
+
+        index(&mut graph, "file:///owner.rb", "module Struct; end");
+        resolve(&mut graph);
+        assert_eq!(
+            graph.deferred_call_resolution(call_id),
+            Some(DeferredCallResolution::Fallback)
+        );
+
+        index(&mut graph, "file:///owner.rb", "class Struct; end");
+        resolve(&mut graph);
+        assert_eq!(
+            graph.deferred_call_resolution(call_id),
+            Some(DeferredCallResolution::Compiler(CompilerKind::StructNew))
+        );
+    }
+
+    #[test]
+    fn alias_cycle_terminates_with_deterministic_fallback() {
+        let mut graph = Graph::new();
+        index(&mut graph, "file:///test.rb", "A = B\nB = A\nFoo = A.new(:name)");
+        let call_id = only_call_id(&graph);
+
+        resolve(&mut graph);
+        assert_eq!(
+            graph.deferred_call_resolution(call_id),
+            Some(DeferredCallResolution::Fallback)
+        );
+
+        resolve(&mut graph);
+        assert_eq!(
+            graph.deferred_call_resolution(call_id),
+            Some(DeferredCallResolution::Fallback)
+        );
+        assert!(integrity::check_integrity(&graph).is_empty());
+    }
+
+    #[test]
+    fn later_constant_value_does_not_replace_class_owner_identity() {
+        let mut graph = Graph::new();
+        index(
+            &mut graph,
+            "file:///test.rb",
+            "class Struct; end\nStruct = 123\nFoo = Struct.new(:name)",
+        );
+        let call_id = only_call_id(&graph);
+
+        resolve(&mut graph);
+
+        assert_eq!(
+            graph.deferred_call_resolution(call_id),
+            Some(DeferredCallResolution::Compiler(CompilerKind::StructNew))
+        );
+    }
+
+    #[test]
+    fn multi_hop_alias_path_change_re_evaluates() {
+        let mut graph = Graph::new();
+        index(&mut graph, "file:///types.rb", "class Struct; end\nclass Other; end");
+        index(&mut graph, "file:///mid.rb", "AliasB = Struct");
+        index(&mut graph, "file:///binding.rb", "AliasA = AliasB");
+        index(&mut graph, "file:///use.rb", "Foo = AliasA.new(:name)");
+        let call_id = only_call_id(&graph);
+        resolve(&mut graph);
+        assert_eq!(
+            graph.deferred_call_resolution(call_id),
+            Some(DeferredCallResolution::Compiler(CompilerKind::StructNew))
+        );
+
+        index(&mut graph, "file:///mid.rb", "AliasB = Other");
+        resolve(&mut graph);
+        assert_eq!(
+            graph.deferred_call_resolution(call_id),
+            Some(DeferredCallResolution::Fallback)
+        );
+    }
+
+    #[test]
+    fn unrelated_struct_reference_does_not_wake_deferred_call() {
+        let mut graph = Graph::new();
+        index(&mut graph, "file:///types.rb", "class Struct; end\nclass Other; end");
+        index(&mut graph, "file:///binding.rb", "Alias = Struct");
+        index(&mut graph, "file:///use.rb", "Foo = Alias.new(:name)");
+        index(&mut graph, "file:///unrelated.rb", "Unrelated = Struct");
+        let call_id = only_call_id(&graph);
+        resolve(&mut graph);
+        assert_eq!(
+            graph.deferred_call_resolution(call_id),
+            Some(DeferredCallResolution::Compiler(CompilerKind::StructNew))
+        );
+
+        // Changing an unrelated alias to Struct must not invalidate Foo's candidate.
+        index(&mut graph, "file:///unrelated.rb", "Unrelated = Other");
+        // Do not resolve — if the candidate was incorrectly woken it would be Pending.
+        assert_eq!(
+            graph.deferred_call_resolution(call_id),
+            Some(DeferredCallResolution::Compiler(CompilerKind::StructNew))
+        );
+        assert!(
+            !graph
+                .take_pending_work()
+                .iter()
+                .any(|unit| matches!(unit, crate::model::graph::Unit::DeferredCall(id) if *id == call_id))
+        );
+    }
+
+    #[test]
+    fn unrelated_alias_does_not_wake_deferred_call() {
+        let mut graph = Graph::new();
+        index(&mut graph, "file:///types.rb", "class Struct; end\nclass Other; end");
+        index(&mut graph, "file:///binding.rb", "AliasA = Struct");
+        index(&mut graph, "file:///other_alias.rb", "OtherAlias = Struct");
+        index(&mut graph, "file:///use.rb", "Foo = AliasA.new(:name)");
+        let call_id = only_call_id(&graph);
+        resolve(&mut graph);
+        assert_eq!(
+            graph.deferred_call_resolution(call_id),
+            Some(DeferredCallResolution::Compiler(CompilerKind::StructNew))
+        );
+
+        index(&mut graph, "file:///other_alias.rb", "OtherAlias = Other");
+        assert_eq!(
+            graph.deferred_call_resolution(call_id),
+            Some(DeferredCallResolution::Compiler(CompilerKind::StructNew))
+        );
+        assert!(
+            !graph
+                .take_pending_work()
+                .iter()
+                .any(|unit| matches!(unit, crate::model::graph::Unit::DeferredCall(id) if *id == call_id))
+        );
+    }
+
+    #[test]
+    fn alias_expansion_is_replay_valid_through_applier() {
+        let source = "class Struct; end\nAlias = Struct\nFoo = Alias.new(:name)";
+        let mut graph = Graph::new();
+        index(&mut graph, "file:///test.rb", source);
+        let call_id = only_call_id(&graph);
+        let receiver_name_id = graph.deferred_calls()[&call_id].receiver_name_id();
+        let assignment_name_id = graph.deferred_calls()[&call_id].assignment().name_id();
+        resolve(&mut graph);
+        assert_eq!(
+            graph.deferred_call_resolution(call_id),
+            Some(DeferredCallResolution::Compiler(CompilerKind::StructNew))
+        );
+
+        let expansion = graph.take_deferred_call_expansion(call_id).unwrap();
+        let Operation::EnterClass(enter) = &expansion[0] else {
+            panic!("expected EnterClass");
+        };
+        assert_eq!(enter.superclass_name, Some(receiver_name_id));
+
+        // Replay without the shadow DefineConstant(Foo): authoritative contribution would
+        // replace that constant, not coexist with EnterClass at the same DefinitionId.
+        let built =
+            crate::operation::ruby_builder::RubyOperationBuilder::new("file:///test.rb".to_string(), source).build();
+        let crate::operation::ruby_builder::OperationBuilderResult {
+            uri_id,
+            document,
+            items,
+            strings,
+            names,
+        } = built;
+        let items = items
+            .into_iter()
+            .filter(|item| match item {
+                crate::operation::CompiledItem::DeferredCall(_) => false,
+                crate::operation::CompiledItem::Operation(crate::operation::Operation::DefineConstant(op)) => {
+                    op.name_id != assignment_name_id
+                }
+                crate::operation::CompiledItem::Operation(_) => true,
+            })
+            .collect();
+        let local =
+            crate::operation::applier::apply_operations(crate::operation::ruby_builder::OperationBuilderResult {
+                uri_id,
+                document,
+                items,
+                strings,
+                names,
+            });
+        let local = crate::operation::applier::apply_additional_operations(local, expansion);
+        let class_def = local
+            .definitions()
+            .values()
+            .find_map(|definition| match definition {
+                crate::model::definitions::Definition::Class(class_def)
+                    if *class_def.name_id() == assignment_name_id =>
+                {
+                    Some(class_def.as_ref())
+                }
+                _ => None,
+            })
+            .expect("expected ClassDefinition from expansion replay");
+        let superclass_ref = class_def.superclass_ref().expect("superclass ref must bind");
+        let superclass_name = *local.constant_references().get(superclass_ref).unwrap().name_id();
+        assert_eq!(superclass_name, receiver_name_id);
+
+        // Source Alias still resolves to Struct through ordinary alias machinery.
+        assert_eq!(
+            graph.resolve_alias(&crate::model::ids::declaration_id_from_lookup_name("Alias")),
+            Some(crate::model::ids::declaration_id_from_lookup_name("Struct"))
+        );
+    }
+
+    #[test]
+    fn in_stream_expansion_affects_downstream_resolution() {
+        let uri = "file:///test.rb";
+        let source = r"
+            class Struct; end
+            Foo = Struct.new(:name)
+            class Bar < Foo; end
+        ";
+        let mut observation_graph = Graph::new();
+        index(&mut observation_graph, uri, source);
+        let call_id = only_call_id(&observation_graph);
+        let assignment_name_id = observation_graph.deferred_calls()[&call_id].assignment().name_id();
+        resolve(&mut observation_graph);
+        let expansion = observation_graph.take_deferred_call_expansion(call_id).unwrap();
+
+        let graph = apply_expansion_in_stream(uri, source, call_id, assignment_name_id, expansion);
+        let struct_id = crate::model::ids::declaration_id_from_lookup_name("Struct");
+        let foo_id = crate::model::ids::declaration_id_from_lookup_name("Foo");
+        let bar_id = crate::model::ids::declaration_id_from_lookup_name("Bar");
+
+        let foo = graph.declarations().get(&foo_id).unwrap();
+        assert!(matches!(
+            foo,
+            crate::model::declaration::Declaration::Namespace(crate::model::declaration::Namespace::Class(_))
+        ));
+        let foo_namespace = foo.as_namespace().unwrap();
+        assert!(
+            foo_namespace.ancestors().iter().any(
+                |ancestor| matches!(ancestor, crate::model::declaration::Ancestor::Complete(id) if *id == struct_id)
+            )
+        );
+        assert!(foo_namespace.members().contains_key(&StringId::from("name")));
+
+        let bar = graph.declarations().get(&bar_id).unwrap().as_namespace().unwrap();
+        assert!(
+            bar.ancestors()
+                .iter()
+                .any(|ancestor| matches!(ancestor, crate::model::declaration::Ancestor::Complete(id) if *id == foo_id))
+        );
+        assert!(integrity::check_integrity(&graph).is_empty());
+    }
+
+    #[test]
+    fn in_stream_expansion_preserves_nested_execution_context() {
+        let uri = "file:///test.rb";
+        let source = r"
+            class Struct; end
+            module Outer
+              Foo = Struct.new(:name)
+              class Bar < Foo; end
+            end
+        ";
+        let mut observation_graph = Graph::new();
+        index(&mut observation_graph, uri, source);
+        let call_id = only_call_id(&observation_graph);
+        let assignment_name_id = observation_graph.deferred_calls()[&call_id].assignment().name_id();
+        resolve(&mut observation_graph);
+        let expansion = observation_graph.take_deferred_call_expansion(call_id).unwrap();
+
+        let graph = apply_expansion_in_stream(uri, source, call_id, assignment_name_id, expansion);
+        let struct_id = crate::model::ids::declaration_id_from_lookup_name("Struct");
+        let foo_id = crate::model::ids::declaration_id_from_lookup_name("Outer::Foo");
+        let bar_id = crate::model::ids::declaration_id_from_lookup_name("Outer::Bar");
+
+        let foo = graph.declarations().get(&foo_id).unwrap().as_namespace().unwrap();
+        assert!(
+            foo.ancestors().iter().any(
+                |ancestor| matches!(ancestor, crate::model::declaration::Ancestor::Complete(id) if *id == struct_id)
+            )
+        );
+        assert!(foo.members().contains_key(&StringId::from("name")));
+
+        let bar = graph.declarations().get(&bar_id).unwrap().as_namespace().unwrap();
+        assert!(
+            bar.ancestors()
+                .iter()
+                .any(|ancestor| matches!(ancestor, crate::model::declaration::Ancestor::Complete(id) if *id == foo_id))
+        );
+        assert!(integrity::check_integrity(&graph).is_empty());
+    }
+
+    #[test]
+    fn out_of_band_replay_supports_the_self_contained_nested_struct_expansion() {
+        let uri = "file:///test.rb";
+        let source = r"
+            class Struct; end
+            module Outer
+              Foo = Struct.new(:name)
+              class Bar < Foo; end
+            end
+        ";
+        let mut observation_graph = Graph::new();
+        index(&mut observation_graph, uri, source);
+        let call_id = only_call_id(&observation_graph);
+        let assignment_name_id = observation_graph.deferred_calls()[&call_id].assignment().name_id();
+        resolve(&mut observation_graph);
+        let expansion = observation_graph.take_deferred_call_expansion(call_id).unwrap();
+
+        let graph = apply_expansion_out_of_band(uri, source, assignment_name_id, expansion);
+        let foo_id = crate::model::ids::declaration_id_from_lookup_name("Outer::Foo");
+        let bar_id = crate::model::ids::declaration_id_from_lookup_name("Outer::Bar");
+
+        let foo = graph.declarations().get(&foo_id).unwrap().as_namespace().unwrap();
+        assert!(foo.members().contains_key(&StringId::from("name")));
+        let bar = graph.declarations().get(&bar_id).unwrap().as_namespace().unwrap();
+        assert!(
+            bar.ancestors()
+                .iter()
+                .any(|ancestor| matches!(ancestor, crate::model::declaration::Ancestor::Complete(id) if *id == foo_id))
+        );
+        assert!(integrity::check_integrity(&graph).is_empty());
+    }
+
+    #[test]
+    fn document_delete_removes_candidate_and_reverse_dependency() {
+        let mut graph = Graph::new();
+        index(
+            &mut graph,
+            "file:///test.rb",
+            "class Struct; end\nFoo = Struct.new(:name)",
+        );
+        let call_id = only_call_id(&graph);
+        let receiver_name_id = graph.deferred_calls()[&call_id].receiver_name_id();
+
+        graph.delete_document("file:///test.rb");
+
+        assert!(!graph.deferred_calls().contains_key(&call_id));
+        assert!(
+            graph.name_dependents().get(&receiver_name_id).is_none_or(
+                |dependents| !dependents.contains(&crate::model::graph::NameDependent::DeferredCall(call_id))
+            )
+        );
+    }
+
+    #[test]
+    fn document_reindex_removes_stale_candidate() {
+        let mut graph = Graph::new();
+        index(
+            &mut graph,
+            "file:///test.rb",
+            "class Struct; end\nFoo = Struct.new(:name)",
+        );
+        let call_id = only_call_id(&graph);
+
+        index(&mut graph, "file:///test.rb", "class Struct; end\nFoo = 1");
+
+        assert!(!graph.deferred_calls().contains_key(&call_id));
+        assert_eq!(graph.deferred_call_resolution(call_id), None);
+        assert!(graph.deferred_call_expansion(call_id).is_none());
+    }
+
+    #[test]
+    fn deferred_call_cleanup_does_not_untrack_shared_assignment_name() {
+        for reindex in [false, true] {
+            let mut graph = Graph::new();
+            index(&mut graph, "file:///candidate.rb", "Foo = Bar.new(:candidate_only)");
+            index(&mut graph, "file:///survivor.rb", "Foo = 123");
+            resolve(&mut graph);
+
+            let call_id = only_call_id(&graph);
+            let assignment_name_id = graph.deferred_calls()[&call_id].assignment().name_id();
+            let argument_string_id = match graph.deferred_calls()[&call_id].arguments()[0] {
+                DeferredArgument::LiteralName(str_id) => str_id,
+                DeferredArgument::Unsupported => panic!("expected literal argument"),
+            };
+
+            if reindex {
+                index(&mut graph, "file:///candidate.rb", "Candidate = 456");
+            } else {
+                graph.delete_document("file:///candidate.rb");
+            }
+
+            assert!(graph.names().contains_key(&assignment_name_id));
+            assert!(!graph.strings().contains_key(&argument_string_id));
+            assert!(graph.deferred_calls().is_empty());
+            assert!(integrity::check_integrity(&graph).is_empty());
+        }
+    }
+
+    #[test]
+    fn alias_target_deletion_re_evaluates_deferred_call() {
+        let mut graph = Graph::new();
+        index(&mut graph, "file:///types.rb", "class Struct; end\nclass Other; end");
+        index(&mut graph, "file:///binding.rb", "Alias = Struct");
+        index(&mut graph, "file:///use.rb", "Foo = Alias.new(:name)");
+        let call_id = only_call_id(&graph);
+        resolve(&mut graph);
+        assert_eq!(
+            graph.deferred_call_resolution(call_id),
+            Some(DeferredCallResolution::Compiler(CompilerKind::StructNew))
+        );
+
+        // Delete Struct without touching the Alias binding or use site. Matching depended on
+        // the normalized owner, so the candidate must re-evaluate.
+        index(&mut graph, "file:///types.rb", "class Other; end");
+        resolve(&mut graph);
+        assert_ne!(
+            graph.deferred_call_resolution(call_id),
+            Some(DeferredCallResolution::Compiler(CompilerKind::StructNew))
+        );
+    }
+
+    #[test]
+    fn pending_receiver_matches_after_owner_appears() {
+        let mut graph = Graph::new();
+        index(&mut graph, "file:///use.rb", "Foo = Struct.new(:name)");
+        let call_id = only_call_id(&graph);
+        resolve(&mut graph);
+        assert_eq!(
+            graph.deferred_call_resolution(call_id),
+            Some(DeferredCallResolution::Pending)
+        );
+
+        index(&mut graph, "file:///types.rb", "class Struct; end");
+        resolve(&mut graph);
+        assert_eq!(
+            graph.deferred_call_resolution(call_id),
+            Some(DeferredCallResolution::Compiler(CompilerKind::StructNew))
+        );
+    }
+
+    #[test]
+    fn receiver_change_re_evaluates_without_reindexing_use_site() {
+        let mut graph = Graph::new();
+        index(&mut graph, "file:///types.rb", "class Struct; end\nclass Other; end");
+        index(&mut graph, "file:///binding.rb", "Alias = Struct");
+        index(&mut graph, "file:///use.rb", "Foo = Alias.new(:name)");
+        let call_id = only_call_id(&graph);
+        resolve(&mut graph);
+        assert_eq!(
+            graph.deferred_call_resolution(call_id),
+            Some(DeferredCallResolution::Compiler(CompilerKind::StructNew))
+        );
+
+        index(&mut graph, "file:///binding.rb", "Alias = Other");
+        resolve(&mut graph);
+        assert_eq!(
+            graph.deferred_call_resolution(call_id),
+            Some(DeferredCallResolution::Fallback)
+        );
+
+        index(&mut graph, "file:///binding.rb", "Alias = Struct");
+        resolve(&mut graph);
+        assert_eq!(
+            graph.deferred_call_resolution(call_id),
+            Some(DeferredCallResolution::Compiler(CompilerKind::StructNew))
+        );
+    }
+}

--- a/rust/rubydex/src/operation/deferred.rs
+++ b/rust/rubydex/src/operation/deferred.rs
@@ -931,6 +931,117 @@ mod tests {
         assert!(integrity::check_integrity(&graph).is_empty());
     }
 
+    /// Vinicius unified-resolution oracle: when the Struct.new expansion is substituted at its
+    /// original stream position, the generated Foo namespace participates in ordinary ancestor-based
+    /// constant resolution (`Bar < Foo` → `SOME_REF` → `Struct::SOME_REF`).
+    ///
+    /// This proves IR/semantic expressiveness of existing Operations under in-stream execution.
+    /// It does **not** claim production DeferredCall already applies expansions authoritatively.
+    #[test]
+    fn in_stream_expansion_affects_ordinary_constant_resolution() {
+        let uri = "file:///test.rb";
+        let source = r"
+            class Struct
+              SOME_REF = 1
+            end
+
+            Foo = Struct.new
+
+            class Bar < Foo
+              SOME_REF
+            end
+        ";
+        let mut observation_graph = Graph::new();
+        index(&mut observation_graph, uri, source);
+        let call_id = only_call_id(&observation_graph);
+        let assignment_name_id = observation_graph.deferred_calls()[&call_id].assignment().name_id();
+        resolve(&mut observation_graph);
+        assert_eq!(
+            observation_graph.deferred_call_resolution(call_id),
+            Some(DeferredCallResolution::Compiler(CompilerKind::StructNew))
+        );
+        let expansion = observation_graph.take_deferred_call_expansion(call_id).unwrap();
+
+        let graph = apply_expansion_in_stream(uri, source, call_id, assignment_name_id, expansion);
+        let struct_id = crate::model::ids::declaration_id_from_lookup_name("Struct");
+        let some_ref_id = crate::model::ids::declaration_id_from_lookup_name("Struct::SOME_REF");
+        let foo_id = crate::model::ids::declaration_id_from_lookup_name("Foo");
+        let bar_id = crate::model::ids::declaration_id_from_lookup_name("Bar");
+
+        assert!(
+            graph.declarations().contains_key(&some_ref_id),
+            "expected Struct::SOME_REF declaration"
+        );
+
+        let foo = graph
+            .declarations()
+            .get(&foo_id)
+            .expect("Foo declaration missing after in-stream expansion");
+        assert!(
+            matches!(
+                foo,
+                crate::model::declaration::Declaration::Namespace(crate::model::declaration::Namespace::Class(_))
+            ),
+            "Foo generation: expected Foo to be a class namespace"
+        );
+        let foo_namespace = foo.as_namespace().unwrap();
+        assert!(
+            foo_namespace.ancestors().iter().any(
+                |ancestor| matches!(ancestor, crate::model::declaration::Ancestor::Complete(id) if *id == struct_id)
+            ),
+            "Foo -> Struct: expected Struct in Foo's ancestor chain"
+        );
+
+        let bar = graph
+            .declarations()
+            .get(&bar_id)
+            .expect("Bar declaration missing")
+            .as_namespace()
+            .expect("Bar should be a namespace");
+        assert!(
+            bar.ancestors()
+                .iter()
+                .any(|ancestor| matches!(ancestor, crate::model::declaration::Ancestor::Complete(id) if *id == foo_id)),
+            "Bar -> Foo: expected Foo in Bar's ancestor chain"
+        );
+
+        let some_ref_str = StringId::from("SOME_REF");
+        let bar_some_ref_targets: Vec<_> = graph
+            .constant_references()
+            .values()
+            .filter_map(|reference| {
+                let name_ref = graph.names().get(reference.name_id())?;
+                if *name_ref.str() != some_ref_str {
+                    return None;
+                }
+                // The expression `SOME_REF` inside `class Bar` is nested under Bar's name.
+                let nesting = name_ref.nesting().as_ref()?;
+                let nesting_ref = graph.names().get(nesting)?;
+                let crate::model::name::NameRef::Resolved(nesting_resolved) = nesting_ref else {
+                    return None;
+                };
+                if *nesting_resolved.declaration_id() != bar_id {
+                    return None;
+                }
+                match name_ref {
+                    crate::model::name::NameRef::Resolved(resolved) => Some(*resolved.declaration_id()),
+                    crate::model::name::NameRef::Unresolved(_) => None,
+                }
+            })
+            .collect();
+        assert_eq!(
+            bar_some_ref_targets.as_slice(),
+            &[some_ref_id],
+            "Bar::SOME_REF -> Struct::SOME_REF: expected the SOME_REF reference inside Bar to resolve to Struct::SOME_REF, got {bar_some_ref_targets:?}"
+        );
+
+        let integrity_issues = integrity::check_integrity(&graph);
+        assert!(
+            integrity_issues.is_empty(),
+            "integrity: unexpected issues: {integrity_issues:?}"
+        );
+    }
+
     #[test]
     fn out_of_band_replay_supports_the_self_contained_nested_struct_expansion() {
         let uri = "file:///test.rb";

--- a/rust/rubydex/src/operation/mod.rs
+++ b/rust/rubydex/src/operation/mod.rs
@@ -7,8 +7,8 @@
 //! Each operation is self-contained: it carries enough context (`name_id`, etc.) to know what it
 //! defines, while scope context is provided by surrounding Enter/Exit scope operations.
 //!
-//! The builder produces a `Vec<Operation>` for each file. These operations are then applied in order
-//! by the applier to produce definitions and declarations in the graph.
+//! The builder produces a `Vec<CompiledItem>` for each file. Semantic operations are applied in order,
+//! while resolution-dependent calls are preserved for the resolver.
 //!
 //! # Example
 //!
@@ -27,9 +27,11 @@
 //! 5. `ExitScope` # exit class Foo
 
 pub mod applier;
+pub mod deferred;
 pub mod printer;
 pub mod ruby_builder;
 
+use crate::assert_mem_size;
 use crate::model::{
     comment::Comment,
     definitions::{DefinitionFlags, Signatures},
@@ -37,6 +39,18 @@ use crate::model::{
     visibility::Visibility,
 };
 use crate::offset::Offset;
+use deferred::DeferredCall;
+
+/// An item produced by a source compiler.
+///
+/// Semantic operations and resolution-dependent calls share one stream so source ordering is
+/// preserved without treating a deferred call as a semantic operation.
+#[derive(Debug)]
+pub enum CompiledItem {
+    Operation(Operation),
+    DeferredCall(DeferredCall),
+}
+assert_mem_size!(CompiledItem, 96);
 
 /// An ordered instruction extracted from Ruby/RBS source code.
 ///
@@ -83,6 +97,7 @@ pub enum Operation {
     /// Record a reference to a method (for tracking usages).
     ReferenceMethod(ReferenceMethod),
 }
+assert_mem_size!(Operation, 96);
 
 /// A resolved target as it appears in source code.
 ///

--- a/rust/rubydex/src/operation/printer.rs
+++ b/rust/rubydex/src/operation/printer.rs
@@ -7,11 +7,12 @@ use crate::model::{
     string_ref::StringRef,
     visibility::Visibility,
 };
+use crate::operation::deferred::{DeferredArgument, DeferredCall};
 use crate::operation::{
-    AliasConstant, AliasGlobalVariable, AliasMethod, AttrKind, DefineAttribute, DefineClassVariable, DefineConstant,
-    DefineGlobalVariable, DefineInstanceVariable, EnterClass, EnterMethod, EnterModule, EnterSingletonClass, Mixin,
-    MixinKind, Operation, ReferenceConstant, ReferenceMethod, SetConstantVisibility, SetDefaultVisibility,
-    SetMethodVisibility, Target,
+    AliasConstant, AliasGlobalVariable, AliasMethod, AttrKind, CompiledItem, DefineAttribute, DefineClassVariable,
+    DefineConstant, DefineGlobalVariable, DefineInstanceVariable, EnterClass, EnterMethod, EnterModule,
+    EnterSingletonClass, Mixin, MixinKind, Operation, ReferenceConstant, ReferenceMethod, SetConstantVisibility,
+    SetDefaultVisibility, SetMethodVisibility, Target,
 };
 
 struct OperationPrinter<'a> {
@@ -92,6 +93,27 @@ impl OperationPrinter<'_> {
             Operation::ReferenceConstant(op) => self.print_reference_constant(op),
             Operation::ReferenceMethod(op) => self.print_reference_method(op),
         }
+    }
+
+    fn print_deferred_call(&mut self, call: &DeferredCall) {
+        let indent = self.indent();
+        let receiver = self.name_str(call.receiver_name_id());
+        let method = self.string_value(call.method_name());
+        let assignment = self.name_str(call.assignment().name_id());
+        let arguments = call
+            .arguments()
+            .iter()
+            .map(|argument| match argument {
+                DeferredArgument::LiteralName(str_id) => self.string_value(*str_id),
+                DeferredArgument::Unsupported => "<unsupported>".to_string(),
+            })
+            .collect::<Vec<_>>()
+            .join(", ");
+        writeln!(
+            self.out,
+            "{indent}DeferredCall({assignment} = {receiver}.{method}({arguments}))"
+        )
+        .unwrap();
     }
 
     fn print_enter_class(&mut self, op: &EnterClass) {
@@ -254,6 +276,32 @@ pub fn print_operations(
 
     for op in operations {
         printer.print_operation(op);
+    }
+
+    printer.out.trim_end().to_string()
+}
+
+#[must_use]
+#[allow(clippy::implicit_hasher)]
+pub fn print_compiled_items(
+    items: &[CompiledItem],
+    strings: &IdentityHashMap<StringId, StringRef>,
+    names: &IdentityHashMap<NameId, NameRef>,
+    include_references: bool,
+) -> String {
+    let mut printer = OperationPrinter {
+        strings,
+        names,
+        out: String::new(),
+        depth: 0,
+        include_references,
+    };
+
+    for item in items {
+        match item {
+            CompiledItem::Operation(operation) => printer.print_operation(operation),
+            CompiledItem::DeferredCall(call) => printer.print_deferred_call(call),
+        }
     }
 
     printer.out.trim_end().to_string()

--- a/rust/rubydex/src/operation/ruby_builder.rs
+++ b/rust/rubydex/src/operation/ruby_builder.rs
@@ -1,7 +1,7 @@
-//! Visit the Ruby AST and produce an ordered list of operations.
+//! Visit the Ruby AST and produce an ordered list of compiled items.
 //!
-//! Walks the parsed AST and produces `Vec<Operation>` that can later be applied
-//! by the applier to create definitions and declarations in a `LocalGraph`.
+//! Walks the parsed AST and produces `Vec<CompiledItem>` containing semantic operations and
+//! resolution-dependent calls.
 
 use std::collections::hash_map::Entry;
 
@@ -15,19 +15,20 @@ use crate::model::name::{Name, NameRef, ParentScope};
 use crate::model::string_ref::StringRef;
 use crate::model::visibility::Visibility;
 use crate::offset::Offset;
-use crate::operation::{self as op, AttrKind, MixinKind, Operation, Target};
+use crate::operation::deferred::{DeferredArgument, DeferredCall, DeferredConstantAssignment};
+use crate::operation::{self as op, AttrKind, CompiledItem, MixinKind, Operation, Target};
 
 use ruby_prism::{ParseResult, Visit};
 
 /// The result of running the operation builder on a Ruby source file.
 ///
-/// Contains the ordered operations and all interning data (strings, names, references)
+/// Contains the ordered compiled items and all interning data (strings, names, references)
 /// needed to later apply the operations to a graph.
 #[derive(Debug)]
 pub struct OperationBuilderResult {
     pub uri_id: UriId,
     pub document: Document,
-    pub operations: Vec<Operation>,
+    pub items: Vec<CompiledItem>,
     pub strings: IdentityHashMap<StringId, StringRef>,
     pub names: IdentityHashMap<NameId, NameRef>,
 }
@@ -68,7 +69,7 @@ impl VisibilityModifier {
     }
 }
 
-/// Visits the Ruby AST and produces an ordered list of operations.
+/// Visits the Ruby AST and produces an ordered list of compiled items.
 pub struct RubyOperationBuilder<'a> {
     uri_id: UriId,
     source: &'a str,
@@ -82,7 +83,7 @@ pub struct RubyOperationBuilder<'a> {
     visibility_stack: Vec<VisibilityModifier>,
     pending_decorator_offset: Option<Offset>,
     // Output
-    operations: Vec<Operation>,
+    items: Vec<CompiledItem>,
 }
 
 impl<'a> RubyOperationBuilder<'a> {
@@ -100,7 +101,7 @@ impl<'a> RubyOperationBuilder<'a> {
             nesting_stack: Vec::new(),
             visibility_stack: vec![VisibilityModifier::new(Visibility::Private, false, Offset::new(0, 0))],
             pending_decorator_offset: None,
-            operations: Vec::new(),
+            items: Vec::new(),
         }
     }
 
@@ -130,10 +131,14 @@ impl<'a> RubyOperationBuilder<'a> {
         OperationBuilderResult {
             uri_id: self.uri_id,
             document: self.document,
-            operations: self.operations,
+            items: self.items,
             strings: self.strings,
             names: self.names,
         }
+    }
+
+    fn push_operation(&mut self, operation: Operation) {
+        self.items.push(CompiledItem::Operation(operation));
     }
 
     // -- Interning --
@@ -364,12 +369,11 @@ impl<'a> RubyOperationBuilder<'a> {
         let name_id = self.add_name(string_id, parent_scope_id, self.current_lexical_scope_name_id());
 
         if push_final_reference {
-            self.operations
-                .push(Operation::ReferenceConstant(op::ReferenceConstant {
-                    name_id,
-                    uri_id: self.uri_id,
-                    offset,
-                }));
+            self.push_operation(Operation::ReferenceConstant(op::ReferenceConstant {
+                name_id,
+                uri_id: self.uri_id,
+                offset,
+            }));
         }
 
         Some(name_id)
@@ -378,7 +382,7 @@ impl<'a> RubyOperationBuilder<'a> {
     fn index_method_reference(&mut self, name: String, location: &ruby_prism::Location, receiver: Option<NameId>) {
         let offset = Offset::from_prism_location(location);
         let str_id = self.intern_string(name);
-        self.operations.push(Operation::ReferenceMethod(op::ReferenceMethod {
+        self.push_operation(Operation::ReferenceMethod(op::ReferenceMethod {
             str_id,
             uri_id: self.uri_id,
             offset,
@@ -478,12 +482,11 @@ impl<'a> RubyOperationBuilder<'a> {
 
         let location = receiver.map_or(fallback_location, ruby_prism::Node::location);
         let offset = Offset::from_prism_location(&location);
-        self.operations
-            .push(Operation::ReferenceConstant(op::ReferenceConstant {
-                name_id: new_name_id,
-                uri_id: self.uri_id,
-                offset,
-            }));
+        self.push_operation(Operation::ReferenceConstant(op::ReferenceConstant {
+            name_id: new_name_id,
+            uri_id: self.uri_id,
+            offset,
+        }));
         Some(new_name_id)
     }
 
@@ -635,12 +638,11 @@ impl<'a> RubyOperationBuilder<'a> {
         let (comments, flags) = self.find_comments_for(offset.start());
         let superclass_name = superclass_node.as_ref().and_then(|n| {
             if let Some(id) = self.index_constant_reference(n, false) {
-                self.operations
-                    .push(Operation::ReferenceConstant(op::ReferenceConstant {
-                        name_id: id,
-                        uri_id: self.uri_id,
-                        offset: Offset::from_prism_location(&n.location()),
-                    }));
+                self.push_operation(Operation::ReferenceConstant(op::ReferenceConstant {
+                    name_id: id,
+                    uri_id: self.uri_id,
+                    offset: Offset::from_prism_location(&n.location()),
+                }));
                 return Some(id);
             }
 
@@ -649,12 +651,11 @@ impl<'a> RubyOperationBuilder<'a> {
                 if let Some(receiver) = call.receiver()
                     && let Some(id) = self.index_constant_reference(&receiver, false)
                 {
-                    self.operations
-                        .push(Operation::ReferenceConstant(op::ReferenceConstant {
-                            name_id: id,
-                            uri_id: self.uri_id,
-                            offset: Offset::from_prism_location(&receiver.location()),
-                        }));
+                    self.push_operation(Operation::ReferenceConstant(op::ReferenceConstant {
+                        name_id: id,
+                        uri_id: self.uri_id,
+                        offset: Offset::from_prism_location(&receiver.location()),
+                    }));
                     return Some(id);
                 }
             }
@@ -690,7 +691,7 @@ impl<'a> RubyOperationBuilder<'a> {
         };
 
         if let Some(name_id) = name_id {
-            self.operations.push(Operation::EnterClass(op::EnterClass {
+            self.push_operation(Operation::EnterClass(op::EnterClass {
                 name_id,
                 uri_id: self.uri_id,
                 offset: offset.clone(),
@@ -720,7 +721,7 @@ impl<'a> RubyOperationBuilder<'a> {
             }
             self.visibility_stack.pop();
             self.nesting_stack.pop();
-            self.operations.push(Operation::ExitScope);
+            self.push_operation(Operation::ExitScope);
         }
     }
 
@@ -752,7 +753,7 @@ impl<'a> RubyOperationBuilder<'a> {
         };
 
         if let Some(name_id) = name_id {
-            self.operations.push(Operation::EnterModule(op::EnterModule {
+            self.push_operation(Operation::EnterModule(op::EnterModule {
                 name_id,
                 uri_id: self.uri_id,
                 offset: offset.clone(),
@@ -781,7 +782,7 @@ impl<'a> RubyOperationBuilder<'a> {
             }
             self.visibility_stack.pop();
             self.nesting_stack.pop();
-            self.operations.push(Operation::ExitScope);
+            self.push_operation(Operation::ExitScope);
         }
     }
 
@@ -815,6 +816,101 @@ impl<'a> RubyOperationBuilder<'a> {
         }
 
         self.index_method_reference_for_call(&call_node);
+        true
+    }
+
+    /// Captures a resolution-dependent constant assignment as a **shadow** observation candidate.
+    ///
+    /// Pass 2 prototype policy: eligible `Const = Receiver.new(...)` sites still emit the normal
+    /// `DefineConstant` contribution (preserving `OperationBuilder` graph semantics) and *also*
+    /// emit a non-authoritative `DeferredCall` for semantic compiler-selection experiments.
+    /// Matched Struct expansions are not applied to the Graph in this pass.
+    fn defer_constant_assignment_call(&mut self, node: &ruby_prism::Node, value: &ruby_prism::Node) -> bool {
+        let Some(call_node) = value.as_call_node() else {
+            return false;
+        };
+
+        if call_node.name().as_slice() != b"new" || call_node.block().is_some() {
+            return false;
+        }
+
+        let Some(receiver) = call_node.receiver() else {
+            return false;
+        };
+        if !matches!(
+            receiver,
+            ruby_prism::Node::ConstantReadNode { .. } | ruby_prism::Node::ConstantPathNode { .. }
+        ) {
+            return false;
+        }
+
+        let Some(assignment_name_id) = self.index_constant_reference(node, false) else {
+            return false;
+        };
+
+        let offset = Offset::from_prism_location(&node.location());
+        let name_location = match node {
+            ruby_prism::Node::ConstantWriteNode { .. } => node.as_constant_write_node().unwrap().name_loc(),
+            ruby_prism::Node::ConstantPathWriteNode { .. } => {
+                node.as_constant_path_write_node().unwrap().target().name_loc()
+            }
+            _ => return false,
+        };
+        let name_offset = Offset::from_prism_location(&name_location);
+        let (comments, mut flags) = self.find_comments_for(name_offset.start());
+        flags |= DefinitionFlags::PROMOTABLE;
+
+        // Preserve ordinary OperationBuilder semantics for the LHS.
+        self.push_operation(Operation::DefineConstant(op::DefineConstant {
+            name_id: assignment_name_id,
+            uri_id: self.uri_id,
+            offset: name_offset.clone(),
+            comments,
+            flags: flags.clone(),
+        }));
+
+        let Some(method_receiver_name_id) = self.method_receiver(Some(&receiver), call_node.location()) else {
+            return false;
+        };
+        let receiver_name_id = match self.names.get(&method_receiver_name_id).unwrap().parent_scope() {
+            ParentScope::Attached(receiver_name_id) => *receiver_name_id,
+            _ => return false,
+        };
+
+        let arguments = if let Some(arguments) = call_node.arguments() {
+            let mut deferred_arguments = Vec::new();
+            for argument in &arguments.arguments() {
+                if let Some((name, _)) = Self::extract_literal_name(&argument) {
+                    deferred_arguments.push(DeferredArgument::LiteralName(self.intern_string(name)));
+                } else {
+                    // Keep nested constant/method refs indexed even when the arg is
+                    // unsupported for deferred compilation.
+                    self.visit(&argument);
+                    deferred_arguments.push(DeferredArgument::Unsupported);
+                }
+            }
+            deferred_arguments.into_boxed_slice()
+        } else {
+            Box::default()
+        };
+
+        let method_name = self.intern_string(String::from_utf8_lossy(call_node.name().as_slice()).to_string());
+        let assignment = DeferredConstantAssignment::new(assignment_name_id, offset, name_offset, flags);
+        let call = DeferredCall::new(
+            self.uri_id,
+            Offset::from_prism_location(&call_node.location()),
+            receiver_name_id,
+            method_name,
+            assignment,
+            arguments,
+        );
+        self.items.push(CompiledItem::DeferredCall(call));
+        self.push_operation(Operation::ReferenceMethod(op::ReferenceMethod {
+            str_id: method_name,
+            uri_id: self.uri_id,
+            offset: Offset::from_prism_location(&call_node.message_loc().unwrap()),
+            receiver: Some(Target::Constant(method_receiver_name_id)),
+        }));
         true
     }
 
@@ -862,14 +958,13 @@ impl<'a> RubyOperationBuilder<'a> {
 
         // Mixin operations with multiple arguments are inserted in reverse
         for (name_id, offset) in mixin_arguments.into_iter().rev() {
-            self.operations
-                .push(Operation::ReferenceConstant(op::ReferenceConstant {
-                    name_id,
-                    uri_id: self.uri_id,
-                    offset,
-                }));
+            self.push_operation(Operation::ReferenceConstant(op::ReferenceConstant {
+                name_id,
+                uri_id: self.uri_id,
+                offset,
+            }));
 
-            self.operations.push(Operation::Mixin(op::Mixin {
+            self.push_operation(Operation::Mixin(op::Mixin {
                 kind,
                 target: Target::Constant(name_id),
             }));
@@ -923,16 +1018,15 @@ impl<'a> RubyOperationBuilder<'a> {
             let str_id = self.intern_string(name);
             let offset = Offset::from_prism_location(&location);
 
-            self.operations
-                .push(Operation::SetConstantVisibility(op::SetConstantVisibility {
-                    receiver: receiver_name_id.map(Target::Constant),
-                    target: str_id,
-                    visibility,
-                    uri_id: self.uri_id,
-                    offset,
-                    comments: Box::default(),
-                    flags: DefinitionFlags::empty(),
-                }));
+            self.push_operation(Operation::SetConstantVisibility(op::SetConstantVisibility {
+                receiver: receiver_name_id.map(Target::Constant),
+                target: str_id,
+                visibility,
+                uri_id: self.uri_id,
+                offset,
+                comments: Box::default(),
+                flags: DefinitionFlags::empty(),
+            }));
         }
     }
 
@@ -958,7 +1052,7 @@ impl<'a> RubyOperationBuilder<'a> {
         if promotable {
             flags |= DefinitionFlags::PROMOTABLE;
         }
-        self.operations.push(Operation::DefineConstant(op::DefineConstant {
+        self.push_operation(Operation::DefineConstant(op::DefineConstant {
             name_id,
             uri_id: self.uri_id,
             offset,
@@ -1020,7 +1114,7 @@ impl<'a> RubyOperationBuilder<'a> {
         let offset = Offset::from_prism_location(&location);
         let (comments, flags) = self.find_comments_for(offset.start());
 
-        self.operations.push(Operation::AliasConstant(op::AliasConstant {
+        self.push_operation(Operation::AliasConstant(op::AliasConstant {
             name_id,
             target_name_id,
             uri_id: self.uri_id,
@@ -1074,24 +1168,22 @@ impl<'a> RubyOperationBuilder<'a> {
             if matches!(arg, ruby_prism::Node::DefNode { .. }) || (arg_count == 1 && Self::is_attr_call(&arg)) {
                 let previous_visibility = self.current_visibility().visibility;
 
-                self.operations
-                    .push(Operation::SetDefaultVisibility(op::SetDefaultVisibility {
-                        visibility,
-                        uri_id: self.uri_id,
-                        offset: call_offset.clone(),
-                    }));
+                self.push_operation(Operation::SetDefaultVisibility(op::SetDefaultVisibility {
+                    visibility,
+                    uri_id: self.uri_id,
+                    offset: call_offset.clone(),
+                }));
 
                 self.visibility_stack
                     .push(VisibilityModifier::new(visibility, true, call_offset.clone()));
                 self.visit(&arg);
                 self.visibility_stack.pop();
 
-                self.operations
-                    .push(Operation::SetDefaultVisibility(op::SetDefaultVisibility {
-                        visibility: previous_visibility,
-                        uri_id: self.uri_id,
-                        offset: call_offset.clone(),
-                    }));
+                self.push_operation(Operation::SetDefaultVisibility(op::SetDefaultVisibility {
+                    visibility: previous_visibility,
+                    uri_id: self.uri_id,
+                    offset: call_offset.clone(),
+                }));
             } else if matches!(
                 arg,
                 ruby_prism::Node::SymbolNode { .. } | ruby_prism::Node::StringNode { .. }
@@ -1135,14 +1227,13 @@ impl<'a> RubyOperationBuilder<'a> {
         let str_id = self.intern_string(format!("{name}()"));
         let offset = Offset::from_prism_location(&location);
 
-        self.operations
-            .push(Operation::SetMethodVisibility(op::SetMethodVisibility {
-                str_id,
-                visibility,
-                uri_id: self.uri_id,
-                offset,
-                flags,
-            }));
+        self.push_operation(Operation::SetMethodVisibility(op::SetMethodVisibility {
+            str_id,
+            visibility,
+            uri_id: self.uri_id,
+            offset,
+            flags,
+        }));
     }
 
     fn create_method_visibility_operation_from_name(
@@ -1155,14 +1246,13 @@ impl<'a> RubyOperationBuilder<'a> {
         let str_id = self.intern_string(format!("{name}()"));
         let offset = Offset::from_prism_location(location);
 
-        self.operations
-            .push(Operation::SetMethodVisibility(op::SetMethodVisibility {
-                str_id,
-                visibility,
-                uri_id: self.uri_id,
-                offset,
-                flags,
-            }));
+        self.push_operation(Operation::SetMethodVisibility(op::SetMethodVisibility {
+            str_id,
+            visibility,
+            uri_id: self.uri_id,
+            offset,
+            flags,
+        }));
     }
 
     #[allow(clippy::too_many_lines)]
@@ -1311,14 +1401,13 @@ impl<'a> RubyOperationBuilder<'a> {
         let offset = Offset::from_prism_location(location);
         let (comments, flags) = self.find_comments_for(offset.start());
 
-        self.operations
-            .push(Operation::DefineGlobalVariable(op::DefineGlobalVariable {
-                str_id,
-                uri_id: self.uri_id,
-                offset,
-                comments,
-                flags,
-            }));
+        self.push_operation(Operation::DefineGlobalVariable(op::DefineGlobalVariable {
+            str_id,
+            uri_id: self.uri_id,
+            offset,
+            comments,
+            flags,
+        }));
     }
 
     fn add_instance_variable_definition(&mut self, location: &ruby_prism::Location) {
@@ -1327,14 +1416,13 @@ impl<'a> RubyOperationBuilder<'a> {
         let offset = Offset::from_prism_location(location);
         let (comments, flags) = self.find_comments_for(offset.start());
 
-        self.operations
-            .push(Operation::DefineInstanceVariable(op::DefineInstanceVariable {
-                str_id,
-                uri_id: self.uri_id,
-                offset,
-                comments,
-                flags,
-            }));
+        self.push_operation(Operation::DefineInstanceVariable(op::DefineInstanceVariable {
+            str_id,
+            uri_id: self.uri_id,
+            offset,
+            comments,
+            flags,
+        }));
     }
 
     fn add_class_variable_definition(&mut self, location: &ruby_prism::Location) {
@@ -1343,14 +1431,13 @@ impl<'a> RubyOperationBuilder<'a> {
         let offset = Offset::from_prism_location(location);
         let (comments, flags) = self.find_comments_for(offset.start());
 
-        self.operations
-            .push(Operation::DefineClassVariable(op::DefineClassVariable {
-                str_id,
-                uri_id: self.uri_id,
-                offset,
-                comments,
-                flags,
-            }));
+        self.push_operation(Operation::DefineClassVariable(op::DefineClassVariable {
+            str_id,
+            uri_id: self.uri_id,
+            offset,
+            comments,
+            flags,
+        }));
     }
 
     fn visit_method_body(&mut self, receiver: Option<NestingReceiver>, body: Option<&ruby_prism::Node<'_>>) {
@@ -1483,15 +1570,14 @@ impl Visit<'_> for RubyOperationBuilder<'_> {
         let string_id = self.intern_string(singleton_class_name);
         let nesting = self.current_lexical_scope_name_id();
         let name_id = self.add_name(string_id, ParentScope::Attached(attached_target), nesting);
-        self.operations
-            .push(Operation::EnterSingletonClass(op::EnterSingletonClass {
-                name_id,
-                uri_id: self.uri_id,
-                offset: offset.clone(),
-                name_offset,
-                comments,
-                flags,
-            }));
+        self.push_operation(Operation::EnterSingletonClass(op::EnterSingletonClass {
+            name_id,
+            uri_id: self.uri_id,
+            offset: offset.clone(),
+            name_offset,
+            comments,
+            flags,
+        }));
 
         self.nesting_stack.push(Nesting::LexicalScope {
             name_id,
@@ -1504,7 +1590,7 @@ impl Visit<'_> for RubyOperationBuilder<'_> {
         }
         self.visibility_stack.pop();
         self.nesting_stack.pop();
-        self.operations.push(Operation::ExitScope);
+        self.push_operation(Operation::ExitScope);
     }
 
     #[allow(clippy::too_many_lines)]
@@ -1573,7 +1659,7 @@ impl Visit<'_> for RubyOperationBuilder<'_> {
             let singleton_receiver = Some(Target::ExplicitSelf);
             let body = node.body();
 
-            self.operations.push(Operation::EnterMethod(op::EnterMethod {
+            self.push_operation(Operation::EnterMethod(op::EnterMethod {
                 str_id,
                 uri_id: self.uri_id,
                 offset: offset.clone(),
@@ -1583,9 +1669,9 @@ impl Visit<'_> for RubyOperationBuilder<'_> {
                 signatures: Signatures::Simple(parameters.clone().into_boxed_slice()),
                 receiver: singleton_receiver,
             }));
-            self.operations.push(Operation::ExitScope);
+            self.push_operation(Operation::ExitScope);
 
-            self.operations.push(Operation::EnterMethod(op::EnterMethod {
+            self.push_operation(Operation::EnterMethod(op::EnterMethod {
                 str_id,
                 uri_id: self.uri_id,
                 offset: offset.clone(),
@@ -1596,25 +1682,24 @@ impl Visit<'_> for RubyOperationBuilder<'_> {
                 receiver,
             }));
             self.visit_method_body(method_nesting_receiver, body.as_ref());
-            self.operations.push(Operation::ExitScope);
+            self.push_operation(Operation::ExitScope);
         } else {
             // Singleton methods at top level have receiver=None (no class to point self to).
             // Bracket with SetDefaultVisibility(Public) so the applier assigns the correct visibility.
             let needs_singleton_visibility_bracket = is_singleton && receiver.is_none();
             let previous_visibility = if needs_singleton_visibility_bracket {
                 let prev = self.current_visibility().visibility;
-                self.operations
-                    .push(Operation::SetDefaultVisibility(op::SetDefaultVisibility {
-                        visibility: Visibility::Public,
-                        uri_id: self.uri_id,
-                        offset: offset.clone(),
-                    }));
+                self.push_operation(Operation::SetDefaultVisibility(op::SetDefaultVisibility {
+                    visibility: Visibility::Public,
+                    uri_id: self.uri_id,
+                    offset: offset.clone(),
+                }));
                 Some(prev)
             } else {
                 None
             };
 
-            self.operations.push(Operation::EnterMethod(op::EnterMethod {
+            self.push_operation(Operation::EnterMethod(op::EnterMethod {
                 str_id,
                 uri_id: self.uri_id,
                 offset: offset.clone(),
@@ -1626,15 +1711,14 @@ impl Visit<'_> for RubyOperationBuilder<'_> {
             }));
             let body = node.body();
             self.visit_method_body(method_nesting_receiver, body.as_ref());
-            self.operations.push(Operation::ExitScope);
+            self.push_operation(Operation::ExitScope);
 
             if let Some(prev) = previous_visibility {
-                self.operations
-                    .push(Operation::SetDefaultVisibility(op::SetDefaultVisibility {
-                        visibility: prev,
-                        uri_id: self.uri_id,
-                        offset: offset.clone(),
-                    }));
+                self.push_operation(Operation::SetDefaultVisibility(op::SetDefaultVisibility {
+                    visibility: prev,
+                    uri_id: self.uri_id,
+                    offset: offset.clone(),
+                }));
             }
         }
     }
@@ -1661,6 +1745,9 @@ impl Visit<'_> for RubyOperationBuilder<'_> {
     fn visit_constant_write_node(&mut self, node: &ruby_prism::ConstantWriteNode) {
         let value = node.value();
         if self.handle_dynamic_class_or_module(&node.as_node(), &value) {
+            return;
+        }
+        if self.defer_constant_assignment_call(&node.as_node(), &value) {
             return;
         }
 
@@ -1694,6 +1781,9 @@ impl Visit<'_> for RubyOperationBuilder<'_> {
     fn visit_constant_path_write_node(&mut self, node: &ruby_prism::ConstantPathWriteNode) {
         let value = node.value();
         if self.handle_dynamic_class_or_module(&node.as_node(), &value) {
+            return;
+        }
+        if self.defer_constant_assignment_call(&node.as_node(), &value) {
             return;
         }
 
@@ -1772,7 +1862,7 @@ impl Visit<'_> for RubyOperationBuilder<'_> {
                 let offset = Offset::from_prism_location(&location);
                 let (comments, flags) = builder.find_comments_for(comment_offset);
 
-                builder.operations.push(Operation::DefineAttribute(op::DefineAttribute {
+                builder.push_operation(Operation::DefineAttribute(op::DefineAttribute {
                     kind,
                     str_id,
                     uri_id: builder.uri_id,
@@ -1855,7 +1945,7 @@ impl Visit<'_> for RubyOperationBuilder<'_> {
                 };
 
                 let ref_str_id = self.intern_string(format!("{old_name}()"));
-                self.operations.push(Operation::ReferenceMethod(op::ReferenceMethod {
+                self.push_operation(Operation::ReferenceMethod(op::ReferenceMethod {
                     str_id: ref_str_id,
                     uri_id: self.uri_id,
                     offset: old_offset.clone(),
@@ -1865,7 +1955,7 @@ impl Visit<'_> for RubyOperationBuilder<'_> {
                 let offset = Offset::from_prism_location(&node.location());
                 let (comments, flags) = self.find_comments_for(offset.start());
 
-                self.operations.push(Operation::AliasMethod(op::AliasMethod {
+                self.push_operation(Operation::AliasMethod(op::AliasMethod {
                     new_name_str_id,
                     old_name_str_id,
                     uri_id: self.uri_id,
@@ -1928,12 +2018,11 @@ impl Visit<'_> for RubyOperationBuilder<'_> {
                 } else {
                     let last_visibility = self.visibility_stack.last_mut().unwrap();
                     *last_visibility = VisibilityModifier::new(visibility, false, offset);
-                    self.operations
-                        .push(Operation::SetDefaultVisibility(op::SetDefaultVisibility {
-                            visibility,
-                            uri_id: self.uri_id,
-                            offset: Offset::from_prism_location(&node.location()),
-                        }));
+                    self.push_operation(Operation::SetDefaultVisibility(op::SetDefaultVisibility {
+                        visibility,
+                        uri_id: self.uri_id,
+                        offset: Offset::from_prism_location(&node.location()),
+                    }));
                 }
             }
             "new" => {
@@ -2165,7 +2254,7 @@ impl Visit<'_> for RubyOperationBuilder<'_> {
         let new_name_str_id = self.intern_string(new_name);
         let old_name_str_id = self.intern_string(old_name.clone());
 
-        self.operations.push(Operation::AliasMethod(op::AliasMethod {
+        self.push_operation(Operation::AliasMethod(op::AliasMethod {
             new_name_str_id,
             old_name_str_id,
             uri_id: self.uri_id,
@@ -2186,15 +2275,14 @@ impl Visit<'_> for RubyOperationBuilder<'_> {
         let offset = Offset::from_prism_location(&node.location());
         let (comments, flags) = self.find_comments_for(offset.start());
 
-        self.operations
-            .push(Operation::AliasGlobalVariable(op::AliasGlobalVariable {
-                new_name_str_id,
-                old_name_str_id,
-                uri_id: self.uri_id,
-                offset,
-                comments,
-                flags,
-            }));
+        self.push_operation(Operation::AliasGlobalVariable(op::AliasGlobalVariable {
+            new_name_str_id,
+            old_name_str_id,
+            uri_id: self.uri_id,
+            offset,
+            comments,
+            flags,
+        }));
     }
 
     fn visit_and_node(&mut self, node: &ruby_prism::AndNode) {
@@ -2239,14 +2327,14 @@ mod tests {
 
     fn assert_operations(source: &str, expected: &str) {
         let result = build_operations(source);
-        let actual = printer::print_operations(&result.operations, &result.strings, &result.names, false);
+        let actual = printer::print_compiled_items(&result.items, &result.strings, &result.names, false);
         let expected = normalize_expected(expected);
         assert_eq!(actual, expected, "\n\nActual:\n{actual}\n\nExpected:\n{expected}\n");
     }
 
     fn assert_operations_with_references(source: &str, expected: &str) {
         let result = build_operations(source);
-        let actual = printer::print_operations(&result.operations, &result.strings, &result.names, true);
+        let actual = printer::print_compiled_items(&result.items, &result.strings, &result.names, true);
         let expected = normalize_expected(expected);
         assert_eq!(actual, expected, "\n\nActual:\n{actual}\n\nExpected:\n{expected}\n");
     }
@@ -2490,6 +2578,42 @@ mod tests {
             DefineConstant(FOO)
             EnterClass(Bar)
               DefineConstant(BAZ)
+            ExitScope
+            ",
+        );
+    }
+
+    #[test]
+    fn build_deferred_constant_assignment_call() {
+        assert_operations_with_references(
+            "
+            Foo = Candidate.new(:name, \"email\", Bar)
+            ",
+            "
+            DefineConstant(Foo)
+            ReferenceConstant(Candidate)
+            ReferenceConstant(Candidate::<Candidate>)
+            ReferenceConstant(Bar)
+            DeferredCall(Foo = Candidate.new(name, email, <unsupported>))
+            ReferenceMethod(new)
+            ",
+        );
+    }
+
+    #[test]
+    fn does_not_defer_calls_with_blocks() {
+        // Unsupported boundary: block forms are not deferred in this pass. They fall through
+        // to ordinary constant assignment; nested defs may attach to the wrong owner until
+        // deferred block replay exists.
+        assert_operations(
+            "
+            Foo = Candidate.new do
+              def bar; end
+            end
+            ",
+            "
+            DefineConstant(Foo)
+            EnterMethod(bar())
             ExitScope
             ",
         );

--- a/rust/rubydex/src/resolution.rs
+++ b/rust/rubydex/src/resolution.rs
@@ -8,13 +8,18 @@ use crate::model::{
         Declaration, GlobalVariableDeclaration, InstanceVariableDeclaration, MethodDeclaration, ModuleDeclaration,
         Namespace, SingletonClassDeclaration, TodoDeclaration,
     },
-    definitions::{Definition, Mixin, Receiver},
+    definitions::{Definition, DefinitionFlags, Mixin, Receiver},
     graph::{Graph, Unit},
     identity_maps::{IdentityHashBuilder, IdentityHashMap, IdentityHashSet},
-    ids::{ConstantReferenceId, DeclarationId, DefinitionId, NameId, StringId, UriId},
+    ids::{
+        ConstantReferenceId, DeclarationId, DeferredCallId, DefinitionId, NameId, StringId, UriId,
+        declaration_id_from_lookup_name,
+    },
     name::{Name, NameRef, ParentScope},
     visibility::Visibility,
 };
+use crate::operation::deferred::{CompilerKind, DeferredArgument, DeferredCallResolution};
+use crate::operation::{self as op, AttrKind, Operation};
 
 enum Outcome {
     /// The constant was successfully resolved to the given declaration ID.
@@ -148,6 +153,9 @@ impl<'a> Resolver<'a> {
                     }
                     Unit::Ancestors(id) => {
                         self.handle_ancestor_unit(id);
+                    }
+                    Unit::DeferredCall(id) => {
+                        self.handle_deferred_call(unit_id, id);
                     }
                 }
             }
@@ -298,6 +306,165 @@ impl<'a> Resolver<'a> {
                 self.graph.push_work(unit_id);
             }
         }
+    }
+
+    fn handle_deferred_call(&mut self, unit_id: Unit, id: DeferredCallId) {
+        let Some(call) = self.graph.deferred_calls().get(&id) else {
+            return;
+        };
+        let receiver_name_id = call.receiver_name_id();
+        let method_name = call.method_name();
+        let arguments_supported = call
+            .arguments()
+            .iter()
+            .all(|argument| matches!(argument, DeferredArgument::LiteralName(_)));
+
+        let owner_id = match self.resolve_constant_internal(receiver_name_id) {
+            Outcome::Resolved(owner_id) => owner_id,
+            Outcome::Retry { .. } => {
+                self.unit_queue.push_back(unit_id);
+                return;
+            }
+            Outcome::Unresolved => {
+                // Mirror ConstantRef: park for a later incremental resolve rather than
+                // spinning inside the current fixed-point pass.
+                self.graph.push_work(unit_id);
+                return;
+            }
+        };
+
+        let (normalized_owners, alias_path_deps) = self.resolve_alias_chain_with_dependencies(owner_id);
+        if normalized_owners.iter().any(|owner_id| {
+            matches!(
+                self.graph.declarations().get(owner_id),
+                Some(Declaration::ConstantAlias(_))
+            )
+        }) {
+            self.unit_queue.push_back(unit_id);
+            return;
+        }
+
+        let compiler = if arguments_supported && normalized_owners.len() == 1 {
+            self.match_builtin_compiler(normalized_owners[0], method_name)
+        } else {
+            None
+        };
+
+        let (resolution, expansion) = match compiler {
+            Some(compiler) => (
+                DeferredCallResolution::Compiler(compiler),
+                // Expansion is inspection-only; ordinary DefineConstant remains authoritative.
+                self.expand_deferred_call(id, compiler),
+            ),
+            None => (DeferredCallResolution::Fallback, Box::default()),
+        };
+        self.graph
+            .record_deferred_call_result(id, resolution, expansion, &alias_path_deps);
+        self.made_progress = true;
+    }
+
+    fn match_builtin_compiler(&self, owner_id: DeclarationId, method_name: StringId) -> Option<CompilerKind> {
+        let new_method = StringId::from("new");
+        if owner_id != declaration_id_from_lookup_name("Struct") || method_name != new_method {
+            return None;
+        }
+        // Identity alone is not enough: only a class namespace is a Struct compiler owner.
+        match self.graph.declarations().get(&owner_id) {
+            Some(Declaration::Namespace(Namespace::Class(_))) => Some(CompilerKind::StructNew),
+            _ => None,
+        }
+    }
+
+    fn expand_deferred_call(&self, id: DeferredCallId, compiler: CompilerKind) -> Box<[Operation]> {
+        let call = self.graph.deferred_calls().get(&id).unwrap();
+        // Semantic match may normalize Alias → Struct, but generated IR must keep the source
+        // receiver NameId so the live ReferenceConstant(Alias) satisfies OperationApplier.
+        let superclass_name = call.receiver_name_id();
+        match compiler {
+            CompilerKind::StructNew => {
+                // Delta IR relative to already-emitted indexing refs: EnterClass + attrs +
+                // ExitScope. ReferenceConstant/ReferenceMethod for the call site remain in
+                // the live CompiledItem stream.
+                let mut operations = Vec::with_capacity(call.arguments().len() + 2);
+                operations.push(Operation::EnterClass(op::EnterClass {
+                    name_id: call.assignment().name_id(),
+                    uri_id: call.uri_id(),
+                    offset: call.assignment().offset().clone(),
+                    name_offset: call.assignment().name_offset().clone(),
+                    comments: Box::default(),
+                    flags: call.assignment().flags(),
+                    superclass_name: Some(superclass_name),
+                    is_lexical_scope: false,
+                }));
+                for argument in call.arguments() {
+                    if let DeferredArgument::LiteralName(str_id) = argument {
+                        operations.push(Operation::DefineAttribute(op::DefineAttribute {
+                            kind: AttrKind::Accessor,
+                            str_id: *str_id,
+                            uri_id: call.uri_id(),
+                            offset: call.offset().clone(),
+                            comments: Box::default(),
+                            flags: DefinitionFlags::empty(),
+                        }));
+                    }
+                }
+                operations.push(Operation::ExitScope);
+                operations.into_boxed_slice()
+            }
+        }
+    }
+
+    /// Like `resolve_alias_chains`, but also returns the exact target `NameId`s traversed.
+    fn resolve_alias_chain_with_dependencies(
+        &self,
+        declaration_id: DeclarationId,
+    ) -> (Vec<DeclarationId>, Vec<NameId>) {
+        let mut results = Vec::new();
+        let mut dependencies = Vec::new();
+        let mut queue = VecDeque::from([declaration_id]);
+        let mut seen = HashSet::new();
+
+        while let Some(current) = queue.pop_front() {
+            if !seen.insert(current) {
+                continue;
+            }
+
+            match self.graph.declarations().get(&current) {
+                Some(Declaration::ConstantAlias(_)) => {
+                    let mut targets = Vec::new();
+                    for definition_id in self.graph.declarations().get(&current).unwrap().definitions() {
+                        let Some(Definition::ConstantAlias(alias_def)) = self.graph.definitions().get(definition_id)
+                        else {
+                            continue;
+                        };
+                        let target_name_id = *alias_def.target_name_id();
+                        if !dependencies.contains(&target_name_id) {
+                            dependencies.push(target_name_id);
+                        }
+                        if let Some(NameRef::Resolved(resolved)) = self.graph.names().get(&target_name_id) {
+                            let target_id = *resolved.declaration_id();
+                            if !targets.contains(&target_id) {
+                                targets.push(target_id);
+                            }
+                        }
+                    }
+                    if targets.is_empty() {
+                        // Target not resolved yet — keep the alias for retry.
+                        results.push(current);
+                    } else {
+                        queue.extend(targets);
+                    }
+                }
+                Some(_) => {
+                    results.push(current);
+                }
+                None => {
+                    panic!("Declaration {current:?} not found in graph");
+                }
+            }
+        }
+
+        (results, dependencies)
     }
 
     /// Handles a unit of work for linearizing ancestors of a declaration
@@ -1859,6 +2026,7 @@ impl<'a> Resolver<'a> {
     /// In this case `Bar` must already be processed so the `Bar` reference inside `Foo` resolves, which then unblocks
     /// `Baz` and finally `Qux`. Notice how `Qux` is a simple name nested under a complex one, so it too sorts late —
     /// which is why depth accounts for the parent scopes across the entire nesting, not just for the name itself.
+    #[allow(clippy::too_many_lines)]
     fn prepare_units(&mut self) -> Vec<DefinitionId> {
         let work = self.graph.take_pending_work();
         let estimated = work.len() / 2;
@@ -1866,6 +2034,7 @@ impl<'a> Resolver<'a> {
         let mut others = Vec::with_capacity(estimated);
         let mut singleton_methods = Vec::new();
         let mut const_refs = Vec::new();
+        let mut deferred_calls = Vec::new();
         let mut ancestors = vec![*BASIC_OBJECT_ID, *KERNEL_ID, *OBJECT_ID, *MODULE_ID, *CLASS_ID];
         let names = self.graph.names();
         // Every name captured its depth during indexing (see `Name::compute_depth`), so ordering the units below is a
@@ -1892,6 +2061,7 @@ impl<'a> Resolver<'a> {
         // and the same definition/reference ID can be enqueued more than once.
         let mut seen_defs = IdentityHashSet::<DefinitionId>::default();
         let mut seen_references = IdentityHashSet::<ConstantReferenceId>::default();
+        let mut seen_deferred_calls = IdentityHashSet::<DeferredCallId>::default();
         let mut seen_ancestors = IdentityHashSet::<DeclarationId>::default();
 
         for unit in work {
@@ -1959,6 +2129,17 @@ impl<'a> Resolver<'a> {
                         ancestors.push(id);
                     }
                 }
+                Unit::DeferredCall(id) => {
+                    if !seen_deferred_calls.insert(id) {
+                        continue;
+                    }
+                    let Some(call) = self.graph.deferred_calls().get(&id) else {
+                        continue;
+                    };
+                    let uri_rank = *uri_ranks.get(&call.uri_id()).unwrap();
+                    let depth = depth_of(&call.receiver_name_id());
+                    deferred_calls.push((Unit::DeferredCall(id), (depth, uri_rank, call.offset())));
+                }
             }
         }
 
@@ -1967,12 +2148,14 @@ impl<'a> Resolver<'a> {
         definitions.sort_unstable_by_key(|(_, key)| *key);
 
         const_refs.sort_unstable_by_key(|(_, key)| *key);
+        deferred_calls.sort_unstable_by_key(|(_, key)| *key);
 
         others.sort_unstable_by_key(|(_, key)| *key);
 
-        // Definitions first, then constant refs, then singleton methods, then ancestors
+        // Definitions first, then constant refs and deferred calls, then singleton methods and ancestors.
         self.unit_queue.extend(definitions.into_iter().map(|(id, _)| id));
         self.unit_queue.extend(const_refs.into_iter().map(|(id, _)| id));
+        self.unit_queue.extend(deferred_calls.into_iter().map(|(id, _)| id));
         self.unit_queue.extend(singleton_methods);
         self.unit_queue.extend(ancestors.into_iter().map(Unit::Ancestors));
 

--- a/rust/rubydex/src/test_utils/graph_test.rs
+++ b/rust/rubydex/src/test_utils/graph_test.rs
@@ -133,6 +133,11 @@ impl GraphTest {
                 .constant_references()
                 .get(id)
                 .and_then(|r| self.name_str(r.name_id())),
+            NameDependent::DeferredCall(id) => self
+                .graph()
+                .deferred_calls()
+                .get(id)
+                .and_then(|call| self.name_str(&call.receiver_name_id())),
         }
     }
 

--- a/rust/rubydex/src/test_utils/local_graph_test.rs
+++ b/rust/rubydex/src/test_utils/local_graph_test.rs
@@ -258,6 +258,11 @@ impl LocalGraphTest {
                 .constant_references()
                 .get(id)
                 .and_then(|r| self.name_str(r.name_id())),
+            NameDependent::DeferredCall(id) => self
+                .graph()
+                .deferred_calls()
+                .get(id)
+                .and_then(|call| self.name_str(&call.receiver_name_id())),
         }
     }
 }


### PR DESCRIPTION
## Summary

This is a draft architecture prototype for #958.

I wanted to test one question before implementing the registration API: how should Rubydex handle a DSL-shaped call when the compiler cannot be selected correctly until the receiver has semantic identity?

The prototype keeps normal `OperationBuilder` behavior authoritative, records eligible calls as deferred compiler candidates, resolves the receiver through normal constant resolution and aliases, and then emits ordinary existing `Operation`s from a test `Struct.new` compiler.

I stopped before making those generated operations authoritative. That execution boundary overlaps with the ordered IR / Chunk / VM direction discussed in #798 and the incremental work in #960.

```mermaid
flowchart LR
    A[RubyOperationBuilder] --> B[Known Operation]
    A --> C[Deferred compiler call]
    C --> D[Resolver: owner + aliases]
    D --> E[Existing Operations]
    B --> F[Semantic graph]
    E -. authoritative execution is open .-> F
```

Current prototype scope:

```text
constant assignment
+ explicit constant receiver
+ method `new`
+ no block
```

Example:

```ruby
Foo = Candidate.new(:name)
```

The normal `DefineConstant(Foo)` still wins, so graph semantics do not change. The deferred call is only an observation used to test compiler selection and generated IR.

This only exercises the OperationBuilder path and temporarily changes its result from `Vec<Operation>` to `Vec<CompiledItem>` to preserve ordering. I'm not proposing that public Rust API shape as settled.

## What this shows

### Compiler selection belongs after semantic resolution

Receiver text is not enough.

The tests cover direct and root-qualified `Struct`, one/multi-hop aliases, lexical shadows, wrong declaration kinds, reopened owners, multiple resolved alias targets, ambiguity removal, class/module/class transitions, and alias cycles.

The reliable boundary is the resolved `DeclarationId` after normal constant resolution and alias normalization.

### The existing worklist model can carry the experiment

Deferred candidates use the existing `NameDependent`, `Unit`, and `pending_work` machinery.

Dependencies are limited to the receiver plus the alias path actually traversed:

```text
Struct                     -> 1 edge
Alias -> Struct            -> 2 edges
AliasA -> AliasB -> Struct -> 3 edges
```

Unrelated aliases/references do not wake the candidate.

The prototype duplicates a small amount of alias traversal to capture dependency provenance. I would expect a production version to expose that from the canonical resolver, especially with #960 in flight.

### Existing Operations can model the tested Struct effect

For:

```ruby
Foo = Struct.new(:name)
```

the test compiler emits existing operations equivalent to:

```text
ReferenceConstant(Struct)
EnterClass(Foo, superclass=Struct, is_lexical_scope=false)
DefineAttribute(accessor, name)
ExitScope
```

A test-only substitution at the original stream position proves that this can affect normal resolution:

```ruby
class Struct; end
Foo = Struct.new(:name)
class Bar < Foo; end
```

`Foo` becomes a class with superclass `Struct`, owns the generated attribute, and `Bar < Foo` resolves normally.

Using the dependency chain from #958, the same in-stream oracle also resolves an ordinary `SOME_REF` inside `Bar < Foo` through the DSL-generated `Foo < Struct` chain to `Struct::SOME_REF`.

The same oracle works for `Outer::Foo` / `Outer::Bar` while keeping the generated class non-lexical.

This is an IR expressiveness oracle, not a production-complete implementation of `Struct.new`.

## Where I stopped

The unresolved part is how selected compiler output becomes authoritative.

`OperationApplier` consumes an ordered stream with transient state such as owner, lexical scope, visibility, preceding references, and instruction position. #1024 now preserves exact lexical constant-resolution context from a namespace `Definition` / `NameId`, but generic DSL execution can still depend on additional stream state.

The narrow Struct expansion can replay pre-merge because it establishes most of the state it needs itself. I don't think that is enough evidence to make out-of-band replay the general model.

Applying generated semantics after `LocalGraph` has merged would also require graph surgery and reintroduce the replacement/ownership problems explored by earlier approaches.

The prototype also exposes an ordering limit:

```ruby
class Struct; end
Struct = 123
Foo = Struct.new(:name)
```

Rubydex still has a class-shaped `Struct` declaration, so the prototype selects the Struct compiler. I left source-order runtime-value tracking out of #958; it appears tied to ordered IR execution rather than compiler matching.

## Cost

I benchmarked the `OperationBuilder` backend against the same baseline on synthetic corpora plus `ruby-lsp`, Rails, Tapioca, and Discourse.

Real-world candidate counts for this narrow shape were low:

| Corpus | Candidates |
| --- | ---: |
| ruby-lsp | 1 |
| tapioca | 5 |
| discourse | 94 |
| rails | 121 |

Real-world RSS deltas were roughly 1ΓÇô2%, with ~0.6% on candidate-free corpora. Stress tests showed cost scaling with candidate count and actual alias depth.

Windows CPU timings were noisy, so I would not draw performance conclusions from those yet.

## Questions

Before taking this further, I'd like guidance on two things:

1. **Where should a resolution-dependent compiler invocation live?**  
   The prototype uses an ordered `CompiledItem::DeferredCall`. Would this fit better as an IR instruction interpreted by the future VM / Chunk model from #798?

2. **What ordered execution state should authoritative expansion retain?**  
   Should execution pause/resume at the original stream position when semantic dependencies are unresolved, or should owner/visibility/reference/block state become explicitly replayable?

Those answers also affect fallback-vs-compiler ownership, reverse/unload behavior, compiler-owner bootstrap, and how dependency provenance should integrate with #960.

## Deliberately out of scope

This draft does not add the public compiler registry, Ruby/C/FFI registration, Ruby callbacks, block or implicit-receiver DSLs, authoritative replay, reverse operations, or additional DSL compilers.

I want to settle the execution boundary before adding those layers.

## Validation

Current branch is rebased on `main`.

- `cargo fmt --check` ΓÇö pass
- `cargo clippy --lib --all-features` ΓÇö pass
- `cargo test` ΓÇö 1188 library + 9 CLI + 2 doctests passed
- focused `operation::deferred` tests ΓÇö 33 passed

This draft is for architecture review, not as a complete fix for #958.

