### PR TITLE
Require yaml in Rubydex::Skill

### DIFF
--- a/lib/rubydex/skill.rb
+++ b/lib/rubydex/skill.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "yaml"
 require "rubydex/errors"
 
 module Rubydex


### PR DESCRIPTION
Fixes #1031.

`Skill.parse_frontmatter` calls `YAML.safe_load` (`lib/rubydex/skill.rb:69`) and rescues `Psych::Exception` (:70), but nothing under `lib/` requires `yaml`. Ruby 4.0 no longer autoloads it, so `rdx skill <id>` aborts with a `NameError` on the rescue clause before it can print anything:

```
$ rdx skill send-private-method
lib/rubydex/skill.rb:70:in 'Rubydex::Skill.parse_frontmatter':
  uninitialized constant #<Class:Rubydex::Skill>::Psych (NameError)
```

The test suite doesn't catch it because the test process pulls `yaml` in transitively; `exe/rdx` loads a thinner chain.

With this line added, `rdx skill send-private-method` prints the skill body. Verified on rubydex v0.4.0 (`arm64-darwin`), Ruby 4.0.3, macOS 15.6.
