### PR TITLE
Make generate rules a pre-requisite of compile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -58,7 +58,7 @@ task :generate_rules do
   sh "cargo run --quiet --bin generate_ruby_rules", chdir: "rust"
 end
 
-Rake::Task[:compile].enhance([:generate_rules])
+task compile: :generate_rules
 
 task compile_release: :clean do
   ENV["RELEASE"] = "true"


### PR DESCRIPTION
It seems that the way `cibuildgem` invokes `rake compile` fails if we try to access the task eagerly (see https://github.com/Shopify/rubydex/actions/runs/33557607498/job/100024083381).

I believe we might be able to fix it by moving the rule generation as a dependency rather than using enhance.

I'm able to reproduce the problem on main by listing rake tasks with the patch included by `cibuildgem`:

```shell
bundle exec rake -r path/to/cibuildgem/lib/cibuildgem/extension_patch.rb --tasks
```

After this change, listing tasks works as expected and compile is present.