### PR TITLE
Remove optional test case file from exported RBI

### DIFF
--- a/rbi/rubydex.rbi
+++ b/rbi/rubydex.rbi
@@ -535,58 +535,6 @@ class Rubydex::Linter::Rules::RuleStructure < Rubydex::Linter::CustomRule
   def lint; end
 end
 
-class Rubydex::Linter::RuleTestCase < Minitest::Test
-  DEFAULT_FILE = T.let(T.unsafe(nil), String)
-  ANNOTATION_PATTERN = T.let(T.unsafe(nil), Regexp)
-
-  sig { returns(String) }
-  def workspace_path; end
-
-  sig { params(name: String).void }
-  def initialize(name); end
-
-  sig { void }
-  def teardown; end
-
-  sig { returns(T.class_of(Rubydex::Linter::CustomRule)) }
-  def rule_class; end
-
-  sig { params(sources: T::Hash[String, String]).void }
-  def add_shared_source(sources); end
-
-  sig { returns(T::Array[String]) }
-  def ignored_diagnostic_files; end
-
-  sig { returns(Rubydex::LinterConfig) }
-  def rule_config; end
-
-  sig do
-    params(
-      args: T.any(String, T::Hash[T.any(String, Symbol), String]),
-      rule_builder: T.nilable(T.proc.params(graph: Rubydex::Graph).returns(Rubydex::Linter::CustomRule)),
-    ).returns(T::Array[Rubydex::Diagnostic])
-  end
-  def assert_diagnostics(*args, &rule_builder); end
-
-  sig do
-    params(
-      args: T.any(String, T::Hash[T.any(String, Symbol), String]),
-      rule_builder: T.nilable(T.proc.params(graph: Rubydex::Graph).returns(Rubydex::Linter::CustomRule)),
-    ).returns(T::Array[Rubydex::Diagnostic])
-  end
-  def assert_no_diagnostics(*args, &rule_builder); end
-
-  sig do
-    params(
-      dependency: String,
-      args: T.any(String, T::Hash[T.any(String, Symbol), String]),
-      after_excluding: T::Array[String],
-      rule_builder: T.nilable(T.proc.params(graph: Rubydex::Graph).returns(Rubydex::Linter::CustomRule)),
-    ).void
-  end
-  def assert_handles_missing_required_dependency(dependency, *args, after_excluding: [], &rule_builder); end
-end
-
 class Rubydex::Linter::Runner
   sig do
     params(


### PR DESCRIPTION
The `RuleTestCase` file is optional. Apps only load it if they are creating custom rules and if they use `Minitest` (we are not providing helpers for Test Unit or RSpec).

If we include the information in the exported RBI, it leads to type checking errors like [these](https://github.com/Shopify/rbi-central/pull/416), where `Minitest` is not defined because we don't depend on it, but it appears in the Rubydex exported RBI. It also propagates easily because Tapioca depends on Rubydex, making the RBIs for its own dependencies invalid.

We don't even need to include this in the exported RBI since Tapioca can generate the definitions for it (it's all Ruby code). This PR removes `RuleTestCase` from the RBI to avoid causing type checking errors.

**Note**: we may want to provide a helper module instead of a parent class, which makes it easier to share the testing logic with any framework, but I'm not including that change as part of this PR.