### PR TITLE
Use Box<str> for Document uri

### DIFF
--- a/rust/rubydex-sys/src/graph_api.rs
+++ b/rust/rubydex-sys/src/graph_api.rs
@@ -745,7 +745,7 @@ pub unsafe extern "C" fn rdx_index_source(
     };
 
     with_mut_graph(pointer, |graph| {
-        indexing::index_source(graph, &uri_str, source_str, &language);
+        indexing::index_source(graph, uri_str.into(), source_str, &language);
         IndexSourceResult::Success
     })
 }

--- a/rust/rubydex/src/indexing.rs
+++ b/rust/rubydex/src/indexing.rs
@@ -101,7 +101,7 @@ impl Job for IndexingJob {
         };
 
         let language = self.path.extension().map_or(LanguageId::Ruby, LanguageId::from);
-        let local_graph = build_local_graph(url.to_string(), &source, &language, self.backend);
+        let local_graph = build_local_graph(url.to_string().into(), &source, &language, self.backend);
 
         self.local_graph_tx
             .send(local_graph)
@@ -110,8 +110,8 @@ impl Job for IndexingJob {
 }
 
 /// Indexes a single source string in memory, dispatching to the appropriate indexer based on `language_id`.
-pub fn index_source(graph: &mut Graph, uri: &str, source: &str, language_id: &LanguageId) {
-    let local_graph = build_local_graph(uri.to_string(), source, language_id, IndexerBackend::RubyIndexer);
+pub fn index_source(graph: &mut Graph, uri: Box<str>, source: &str, language_id: &LanguageId) {
+    let local_graph = build_local_graph(uri, source, language_id, IndexerBackend::RubyIndexer);
     graph.consume_document_changes(local_graph);
 }
 
@@ -153,7 +153,7 @@ pub fn index_files(graph: &mut Graph, paths: Vec<PathBuf>, backend: IndexerBacke
 
 /// Indexes a source string using the appropriate indexer for the given language.
 #[must_use]
-pub fn build_local_graph(uri: String, source: &str, language: &LanguageId, backend: IndexerBackend) -> LocalGraph {
+pub fn build_local_graph(uri: Box<str>, source: &str, language: &LanguageId, backend: IndexerBackend) -> LocalGraph {
     match language {
         LanguageId::Ruby => match backend {
             IndexerBackend::RubyIndexer => {
@@ -228,7 +228,7 @@ mod tests {
         assert_eq!(6, graph.definitions().len());
         assert_eq!(2, graph.documents().len());
 
-        index_source(&mut graph, &uri, "", &LanguageId::Ruby);
+        index_source(&mut graph, uri.into(), "", &LanguageId::Ruby);
 
         assert_eq!(5, graph.definitions().len());
         assert_eq!(2, graph.documents().len());

--- a/rust/rubydex/src/indexing/rbs_indexer.rs
+++ b/rust/rubydex/src/indexing/rbs_indexer.rs
@@ -33,8 +33,8 @@ pub struct RBSIndexer<'a> {
 
 impl<'a> RBSIndexer<'a> {
     #[must_use]
-    pub fn new(uri: String, source: &'a str) -> Self {
-        let uri_id = UriId::from(&uri);
+    pub fn new(uri: Box<str>, source: &'a str) -> Self {
+        let uri_id = UriId::from(&*uri);
         let local_graph = LocalGraph::new(uri_id, Document::new(uri, source));
 
         Self {
@@ -1454,7 +1454,7 @@ mod tests {
     fn split_multiline_comments_crlf() {
         // Build the indexer directly to bypass normalize_indentation, which strips \r
         let source = "# First line\r\n# Second line\r\nclass Foo\r\nend\r\n";
-        let mut indexer = RBSIndexer::new("file:///foo.rbs".to_string(), source);
+        let mut indexer = RBSIndexer::new("file:///foo.rbs".into(), source);
         indexer.index();
         let context = LocalGraphTest::from_local_graph("file:///foo.rbs", source, indexer.local_graph());
 

--- a/rust/rubydex/src/indexing/ruby_indexer.rs
+++ b/rust/rubydex/src/indexing/ruby_indexer.rs
@@ -93,8 +93,8 @@ pub struct RubyIndexer<'a> {
 
 impl<'a> RubyIndexer<'a> {
     #[must_use]
-    pub fn new(uri: String, source: &'a str) -> Self {
-        let uri_id = UriId::from(&uri);
+    pub fn new(uri: Box<str>, source: &'a str) -> Self {
+        let uri_id = UriId::from(&*uri);
         let local_graph = LocalGraph::new(uri_id, Document::new(uri, source));
 
         Self {

--- a/rust/rubydex/src/model/built_in.rs
+++ b/rust/rubydex/src/model/built_in.rs
@@ -48,7 +48,7 @@ pub fn add_built_in_data(graph: &mut Graph) {
       class Class < Module
       end
     ";
-    indexing::index_source(graph, uri.as_ref(), source, &LanguageId::Rbs);
+    indexing::index_source(graph, uri.to_string().into(), source, &LanguageId::Rbs);
 
     // Creating declarations eagerly is still necessary because we need to associate correct ownership data no matter in
     // what order we discover classes and modules

--- a/rust/rubydex/src/model/document.rs
+++ b/rust/rubydex/src/model/document.rs
@@ -12,7 +12,7 @@ use crate::model::ids::{ConstantReferenceId, DefinitionId, MethodReferenceId};
 // definitions and references discovered in it
 #[derive(Debug)]
 pub struct Document {
-    uri: String,
+    uri: Box<str>,
     line_index: LineIndex,
     definition_ids: Vec<DefinitionId>,
     method_reference_ids: Vec<MethodReferenceId>,
@@ -20,11 +20,11 @@ pub struct Document {
     diagnostics: Vec<Diagnostic>,
     content_hash: u64,
 }
-assert_mem_size!(Document, 184);
+assert_mem_size!(Document, 176);
 
 impl Document {
     #[must_use]
-    pub fn new(uri: String, source: &str) -> Self {
+    pub fn new(uri: Box<str>, source: &str) -> Self {
         Self {
             uri,
             line_index: LineIndex::new(source),
@@ -176,7 +176,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "Cannot add the same exact definition to a document twice. Duplicate definition IDs")]
     fn inserting_duplicate_definitions() {
-        let mut document = Document::new("file:///foo.rb".to_string(), "class Foo; end");
+        let mut document = Document::new("file:///foo.rb".into(), "class Foo; end");
         let def_id = DefinitionId::new(123);
 
         document.add_definition(def_id);
@@ -187,7 +187,7 @@ mod tests {
 
     #[test]
     fn tracking_references() {
-        let mut document = Document::new("file:///foo.rb".to_string(), "class Foo; end");
+        let mut document = Document::new("file:///foo.rb".into(), "class Foo; end");
         let method_ref = MethodReferenceId::new(1);
         let constant_ref = ConstantReferenceId::new(2);
 
@@ -202,7 +202,7 @@ mod tests {
     fn require_path() {
         let root = test_root();
         let path = root.join("lib").join("foo").join("bar.rb");
-        let uri = Url::from_file_path(path).unwrap().to_string();
+        let uri = Url::from_file_path(path).unwrap().to_string().into();
         let load_paths = [root.join("lib")];
 
         let document = Document::new(uri, "");
@@ -213,7 +213,7 @@ mod tests {
     fn require_path_first_load_path_wins() {
         let root = test_root();
         let path = root.join("a").join("b").join("foo.rb");
-        let uri = Url::from_file_path(path).unwrap().to_string();
+        let uri = Url::from_file_path(path).unwrap().to_string().into();
         let load_path_a = root.join("a");
         let load_path_ab = root.join("a").join("b");
         let load_paths = [load_path_a, load_path_ab];
@@ -228,18 +228,18 @@ mod tests {
         let load_paths = [root.join("lib")];
 
         // non-file URI
-        let document = Document::new("untitled:Untitled-1".to_string(), "");
+        let document = Document::new("untitled:Untitled-1".into(), "");
         assert!(document.require_path(&load_paths).is_none());
 
         // non-.rb extension
         let path = root.join("lib").join("foo.so");
-        let uri = Url::from_file_path(path).unwrap().to_string();
+        let uri = Url::from_file_path(path).unwrap().to_string().into();
         let document = Document::new(uri, "");
         assert!(document.require_path(&load_paths).is_none());
 
         // /libfoo is not under /lib - should not match due to partial directory name
         let path = root.join("libfoo").join("bar.rb");
-        let uri = Url::from_file_path(path).unwrap().to_string();
+        let uri = Url::from_file_path(path).unwrap().to_string().into();
         let document = Document::new(uri, "");
         assert!(document.require_path(&load_paths).is_none());
     }
@@ -248,7 +248,7 @@ mod tests {
     fn require_path_with_spaces() {
         let root = test_root();
         let path = root.join("lib").join("space foo").join("bar.rb");
-        let uri = Url::from_file_path(path).unwrap().to_string();
+        let uri = Url::from_file_path(path).unwrap().to_string().into();
         let load_paths = [root.join("lib")];
 
         let document = Document::new(uri, "");

--- a/rust/rubydex/src/operation/ruby_builder.rs
+++ b/rust/rubydex/src/operation/ruby_builder.rs
@@ -87,8 +87,8 @@ pub struct RubyOperationBuilder<'a> {
 
 impl<'a> RubyOperationBuilder<'a> {
     #[must_use]
-    pub fn new(uri: String, source: &'a str) -> Self {
-        let uri_id = UriId::from(&uri);
+    pub fn new(uri: Box<str>, source: &'a str) -> Self {
+        let uri_id = UriId::from(&*uri);
 
         Self {
             uri_id,
@@ -2229,7 +2229,7 @@ mod tests {
 
     fn build_operations(source: &str) -> OperationBuilderResult {
         let source = crate::test_utils::normalize_indentation(source);
-        let builder = RubyOperationBuilder::new("file:///test.rb".to_string(), &source);
+        let builder = RubyOperationBuilder::new("file:///test.rb".into(), &source);
         builder.build()
     }
 

--- a/rust/rubydex/src/test_utils/graph_test.rs
+++ b/rust/rubydex/src/test_utils/graph_test.rs
@@ -44,14 +44,14 @@ impl GraphTest {
     /// Indexes a Ruby source
     pub fn index_uri(&mut self, uri: &str, source: &str) {
         let source = normalize_indentation(source);
-        let local_graph = indexing::build_local_graph(uri.to_string(), &source, &LanguageId::Ruby, self.backend);
+        let local_graph = indexing::build_local_graph(uri.into(), &source, &LanguageId::Ruby, self.backend);
         self.graph.consume_document_changes(local_graph);
     }
 
     /// Indexes an RBS source
     pub fn index_rbs_uri(&mut self, uri: &str, source: &str) {
         let source = normalize_indentation(source);
-        indexing::index_source(&mut self.graph, uri, &source, &LanguageId::Rbs);
+        indexing::index_source(&mut self.graph, uri.into(), &source, &LanguageId::Rbs);
     }
 
     pub fn delete_uri(&mut self, uri: &str) {

--- a/rust/rubydex/src/test_utils/local_graph_test.rs
+++ b/rust/rubydex/src/test_utils/local_graph_test.rs
@@ -24,22 +24,29 @@ impl LocalGraphTest {
 
     #[must_use]
     pub fn new_with_backend(uri: &str, source: &str, backend: IndexerBackend) -> Self {
-        let uri = uri.to_string();
         let source = normalize_indentation(source);
-        let graph = build_local_graph(uri.clone(), &source, &LanguageId::Ruby, backend);
-        Self { uri, source, graph }
+        let graph = build_local_graph(uri.into(), &source, &LanguageId::Ruby, backend);
+
+        Self {
+            uri: uri.to_string(),
+            source,
+            graph,
+        }
     }
 
     #[must_use]
     pub fn new_rbs(uri: &str, source: &str) -> Self {
-        let uri = uri.to_string();
         let source = normalize_indentation(source);
 
-        let mut indexer = RBSIndexer::new(uri.clone(), &source);
+        let mut indexer = RBSIndexer::new(uri.into(), &source);
         indexer.index();
         let graph = indexer.local_graph();
 
-        Self { uri, source, graph }
+        Self {
+            uri: uri.to_string(),
+            source,
+            graph,
+        }
     }
 
     #[must_use]


### PR DESCRIPTION
Another easy win: document URIs are immutable and so we can use `Box<str>` and save 8 bytes per document.