### PR TITLE
Box comment's content

### DIFF
--- a/rust/rubydex-sys/src/definition_api.rs
+++ b/rust/rubydex-sys/src/definition_api.rs
@@ -248,7 +248,7 @@ pub unsafe extern "C" fn rdx_definition_comments(pointer: GraphPointer, definiti
             .comments()
             .iter()
             .map(|c| CommentEntry {
-                string: CString::new(c.string().as_str()).unwrap().into_raw().cast_const(),
+                string: CString::new(c.string()).unwrap().into_raw().cast_const(),
                 location: create_location_for_uri_and_offset(graph, document, c.offset()),
             })
             .collect::<Vec<CommentEntry>>()

--- a/rust/rubydex/src/indexing/rbs_indexer.rs
+++ b/rust/rubydex/src/indexing/rbs_indexer.rs
@@ -197,7 +197,7 @@ impl<'a> RBSIndexer<'a> {
             // Skip past indentation to the comment text
             current_offset += line_indent as u32;
 
-            let line_text = line[line_indent..].to_string();
+            let line_text: Box<str> = line[line_indent..].into();
             let line_bytes = line_text.len() as u32;
             let offset = Offset::new(current_offset, current_offset + line_bytes);
             comments.push(Comment::new(offset, line_text));

--- a/rust/rubydex/src/indexing/ruby_indexer.rs
+++ b/rust/rubydex/src/indexing/ruby_indexer.rs
@@ -1547,7 +1547,7 @@ impl CommentGroup {
 
         self.comments.push(Comment::new(
             Offset::from_prism_location(&comment.location()),
-            text.trim().to_string(),
+            text.trim().into(),
         ));
     }
 

--- a/rust/rubydex/src/model/comment.rs
+++ b/rust/rubydex/src/model/comment.rs
@@ -4,13 +4,13 @@ use crate::offset::Offset;
 #[derive(Debug, Clone)]
 pub struct Comment {
     offset: Offset,
-    string: String,
+    string: Box<str>,
 }
-assert_mem_size!(Comment, 32);
+assert_mem_size!(Comment, 24);
 
 impl Comment {
     #[must_use]
-    pub fn new(offset: Offset, string: String) -> Self {
+    pub fn new(offset: Offset, string: Box<str>) -> Self {
         Self { offset, string }
     }
 
@@ -20,7 +20,7 @@ impl Comment {
     }
 
     #[must_use]
-    pub fn string(&self) -> &String {
+    pub fn string(&self) -> &str {
         &self.string
     }
 }

--- a/rust/rubydex/src/model/graph.rs
+++ b/rust/rubydex/src/model/graph.rs
@@ -2090,14 +2090,14 @@ mod tests {
         let definitions = context.graph().get("CommentedClass").unwrap();
         let def = definitions.first().unwrap();
         assert_eq!(
-            def.comments().iter().map(Comment::string).collect::<Vec<&String>>(),
+            def.comments().iter().map(Comment::string).collect::<Vec<&str>>(),
             ["# This is a class comment", "# Multi-line comment"]
         );
 
         let definitions = context.graph().get("CommentedModule").unwrap();
         let def = definitions.first().unwrap();
         assert_eq!(
-            def.comments().iter().map(Comment::string).collect::<Vec<&String>>(),
+            def.comments().iter().map(Comment::string).collect::<Vec<&str>>(),
             ["# Module comment"]
         );
 

--- a/rust/rubydex/src/operation/ruby_builder.rs
+++ b/rust/rubydex/src/operation/ruby_builder.rs
@@ -1396,7 +1396,7 @@ impl CommentGroup {
         }
         self.comments.push(Comment::new(
             Offset::from_prism_location(&comment.location()),
-            text.trim().to_string(),
+            text.trim().into(),
         ));
     }
 


### PR DESCRIPTION
A micro memory optimization: we were storing a `String` for each comment's content even though we never modify them (and shouldn't allow it!).

We can use the same trick we're using everywhere else and use a `Box<str>` to represent the string as immutable and save a bit of memory. It's not a world changing amount (~10MB), but I'd argue the immutability aspect is also worth the change.