### PR TITLE
Move release profile to Makefile

### DIFF
--- a/ext/rubydex/extconf.rb
+++ b/ext/rubydex/extconf.rb
@@ -23,12 +23,12 @@ release = ENV["RELEASE"] || !developing_rubydex
 root_dir = gem_dir.join("rust")
 target_dir = root_dir.join("target")
 target_dir = target_dir.join("x86_64-pc-windows-gnu") if Gem.win_platform?
-target_dir = target_dir.join(release ? "release" : "debug")
+target_dir = target_dir.join("$(RUST_PROFILE)")
 
 bindings_path = root_dir.join("rubydex-sys").join("rustbindings.h")
 
 cargo_args = ["--manifest-path #{root_dir.join("Cargo.toml")}"]
-cargo_args << "--release" if release
+cargo_args << "$(CARGO_PROFILE_FLAG)"
 
 if Gem.win_platform?
   cargo_args << "--target x86_64-pc-windows-gnu"
@@ -102,6 +102,8 @@ makefile = File.read("Makefile")
 
 new_makefile = makefile.gsub("$(OBJS): $(HDRS) $(ruby_headers)", <<~MAKEFILE.chomp)
   .PHONY: compile_rust
+  RUST_PROFILE = $(if $(strip $(RELEASE)),release,#{developing_rubydex ? "debug" : "release"})
+  CARGO_PROFILE_FLAG = $(if $(filter release,$(RUST_PROFILE)),--release)
   RUST_SRCS = #{File.expand_path("Cargo.toml", root_dir)} #{File.expand_path("Cargo.lock", root_dir)} #{rust_srcs.join(" ")}
 
   .rust_built: $(RUST_SRCS)


### PR DESCRIPTION
I noticed that we needed a `rake clean` whenever switching between building the project in debug/release mode. The reason is because the signal was not being encoded as part of the Makefile. We needed the `clean` to re-generate the makefile from scratch. That's inconvenient.

By moving the profile into the Makefile, we fix the issue as we move the check to compilation time and not Makefile generation time.

**Before**
```sh
# compile the C extension
bundle exec rake compile

# did nothing because the Makefile was stale, requiring a clean first
RELEASE=true bundle exec rake compile 
```

**After**
```sh
# Compile the extension in debug mode (check the `cp` command execution copying from `target/debug`
bundle exec rake compile

# Compile the extension in release mode (`cp` command copies from `target/release`)
RELEASE=true bundle exec rake compile 
```

Note that this was a development-only inconvenience. Our gem releases were already working properly.